### PR TITLE
chore(infra): stop a rejected alert rule blocking the Grafana deploy

### DIFF
--- a/.github/workflows/deploy-grafana.yml
+++ b/.github/workflows/deploy-grafana.yml
@@ -56,9 +56,33 @@ jobs:
           GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
 
+      # Everything except alert rules. Split from the step below so a rejected rule
+      # cannot take the dashboards down with it — see that step for why that happens.
       - name: Push resources
         if: github.event_name == 'push'
-        run: gcx resources push -p internal/grafana/resources --on-error abort
+        run: |
+          shopt -s nullglob
+          for dir in internal/grafana/resources/*/; do
+            case "$dir" in *alertrules*) continue ;; esac
+            gcx resources push -p "$dir" --on-error abort
+          done
+        env:
+          GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+
+      # Alert rules are the one resource type that can fail here having passed the PR
+      # dry run, because alerting has no server-side dry-run — the PR reports them as
+      # "skipped". A newly created rule carrying group labels is rejected outright
+      # ("cannot set group when creating a new rule"), so the first time any new rule
+      # lands, this step is where it surfaces. Kept last and separate so that failure
+      # costs the rule, not every dashboard in the tree. Still fails the job.
+      - name: Push alert rules
+        if: github.event_name == 'push'
+        run: |
+          shopt -s nullglob
+          for dir in internal/grafana/resources/*alertrules*/; do
+            gcx resources push -p "$dir" --on-error abort
+          done
         env:
           GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -22,6 +22,19 @@ Every provisioned dashboard carries the tags `provisioned` and `repo:tldraw/tldr
 2. Open a PR. CI validates the resources and dry-runs the push so you can see what would change. (The alerting API doesn't support server-side dry-run, so alert rules show as "skipped: client-side check only" — that's expected, not an error.)
 3. Merge. The deploy workflow (`.github/workflows/deploy-grafana.yml`) pushes to Grafana Cloud.
 
+## Adding a new alert rule
+
+A rule file carrying `grafana.com/group` labels cannot be _created_ by the push. Grafana rejects it with `cannot set group when creating a new rule` — the resource API can only update a rule that is already in a group. Nothing catches this earlier: alerting has no server-side dry-run, so the PR reports the rule as "skipped" and goes green.
+
+Bootstrap the group once by hand, then let the push adopt it:
+
+    gcx api /api/v1/provisioning/folder/<folder uid>/rule-groups/<group> \
+      -X PUT -H 'X-Disable-Provenance: true' -d @group.json
+
+`group.json` uses the classic provisioning shape (`{title, folderUid, interval, rules: [...]}`), which is not the shape of the file in this tree: `spec.expressions` becomes a `data` array, the expression carrying `source: true` becomes `condition`, and `spec.trigger.interval` becomes the group's `interval` in seconds. `X-Disable-Provenance: true` is what leaves provenance clear so the push can take ownership afterwards.
+
+`dotcom-file-do-exceptions` was created this way on 2026-08-18, after PR #10052's deploy failed on it.
+
 ## Pulling fresh state
 
 If you prototyped a dashboard in the Grafana UI and want to adopt it, pull it into the tree with a local gcx context (`gcx login`):


### PR DESCRIPTION
#10052's deploy off main failed and took everything with it. The push runs as a single `gcx resources push -p internal/grafana/resources --on-error abort`, so when Grafana rejected the new alert rule, no dashboard deployed either — `nivs2rl` sat at the version it had from 2026-08-12 for two hours, without the panel that PR added.

The rejection itself:

```
403 Forbidden
alertrules.rules.alerting.grafana.app "dotcom-file-do-exceptions" is forbidden:
cannot set group when creating a new rule
```

A rule file carrying `grafana.com/group` labels can't be created by the resource API — it can only update a rule already in a group. That is now bootstrapped and the deploy is green again (`✔ 27 resources pushed, 0 errors`, confirmed idempotent over two consecutive runs), so this PR is about the blast radius rather than that rule.

Alert rules move to their own push step, last. A rejected rule still fails the job — it just no longer costs every dashboard in the tree.

### Notes for reviewers

- **Globbed, not two fixed paths.** There are six resource-type directories (`folders`, and four dashboard API versions besides `v1`). Naming a dashboards path and an alertrules path explicitly would have silently stopped deploying the other four.
- **`--on-error abort` is kept on both steps.** The problem was never the abort, it was that one command covered everything. Failures stay loud.
- **This class of failure can only surface on main.** Alerting has no server-side dry-run, so the PR check reports rules as "skipped" and goes green regardless — which is exactly what happened on #10052. Splitting the step is the only place the cost can be contained.
- The README gains the bootstrap procedure. The existing note next to it covers adopting a `converted_prometheus` import; this is the plain "new rule, first deploy" case, which reads as a different problem until you've hit it.

### Change type

- [x] `other`

### Test plan

1. `gcx resources push -p internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app --dry-run --on-error abort` — a scoped path resolves and finds the 13 rules, confirming the split works.
2. `ls -d internal/grafana/resources/*/` — six type directories, hence the glob.
3. The workflow file parses as YAML with the expected six steps.
4. Recovery of the original failure is already verified on main: run `32116793640` attempt 3 reports `✔ 27 resources pushed, 0 errors`, and `nivs2rl` is now version 16 carrying `DO exceptions by namespace`.

This PR's own effect is only observable on merge, since the changed step is `if: github.event_name == 'push'`.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal only: no user-facing change.
