### PR TITLE
test: drain deferred React work before jsdom teardown

### DIFF
--- a/internal/config/vitest/setup.ts
+++ b/internal/config/vitest/setup.ts
@@ -95,6 +95,22 @@ if (typeof Element !== 'undefined') {
 	}
 }
 
+// Captured before any test file installs fake timers.
+const realSetTimeout = globalThis.setTimeout
+const realSetImmediate = globalThis.setImmediate
+
+// Drain deferred React work before vitest tears down jsdom: exportToSvg unmounts its root in a
+// setTimeout(0) and every react-dom commit schedules a setImmediate that reads `window.event`.
+// Landing after teardown, those throw "window is not defined" as an unhandled error (flaky CI).
+if (typeof window !== 'undefined') {
+	afterAll(async () => {
+		for (let i = 0; i < 2; i++) {
+			await new Promise((resolve) => realSetTimeout(resolve, 0))
+			await new Promise((resolve) => realSetImmediate(resolve))
+		}
+	})
+}
+
 function convertNumbersInObject(obj: any, roundToNearest: number): any {
 	if (!obj) return obj
 	if (Array.isArray(obj)) {

--- a/internal/config/vitest/setup.ts
+++ b/internal/config/vitest/setup.ts
@@ -104,6 +104,8 @@ const realSetImmediate = globalThis.setImmediate
 // Landing after teardown, those throw "window is not defined" as an unhandled error (flaky CI).
 if (typeof window !== 'undefined') {
 	afterAll(async () => {
+		// two passes: pass 1 fires pending timeouts and the setImmediate they enqueue; pass 2 covers
+		// the scheduler re-arming itself when it yields mid-work
 		for (let i = 0; i < 2; i++) {
 			await new Promise((resolve) => realSetTimeout(resolve, 0))
 			await new Promise((resolve) => realSetImmediate(resolve))


### PR DESCRIPTION
In order to stop the "Tests & checks" job failing with a vitest unhandled `ReferenceError: window is not defined` from `react-dom` / `scheduler` after every test passed (e.g. [this run](https://github.com/tldraw/tldraw/actions/runs/32115596157/job/95644272699) on #10018, attributed to `packages/tldraw/src/test/commands/getSvgString.test.ts`), this PR drains deferred React work in a shared `afterAll` before vitest tears down the jsdom environment.

Root cause: `exportToSvg` unmounts its React root in a `setTimeout(0)` (`packages/editor/src/lib/exports/exportToSvg.tsx`), and every react-dom commit schedules a scheduler callback (`setImmediate` in node) that reads `window.event`. `getSvgString.test.ts` uses real timers, so when the last test finishes the unmount is still pending. jsdom's globals are removed ~2ms after the last test ends; on a slow runner the timer + scheduler tick land after that and throw as an uncaught exception. Any react-dom commit right at end-of-file has the same exposure, so the fix lives in `internal/config/vitest/setup.ts` (shared preset) rather than in the export path: `afterAll` awaits real `setTimeout(0)` + `setImmediate` (captured before `TestEditor` installs fake timers), so pending unmounts and scheduler callbacks run while `window` still exists.

Verification: could not hit the exact CI race on an idle laptop, so widened the unmount delay to 3ms locally and instrumented it. Without this change 5/6 runs saw the deferred unmount execute with `window === undefined`; with it 0/6 (66/66 exports clean). `packages/tldraw` `src/test/commands` and `packages/editor` `src/lib/exports` suites pass.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests
