### PR TITLE
fix(editor): make development detection accurate for native app URLs

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -530,20 +530,30 @@ describe('LicenseManager', () => {
 			}
 		})
 
-		it('Is development mode on a loopback host regardless of protocol', async () => {
+		it.each([
+			['http://localhost:5173/', true],
+			['http://127.0.0.1:3000/', true],
+			['https://localhost:8443/', true],
+			['https://[::1]:8443/', true],
+			['http://192.168.1.5:3000/', true],
+			['http://staging-box/', true],
+			['https://www.example.com/', false],
+			['tauri://localhost/index.html', false],
+			['http://tauri.localhost/index.html', false],
+			['app://tauri.localhost/com.example.app', false],
+			['app-bundle://localhost/index.html', false],
+		])('Development mode at %s is %s', async (href, expected) => {
 			process.env.NODE_ENV = 'production'
 			try {
 				// @ts-ignore
 				delete window.location
 				// @ts-ignore
-				window.location = new URL('app-bundle://localhost/index.html')
+				window.location = new URL(href)
 
 				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
-				const loopbackLicenseManager = new LicenseManager('', keyPair.publicKey)
-				const result = (await loopbackLicenseManager.getLicenseFromKey(
-					licenseKey
-				)) as ValidLicenseKeyResult
-				expect(result.isDevelopment).toBe(true)
+				const manager = new LicenseManager('', keyPair.publicKey)
+				const result = (await manager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(expected)
 			} finally {
 				process.env.NODE_ENV = 'test'
 			}
@@ -564,6 +574,29 @@ describe('LicenseManager', () => {
 			)) as ValidLicenseKeyResult
 			expect(result.isDomainValid).toBe(false)
 		})
+
+		it.each(['tauri://localhost/index.html', 'http://tauri.localhost/index.html'])(
+			'Does not license an unrelated key at %s',
+			async (href) => {
+				process.env.NODE_ENV = 'production'
+				try {
+					// @ts-ignore
+					delete window.location
+					// @ts-ignore
+					window.location = new URL(href)
+
+					const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+					const manager = new LicenseManager('', keyPair.publicKey)
+					const result = (await manager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+					expect(result).toMatchObject({ isDevelopment: false, isDomainValid: false })
+					expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
+						'unlicensed-production'
+					)
+				} finally {
+					process.env.NODE_ENV = 'test'
+				}
+			}
+		)
 	})
 
 	describe('License types and flags', () => {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -174,9 +174,17 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
+		const protocol = window.location.protocol
+		const hostname = window.location.hostname
+
+		// Tauri uses `tauri://localhost` on macOS and Linux and `http://tauri.localhost` on Windows.
+		if (hostname.toLowerCase().endsWith('.localhost')) {
+			return process.env.NODE_ENV !== 'production'
+		}
+
 		return (
-			window.location.protocol === 'http:' ||
-			this.isLoopbackHost(window.location.hostname) ||
+			protocol === 'http:' ||
+			(protocol === 'https:' && this.isLoopbackHost(hostname)) ||
 			process.env.NODE_ENV !== 'production'
 		)
 	}


### PR DESCRIPTION
In order for apps built with Tauri to be licensed the same way as any other production deployment, this makes `LicenseManager`'s development detection accurate for the URLs native app frameworks serve from.

Tauri compiles its origin in as a constant — `tauri://localhost` on macOS, iOS and Linux, and `http://tauri.localhost` on Windows and Android. Both shapes matched the existing development heuristic, the first through the loopback host check and the second through the `http:` check, so a shipped Tauri app was classified as a developer's machine rather than a production deployment and its license configuration had no effect.

Development is now named more precisely: a loopback host only signals development over `https:`, and a `.localhost` subdomain defers to `NODE_ENV`. Local development is unaffected — `http:` on any host, loopback over `https:`, and a non-production build all still resolve to development.

One consequence worth flagging: a Tauri app is now a production deployment, so it needs a license whose hosts match its origin. This is the same shift #10021 made for apps served from custom protocols.

### Change type

- [x] `bugfix`

### Test plan

1. Build a Tauri app with a license whose hosts match its origin, and confirm it resolves to `licensed` with features gated by the license flags.
2. Confirm a key whose hosts don't match the app's origin resolves to `unlicensed-production`.
3. Confirm local development — `http:`, a loopback host, or a non-production build — is unaffected.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix license validation treating native apps served from Tauri's origins as development environments.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -2   |
| Tests     | +40 / -7   |
