### PR TITLE
[HOTFIX] fix(editor): license fixes and product metadata

### DIFF
--- a/internal/docs/product-stable-ids.md
+++ b/internal/docs/product-stable-ids.md
@@ -1,0 +1,83 @@
+# Product stable ids
+
+Every published package in `packages/` declares which commercial component it belongs to via a `tldraw_product` field in its `package.json`. These stable ids are what legal and sales reference in order forms, so they must be unambiguous and durable: renaming, moving, or refactoring code never changes a stable id.
+
+## The shape of the taxonomy
+
+The taxonomy has exactly two levels, matching the order form's "Product in Scope" section:
+
+- **Products** are the top-level line items — the checkboxes a customer ticks. Today: SDK and the Collaboration module.
+- **Features** are parts of a product that can be licensed on their own, listed indented beneath their parent. Commenting is a feature of the Collaboration module.
+
+```
+[ ] SDK
+      [ ] Sync, Driver, Mermaid, Create tldraw CLI   (included, not separately licensed)
+[ ] Collaboration module
+      [ ] Commenting
+```
+
+A feature that isn't premium is _included_ in its parent rather than separately licensable — it appears in the manifest so legal can see what a product contains, but it isn't its own checkbox.
+
+Individual npm packages are not part of this taxonomy. A package declares the component it implements and inherits that component's entitlement; several packages can (and do) share one stable id. `@tldraw/commenting`, `@tldraw/mentions`, and `@tldraw/sync-collaboration` all implement `tldraw:commenting`, and none of them are order form line items.
+
+## Why package.json
+
+- npm publishes `package.json` verbatim and published versions are immutable, so every shipped version carries a permanent record of its stable id and premium status. "What did `@tldraw/commenting@5.3.0` claim to be" is answerable forever via the npm registry (for example `https://registry.npmjs.org/@tldraw/commenting/latest`).
+- The metadata travels with the package through renames and moves.
+- The release process already rewrites every package's `package.json`, so no separate manifest file can drift out of date.
+
+## The `tldraw_product` field
+
+```json
+"tldraw_product": {
+	"stableId": "tldraw:commenting",
+	"name": "Commenting",
+	"type": "feature",
+	"parent": "tldraw:collaboration",
+	"premium": true,
+	"licenseFlag": "FEAT_COMMENTING"
+}
+```
+
+- `stableId` — immutable commercial identifier, `tldraw:<kebab-case>`. This is what contracts reference.
+- `name` — the customer-facing label, matching the wording on the order form. Unlike the stable id this may be reworded.
+- `type` — `product` (top-level line item) or `feature` (part of a parent).
+- `parent` — for features, the component they belong to.
+- `premium` — whether the component is separately licensed rather than part of the standard SDK offering.
+- `licenseFlag` — for premium components, the license key `FLAGS` bit in `packages/editor/src/lib/license/LicenseManager.ts` that entitles a customer to the component. This is the bridge between order forms and runtime enforcement: a license key whose flags include this bit grants the component.
+
+## Rules
+
+- A stable id never changes when code is renamed, moved, split, or refactored. If a package is renamed, the `tldraw_product` field moves with it unchanged.
+- A new stable id is minted only for a genuinely new commercial component — something sales would list on an order form. Major version bumps do not mint new ids; the order form grants "all versions made available during the Order Form Term", so version entitlement is handled by the term and the license key's expiry, never by the id.
+- Moving a package to a different component is the expensive operation, because customers have signed order forms citing the old one. When a package is likely to become separately licensable later, give it its own component up front.
+- All packages sharing a stable id must have identical metadata.
+- Every published package in `packages/` must have the field. `yarn check-packages` (run in CI) enforces this, validates `licenseFlag` values against `LicenseManager`, checks that every `parent` resolves, and checks that packages pointing at `LICENSE.md` actually ship one.
+
+## How legal references a component
+
+Reference components by stable id, for example: "SDK (`tldraw:sdk-core`) and the Collaboration module (`tldraw:collaboration`), including Commenting (`tldraw:commenting`)".
+
+- `yarn product-manifest` prints the manifest as a JSON tree: products, their features, and the packages implementing each.
+- For any published version, the npm registry copy of each package's `package.json` is the immutable record.
+
+## Current components
+
+Run `yarn product-manifest` for the authoritative list. As of the introduction of this convention:
+
+| Stable id              | Name                 | Parent                 | Premium                    | Packages                                                                                                                                                                         |
+| ---------------------- | -------------------- | ---------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tldraw:sdk-core`      | SDK                  | —                      | no                         | `tldraw`, `@tldraw/tldraw`, `@tldraw/editor`, `@tldraw/assets`, `@tldraw/state`, `@tldraw/state-react`, `@tldraw/store`, `@tldraw/tlschema`, `@tldraw/utils`, `@tldraw/validate` |
+| `tldraw:sync`          | Sync                 | `tldraw:sdk-core`      | no                         | `@tldraw/sync`, `@tldraw/sync-core`                                                                                                                                              |
+| `tldraw:driver`        | Driver               | `tldraw:sdk-core`      | no                         | `@tldraw/driver`                                                                                                                                                                 |
+| `tldraw:mermaid`       | Mermaid              | `tldraw:sdk-core`      | no                         | `@tldraw/mermaid`                                                                                                                                                                |
+| `tldraw:create-tldraw` | Create tldraw CLI    | `tldraw:sdk-core`      | no                         | `create-tldraw`                                                                                                                                                                  |
+| `tldraw:collaboration` | Collaboration module | —                      | yes (`FEAT_COLLABORATION`) | `@tldraw/collaboration`                                                                                                                                                          |
+| `tldraw:commenting`    | Commenting           | `tldraw:collaboration` | yes (`FEAT_COMMENTING`)    | `@tldraw/commenting`, `@tldraw/mentions`, `@tldraw/sync-collaboration`                                                                                                           |
+
+Entitlement flows down the tree:
+
+- `FEAT_COLLABORATION` — the umbrella flag; grants the whole Collaboration module.
+- `FEAT_COMMENTING` — grants commenting.
+
+`@tldraw/mentions` implements commenting today because `@tldraw/commenting` depends on it, so every customer entitled to commenting is entitled to mentions. If mentions later becomes usable on its own — in shape rich text, say — it will need its own component and license flag at that point.

--- a/internal/scripts/check-packages.ts
+++ b/internal/scripts/check-packages.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs'
 import path, { join, relative } from 'path'
 import kleur from 'kleur'
 import {
@@ -6,8 +7,10 @@ import {
 	readJsonIfExists,
 	writeCodeFile,
 	writeJsonFile,
+	writeStringFile,
 } from './lib/file'
 import { nicelog } from './lib/nicelog'
+import { PRODUCT_CONFIG_KEY } from './lib/types'
 import { Package, getAllWorkspacePackages } from './lib/workspace'
 
 const packagesWithoutTSConfigs: ReadonlySet<string> = new Set(['config'])
@@ -337,6 +340,132 @@ async function checkLibraryContents({
 	return true
 }
 
+const LICENSE_POINTER_CONTENTS =
+	'This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)\n'
+
+// The stable id convention is documented in internal/docs/product-stable-ids.md. Every published
+// package in packages/ must declare which commercial component it belongs to, and premium
+// components must name the license key flag that entitles them.
+async function checkProductMetadata({
+	packages,
+	fix,
+}: {
+	packages: Package[]
+	fix: boolean
+}): Promise<boolean> {
+	let errorCount = 0
+	const error = (name: string, message: string) => {
+		errorCount++
+		nicelog(['❌ ', kleur.red(`${name}: `), message].join(''))
+	}
+
+	const licenseManagerSource = await readFileIfExists(
+		join(REPO_ROOT, 'packages/editor/src/lib/license/LicenseManager.ts')
+	)
+	if (!licenseManagerSource) {
+		throw new Error('Could not read LicenseManager.ts to validate license flags')
+	}
+	const knownLicenseFlags = new Set(
+		[...licenseManagerSource.matchAll(/^\t(FEAT_[A-Z0-9_]+):/gm)].map((m) => m[1])
+	)
+
+	const byStableId = new Map<string, { name: string; config: string }[]>()
+
+	for (const { packageJson, name, relativePath, path: packageDir } of packages) {
+		if (!relativePath.startsWith('packages/') || packageJson.private) continue
+
+		// published packages that point at LICENSE.md must actually ship one, since npm only
+		// includes license files that exist inside the package directory
+		if (packageJson.license === 'SEE LICENSE IN LICENSE.md') {
+			const licensePath = join(packageDir, 'LICENSE.md')
+			if (!existsSync(licensePath)) {
+				if (fix) {
+					await writeStringFile(licensePath, LICENSE_POINTER_CONTENTS)
+					nicelog(['⚠️ ', kleur.yellow(`${name}: `), 'added missing LICENSE.md'].join(''))
+				} else {
+					error(name, 'is missing LICENSE.md (run `yarn check-packages --fix`)')
+				}
+			}
+		}
+
+		const product = packageJson[PRODUCT_CONFIG_KEY]
+		if (!product) {
+			error(
+				name,
+				`is missing the "${PRODUCT_CONFIG_KEY}" field in package.json. ` +
+					'See internal/docs/product-stable-ids.md for how to choose a stable id.'
+			)
+			continue
+		}
+
+		if (!/^tldraw:[a-z0-9-]+$/.test(product.stableId)) {
+			error(name, `has invalid stableId "${product.stableId}" (expected tldraw:<kebab-case>)`)
+		}
+		if (product.premium && !product.licenseFlag) {
+			error(name, 'is premium but has no licenseFlag')
+		}
+		if (!product.premium && product.licenseFlag) {
+			error(name, 'has a licenseFlag but is not premium')
+		}
+		if (product.licenseFlag && !knownLicenseFlags.has(product.licenseFlag)) {
+			error(
+				name,
+				`has licenseFlag "${product.licenseFlag}" which does not exist in LicenseManager FLAGS`
+			)
+		}
+
+		if (product.type === 'feature' && !product.parent) {
+			error(name, 'is a feature but has no parent component')
+		}
+		if (product.type === 'product' && product.parent) {
+			error(name, 'is a top-level product but declares a parent')
+		}
+		if (product.parent === product.stableId) {
+			error(name, 'is its own parent')
+		}
+
+		// all packages sharing a stable id must agree on the rest of the metadata, since they
+		// describe the same commercial component
+		const configKey = JSON.stringify([
+			product.name,
+			product.type,
+			product.parent ?? null,
+			product.premium,
+			product.licenseFlag ?? null,
+		])
+		const others = byStableId.get(product.stableId) ?? []
+		others.push({ name, config: configKey })
+		byStableId.set(product.stableId, others)
+	}
+
+	for (const [stableId, entries] of byStableId) {
+		if (new Set(entries.map((e) => e.config)).size > 1) {
+			error(
+				stableId,
+				`packages disagree on product metadata: ${entries.map((e) => e.name).join(', ')}`
+			)
+		}
+	}
+
+	// every parent must be a component that actually exists, or the order form would reference a
+	// line item nothing defines
+	for (const { packageJson, name, relativePath } of packages) {
+		if (!relativePath.startsWith('packages/') || packageJson.private) continue
+		const parent = packageJson[PRODUCT_CONFIG_KEY]?.parent
+		if (parent && !byStableId.has(parent)) {
+			error(name, `has parent "${parent}" which is not a known component`)
+		}
+	}
+
+	if (errorCount) {
+		nicelog(kleur.red(`Found ${errorCount} errors`))
+		return false
+	}
+
+	nicelog(['✅ ', kleur.green('product metadata ok')].join(''))
+	return true
+}
+
 async function group<T>(name: string, cb: () => Promise<T>) {
 	console.group(name)
 	try {
@@ -359,8 +488,11 @@ async function main({ fix }: { fix: boolean }) {
 	const libsOk = await group('Checking library source files...', () =>
 		checkLibraryContents({ packages, fix })
 	)
+	const productMetadataOk = await group('Checking product metadata...', () =>
+		checkProductMetadata({ packages, fix })
+	)
 
-	if (!scriptsOk || !tsConfigsOk || !libsOk) {
+	if (!scriptsOk || !tsConfigsOk || !libsOk || !productMetadataOk) {
 		process.exit(1)
 	}
 }

--- a/internal/scripts/lib/types.ts
+++ b/internal/scripts/lib/types.ts
@@ -24,11 +24,42 @@ export const TemplateConfig = T.object({
 })
 export type TemplateConfig = T.TypeOf<typeof TemplateConfig>
 
+export const PRODUCT_CONFIG_KEY = 'tldraw_product' as const
+
+/**
+ * Commercial product metadata for a published package. The `stableId` identifies the commercial
+ * component a package belongs to; it is referenced by legal in order forms and must never change,
+ * even if the package is renamed or moved. Several packages can share one stable id. See
+ * `internal/docs/product-stable-ids.md` for the full convention.
+ */
+export const ProductConfig = T.object({
+	// Immutable commercial identifier, e.g. `tldraw:sdk-core`. Never changes on rename/refactor.
+	stableId: T.string,
+	// Customer-facing label, matching the wording used on the order form, e.g. 'Collaboration
+	// module'. Unlike stableId this may be reworded; the id is what contracts reference.
+	name: T.string,
+	// `product` is a top-level order form line item; `feature` is an optional part of its parent
+	// that can be licensed on its own, listed indented beneath it on the order form.
+	type: T.literalEnum('product', 'feature'),
+	// The component this one belongs to, e.g. commenting's parent is the collaboration module.
+	// Components without a parent are top-level order form line items.
+	parent: T.string.optional(),
+	// Whether this component is separately licensed rather than part of the standard SDK offering.
+	premium: T.boolean,
+	// For premium components: the license key FLAGS bit (in packages/editor's LicenseManager) that
+	// entitles a customer to this component.
+	licenseFlag: T.string.optional(),
+})
+export type ProductConfig = T.TypeOf<typeof ProductConfig>
+
 export const PackageJson = T.object({
 	name: T.string,
 	private: T.boolean.optional(),
 	workspaces: T.arrayOf(T.string).optional(),
 	[EXPORT_CONFIG_KEY]: TemplateConfig.optional(),
+	[PRODUCT_CONFIG_KEY]: ProductConfig.optional(),
+	license: T.string.optional(),
+	description: T.string.optional(),
 	scripts: T.dict(T.string, T.nullable(T.string)).optional(),
 	dependencies: T.dict(T.string, T.string).optional(),
 	devDependencies: T.dict(T.string, T.string).optional(),

--- a/internal/scripts/product-manifest.ts
+++ b/internal/scripts/product-manifest.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { REPO_ROOT, readJsonIfExists } from './lib/file'
+import { PRODUCT_CONFIG_KEY, ProductConfig } from './lib/types'
+import { getAllWorkspacePackages } from './lib/workspace'
+
+interface ManifestComponent extends ProductConfig {
+	packages: { name: string; description?: string }[]
+	features: ManifestComponent[]
+}
+
+/**
+ * Prints the product manifest: the commercial components customers license, as a tree. Top-level
+ * entries are order form line items; their `features` are the parts that can be licensed
+ * individually, listed indented beneath them on the order form.
+ *
+ * This is the aggregate view of the `tldraw_product` fields in each package's package.json — those
+ * fields are the source of truth, and are validated by `yarn check-packages`. See
+ * internal/docs/product-stable-ids.md.
+ */
+async function main() {
+	const lernaJson = (await readJsonIfExists(join(REPO_ROOT, 'lerna.json'))) as {
+		version: string
+	} | null
+	if (!lernaJson) throw new Error('Could not read lerna.json')
+
+	const componentsById = new Map<string, ManifestComponent>()
+
+	for (const { packageJson, relativePath } of await getAllWorkspacePackages()) {
+		if (!relativePath.startsWith('packages/') || packageJson.private) continue
+		const product = packageJson[PRODUCT_CONFIG_KEY]
+		if (!product) continue
+
+		// packages sharing a stable id are required to have identical product metadata; this is
+		// enforced by `yarn check-packages`, so taking the first package's config here is safe
+		const component = componentsById.get(product.stableId) ?? {
+			...product,
+			packages: [],
+			features: [],
+		}
+		component.packages.push({
+			name: packageJson.name,
+			description: packageJson.description,
+		})
+		componentsById.set(product.stableId, component)
+	}
+
+	const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name)
+	const all = [...componentsById.values()].sort(byName)
+	for (const component of all) {
+		component.packages.sort(byName)
+	}
+
+	// nest features under the component they belong to. `check-packages` guarantees every parent
+	// resolves, so nothing can be silently dropped here.
+	for (const component of all) {
+		if (component.parent) {
+			componentsById.get(component.parent)!.features.push(component)
+		}
+	}
+	// the standard offering leads, then the premium modules, matching the order form's layout
+	const products = all
+		.filter((component) => !component.parent)
+		.sort((a, b) => Number(a.premium) - Number(b.premium) || byName(a, b))
+
+	// eslint-disable-next-line no-console
+	console.log(JSON.stringify({ version: lernaJson.version, products }, null, '\t'))
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"profile-typescript": "tsx internal/scripts/profile-typescript.ts",
 		"profile-tsserver": "tsx internal/scripts/profile-tsserver.ts",
 		"check-packages": "tsx internal/scripts/check-packages.ts",
+		"product-manifest": "tsx internal/scripts/product-manifest.ts",
 		"check-circular-deps": "tsx internal/scripts/check-circular-deps.ts",
 		"update-pr-template": "tsx internal/scripts/update-pr-template.ts",
 		"generate-test-licenses": "tsx internal/scripts/generate-test-licenses.ts",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/collaboration/LICENSE.md
+++ b/packages/collaboration/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:collaboration",
+		"name": "Collaboration module",
+		"type": "product",
+		"premium": true,
+		"licenseFlag": "FEAT_COLLABORATION"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/commenting/LICENSE.md
+++ b/packages/commenting/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/commenting/package.json
+++ b/packages/commenting/package.json
@@ -8,6 +8,14 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:commenting",
+		"name": "Commenting",
+		"type": "feature",
+		"parent": "tldraw:collaboration",
+		"premium": true,
+		"licenseFlag": "FEAT_COMMENTING"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/commenting/src/canvas/license.ts
+++ b/packages/commenting/src/canvas/license.ts
@@ -1,15 +1,17 @@
-import { useLicenseContext, useLicenseFeatureFlag } from 'tldraw'
+import { useLicenseFeatureFlag, useMaybeLicenseManager } from 'tldraw'
 
 /**
  * Whether commenting is licensed for this editor. Enabled in development; in production it requires
  * a tldraw license that includes the commenting feature (or the collaboration umbrella that grants
  * it). Reactive: re-reads when license validation resolves, and returns `false` while validation is
- * pending, so gated UI stays hidden until the license is confirmed.
+ * pending, so gated UI stays hidden until the license is confirmed. Works outside `<Tldraw />` too:
+ * UI mounted via `EditorProvider` resolves the license through the editor, and with no editor at
+ * all this is `false`.
  *
  * The built-in commenting components (`CanvasComments`, `CanvasCommentsSidebar`, and the comment
  * tool's Quick Action) gate on this. Use it to gate any custom commenting UI the same way.
  * @public
  */
 export function useCommentingEnabled(): boolean {
-	return useLicenseFeatureFlag(useLicenseContext(), 'commenting')
+	return useLicenseFeatureFlag(useMaybeLicenseManager(), 'commenting')
 }

--- a/packages/create-tldraw/LICENSE.md
+++ b/packages/create-tldraw/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/create-tldraw/package.json
+++ b/packages/create-tldraw/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:create-tldraw",
+		"name": "Create tldraw CLI",
+		"type": "feature",
+		"parent": "tldraw:sdk-core",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/driver/LICENSE.md
+++ b/packages/driver/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:driver",
+		"name": "Driver",
+		"type": "feature",
+		"parent": "tldraw:sdk-core",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1497,6 +1497,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     isShapeOfType<T extends TLShape = TLShape>(shapeId: TLShapeId, type: T['type']): boolean;
     isShapeOrAncestorLocked(shape?: TLShape | TLShapeId): boolean;
+    // @internal
+    licenseManager?: LicenseManager;
     loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot, opts?: TLLoadSnapshotOptions): this;
     markEventAsHandled(e: {
         nativeEvent: Event;
@@ -5097,7 +5099,7 @@ export function useIsEditing(shapeId: TLShapeId): boolean;
 export function useLicenseContext(): LicenseManager;
 
 // @internal
-export function useLicenseFeatureFlag(licenseManager: LicenseManager, feature: LicenseFeatureName): boolean;
+export function useLicenseFeatureFlag(licenseManager: LicenseManager | null, feature: LicenseFeatureName): boolean;
 
 // @internal (undocumented)
 export function useLocalStore(options: {
@@ -5108,6 +5110,9 @@ export function useLocalStore(options: {
 
 // @public (undocumented)
 export function useMaybeEditor(): Editor | null;
+
+// @internal
+export function useMaybeLicenseManager(): LicenseManager | null;
 
 // @internal (undocumented)
 export function useOnMount(onMount?: TLOnMountHandler): void;

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -341,7 +341,11 @@ export {
 	type LicenseState,
 	type ValidLicenseKeyResult,
 } from './lib/license/LicenseManager'
-export { LICENSE_TIMEOUT, useLicenseContext } from './lib/license/LicenseProvider'
+export {
+	LICENSE_TIMEOUT,
+	useLicenseContext,
+	useMaybeLicenseManager,
+} from './lib/license/LicenseProvider'
 export { useLicenseFeatureFlag } from './lib/license/useLicenseManagerState'
 export {
 	defaultTldrawOptions,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -51,7 +51,7 @@ import { useLocalStore } from './hooks/useLocalStore'
 import { useRefState } from './hooks/useRefState'
 import { useStateAttribute } from './hooks/useStateAttribute'
 import { useZoomCss } from './hooks/useZoomCss'
-import { LicenseProvider } from './license/LicenseProvider'
+import { LicenseProvider, useLicenseContext } from './license/LicenseProvider'
 import { Watermark } from './license/Watermark'
 import { TldrawOptions } from './options'
 import { TLDeepLinkOptions } from './utils/deepLinks'
@@ -497,6 +497,7 @@ function TldrawEditorWithReadyStore({
 >) {
 	const { ErrorFallback } = useEditorComponents()
 	const container = useContainer()
+	const licenseManager = useLicenseContext()
 
 	const [editor, setEditor] = useRefState<Editor | null>(null)
 
@@ -563,6 +564,7 @@ function TldrawEditorWithReadyStore({
 				themes: themes,
 				initialTheme: initialTheme,
 			})
+			editor.licenseManager = licenseManager
 
 			editor.updateViewportScreenBounds(canvasRef.current ?? container)
 
@@ -598,6 +600,7 @@ function TldrawEditorWithReadyStore({
 			user,
 			setEditor,
 			licenseKey,
+			licenseManager,
 			getShapeVisibility,
 			assetUrls,
 		]

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -120,6 +120,7 @@ import { exportToSvg } from '../exports/exportToSvg'
 import { getSvgAsImageWithOptions, trimSvgToContent } from '../exports/getSvgAsImage'
 import { tlmenus } from '../globals/menus'
 import { tltime } from '../globals/time'
+import { LicenseManager } from '../license/LicenseManager'
 import { TldrawOptions, defaultTldrawOptions } from '../options'
 import { Box, BoxLike } from '../primitives/Box'
 import { EASINGS } from '../primitives/easings'
@@ -972,6 +973,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	readonly options: TldrawOptions
+
+	/**
+	 * The license manager whose feature flags apply to this editor. Assigned by `<TldrawEditor />`
+	 * when it creates the editor, so that UI rendered outside the editor tree can resolve the
+	 * editor's license through the editor instance. Undefined for editors created directly.
+	 *
+	 * @internal
+	 */
+	licenseManager?: LicenseManager
 
 	readonly contextId = uniqueId()
 

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -316,6 +316,42 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
+		it('Fails if the wildcard domain is a prefix of the current hostname', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('https://sub.example.com.other.io')
+
+			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			permissiveHostsInfo[PROPERTIES.HOSTS] = ['*.example.com']
+			const permissiveLicenseKey = await generateLicenseKey(
+				JSON.stringify(permissiveHostsInfo),
+				keyPair
+			)
+			const result = (await licenseManager.getLicenseFromKey(
+				permissiveLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(false)
+		})
+
+		it('Fails if the current hostname only ends with the wildcard domain', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('https://notexample.com')
+
+			const permissiveHostsInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			permissiveHostsInfo[PROPERTIES.HOSTS] = ['*.example.com']
+			const permissiveLicenseKey = await generateLicenseKey(
+				JSON.stringify(permissiveHostsInfo),
+				keyPair
+			)
+			const result = (await licenseManager.getLicenseFromKey(
+				permissiveLicenseKey
+			)) as ValidLicenseKeyResult
+			expect(result.isDomainValid).toBe(false)
+		})
+
 		it('Fails if has a subdomain wildcard isnt for the same base domain', async () => {
 			// @ts-ignore
 			delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -422,6 +422,97 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
+		it('Is not development mode on a custom protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://app/index.html')
+
+				const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+				nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
+				const nativeLicenseKey = await generateLicenseKey(
+					JSON.stringify(nativeLicenseInfo),
+					keyPair
+				)
+				const nativeLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await nativeLicenseManager.getLicenseFromKey(
+					nativeLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({
+					isLicenseParseable: true,
+					isNativeLicense: true,
+					isDomainValid: true,
+					isDevelopment: false,
+				})
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe('licensed')
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Validates the domain on a custom protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://app/index.html')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const customProtocolLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await customProtocolLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({ isDomainValid: false, isDevelopment: false })
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
+					'unlicensed-production'
+				)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is development mode over http on a non-loopback host', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('http://www.example.com')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const httpLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await httpLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is development mode on a loopback host regardless of protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://localhost/index.html')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const loopbackLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await loopbackLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
 		it('Fails if it is a native app with the wrong protocol', async () => {
 			// @ts-ignore
 			delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -530,20 +530,30 @@ describe('LicenseManager', () => {
 			}
 		})
 
-		it('Is development mode on a loopback host regardless of protocol', async () => {
+		it.each([
+			['http://localhost:5173/', true],
+			['http://127.0.0.1:3000/', true],
+			['https://localhost:8443/', true],
+			['https://[::1]:8443/', true],
+			['http://192.168.1.5:3000/', true],
+			['http://staging-box/', true],
+			['https://www.example.com/', false],
+			['tauri://localhost/index.html', false],
+			['http://tauri.localhost/index.html', false],
+			['app://tauri.localhost/com.example.app', false],
+			['app-bundle://localhost/index.html', false],
+		])('Development mode at %s is %s', async (href, expected) => {
 			process.env.NODE_ENV = 'production'
 			try {
 				// @ts-ignore
 				delete window.location
 				// @ts-ignore
-				window.location = new URL('app-bundle://localhost/index.html')
+				window.location = new URL(href)
 
 				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
-				const loopbackLicenseManager = new LicenseManager('', keyPair.publicKey)
-				const result = (await loopbackLicenseManager.getLicenseFromKey(
-					licenseKey
-				)) as ValidLicenseKeyResult
-				expect(result.isDevelopment).toBe(true)
+				const manager = new LicenseManager('', keyPair.publicKey)
+				const result = (await manager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(expected)
 			} finally {
 				process.env.NODE_ENV = 'test'
 			}
@@ -564,6 +574,29 @@ describe('LicenseManager', () => {
 			)) as ValidLicenseKeyResult
 			expect(result.isDomainValid).toBe(false)
 		})
+
+		it.each(['tauri://localhost/index.html', 'http://tauri.localhost/index.html'])(
+			'Does not license an unrelated key at %s',
+			async (href) => {
+				process.env.NODE_ENV = 'production'
+				try {
+					// @ts-ignore
+					delete window.location
+					// @ts-ignore
+					window.location = new URL(href)
+
+					const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+					const manager = new LicenseManager('', keyPair.publicKey)
+					const result = (await manager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+					expect(result).toMatchObject({ isDevelopment: false, isDomainValid: false })
+					expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
+						'unlicensed-production'
+					)
+				} finally {
+					process.env.NODE_ENV = 'test'
+				}
+			}
+		)
 	})
 
 	describe('License types and flags', () => {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -174,9 +174,17 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
+		const protocol = window.location.protocol
+		const hostname = window.location.hostname
+
+		// Tauri uses `tauri://localhost` on macOS and Linux and `http://tauri.localhost` on Windows.
+		if (hostname.toLowerCase().endsWith('.localhost')) {
+			return process.env.NODE_ENV !== 'production'
+		}
+
 		return (
-			window.location.protocol === 'http:' ||
-			this.isLoopbackHost(window.location.hostname) ||
+			protocol === 'http:' ||
+			(protocol === 'https:' && this.isLoopbackHost(hostname)) ||
 			process.env.NODE_ENV !== 'production'
 		)
 	}

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -174,9 +174,8 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
-		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise
 		return (
-			!['https:', 'vscode-webview:'].includes(window.location.protocol) ||
+			window.location.protocol === 'http:' ||
 			this.isLoopbackHost(window.location.hostname) ||
 			process.env.NODE_ENV !== 'production'
 		)

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -406,7 +406,9 @@ export class LicenseManager {
 
 			// Glob testing, we only support '*.somedomain.com' right now.
 			if (host.includes('*')) {
-				const globToRegex = new RegExp(host.replace(/\*/g, '.*?'))
+				const globToRegex = new RegExp(
+					normalizedHostOrUrlRegex.replace(/\./g, '\\.').replace(/\*/g, '.*?') + '$'
+				)
 				return globToRegex.test(currentHostname) || globToRegex.test(`www.${currentHostname}`)
 			}
 

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,13 +1,34 @@
 import { useValue } from '@tldraw/state-react'
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { useMaybeEditor } from '../hooks/useEditor'
 import { LicenseManager } from './LicenseManager'
 
 /** @internal */
-export const LicenseContext = createContext({} as LicenseManager)
+export const LicenseContext = createContext<LicenseManager | null>(null)
 
 /** @internal */
-export function useLicenseContext() {
-	return useContext(LicenseContext)
+export function useLicenseContext(): LicenseManager {
+	const licenseManager = useMaybeLicenseManager()
+	if (!licenseManager) {
+		throw new Error(
+			'useLicenseContext must be used inside of the <Tldraw /> or <TldrawEditor /> components, or inside an <EditorProvider /> wrapping an editor created by them'
+		)
+	}
+	return licenseManager
+}
+
+/**
+ * Returns the license manager for the current editor, or `null` if there is none. Reads the
+ * license context when inside `<TldrawEditor />`, and otherwise falls back to the license manager
+ * of the nearest editor, so UI mounted outside the editor tree (via `EditorProvider`) resolves the
+ * same license as the editor it belongs to.
+ *
+ * @internal
+ */
+export function useMaybeLicenseManager(): LicenseManager | null {
+	const licenseManager = useContext(LicenseContext)
+	const editor = useMaybeEditor()
+	return licenseManager ?? editor?.licenseManager ?? null
 }
 
 function shouldHideEditorAfterDelay(licenseState: string): boolean {

--- a/packages/editor/src/lib/license/useLicenseManagerState.ts
+++ b/packages/editor/src/lib/license/useLicenseManagerState.ts
@@ -8,16 +8,18 @@ export function useLicenseManagerState(licenseManager: LicenseManager): LicenseS
 
 /**
  * Reactively reads whether a licensable feature is enabled for the current license. Re-renders when
- * license validation resolves.
+ * license validation resolves. Returns `false` when there is no license manager, so gated UI stays
+ * hidden when mounted without an editor or license context.
  *
  * @internal
  */
 export function useLicenseFeatureFlag(
-	licenseManager: LicenseManager,
+	licenseManager: LicenseManager | null,
 	feature: LicenseFeatureName
 ): boolean {
-	return useValue('licenseFeature', () => licenseManager.isFeatureEnabled(feature), [
-		licenseManager,
-		feature,
-	])
+	return useValue(
+		'licenseFeature',
+		() => (licenseManager ? licenseManager.isFeatureEnabled(feature) : false),
+		[licenseManager, feature]
+	)
 }

--- a/packages/mentions/LICENSE.md
+++ b/packages/mentions/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/mentions/package.json
+++ b/packages/mentions/package.json
@@ -8,6 +8,14 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:commenting",
+		"name": "Commenting",
+		"type": "feature",
+		"parent": "tldraw:collaboration",
+		"premium": true,
+		"licenseFlag": "FEAT_COMMENTING"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/mermaid/LICENSE.md
+++ b/packages/mermaid/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:mermaid",
+		"name": "Mermaid",
+		"type": "feature",
+		"parent": "tldraw:sdk-core",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/namespaced-tldraw/package.json
+++ b/packages/namespaced-tldraw/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/state-react/package.json
+++ b/packages/state-react/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "MIT",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "MIT",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "MIT",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/sync-collaboration/LICENSE.md
+++ b/packages/sync-collaboration/LICENSE.md
@@ -1,0 +1,1 @@
+This code is licensed under the [tldraw license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md)

--- a/packages/sync-collaboration/package.json
+++ b/packages/sync-collaboration/package.json
@@ -8,6 +8,14 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:commenting",
+		"name": "Commenting",
+		"type": "feature",
+		"parent": "tldraw:collaboration",
+		"premium": true,
+		"licenseFlag": "FEAT_COMMENTING"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/sync-core/package.json
+++ b/packages/sync-core/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sync",
+		"name": "Sync",
+		"type": "feature",
+		"parent": "tldraw:sdk-core",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -8,6 +8,13 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sync",
+		"name": "Sync",
+		"type": "feature",
+		"parent": "tldraw:sdk-core",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/tldraw/src/lib/ui/hooks/useCommentingEnabled.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useCommentingEnabled.ts
@@ -1,13 +1,15 @@
-import { useLicenseContext, useLicenseFeatureFlag } from '@tldraw/editor'
+import { useLicenseFeatureFlag, useMaybeLicenseManager } from '@tldraw/editor'
 
 /**
  * Whether the commenting feature is licensed for this editor. The default comment quick action and
  * its keyboard shortcut are hidden/disabled unless this is true. Enabled in development; in
  * production it requires a license that includes the commenting feature (or the collaboration
- * umbrella that grants it). Reactive: re-reads when license validation resolves.
+ * umbrella that grants it). Reactive: re-reads when license validation resolves. Works outside
+ * `<Tldraw />` too: UI mounted via `EditorProvider` resolves the license through the editor, and
+ * with no editor at all this is `false`.
  *
  * @internal
  */
 export function useCommentingEnabled(): boolean {
-	return useLicenseFeatureFlag(useLicenseContext(), 'commenting')
+	return useLicenseFeatureFlag(useMaybeLicenseManager(), 'commenting')
 }

--- a/packages/tldraw/src/test/ui-outside-editor.test.tsx
+++ b/packages/tldraw/src/test/ui-outside-editor.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react'
+import { ContainerProvider, EditorProvider, useLicenseContext } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { Tldraw } from '../lib/Tldraw'
+import { DefaultToolbar } from '../lib/ui/components/Toolbar/DefaultToolbar'
+import { TldrawUiContextProvider } from '../lib/ui/context/TldrawUiContextProvider'
+import { useCommentingEnabled } from '../lib/ui/hooks/useCommentingEnabled'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+// Default UI components can be mounted beside <Tldraw /> rather than inside it, wrapped in the
+// providers the caller recreates (container, editor, ui context). The license provider is not
+// among them — it only exists inside <TldrawEditor />.
+describe('default UI mounted outside <Tldraw />', () => {
+	it('renders the default toolbar and resolves license feature flags through the editor', async () => {
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => <Tldraw onMount={onMount} components={{ Toolbar: null }} />,
+			{ waitForPatterns: true }
+		)
+
+		expect(editor.licenseManager).toBeDefined()
+
+		let commentingEnabled: boolean | undefined
+		function CommentingProbe() {
+			commentingEnabled = useCommentingEnabled()
+			return null
+		}
+
+		const result = render(
+			<ContainerProvider container={editor.getContainer()}>
+				<EditorProvider editor={editor}>
+					<TldrawUiContextProvider>
+						<DefaultToolbar />
+						<CommentingProbe />
+					</TldrawUiContextProvider>
+				</EditorProvider>
+			</ContainerProvider>
+		)
+
+		expect(await result.findByTestId('tools.select')).toBeTruthy()
+		// In tests the environment counts as development, where every feature is licensed — so a
+		// `true` here proves the flag resolved via the editor's license manager, not the
+		// fail-closed `false` of having no license manager at all.
+		expect(commentingEnabled).toBe(true)
+	})
+
+	it('license feature flags fail closed with no editor and no license context', () => {
+		let commentingEnabled: boolean | undefined
+		function CommentingProbe() {
+			commentingEnabled = useCommentingEnabled()
+			return null
+		}
+
+		render(<CommentingProbe />)
+
+		expect(commentingEnabled).toBe(false)
+	})
+
+	it('useLicenseContext throws when there is no license provider and no editor', () => {
+		function LicenseProbe() {
+			useLicenseContext()
+			return null
+		}
+
+		// silence React's error boundary logging for the expected throw
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			expect(() => render(<LicenseProbe />)).toThrow(
+				'useLicenseContext must be used inside of the <Tldraw /> or <TldrawEditor /> components'
+			)
+		} finally {
+			consoleError.mockRestore()
+		}
+	})
+})

--- a/packages/tlschema/package.json
+++ b/packages/tlschema/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "MIT",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -8,6 +8,12 @@
 	},
 	"homepage": "https://tldraw.dev",
 	"license": "SEE LICENSE IN LICENSE.md",
+	"tldraw_product": {
+		"stableId": "tldraw:sdk-core",
+		"name": "SDK",
+		"type": "product",
+		"premium": false
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tldraw/tldraw"


### PR DESCRIPTION
In order to get the recent licensing fixes onto dotcom ahead of the regular release, this rolls four already-reviewed and merged PRs onto `hotfixes`. There is no new work here — every commit is a cherry-pick, so the review is that the picks landed cleanly, not a re-review of the changes themselves.

**#10007 — resolve license feature flags for UI mounted outside the editor.** Default UI components mounted beside `<Tldraw />` (the `TldrawUiContextProvider` + `DefaultToolbar` pattern) crashed with `licenseManager.isFeatureEnabled is not a function`, because `LicenseContext` is only provided inside `<TldrawEditor />` and defaulted to `{} as LicenseManager`. The context is now typed `LicenseManager | null`, `<TldrawEditor />` attaches its manager to the editor it creates, and the new `useMaybeLicenseManager()` falls back to the nearest editor's manager — so out-of-editor UI resolves the same license and the same feature flags without constructing a second `LicenseManager`. Closes #9995.

**#10021 — make development environment detection more accurate.** Environment detection keyed off the URL protocol, treating anything that wasn't `https:` or `vscode-webview:` as development. Native apps serve their bundle from a custom protocol (`app-bundle://app/index.html`), so a shipped native app never matched and the `NATIVE_LICENSE` host patterns had no effect. Development is now named directly — `http:`, a loopback host, or a non-production `NODE_ENV` — rather than inferred from "not `https:`", which leaves custom protocols to the existing native-license host matching. Worth flagging: native apps must register their scheme as a secure context, otherwise `crypto.subtle` is unavailable and signatures can't be verified.

**#10053 — tighten wildcard host matching in the license domain check.** The glob-to-regex conversion in `isDomainValid` left literal dots acting as regex wildcards and didn't anchor the pattern, so `*.example.com` could match hostnames it wasn't meant to describe. Dots are escaped, the pattern is anchored to the end of the hostname, and the glob branch now uses the normalized host like the rest of the checks.

**#9977 — stable product ids and license files for published packages.** Metadata, tooling, and docs only, with no runtime or licensing behaviour change: each published package declares the product or feature it implements via a `tldraw_product` field in its `package.json`, validated by `yarn check-packages` and printable as a tree with `yarn product-manifest`. Seven packages declared `"SEE LICENSE IN LICENSE.md"` but shipped no such file; they now ship the same one-line pointer as `tldraw` and `@tldraw/sync`.

### Change type

- [x] `bugfix`

### Test plan

1. Confirm each cherry-pick matches its original commit on `main` and that the branch builds.
2. Deploy and confirm licensed dotcom features resolve as expected.

- [x] Unit tests (carried over from the original PRs)

### Release notes

- Fixed default UI components (such as `DefaultToolbar` and `DefaultQuickActionsContent`) crashing when mounted outside the `Tldraw` component.
- Fixed license validation treating native apps served from custom protocols as development environments.
- Fixed wildcard license host matching so `*.example.com` matches only that domain's subdomains.

### API changes

- Added internal `useMaybeLicenseManager()`: the license manager from context, falling back to the nearest editor's, or `null`.
- Added internal `Editor.licenseManager`, assigned by `<TldrawEditor />` when it creates the editor.
- Changed internal `useLicenseFeatureFlag` to accept `LicenseManager | null` and return `false` for `null`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +65 / -20  |
| Tests           | +201 / -0  |
| Automated files | +6 / -1    |
| Config/tooling  | +450 / -1  |
