### PR TITLE
chore(infra): unblock the Grafana deploy and read the zone variable from the API

### DIFF
--- a/.github/workflows/deploy-grafana.yml
+++ b/.github/workflows/deploy-grafana.yml
@@ -56,9 +56,33 @@ jobs:
           GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
 
+      # Everything except alert rules. Split from the step below so a rejected rule
+      # cannot take the dashboards down with it — see that step for why that happens.
       - name: Push resources
         if: github.event_name == 'push'
-        run: gcx resources push -p internal/grafana/resources --on-error abort
+        run: |
+          shopt -s nullglob
+          for dir in internal/grafana/resources/*/; do
+            case "$dir" in *alertrules*) continue ;; esac
+            gcx resources push -p "$dir" --on-error abort
+          done
+        env:
+          GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+
+      # Alert rules are the one resource type that can fail here having passed the PR
+      # dry run, because alerting has no server-side dry-run — the PR reports them as
+      # "skipped". A newly created rule carrying group labels is rejected outright
+      # ("cannot set group when creating a new rule"), so the first time any new rule
+      # lands, this step is where it surfaces. Kept last and separate so that failure
+      # costs the rule, not every dashboard in the tree. Still fails the job.
+      - name: Push alert rules
+        if: github.event_name == 'push'
+        run: |
+          shopt -s nullglob
+          for dir in internal/grafana/resources/*alertrules*/; do
+            gcx resources push -p "$dir" --on-error abort
+          done
         env:
           GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}

--- a/.github/workflows/deploy-grafana.yml
+++ b/.github/workflows/deploy-grafana.yml
@@ -56,14 +56,20 @@ jobs:
           GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
 
-      # Everything except alert rules. Split from the step below so a rejected rule
-      # cannot take the dashboards down with it — see that step for why that happens.
+      # Everything except alert rules, folders first. Two orderings matter and neither is
+      # the alphabetical one this glob would otherwise give: folders have to exist before
+      # anything annotated into them, and alert rules go last (see the step below for why).
+      # A commit adding a folder and a dashboard inside it lands both in one push, so the
+      # folder cannot be assumed to already be there.
       - name: Push resources
         if: github.event_name == 'push'
         run: |
           shopt -s nullglob
+          for dir in internal/grafana/resources/*folders*/; do
+            gcx resources push -p "$dir" --on-error abort
+          done
           for dir in internal/grafana/resources/*/; do
-            case "$dir" in *alertrules*) continue ;; esac
+            case "$dir" in *folders*|*alertrules*) continue ;; esac
             gcx resources push -p "$dir" --on-error abort
           done
         env:

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -22,6 +22,19 @@ Every provisioned dashboard carries the tags `provisioned` and `repo:tldraw/tldr
 2. Open a PR. CI validates the resources and dry-runs the push so you can see what would change. (The alerting API doesn't support server-side dry-run, so alert rules show as "skipped: client-side check only" — that's expected, not an error.)
 3. Merge. The deploy workflow (`.github/workflows/deploy-grafana.yml`) pushes to Grafana Cloud.
 
+## Adding a new alert rule
+
+A rule file carrying `grafana.com/group` labels cannot be _created_ by the push. Grafana rejects it with `cannot set group when creating a new rule` — the resource API can only update a rule that is already in a group. Nothing catches this earlier: alerting has no server-side dry-run, so the PR reports the rule as "skipped" and goes green.
+
+Bootstrap the group once by hand, then let the push adopt it:
+
+    gcx api /api/v1/provisioning/folder/<folder uid>/rule-groups/<group> \
+      -X PUT -H 'X-Disable-Provenance: true' -d @group.json
+
+`group.json` uses the classic provisioning shape (`{title, folderUid, interval, rules: [...]}`), which is not the shape of the file in this tree: `spec.expressions` becomes a `data` array, the expression carrying `source: true` becomes `condition`, and `spec.trigger.interval` becomes the group's `interval` in seconds. `X-Disable-Provenance: true` is what leaves provenance clear so the push can take ownership afterwards.
+
+`dotcom-file-do-exceptions` was created this way on 2026-08-18, after PR #10052's deploy failed on it.
+
 ## Pulling fresh state
 
 If you prototyped a dashboard in the Grafana UI and want to adopt it, pull it into the tree with a local gcx context (`gcx login`):

--- a/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
+++ b/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/nivs2rl.yaml
@@ -2276,23 +2276,47 @@ spec:
         skipUrlSync: false
         type: custom
       - current:
-          selected: true
+          selected: false
           text: tldraw.com
           value: e7567c58962361a2bb9d802f858f5da3
-        description: Aliased for legibility only — the ID is stored in this dashboard's
-          JSON and is not secret.
+        datasource:
+          type: yesoreyeram-infinity-datasource
+          uid: ffuyblsuemj28b
+        definition: Cloudflare zones visible to the datasource's API token
+        description: Listed from the Cloudflare API rather than hardcoded, so a zone
+          added to the account shows up without a dashboard edit. The token behind this
+          datasource currently sees one zone.
         hide: 0
         includeAll: false
         label: Cloudflare zone
         multi: false
         name: zone_id
-        options:
-          - selected: true
-            text: tldraw.com
-            value: e7567c58962361a2bb9d802f858f5da3
-        query: 'tldraw.com : e7567c58962361a2bb9d802f858f5da3'
+        options: []
+        query:
+          infinityQuery:
+            columns:
+              - selector: name
+                text: __text
+                type: string
+              - selector: id
+                text: __value
+                type: string
+            filters: []
+            format: table
+            parser: backend
+            refId: variable
+            root_selector: result
+            source: url
+            type: json
+            url: https://api.cloudflare.com/client/v4/zones
+            url_options:
+              method: GET
+          queryType: infinity
+        refresh: 1
+        regex: ''
         skipUrlSync: false
-        type: custom
+        sort: 1
+        type: query
   time:
     from: now-6h
     to: now


### PR DESCRIPTION
Two changes to the Grafana tree, both fallout from #10052.

## Stop a rejected alert rule blocking the whole deploy

#10052's deploy off main failed and took everything with it. The push runs as a single `gcx resources push -p internal/grafana/resources --on-error abort`, so when Grafana rejected the new alert rule, no dashboard deployed either — `nivs2rl` sat at the version it had from 2026-08-12 for two hours, without the panel that PR added.

```
403 Forbidden
alertrules.rules.alerting.grafana.app "dotcom-file-do-exceptions" is forbidden:
cannot set group when creating a new rule
```

A rule file carrying `grafana.com/group` labels can't be created by the resource API — it can only update a rule already in a group. That is now bootstrapped by hand and the deploy is green again (`✔ 27 resources pushed, 0 errors`, confirmed idempotent over two consecutive runs), so this part is about blast radius rather than that rule.

Alert rules move to their own push step, last. A rejected rule still fails the job — it just no longer costs every dashboard in the tree. The README gains the bootstrap procedure, since the next new rule will hit the same wall.

## Read the zone variable from the Cloudflare API

The dashboard's `zone_id` variable stored the zone tag as a hardcoded custom option. This reads it from `GET /client/v4/zones` through the Infinity datasource instead, with `name` → `__text` and `id` → `__value`, so a zone added to the account shows up without a dashboard edit. No new auth: that datasource's token already carries `#zone:read`.

`account_id` stays hardcoded, deliberately. `GET /client/v4/accounts` returns 200 with `success: true` and an empty result array for this token — it has no account-level read — so an account variable would render an empty dropdown. Deriving it from `result[0].account.id` on the zones call does work, but that makes the account depend on at least one zone existing, which is worse than the literal.

### Notes for reviewers

On the deploy split:

- **Globbed, not two fixed paths.** There are six resource-type directories (`folders`, and four dashboard API versions besides `v1`). Naming a dashboards path and an alertrules path explicitly would have silently stopped deploying the other four.
- **Order is explicit, because the glob's alphabetical order is wrong twice.** Folders sort *after* every `dashboards.*` directory, so a commit adding a folder plus a dashboard annotated into it would push the dashboard while the folder was still missing. Folders now go first and alert rules last; the middle stays globbed. Resulting order: `folders.v1` → `dashboards.v0alpha1/v1/v2/v2beta1` → `alertrules.v0alpha1` (separate step). I could not confirm what ordering the previous single-tree push used — gcx emits only a batch summary, no per-resource order — so this makes the ordering guaranteed rather than inherited.
- **`--on-error abort` is kept on both steps.** The problem was never the abort, it was that one command covered everything. Failures stay loud.
- **This class of failure can only surface on main.** Alerting has no server-side dry-run, so the PR check reports rules as "skipped" and goes green regardless — which is exactly what happened on #10052, whose test plan called it out and got bitten anyway.

On the zone variable:

- **The `query.infinityQuery` nesting is load-bearing — please don't flatten it.** Infinity variable queries are a `VariableQuery` wrapper (`queryType` + `infinityQuery`), not a bare `InfinityQuery`. Both forms save fine through the API and neither errors; the bare one just silently resolves to nothing. Tested both, see the test plan.
- `current.value` still holds the zone tag. That's the fallback for when the API call fails on load, not leftover hardcoding — without it the two zone panels go blank rather than using the last known good value. Grafana rewrites `current` on every save regardless, so removing it would come straight back on the next `gcx resources pull`.
- This is the lower-churn shape, not the higher one. A `query` variable persists `options: []` and fetches at runtime; the custom variable stored the whole option list in the file.
- Only two panels consume `${zone_id}` — `Zone responses by status code` and `5xx responses by host and status`. `dotcom-file-do-exceptions.yaml` doesn't reference the zone at all.

### Change type

- [x] `other`

### Test plan

Deploy split:

1. `gcx resources push -p internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app --dry-run --on-error abort` — a scoped path resolves and finds the 13 rules, confirming the split works.
2. `ls -d internal/grafana/resources/*/` — six type directories, hence the glob.
3. The workflow file parses as YAML with the expected six steps.
4. Recovery of the original failure is already verified on main: run `32116793640` attempt 3 reports `✔ 27 resources pushed, 0 errors`, and `nivs2rl` is now version 16 carrying `DO exceptions by namespace`.

The split's own effect is only observable on merge, since the changed step is `if: github.event_name == 'push'`.

Zone variable:

5. `GET /client/v4/zones` through the Infinity datasource returns `__text: tldraw.com` / `__value: e7567c58962361a2bb9d802f858f5da3` — the exact two-column frame Grafana wants for a query variable. The same response confirms the token's permissions are `#analytics:read` and `#zone:read`, with `total_count: 1`.
6. `GET /client/v4/accounts` returns an empty result for that token, which is why `account_id` is left alone.
7. **Rendered end to end.** A throwaway dashboard carrying two candidate serializations of the same query — this PR's wrapped `query: {queryType: infinity, infinityQuery: {…}}` and a bare `InfinityQuery` — was created via the API and loaded in a browser. The wrapped variable resolved to `tldraw.com` / `e7567c58…`; the bare one resolved to empty. This PR uses the wrapped form. The test dashboard has been deleted.
8. `gcx resources validate -p internal/grafana/resources` — passes, 13 rules skipped as client-side-only (expected).
9. `oxfmt` is a no-op on both files.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal only: no user-facing change.

