### PR TITLE
chore(infra): split DO exceptions by namespace and alert on file rooms

### DIFF
--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,9 +4,9 @@
 
 This directory currently provisions:
 
-- Ten dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP server (shared boards)` (`mcp-server`), `MCP app sessions` (`kotx6wj`), and `Bemo analytics` in the `Dotcom` folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
-- All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
-- The folders `Zero` (dashboards + 9 rules), `Dotcom` (6 dashboards), and `Anthropic` (1 dashboard + 3 cost rules)
+- Eleven dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP server (shared boards)` (`mcp-server`), `MCP app sessions` (`kotx6wj`), and `Bemo analytics` in the `Dotcom` folder; and `Cloudflare platform metrics` (`nivs2rl`), which sits at the root rather than in a folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- All 13 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage, file room DO exceptions)
+- The folders `Zero` (dashboards + 9 rules), `Dotcom` (6 dashboards + 1 rule), and `Anthropic` (1 dashboard + 3 cost rules)
 
 There are two MCP dashboards, for two different servers. `MCP server (shared boards)` covers the public server on the sync worker at `POST /app/mcp` (`apps/dotcom/sync-worker`), which reads its protocol metrics from the `MEASURE` dataset. `MCP app sessions` covers the separate tldraw MCP app worker (`apps/mcp-app`) and its own `MCP_ANALYTICS` dataset. Neither one's panels belong on `Dotcom events` — that dashboard covers the sync worker's own events.
 

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dotcom-file-do-exceptions.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dotcom-file-do-exceptions.yaml
@@ -1,0 +1,94 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: dotcom
+    grafana.com/provenance: ''
+  labels:
+    grafana.app/folder: dotcom
+    grafana.com/group: dotcom-alerts
+    grafana.com/group-index: '1'
+  name: dotcom-file-do-exceptions
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: TLFileDurableObject threw more than 300 uncaught exceptions in the
+      last hour. Quiet hours run 1-50; the bursts that followed hibernation being
+      enabled on 2026-08-13 run 700-1300. Check the "DO exceptions by namespace"
+      panel on the Cloudflare platform metrics dashboard, then Sentry for the
+      matching source tag.
+    summary: File room durable objects are throwing uncaught exceptions
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: ffuyblsuemj28b
+      model:
+        columns:
+          - selector: sum.requests
+            text: exceptions
+            type: number
+        format: table
+        global_query_id: ''
+        parser: backend
+        refId: A
+        root_selector: data.viewer.accounts[0].durableObjectsInvocationsAdaptiveGroups
+        source: url
+        type: graphql
+        url: https://api.cloudflare.com/client/v4/graphql
+        url_options:
+          body_content_type: application/json
+          body_graphql_query: |-
+            query {
+              viewer {
+                accounts(filter: {accountTag: "c34edc4e76350954b63adebde86d5eb1"}) {
+                  durableObjectsInvocationsAdaptiveGroups(limit: 1, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}", namespaceId: "5864db4344ac4c55bfd94e81dd25a043", status: "scriptThrewException"}) {
+                    sum { requests }
+                  }
+                }
+              }
+            }
+          body_type: graphql
+          method: POST
+      relativeTimeRange:
+        from: 1h0m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 300
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 10m0s
+  labels:
+    service: dotcom
+    severity: warning
+  # The query filters to scriptThrewException, so a healthy hour returns no rows at
+  # all rather than a zero. NoData here means "nothing threw" — alerting on it would
+  # invert the rule.
+  noDataState: Ok
+  notificationSettings:
+    receiver: Discord
+    type: SimplifiedRouting
+  title: File room DO exceptions
+  trigger:
+    interval: 10m

--- a/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
+++ b/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
@@ -1316,7 +1316,7 @@ spec:
         dominated by 164dab144e614bb9ac54367e0ffaf56c, which throws ~21k/day on its
         own and is chronic, so anything else is invisible in the aggregate above —
         including file rooms, at ~3k/day. TLDR_DOC / TLFileDurableObject (file rooms)
-        is 5864db4344ac4c55bfd94e81dd25a043; its rate stepped up roughly 30x on
+        is 5864db4344ac4c55bfd94e81dd25a043; it went from ~67/day to 7.2k on
         2026-08-13, the day #9978 stopped the Supabase client blocking hibernation
         and so let the file DO evict for the first time. Cold-start paths that had
         never run while every object stayed resident now do.'

--- a/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
+++ b/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
@@ -1,0 +1,2310 @@
+apiVersion: dashboard.grafana.app/v1
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: ''
+    grafana.app/message: |
+      convert to v2
+    grafana.app/saved-from-ui: Grafana Cloud
+  labels: {}
+  name: nivs2rl
+  namespace: stacks-890472
+spec:
+  annotations:
+    list:
+      - builtIn: 1
+        datasource:
+          type: grafana
+          uid: -- Grafana --
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        type: dashboard
+  editable: true
+  fiscalYearStartMonth: 0
+  graphTooltip: 1
+  links: []
+  liveNow: false
+  panels:
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Requests per worker script across the whole account — covers the
+        missing HTTP traffic metrics for every worker, including asset-upload and tldrawusercontent
+        which emit no app metrics.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 0
+      id: 2
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.scriptName
+              text: worker
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].workersInvocationsAdaptive
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    workersInvocationsAdaptive(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { datetimeFifteenMinutes scriptName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Worker requests
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - worker
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Uncaught-exception error counts per worker script — the free version
+        of the missing exception-rate metric (no per-event labels).
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        'y': 0
+      id: 3
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.scriptName
+              text: worker
+              type: string
+            - selector: sum.errors
+              text: errors
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].workersInvocationsAdaptive
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    workersInvocationsAdaptive(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { errors }
+                      dimensions { datetimeFifteenMinutes scriptName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Worker errors
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - worker
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: 'Requests by invocation status: success, scriptThrewException, exceededResources,
+        clientDisconnected, internalError.'
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 0
+        'y': 8
+      id: 4
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.status
+              text: status
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].workersInvocationsAdaptive
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    workersInvocationsAdaptive(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { datetimeFifteenMinutes status }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Invocation outcomes
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - status
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: CPU time percentiles per worker (microseconds) — the platform-side
+        saturation signal for compute.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: µs
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 8
+        'y': 8
+      id: 5
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.scriptName
+              text: worker
+              type: string
+            - selector: quantiles.cpuTimeP50
+              text: p50
+              type: number
+            - selector: quantiles.cpuTimeP99
+              text: p99
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].workersInvocationsAdaptive
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    workersInvocationsAdaptive(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      quantiles { cpuTimeP50 cpuTimeP99 }
+                      dimensions { datetimeFifteenMinutes scriptName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Worker CPU time p50 / p99
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - worker
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Subrequests (fetch calls to R2, Postgres-over-HTTP, other services)
+        per worker — a proxy for downstream pressure.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 16
+        'y': 8
+      id: 6
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.scriptName
+              text: worker
+              type: string
+            - selector: sum.subrequests
+              text: subrequests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].workersInvocationsAdaptive
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    workersInvocationsAdaptive(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { subrequests }
+                      dimensions { datetimeFifteenMinutes scriptName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Worker subrequests
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - worker
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: DO invocations per script. Each incoming WebSocket message bills
+        as a request, so for the sync-worker this approximates the missing receive_message
+        metric (aggregate only). The scriptName dimension is inferred from Cloudflare
+        dashboards — verify via the schema explorer if it errors.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 16
+      id: 7
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.scriptName
+              text: script
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsInvocationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsInvocationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { datetimeFifteenMinutes scriptName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Durable Object requests
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - script
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: DO requests by invocation status — surfaces DO-side exceptions and
+        resource limits. The status dimension is inferred from Cloudflare dashboards
+        — verify via the schema explorer if it errors.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        'y': 16
+      id: 8
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.status
+              text: status
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsInvocationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsInvocationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { datetimeFifteenMinutes status }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Durable Object invocation outcomes
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - status
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Total DO CPU time per interval across the account (rooms, user DOs,
+        replicator, bemo, MCP sessions combined).
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 25
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: µs
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 24
+      id: 9
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: sum.cpuTime
+              text: cpu time
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: timeseries
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsPeriodicGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsPeriodicGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { cpuTime }
+                      dimensions { datetimeFifteenMinutes }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Durable Object CPU time
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Total bytes stored in DO storage across the account — namespace-level
+        saturation for room SQLite/KV state.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 25
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: decbytes
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        'y': 24
+      id: 10
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeHour
+              text: time
+              type: timestamp
+            - selector: max.storedBytes
+              text: stored bytes
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: timeseries
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsStorageGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsStorageGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      max { storedBytes }
+                      dimensions { datetimeHour }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Durable Object stored bytes
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Billed DO duration summed per namespace over the selected range —
+        where the cost actually sits. TLDR_DOC / TLFileDurableObject (file rooms) is
+        5864db4344ac4c55bfd94e81dd25a043 and normally carries ~98% of the total. Shown
+        as a ranked total rather than a time series because Infinity's backend parser
+        does not pivot a dimension column into separate series.
+      fieldConfig:
+        defaults:
+          color:
+            mode: continuous-GrYlRd
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: short
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 32
+      id: 19
+      options:
+        displayMode: gradient
+        legend:
+          calcs: []
+          displayMode: list
+          overflow: ellipsis
+          placement: bottom
+          showLegend: false
+        maxVizHeight: 300
+        minVizHeight: 16
+        minVizWidth: 8
+        namePlacement: auto
+        orientation: horizontal
+        reduceOptions:
+          calcs:
+            - lastNotNull
+          fields: ''
+          values: true
+        showUnfilled: true
+        sizing: auto
+        valueMode: color
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.namespaceId
+              text: namespace
+              type: string
+            - selector: sum.duration
+              text: duration
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsPeriodicGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsPeriodicGroups(limit: 30, orderBy: [sum_duration_DESC], filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { duration }
+                      dimensions { namespaceId }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: DO duration by namespace (GB·s, over range)
+      type: bargauge
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: "Billed duration for TLDR_DOC / TLFileDurableObject only (namespace
+        5864db4344ac4c55bfd94e81dd25a043, ids from idFromName('/r/' + slug)). This
+        is the line PR #9964 targets: parked background tabs reconnect-looping keep
+        file rooms resident instead of letting them hibernate. Client-side fix deployed
+        2026-08-12 09:24 UTC — it only takes effect as browsers pick up the new bundle,
+        so expect a gradual decline, clearest in the overnight trough."
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: GB·s
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 25
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: short
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        'y': 32
+      id: 20
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: sum.duration
+              text: duration
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: timeseries
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsPeriodicGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsPeriodicGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}", namespaceId: "5864db4344ac4c55bfd94e81dd25a043"}) {
+                      sum { duration activeTime }
+                      dimensions { datetimeFifteenMinutes }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: File room DO duration (GB·s)
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: "Top 50 file room DO instances by active time over the selected range.
+        A room at ~1 hour per hour of range (e.g. ~24h over a 1-day range) is pinned
+        permanently awake rather than hibernating — the signature of the reconnect loop
+        PR #9964 fixes. Identified by Durable Object objectId, never the room slug:
+        idFromName('/r/' + slug) is one-way, so the slug is never sent to Grafana.
+        This matches the sync worker's own policy — every MEASURE event indexes on
+        the DO id for the same reason. Do not reintroduce the `name` dimension: a room
+        slug is the access credential for that board."
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: µs
+        overrides: []
+      gridPos:
+        h: 10
+        w: 24
+        x: 0
+        'y': 40
+      id: 21
+      options:
+        cellHeight: sm
+        footer:
+          countRows: false
+          fields: ''
+          reducer:
+            - sum
+          show: false
+        showHeader: true
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.objectId
+              text: object id
+              type: string
+            - selector: sum.activeTime
+              text: active time
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsPeriodicGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsPeriodicGroups(limit: 50, orderBy: [sum_activeTime_DESC], filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}", namespaceId: "5864db4344ac4c55bfd94e81dd25a043"}) {
+                      sum { activeTime }
+                      dimensions { objectId }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Longest-resident file rooms
+      type: table
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: 'scriptThrewException split out by namespace. The account total is
+        dominated by 164dab144e614bb9ac54367e0ffaf56c, which throws ~21k/day on its
+        own and is chronic, so anything else is invisible in the aggregate above —
+        including file rooms, at ~3k/day. TLDR_DOC / TLFileDurableObject (file rooms)
+        is 5864db4344ac4c55bfd94e81dd25a043; its rate stepped up roughly 30x on
+        2026-08-13, the day #9978 stopped the Supabase client blocking hibernation
+        and so let the file DO evict for the first time. Cold-start paths that had
+        never run while every object stayed resident now do.'
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 24
+        x: 0
+        'y': 50
+      id: 22
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.namespaceId
+              text: namespace
+              type: string
+            - selector: sum.requests
+              text: exceptions
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].durableObjectsInvocationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    durableObjectsInvocationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}", status: "scriptThrewException"}) {
+                      sum { requests }
+                      dimensions { datetimeFifteenMinutes namespaceId }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: DO exceptions by namespace
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - namespace
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Requests per R2 bucket over time — covers the missing asset traffic
+        metrics (ROOMS snapshots, UPLOADS assets, etc.) at bucket granularity.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 58
+      id: 11
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetime
+              text: time
+              type: timestamp
+            - selector: dimensions.bucketName
+              text: bucket
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].r2OperationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    r2OperationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { datetime bucketName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: R2 operations by bucket
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - bucket
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Operation counts by bucket and action type (GetObject, PutObject,
+        …) over the selected range.
+      fieldConfig:
+        defaults:
+          color:
+            mode: continuous-BlPu
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 6
+        x: 12
+        'y': 58
+      id: 12
+      options:
+        displayMode: gradient
+        legend:
+          calcs: []
+          displayMode: list
+          overflow: ellipsis
+          placement: bottom
+          showLegend: false
+        maxVizHeight: 300
+        minVizHeight: 16
+        minVizWidth: 8
+        namePlacement: auto
+        orientation: horizontal
+        reduceOptions:
+          calcs:
+            - lastNotNull
+          fields: ''
+          values: true
+        showUnfilled: true
+        sizing: auto
+        valueMode: color
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.bucketName
+              text: bucket
+              type: string
+            - selector: dimensions.actionType
+              text: action
+              type: string
+            - selector: sum.requests
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].r2OperationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    r2OperationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { requests }
+                      dimensions { bucketName actionType }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: R2 operations by action
+      type: bargauge
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Stored payload bytes per bucket (max over range) — trend this over
+        days to see room-snapshot and upload growth.
+      fieldConfig:
+        defaults:
+          color:
+            mode: continuous-GrYlRd
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+          unit: decbytes
+        overrides: []
+      gridPos:
+        h: 8
+        w: 6
+        x: 18
+        'y': 58
+      id: 13
+      options:
+        displayMode: gradient
+        legend:
+          calcs: []
+          displayMode: list
+          overflow: ellipsis
+          placement: bottom
+          showLegend: false
+        maxVizHeight: 300
+        minVizHeight: 16
+        minVizWidth: 8
+        namePlacement: auto
+        orientation: horizontal
+        reduceOptions:
+          calcs:
+            - lastNotNull
+          fields: ''
+          values: true
+        showUnfilled: true
+        sizing: auto
+        valueMode: color
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.bucketName
+              text: bucket
+              type: string
+            - selector: max.payloadSize
+              text: bytes
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].r2StorageAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    r2StorageAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      max { payloadSize }
+                      dimensions { bucketName }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: R2 storage by bucket
+      type: bargauge
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Average backlog depth (messages) per queue — the saturation signal
+        application code cannot produce. Covers the sync-worker asset-upload queue.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 25
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 0
+        'y': 66
+      id: 14
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeMinute
+              text: time
+              type: timestamp
+            - selector: dimensions.queueId
+              text: queue
+              type: string
+            - selector: avg.messages
+              text: messages
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].queueBacklogAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    queueBacklogAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      avg { messages bytes }
+                      dimensions { datetimeMinute queueId }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Queue backlog
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - queue
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Average concurrent consumer invocations per queue.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 12
+            gradientMode: opacity
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1.5
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 8
+        'y': 66
+      id: 15
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeMinute
+              text: time
+              type: timestamp
+            - selector: dimensions.queueId
+              text: queue
+              type: string
+            - selector: avg.concurrency
+              text: concurrency
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].queueConsumerMetricsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    queueConsumerMetricsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      avg { concurrency }
+                      dimensions { datetimeMinute queueId }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Queue consumer concurrency
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - queue
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Billable message operations by action type and outcome — write/read/ack
+        throughput and failure outcomes per queue.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 8
+        x: 16
+        'y': 66
+      id: 16
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeMinute
+              text: time
+              type: timestamp
+            - selector: dimensions.actionType
+              text: action
+              type: string
+            - selector: dimensions.outcome
+              text: outcome
+              type: string
+            - selector: sum.billableOperations
+              text: operations
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.accounts[0].queueMessageOperationsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  accounts(filter: {accountTag: "${account_id}"}) {
+                    queueMessageOperationsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      sum { billableOperations }
+                      dimensions { datetimeMinute actionType outcome }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Queue message operations
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - action
+              - outcome
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: Edge response status codes for the tldraw.com zone — the free version
+        of the missing per-route error-rate metric (sampled, edge view).
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: bars
+            fillOpacity: 80
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 0
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: never
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: normal
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        'y': 74
+      id: 17
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          enableFacetedFilter: false
+          overflow: ellipsis
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.datetimeFifteenMinutes
+              text: time
+              type: timestamp
+            - selector: dimensions.edgeResponseStatus
+              text: status
+              type: string
+            - selector: count
+              text: requests
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.zones[0].httpRequestsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  zones(filter: {zoneTag: "${zone_id}"}) {
+                    httpRequestsAdaptiveGroups(limit: 10000, filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}"}) {
+                      count
+                      dimensions { datetimeFifteenMinutes edgeResponseStatus }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: Zone responses by status code
+      transformations:
+        - id: partitionByValues
+          options:
+            fields:
+              - status
+            keepFields: false
+            naming:
+              asLabels: true
+      type: timeseries
+    - datasource:
+        type: yesoreyeram-infinity-datasource
+        uid: ffuyblsuemj28b
+      description: "Server errors grouped by request host and edge status over the selected
+        range. Deliberately does NOT group by clientRequestPath: Cloudflare groups server-side,
+        so a path dimension would put full board slugs into the API response, and a
+        display-level mask cannot remove them. Route-level attribution lives in the
+        sync-worker's own events instead."
+      fieldConfig:
+        defaults:
+          color:
+            mode: thresholds
+          custom:
+            align: auto
+            cellOptions:
+              type: auto
+            footer:
+              reducers: []
+            inspect: false
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        'y': 74
+      id: 18
+      options:
+        cellHeight: sm
+        showHeader: true
+        sortBy:
+          - desc: true
+            displayName: errors
+      pluginVersion: 13.2.0-28926505616
+      targets:
+        - columns:
+            - selector: dimensions.clientRequestHTTPHost
+              text: host
+              type: string
+            - selector: dimensions.edgeResponseStatus
+              text: status
+              type: string
+            - selector: count
+              text: errors
+              type: number
+          datasource:
+            type: yesoreyeram-infinity-datasource
+            uid: ffuyblsuemj28b
+          filters: []
+          format: table
+          global_query_id: ''
+          parser: backend
+          refId: A
+          root_selector: data.viewer.zones[0].httpRequestsAdaptiveGroups
+          source: url
+          type: graphql
+          url: https://api.cloudflare.com/client/v4/graphql
+          url_options:
+            body_content_type: application/json
+            body_graphql_query: |-
+              query {
+                viewer {
+                  zones(filter: {zoneTag: "${zone_id}"}) {
+                    httpRequestsAdaptiveGroups(limit: 100, orderBy: [count_DESC], filter: {datetime_geq: "${__from:date:iso}", datetime_leq: "${__to:date:iso}", edgeResponseStatus_geq: 500}) {
+                      count
+                      dimensions { clientRequestHTTPHost edgeResponseStatus }
+                    }
+                  }
+                }
+              }
+            body_type: graphql
+            method: POST
+      title: 5xx responses by host and status
+      type: table
+  preload: false
+  refresh: 5m
+  schemaVersion: 42
+  tags:
+    - tldraw
+    - cloudflare
+    - platform
+    - provisioned
+    - repo:tldraw/tldraw
+  templating:
+    list:
+      - current:
+          selected: true
+          text: tldraw
+          value: c34edc4e76350954b63adebde86d5eb1
+        description: Aliased for legibility only — the ID is stored in this dashboard's
+          JSON and is not secret.
+        hide: 0
+        includeAll: false
+        label: Cloudflare account
+        multi: false
+        name: account_id
+        options:
+          - selected: true
+            text: tldraw
+            value: c34edc4e76350954b63adebde86d5eb1
+        query: 'tldraw : c34edc4e76350954b63adebde86d5eb1'
+        skipUrlSync: false
+        type: custom
+      - current:
+          selected: true
+          text: tldraw.com
+          value: e7567c58962361a2bb9d802f858f5da3
+        description: Aliased for legibility only — the ID is stored in this dashboard's
+          JSON and is not secret.
+        hide: 0
+        includeAll: false
+        label: Cloudflare zone
+        multi: false
+        name: zone_id
+        options:
+          - selected: true
+            text: tldraw.com
+            value: e7567c58962361a2bb9d802f858f5da3
+        query: 'tldraw.com : e7567c58962361a2bb9d802f858f5da3'
+        skipUrlSync: false
+        type: custom
+  time:
+    from: now-6h
+    to: now
+  timepicker:
+    refresh_intervals:
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+  timezone: browser
+  title: Cloudflare platform metrics
+  weekStart: ''


### PR DESCRIPTION
File room durable objects started throwing uncaught exceptions on 2026-08-13, going from ~67/day to a 11.6k/day peak, and nothing we have would have told us. This adopts the dashboard that could show it, splits the metric so it's visible, and alerts on it.

`Cloudflare platform metrics` (`nivs2rl`) was the only dashboard still being edited in the UI, so it comes into the tree first — pulled with `gcx resources pull`, plus the `provisioned` and `repo:tldraw/tldraw` tags the other adopted dashboards carry.

Its `Durable Object invocation outcomes` panel sums every namespace together. One namespace (`164dab…`) throws ~21k/day on its own and has for as long as the data goes back, which is 87% of the account total — so anything else is a rounding error in that panel's stack. The new `DO exceptions by namespace` panel splits `scriptThrewException` by `namespaceId`, which is what makes the file rooms legible at ~3k/day.

The alert fires when TLFileDurableObject (`5864db…`) crosses 300 exceptions in an hour. Quiet hours run 1-50 and the bursts since 2026-08-13 run 700-1300, so the threshold sits above normal and below every burst observed.

### Notes for reviewers

- `noDataState: Ok`, deliberately. The query filters to `scriptThrewException`, so an hour where nothing threw returns no rows rather than a zero — the default `NoData` would page on exactly the healthy case. Verified against a zero-exception window (2026-08-08): the frame comes back empty.
- The daily file room series either side of the step: 15, 249, 7, 22, 21 (Aug 3-7), then 35, 107, 212 (Aug 10-12), then **7244, 11596, 1985, 340** (Aug 13-16), and 3213 so far on Aug 17. #9978 landed 2026-08-13 14:30 UTC and let the file DO evict for the first time, which is the same boundary.
- The dashboard sits at the root rather than in a folder. Left as-is: moving it would change its URL, and that's not this PR's business.
- Only the panel and the tags are edits to the pulled dashboard. Everything else in `nivs2rl.yaml` is gcx output, reformatted by the repo's `oxfmt` pre-commit hook the same way every other dashboard in this tree already is.

### Change type

- [x] `other`

### Test plan

The alerting API has no server-side dry-run, so the rule's query and threshold were checked directly against `/api/ds/query` rather than by creating it:

1. `gcx resources validate -p internal/grafana/resources` — passes, 13 rules skipped as client-side-only (expected).
2. Alert query over a known burst hour (Aug 17 08:00-09:00Z) returns `A = 1267`, threshold `C = 1`.
3. Same query over a quiet hour (Aug 17 02:00-03:00Z) returns `A = 3`, threshold `C = 0`.
4. Same query over a zero-exception day (Aug 8) returns an empty frame — hence `noDataState: Ok`.
5. The panel query over the last 6h returns 77 rows across 6 namespaces, separating `164dab…` (8088) from `5864db…` (3132).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal only: no user-facing change.
