### PR TITLE
fix(editor): tighten wildcard host matching in license domain check

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -316,6 +316,42 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
+		it('Fails if the wildcard domain is a prefix of the current hostname', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('https://sub.example.com.other.io')
+
+			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			permissiveHostsInfo[PROPERTIES.HOSTS] = ['*.example.com']
+			const permissiveLicenseKey = await generateLicenseKey(
+				JSON.stringify(permissiveHostsInfo),
+				keyPair
+			)
+			const result = (await licenseManager.getLicenseFromKey(
+				permissiveLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(false)
+		})
+
+		it('Fails if the current hostname only ends with the wildcard domain', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('https://notexample.com')
+
+			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			permissiveHostsInfo[PROPERTIES.HOSTS] = ['*.example.com']
+			const permissiveLicenseKey = await generateLicenseKey(
+				JSON.stringify(permissiveHostsInfo),
+				keyPair
+			)
+			const result = (await licenseManager.getLicenseFromKey(
+				permissiveLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(false)
+		})
+
 		it('Fails if has a subdomain wildcard isnt for the same base domain', async () => {
 			// @ts-ignore
 			delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -407,7 +407,9 @@ export class LicenseManager {
 
 			// Glob testing, we only support '*.somedomain.com' right now.
 			if (host.includes('*')) {
-				const globToRegex = new RegExp(host.replace(/\*/g, '.*?'))
+				const globToRegex = new RegExp(
+					normalizedHostOrUrlRegex.replace(/\./g, '\\.').replace(/\*/g, '.*?') + '$'
+				)
 				return globToRegex.test(currentHostname) || globToRegex.test(`www.${currentHostname}`)
 			}
 


### PR DESCRIPTION
In order for wildcard license hosts to match exactly the domains they name, this PR tightens the glob-to-regex conversion in `LicenseManager.isDomainValid`. The previous conversion left literal dots in the host acting as regex wildcards and did not anchor the pattern, so `*.example.com` could match hostnames it wasn't meant to describe. The host's dots are now escaped and the pattern is anchored to the end of the hostname, so `*.example.com` matches `sub.example.com` and deeper subdomains (and the apex domain via the existing `www.` fallback) and nothing else. The glob branch also now uses the normalized (lowercased, trimmed) host like the rest of the checks, so casing in the license value can't cause a mismatch.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn test run LicenseManager` in `packages/editor`

- [x] Unit tests

### Release notes

- Fix wildcard license host matching so `*.example.com` matches only that domain's subdomains.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |
| Tests     | +36 / -0   |