### PR TITLE
refactor(editor): simplify pass over the editor package

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1914,7 +1914,7 @@ export abstract class Geometry2d {
     // (undocumented)
     abstract nearestPoint(point: VecLike, _filters?: Geometry2dFilters): Vec;
     // (undocumented)
-    overlapsPolygon(_polygon: VecLike[]): boolean;
+    overlapsPolygon(polygon: VecLike[]): boolean;
     // (undocumented)
     toSimpleSvgPath(): string;
     // (undocumented)
@@ -3757,7 +3757,7 @@ export interface TLDragShapesOverInfo {
 }
 
 // @public (undocumented)
-export const TldrawEditor: React_3.MemoExoticComponent<({ store, components, className, user: _user, options: _options, textOptions: _textOptions, deepLinks: _deepLinks, ...rest }: TldrawEditorProps) => JSX.Element>;
+export const TldrawEditor: MemoExoticComponent<({ store, components, className, user: _user, options: _options, textOptions: _textOptions, deepLinks: _deepLinks, ...rest }: TldrawEditorProps) => JSX.Element>;
 
 // @public
 export interface TldrawEditorBaseProps {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -140,7 +140,7 @@ export {
 	type TLMeasureTextOpts,
 	type TLMeasureTextSpanOpts,
 } from './lib/editor/managers/TextManager/TextManager'
-export { DEFAULT_THEME } from './lib/editor/managers/ThemeManager/defaultThemes'
+export { DEFAULT_THEME, getColorValue } from './lib/editor/managers/ThemeManager/defaultThemes'
 export { ThemeManager, resolveThemes } from './lib/editor/managers/ThemeManager/ThemeManager'
 export { TickManager } from './lib/editor/managers/TickManager/TickManager'
 export { CollaboratorsManager } from './lib/editor/managers/CollaboratorsManager/CollaboratorsManager'
@@ -308,8 +308,7 @@ export {
 	useMaybeEditor,
 	type EditorProviderProps,
 } from './lib/hooks/useEditor'
-export { useEditorComponents } from './lib/hooks/useEditorComponents'
-export type { TLEditorComponents } from './lib/hooks/useEditorComponents'
+export { useEditorComponents, type TLEditorComponents } from './lib/hooks/useEditorComponents'
 export { useEvent, useReactiveEvent } from './lib/hooks/useEvent'
 export { useGlobalMenuIsOpen } from './lib/hooks/useGlobalMenuIsOpen'
 export { useShallowArrayIdentity, useShallowObjectIdentity } from './lib/hooks/useIdentity'
@@ -518,5 +517,3 @@ registerTldrawLibraryVersion(
 	(globalThis as any).TLDRAW_LIBRARY_VERSION,
 	(globalThis as any).TLDRAW_LIBRARY_MODULES
 )
-
-export { getColorValue } from './lib/editor/managers/ThemeManager/defaultThemes'

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -552,6 +552,7 @@ function TldrawEditorWithReadyStore({
 				getContainer: () => container,
 				user,
 				initialState,
+				// we should check for some kind of query parameter that turns off autofocus
 				autoFocus,
 				cameraOptions,
 				options,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@tldraw/tlschema'
 import { annotateError, Required } from '@tldraw/utils'
 import classNames from 'classnames'
-import React, {
+import {
 	memo,
 	ReactNode,
 	useCallback,
@@ -37,8 +37,7 @@ import { resolveThemes } from './editor/managers/ThemeManager/ThemeManager'
 import { TLAnyOverlayUtilConstructor } from './editor/overlays/OverlayUtil'
 import { TLStateNodeConstructor } from './editor/tools/StateNode'
 import { TLCameraOptions } from './editor/types/misc-types'
-import { useEditorComponents } from './hooks/EditorComponentsContext'
-import type { TLEditorComponents } from './hooks/EditorComponentsContext'
+import { useEditorComponents, type TLEditorComponents } from './hooks/EditorComponentsContext'
 import { ContainerProvider, useContainer } from './hooks/useContainer'
 import { useCursor } from './hooks/useCursor'
 import { useDarkMode } from './hooks/useDarkMode'
@@ -553,7 +552,6 @@ function TldrawEditorWithReadyStore({
 				getContainer: () => container,
 				user,
 				initialState,
-				// we should check for some kind of query parameter that turns off autofocus
 				autoFocus,
 				cameraOptions,
 				options,
@@ -561,8 +559,8 @@ function TldrawEditorWithReadyStore({
 				getShapeVisibility,
 				colorScheme: initColorScheme,
 				fontAssetUrls: assetUrls?.fonts,
-				themes: themes,
-				initialTheme: initialTheme,
+				themes,
+				initialTheme,
 			})
 			editor.licenseManager = licenseManager
 
@@ -571,7 +569,7 @@ function TldrawEditorWithReadyStore({
 			// Use the ref here because we only want to do this once when the editor is created.
 			// We don't want changes to the urlStateSync prop to trigger creating new editors.
 			if (deepLinks) {
-				if (!deepLinks?.getUrl) {
+				if (!deepLinks.getUrl) {
 					// load the state from window.location
 					editor.navigateToDeepLink(deepLinks)
 				} else {
@@ -824,7 +822,7 @@ export function useOnMount(onMount?: TLOnMountHandler) {
 		}
 	})
 
-	React.useLayoutEffect(() => {
-		if (editor) return onMountEvent?.(editor)
+	useLayoutEffect(() => {
+		if (editor) return onMountEvent(editor)
 	}, [editor, onMountEvent])
 }

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -58,8 +58,6 @@ export const Shape = memo(function Shape({
 		clipPath: 'none',
 		width: 0,
 		height: 0,
-		x: 0,
-		y: 0,
 	})
 
 	useQuickReactor(
@@ -70,7 +68,6 @@ export const Shape = memo(function Shape({
 
 			const prev = memoizedStuffRef.current
 
-			// Clip path
 			const clipPath = editor.getShapeClipPath(id) ?? 'none'
 			if (clipPath !== prev.clipPath) {
 				setStyleProperty(containerRef.current, 'clip-path', clipPath)
@@ -78,19 +75,14 @@ export const Shape = memo(function Shape({
 				prev.clipPath = clipPath
 			}
 
-			// Page transform
-			const pageTransform = editor.getShapePageTransform(id)
-			const transform = Mat.toCssString(pageTransform)
-			const bounds = editor.getShapeGeometry(shape).bounds
-
-			// Update if the tranform has changed
+			const transform = Mat.toCssString(editor.getShapePageTransform(id))
 			if (transform !== prev.transform) {
 				setStyleProperty(containerRef.current, 'transform', transform)
 				setStyleProperty(bgContainerRef.current, 'transform', transform)
 				prev.transform = transform
 			}
 
-			// Width / Height
+			const bounds = editor.getShapeGeometry(shape).bounds
 			const width = Math.max(bounds.width, 1)
 			const height = Math.max(bounds.height, 1)
 
@@ -110,12 +102,8 @@ export const Shape = memo(function Shape({
 	useLayoutEffect(() => {
 		const container = containerRef.current
 		const bgContainer = bgContainerRef.current
-
-		// Opacity
 		setStyleProperty(container, 'opacity', opacity)
 		setStyleProperty(bgContainer, 'opacity', opacity)
-
-		// Z-Index
 		setStyleProperty(container, 'z-index', index)
 		setStyleProperty(bgContainer, 'z-index', backgroundIndex)
 	}, [opacity, index, backgroundIndex])
@@ -127,7 +115,6 @@ export const Shape = memo(function Shape({
 		const container = containerRef.current
 		if (!container) return
 
-		// Check initial culling state and register with the context
 		const isCulled = editor.getCulledShapes().has(id)
 		register(id, container, bgContainerRef.current, isCulled)
 
@@ -152,7 +139,7 @@ export const Shape = memo(function Shape({
 				</ShapeWrapper>
 			)}
 			<ShapeWrapper ref={containerRef} shape={shape} isBackground={false}>
-				<OptionalErrorBoundary fallback={ShapeErrorFallback as any} onError={annotateError}>
+				<OptionalErrorBoundary fallback={ShapeErrorFallback} onError={annotateError}>
 					<InnerShape shape={shape} util={util} />
 				</OptionalErrorBoundary>
 				{util.getAppOwnedElement && <ContentElementSlot id={id} util={util} />}
@@ -276,8 +263,5 @@ export const InnerShapeBackground = memo(
 			[util, shape.id]
 		)
 	},
-	(prev, next) =>
-		prev.shape.props === next.shape.props &&
-		prev.shape.meta === next.shape.meta &&
-		prev.util === next.util
+	(prev, next) => areShapesContentEqual(prev.shape, next.shape) && prev.util === next.util
 )

--- a/packages/editor/src/lib/components/Shape.tsx
+++ b/packages/editor/src/lib/components/Shape.tsx
@@ -68,6 +68,7 @@ export const Shape = memo(function Shape({
 
 			const prev = memoizedStuffRef.current
 
+			// Clip path
 			const clipPath = editor.getShapeClipPath(id) ?? 'none'
 			if (clipPath !== prev.clipPath) {
 				setStyleProperty(containerRef.current, 'clip-path', clipPath)
@@ -75,13 +76,17 @@ export const Shape = memo(function Shape({
 				prev.clipPath = clipPath
 			}
 
+			// Page transform
 			const transform = Mat.toCssString(editor.getShapePageTransform(id))
+
+			// Update if the tranform has changed
 			if (transform !== prev.transform) {
 				setStyleProperty(containerRef.current, 'transform', transform)
 				setStyleProperty(bgContainerRef.current, 'transform', transform)
 				prev.transform = transform
 			}
 
+			// Width / Height
 			const bounds = editor.getShapeGeometry(shape).bounds
 			const width = Math.max(bounds.width, 1)
 			const height = Math.max(bounds.height, 1)
@@ -102,8 +107,12 @@ export const Shape = memo(function Shape({
 	useLayoutEffect(() => {
 		const container = containerRef.current
 		const bgContainer = bgContainerRef.current
+
+		// Opacity
 		setStyleProperty(container, 'opacity', opacity)
 		setStyleProperty(bgContainer, 'opacity', opacity)
+
+		// Z-Index
 		setStyleProperty(container, 'z-index', index)
 		setStyleProperty(bgContainer, 'z-index', backgroundIndex)
 	}, [opacity, index, backgroundIndex])
@@ -115,6 +124,7 @@ export const Shape = memo(function Shape({
 		const container = containerRef.current
 		if (!container) return
 
+		// Check initial culling state and register with the context
 		const isCulled = editor.getCulledShapes().has(id)
 		register(id, container, bgContainerRef.current, isCulled)
 

--- a/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
+++ b/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
@@ -1,8 +1,10 @@
 import { EffectScheduler, computed } from '@tldraw/state'
+import { areObjectsShallowEqual } from '@tldraw/utils'
 import { memo, useEffect, useRef } from 'react'
 import { useEditor } from '../../hooks/useEditor'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import { Group2d } from '../../primitives/geometry/Group2d'
+import { VecLike } from '../../primitives/Vec'
 import { debugFlags } from '../../utils/debug-flags'
 
 interface RenderInputs {
@@ -39,15 +41,7 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 					zoom: camera.z,
 				}
 			},
-			{
-				isEqual: (a, b) =>
-					a.dpr === b.dpr &&
-					a.w === b.w &&
-					a.h === b.h &&
-					a.cx === b.cx &&
-					a.cy === b.cy &&
-					a.zoom === b.zoom,
-			}
+			{ isEqual: areObjectsShallowEqual }
 		)
 
 		const scheduler = new EffectScheduler('canvas overlays render', () => {
@@ -88,8 +82,7 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 				const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
 				// Shape geometries
-				const renderingShapes = editor.getRenderingShapes()
-				for (const result of renderingShapes) {
+				for (const result of editor.getRenderingShapes()) {
 					const shape = editor.getShape(result.id)
 					if (!shape || shape.type === 'group') continue
 
@@ -123,11 +116,11 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 
 					// Nearest point line
 					const pointInShapeSpace = editor.getPointInShapeSpace(shape, currentPagePoint)
-					const dist = Math.abs(geometry.distanceToPoint(pointInShapeSpace, true)) * zoom
+					const signedDist = geometry.distanceToPoint(pointInShapeSpace, true)
+					const dist = Math.abs(signedDist) * zoom
 					if (dist < 150) {
 						const nearestPoint = geometry.nearestPoint(pointInShapeSpace)
-						const hitInside = geometry.distanceToPoint(pointInShapeSpace, true) < 0
-						ctx.strokeStyle = hitInside ? 'goldenrod' : 'dodgerblue'
+						ctx.strokeStyle = signedDist < 0 ? 'goldenrod' : 'dodgerblue'
 						ctx.lineWidth = 2 / zoom
 						ctx.globalAlpha = 1 - dist / 150
 						ctx.beginPath()
@@ -150,16 +143,8 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 						const geometry = editor.overlays.getOverlayGeometry(overlay)
 						if (!geometry) continue
 						const vertices = geometry.vertices
-						if (vertices.length < 2) continue
-						ctx.beginPath()
-						ctx.moveTo(vertices[0].x, vertices[0].y)
-						for (let i = 1; i < vertices.length; i++) {
-							ctx.lineTo(vertices[i].x, vertices[i].y)
-						}
-						if (geometry.isClosed) {
-							ctx.closePath()
-							ctx.fill()
-						}
+						if (!tracePolyline(ctx, vertices, geometry.isClosed)) continue
+						if (geometry.isClosed) ctx.fill()
 						ctx.stroke()
 						for (const v of vertices) {
 							ctx.beginPath()
@@ -196,13 +181,17 @@ function drawGeometryStroke(ctx: CanvasRenderingContext2D, geometry: Geometry2d)
 		return
 	}
 
-	const vertices = geometry.vertices
-	if (vertices.length < 2) return
+	if (tracePolyline(ctx, geometry.vertices, geometry.isClosed)) ctx.stroke()
+}
+
+/** Begins a path through `vertices`; returns false (leaving no path) when there are fewer than two. */
+function tracePolyline(ctx: CanvasRenderingContext2D, vertices: VecLike[], isClosed: boolean) {
+	if (vertices.length < 2) return false
 	ctx.beginPath()
 	ctx.moveTo(vertices[0].x, vertices[0].y)
 	for (let i = 1; i < vertices.length; i++) {
 		ctx.lineTo(vertices[i].x, vertices[i].y)
 	}
-	if (geometry.isClosed) ctx.closePath()
-	ctx.stroke()
+	if (isClosed) ctx.closePath()
+	return true
 }

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -10,8 +10,6 @@ import { getGlobalWindow } from '../../utils/dom'
 import { hardResetEditor, refreshPage } from '../../utils/runtime'
 import { ErrorBoundary } from '../ErrorBoundary'
 
-const BASE_ERROR_URL = 'https://github.com/tldraw/tldraw/issues/new'
-
 /** @public */
 export type TLErrorFallbackComponent = ComponentType<{ error: unknown; editor?: Editor }>
 
@@ -106,28 +104,6 @@ export const DefaultErrorFallback: TLErrorFallbackComponent = function DefaultEr
 		setDidCopy(true)
 	}
 
-	const refresh = () => {
-		refreshPage()
-	}
-
-	const resetLocalState = async () => {
-		hardResetEditor()
-	}
-
-	const url = new URL(BASE_ERROR_URL)
-	url.searchParams.set('title', errorMessage)
-	url.searchParams.set('labels', `bug`)
-	url.searchParams.set(
-		'body',
-		`Hey, I ran into an error while using tldraw:
-
-\`\`\`js
-${errorStack ?? errorMessage}
-\`\`\`
-
-My browser: ${navigator.userAgent}`
-	)
-
 	return (
 		<div
 			ref={containerRef}
@@ -166,7 +142,7 @@ My browser: ${navigator.userAgent}`
 							<button className="tlui-button" onClick={() => setShouldShowResetConfirmation(false)}>
 								Cancel
 							</button>
-							<button className="tlui-button tl-error-boundary__reset" onClick={resetLocalState}>
+							<button className="tlui-button tl-error-boundary__reset" onClick={hardResetEditor}>
 								Reset data
 							</button>
 						</div>
@@ -219,7 +195,7 @@ My browser: ${navigator.userAgent}`
 								>
 									Reset data
 								</button>
-								<button className="tlui-button tl-error-boundary__refresh" onClick={refresh}>
+								<button className="tlui-button tl-error-boundary__refresh" onClick={refreshPage}>
 									Refresh Page
 								</button>
 							</div>

--- a/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
+++ b/packages/editor/src/lib/config/TLSessionStateSnapshot.ts
@@ -68,10 +68,7 @@ if (window) {
 	} else {
 		deleteFromSessionStorage(tabIdKey)
 	}
-}
-
-if (typeof window !== 'undefined') {
-	getGlobalWindow().addEventListener('beforeunload', () => {
+	window.addEventListener('beforeunload', () => {
 		setInSessionStorage(tabIdKey, TAB_ID)
 	})
 }

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -86,9 +86,6 @@ function migrateSnapshot(data: { version: number; user: any }) {
 	if (data.version < Versions.AddIsSnapMode) {
 		data.user.isSnapMode = false
 	}
-	if (data.version < Versions.MakeFieldsNullable) {
-		// noop
-	}
 	if (data.version < Versions.AddEdgeScrollSpeed) {
 		data.user.edgeScrollSpeed = 1
 	}
@@ -155,11 +152,8 @@ function getRandomColor() {
 
 /** @internal */
 export function userPrefersReducedMotion() {
-	if (typeof window !== 'undefined' && getGlobalWindow().matchMedia) {
-		return getGlobalWindow().matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
-	}
-
-	return false
+	if (typeof window === 'undefined') return false
+	return getGlobalWindow().matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
 }
 
 /** @public */
@@ -211,10 +205,7 @@ function migrateUserPreferences(userData: unknown): TLUserPreferences {
 }
 
 function loadUserPreferences(): TLUserPreferences {
-	const userData = (JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null') ??
-		null) as null | UserDataSnapshot
-
-	return migrateUserPreferences(userData)
+	return migrateUserPreferences(JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null'))
 }
 
 const globalUserPreferences = atom<TLUserPreferences | null>('globalUserData', null)
@@ -237,6 +228,9 @@ export function setUserPreferences(user: TLUserPreferences) {
 	broadcastUserPreferencesChange()
 }
 
+const broadcastOrigin = uniqueId()
+const broadcastEventKey = 'tldraw-user-preferences-change' as const
+
 const isTest = typeof process !== 'undefined' && process.env.NODE_ENV === 'test'
 
 const channel =
@@ -246,24 +240,15 @@ const channel =
 
 channel?.addEventListener('message', (e) => {
 	const data = e.data as undefined | UserChangeBroadcastMessage
-	if (data?.type === broadcastEventKey && data?.origin !== getBroadcastOrigin()) {
+	if (data?.type === broadcastEventKey && data?.origin !== broadcastOrigin) {
 		globalUserPreferences.set(migrateUserPreferences(data.data))
 	}
 })
 
-let _broadcastOrigin = null as null | string
-function getBroadcastOrigin() {
-	if (_broadcastOrigin === null) {
-		_broadcastOrigin = uniqueId()
-	}
-	return _broadcastOrigin
-}
-const broadcastEventKey = 'tldraw-user-preferences-change' as const
-
 function broadcastUserPreferencesChange() {
 	channel?.postMessage({
 		type: broadcastEventKey,
-		origin: getBroadcastOrigin(),
+		origin: broadcastOrigin,
 		data: {
 			user: getUserPreferences(),
 			version: CURRENT_VERSION,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -187,6 +187,7 @@ import { TLHistoryBatchOptions } from './types/history-types'
 import {
 	OptionalKeys,
 	RequiredKeys,
+	TLCameraConstraints,
 	TLCameraMoveOptions,
 	TLCameraOptions,
 	TLGetShapeAtPointOptions,
@@ -492,7 +493,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// Tools.
 		// Accept tools from constructor parameters which may not conflict with the root note's default or
 		// "baked in" tools, select and zoom.
-		for (const Tool of [...tools]) {
+		for (const Tool of tools) {
 			if (hasOwnProperty(this.root.children!, Tool.id)) {
 				throw Error(`Can't override tool with id "${Tool.id}"`)
 			}
@@ -568,6 +569,32 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const createdShapes = new Set<TLShapeId>()
 		let invalidBindingTypes = new Set<TLBinding['type']>()
 
+		const notifyBindingsOfShapeChange = (
+			shapeBefore: TLShape,
+			shapeAfter: TLShape,
+			reason: 'self' | 'ancestry'
+		) => {
+			for (const binding of this.getBindingsInvolvingShape(shapeAfter)) {
+				invalidBindingTypes.add(binding.type)
+				if (binding.fromId === shapeAfter.id) {
+					this.getBindingUtil(binding).onAfterChangeFromShape?.({
+						binding,
+						shapeBefore,
+						shapeAfter,
+						reason,
+					})
+				}
+				if (binding.toId === shapeAfter.id) {
+					this.getBindingUtil(binding).onAfterChangeToShape?.({
+						binding,
+						shapeBefore,
+						shapeAfter,
+						reason,
+					})
+				}
+			}
+		}
+
 		this.disposables.add(
 			this.sideEffects.registerOperationCompleteHandler(() => {
 				// this needs to be cleared here because further effects may delete more shapes
@@ -635,52 +662,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 						}
 					},
 					afterChange: (shapeBefore, shapeAfter) => {
-						for (const binding of this.getBindingsInvolvingShape(shapeAfter)) {
-							invalidBindingTypes.add(binding.type)
-							if (binding.fromId === shapeAfter.id) {
-								this.getBindingUtil(binding).onAfterChangeFromShape?.({
-									binding,
-									shapeBefore,
-									shapeAfter,
-									reason: 'self',
-								})
-							}
-							if (binding.toId === shapeAfter.id) {
-								this.getBindingUtil(binding).onAfterChangeToShape?.({
-									binding,
-									shapeBefore,
-									shapeAfter,
-									reason: 'self',
-								})
-							}
-						}
+						notifyBindingsOfShapeChange(shapeBefore, shapeAfter, 'self')
 
 						// if the shape's parent changed and it has a binding, update the binding
 						if (shapeBefore.parentId !== shapeAfter.parentId) {
 							const notifyBindingAncestryChange = (id: TLShapeId) => {
 								const descendantShape = this.getShape(id)
 								if (!descendantShape) return
-
-								for (const binding of this.getBindingsInvolvingShape(descendantShape)) {
-									invalidBindingTypes.add(binding.type)
-
-									if (binding.fromId === descendantShape.id) {
-										this.getBindingUtil(binding).onAfterChangeFromShape?.({
-											binding,
-											shapeBefore: descendantShape,
-											shapeAfter: descendantShape,
-											reason: 'ancestry',
-										})
-									}
-									if (binding.toId === descendantShape.id) {
-										this.getBindingUtil(binding).onAfterChangeToShape?.({
-											binding,
-											shapeBefore: descendantShape,
-											shapeAfter: descendantShape,
-											reason: 'ancestry',
-										})
-									}
-								}
+								notifyBindingsOfShapeChange(descendantShape, descendantShape, 'ancestry')
 							}
 							notifyBindingAncestryChange(shapeAfter.id)
 							this.visitDescendants(shapeAfter.id, notifyBindingAncestryChange)
@@ -2467,9 +2456,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const selectedShapes = this.getSelectedShapes()
 		if (!selectedShapes.length) return
 		const selectedShape = selectedShapes[0]
-		const children = this.getSortedChildIdsForParent(selectedShape.id)
-			.map((id) => this.getShape(id))
-			.filter((i) => i) as TLShape[]
+		const children = compact(
+			this.getSortedChildIdsForParent(selectedShape.id).map((id) => this.getShape(id))
+		)
 		const sortedChildren = this._getShapesInReadingOrder(children)
 		if (sortedChildren.length === 0) return
 		this._selectShapesAndZoom([sortedChildren[0].id])
@@ -2796,33 +2785,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	setEditingShape(shape: TLShapeId | TLShape | null): this {
 		const id = typeof shape === 'string' ? shape : (shape?.id ?? null)
 
-		if (!id) {
-			// setting the editing shape to null
-			this.run(
-				() => {
-					// Clean up the previous editing shape
-					const prevEditingShapeId = this.getEditingShapeId()
-					if (prevEditingShapeId) {
-						const prevEditingShape = this.getShape(prevEditingShapeId)
-						if (prevEditingShape) {
-							this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-						}
-					}
-
-					// Clean up the editing shape state and rich text editor
-					this._updateCurrentPageState({ editingShapeId: null })
-					this._currentRichTextEditor.set(null)
-				},
-				{ history: 'ignore' }
-			)
-
-			return this
-		}
-
 		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
-		if (!this.canEditShape(id)) return this
+		if (id && !this.canEditShape(id)) return this
 
-		// id was provided and the next editing shape is editable, so set the rich text editor to null
 		this.run(
 			() => {
 				// Clean up the previous editing shape
@@ -2837,6 +2802,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// Clean up the editing shape state and rich text editor
 				this._updateCurrentPageState({ editingShapeId: null })
 				this._currentRichTextEditor.set(null)
+
+				if (!id) return
 
 				// Set the new editing shape
 				this.select(id)
@@ -3275,37 +3242,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// When defaultZoom is default, the default zoom is 100%
 		if (cameraOptions.constraints.initialZoom === 'default') return 1
 
-		const { zx, zy } = getCameraFitXFitY(this, cameraOptions)
-
-		switch (cameraOptions.constraints.initialZoom) {
-			case 'fit-min': {
-				return Math.max(zx, zy)
-			}
-			case 'fit-max': {
-				return Math.min(zx, zy)
-			}
-			case 'fit-x': {
-				return zx
-			}
-			case 'fit-y': {
-				return zy
-			}
-			case 'fit-min-100': {
-				return Math.min(1, Math.max(zx, zy))
-			}
-			case 'fit-max-100': {
-				return Math.min(1, Math.min(zx, zy))
-			}
-			case 'fit-x-100': {
-				return Math.min(1, zx)
-			}
-			case 'fit-y-100': {
-				return Math.min(1, zy)
-			}
-			default: {
-				throw exhaustiveSwitchError(cameraOptions.constraints.initialZoom)
-			}
-		}
+		return getFitZoom(cameraOptions.constraints.initialZoom, getCameraFitXFitY(this, cameraOptions))
 	}
 
 	/**
@@ -3325,37 +3262,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// When defaultZoom is default, the default zoom is 100%
 		if (cameraOptions.constraints.baseZoom === 'default') return 1
 
-		const { zx, zy } = getCameraFitXFitY(this, cameraOptions)
-
-		switch (cameraOptions.constraints.baseZoom) {
-			case 'fit-min': {
-				return Math.max(zx, zy)
-			}
-			case 'fit-max': {
-				return Math.min(zx, zy)
-			}
-			case 'fit-x': {
-				return zx
-			}
-			case 'fit-y': {
-				return zy
-			}
-			case 'fit-min-100': {
-				return Math.min(1, Math.max(zx, zy))
-			}
-			case 'fit-max-100': {
-				return Math.min(1, Math.min(zx, zy))
-			}
-			case 'fit-x-100': {
-				return Math.min(1, zx)
-			}
-			case 'fit-y-100': {
-				return Math.min(1, zy)
-			}
-			default: {
-				throw exhaustiveSwitchError(cameraOptions.constraints.baseZoom)
-			}
-		}
+		return getFitZoom(cameraOptions.constraints.baseZoom, getCameraFitXFitY(this, cameraOptions))
 	}
 
 	private _cameraOptions = atom('camera options', DEFAULT_CAMERA_OPTIONS)
@@ -4255,24 +4162,22 @@ export class Editor extends EventEmitter<TLEventMap> {
 			return this
 		}
 
+		// When centering, capture the page center before the change so it can be restored after
+		const centerBefore =
+			!_willSetInitialBounds && center && !this.getInstanceState().followingUserId
+				? this.getViewportPageBounds().center
+				: null
+
+		this.updateInstanceState({ screenBounds: screenBounds.toJson(), insets })
+		this.emit('resize', screenBounds.toJson())
+
 		if (_willSetInitialBounds) {
 			// If we have just received the initial bounds, don't center the camera.
-			this.updateInstanceState({ screenBounds: screenBounds.toJson(), insets })
-			this.emit('resize', screenBounds.toJson())
 			this.setCamera(this.getCamera())
+		} else if (centerBefore) {
+			this.centerOnPoint(centerBefore)
 		} else {
-			if (center && !this.getInstanceState().followingUserId) {
-				// Get the page center before the change, make the change, and restore it
-				const before = this.getViewportPageBounds().center
-				this.updateInstanceState({ screenBounds: screenBounds.toJson(), insets })
-				this.emit('resize', screenBounds.toJson())
-				this.centerOnPoint(before)
-			} else {
-				// Otherwise,
-				this.updateInstanceState({ screenBounds: screenBounds.toJson(), insets })
-				this.emit('resize', screenBounds.toJson())
-				this._setCamera(Vec.From({ ...this.getCamera() }))
-			}
+			this._setCamera(Vec.From({ ...this.getCamera() }))
 		}
 
 		return this
@@ -5565,15 +5470,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 			if (clipPaths.length === 0) return undefined
 
-			const pageMask = clipPaths.reduce((acc, b) => {
+			return clipPaths.reduce((acc, b) => {
 				const intersection = intersectPolygonPolygon(acc, b)
 				if (intersection) {
 					return intersection.map(Vec.Cast)
 				}
 				return []
 			})
-
-			return pageMask
 		})
 	}
 
@@ -6409,25 +6312,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	isShapeInPage(shape: TLShape | TLShapeId, pageId = this.getCurrentPageId()): boolean {
 		const id = typeof shape === 'string' ? shape : shape.id
-		const shapeToCheck = this.getShape(id)
-		if (!shapeToCheck) return false
-
-		let shapeIsInPage = false
-
-		if (shapeToCheck.parentId === pageId) {
-			shapeIsInPage = true
-		} else {
-			let parent = this.getShape(shapeToCheck.parentId)
-			isInPageSearch: while (parent) {
-				if (parent.parentId === pageId) {
-					shapeIsInPage = true
-					break isInPageSearch
-				}
-				parent = this.getShape(parent.parentId)
-			}
+		let current = this.getShape(id)
+		while (current) {
+			if (current.parentId === pageId) return true
+			current = this.getShape(current.parentId)
 		}
-
-		return shapeIsInPage
+		return false
 	}
 
 	/**
@@ -6538,13 +6428,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				for (let i = 0; i < shapesToReparent.length; i++) {
 					const shape = shapesToReparent[i]
 
-					const pageTransform = this.getShapePageTransform(shape)!
-					if (!pageTransform) continue
-
-					const pagePoint = pageTransform.point()
-					if (!pagePoint) continue
-
-					const newPoint = invertedParentTransform.applyToPoint(pagePoint)
+					const pageTransform = this.getShapePageTransform(shape)
+					const newPoint = invertedParentTransform.applyToPoint(pageTransform.point())
 					const newRotation = pageTransform.rotation() - parentPageRotation
 
 					if (shape.id === parentId) {
@@ -7029,6 +6914,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return workingShape
 	}
 
+	// Translate a shape by a delta given in page space, counter-rotating the delta into the
+	// shape's parent space first so children of rotated parents move along the page axes.
+	private getChangesToTranslateShapeByPageDelta(shape: TLShape, pageDelta: VecLike): TLShape {
+		const localDelta = Vec.From(pageDelta).rot(-this.getShapeParentTransform(shape).rotation())
+		return this.getChangesToTranslateShape(shape, localDelta.add(shape))
+	}
+
 	/**
 	 * Move shapes by a delta.
 	 *
@@ -7050,12 +6942,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const changes: TLShapePartial[] = []
 
 		for (const id of ids) {
-			const shape = this.getShape(id)!
-			const localDelta = Vec.From(offset)
-			const parentTransform = this.getShapeParentTransform(shape)
-			if (parentTransform) localDelta.rot(-parentTransform.rotation())
-
-			changes.push(this.getChangesToTranslateShape(shape, localDelta.add(shape)))
+			changes.push(this.getChangesToTranslateShapeByPageDelta(this.getShape(id)!, offset))
 		}
 
 		this.updateShapes(changes)
@@ -7304,20 +7191,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 		}
 		this.run(() => {
-			if (allUnlocked) {
-				this.updateShapes(
-					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: true }))
-				)
-				this.setSelectedShapes([])
-			} else if (allLocked) {
-				this.updateShapes(
-					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: false }))
-				)
-			} else {
-				this.updateShapes(
-					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: true }))
-				)
-			}
+			// Only unlock when every shape is locked; a mix locks them all
+			const isLocked = !allLocked
+			this.updateShapes(
+				shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked }))
+			)
+			if (allUnlocked) this.setSelectedShapes([])
 		})
 
 		return this
@@ -7732,18 +7611,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			delta[val] = v + shapeGap - pageBounds[val]
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
 				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 
 			v += pageBounds[dim] + shapeGap
@@ -7858,16 +7727,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const delta = Vec.Sub(nextPageBounds.point, pageBounds.point).add(centerDelta)
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					const parentTransform = this.getShapeParentTransform(shape)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
-				}
-
-				shapeDelta.add(shape)
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 		}
 
@@ -7947,18 +7807,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
 				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 		})
 
@@ -8048,18 +7898,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
 				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 
 			v += pageBounds[dim] + gap
@@ -8122,12 +7962,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				for (const shape of shapes) {
 					// First translate
-					const shapeLocalOffset = localOffset.clone()
-					const parentTransform = this.getShapeParentTransform(shape)
-					if (parentTransform) shapeLocalOffset.rot(-parentTransform.rotation())
-					shapeLocalOffset.add(shape)
-					const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
-					this.updateShape(changes)
+					this.updateShape(this.getChangesToTranslateShapeByPageDelta(shape, localOffset))
 
 					// Then resize
 					this.resizeShape(shape.id, scale, {
@@ -8194,12 +8029,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			for (const shape of shapes) {
 				// First translate
-				const shapeLocalOffset = localOffset.clone()
-				const parentTransform = this.getShapeParentTransform(shape)
-				if (parentTransform) shapeLocalOffset.rot(-parentTransform.rotation())
-				shapeLocalOffset.add(shape)
-				const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
-				this.updateShape(changes)
+				this.updateShape(this.getChangesToTranslateShapeByPageDelta(shape, localOffset))
 
 				// Then resize
 				this.resizeShape(shape.id, scale, {
@@ -9117,7 +8947,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	updateShapes<T extends TLShape>(partials: (TLShapePartial<T> | null | undefined)[]) {
-		const compactedPartials: TLShapePartial<T>[] = Array(partials.length)
+		const compactedPartials: TLShapePartial<T>[] = []
 
 		for (let i = 0, n = partials.length; i < n; i++) {
 			const partial = partials[i]
@@ -9354,18 +9184,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!currentTool) return styles
 
 		if (currentTool.shapeType) {
-			if (
+			const hideColor =
 				currentTool.shapeType === 'frame' &&
 				!(this.getShapeUtil('frame')!.options as any).showColors
-			) {
-				for (const style of this.styleProps[currentTool.shapeType].keys()) {
-					if (style.id === 'tldraw:color') continue
-					styles.applyValue(style, this.getStyleForNextShape(style))
-				}
-			} else {
-				for (const style of this.styleProps[currentTool.shapeType].keys()) {
-					styles.applyValue(style, this.getStyleForNextShape(style))
-				}
+			for (const style of this.styleProps[currentTool.shapeType].keys()) {
+				if (hideColor && style.id === 'tldraw:color') continue
+				styles.applyValue(style, this.getStyleForNextShape(style))
 			}
 		}
 
@@ -9381,27 +9205,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	@computed getSharedOpacity(): SharedStyle<number> {
 		if (this.isIn('select') && this.getSelectedShapeIds().length > 0) {
-			const shapesToCheck: TLShape[] = []
-			const addShape = (shapeId: TLShapeId) => {
-				const shape = this.getShape(shapeId)
-				if (!shape) return
-				// For groups, ignore the opacity of the group shape and instead include
-				// the opacity of the group's children. These are the shapes that would have
-				// their opacity changed if the user called `setOpacity` on the current selection.
-				if (this.isShapeOfType(shape, 'group')) {
-					for (const childId of this.getSortedChildIdsForParent(shape.id)) {
-						addShape(childId)
-					}
-				} else {
-					shapesToCheck.push(shape)
-				}
-			}
-			for (const shapeId of this.getSelectedShapeIds()) {
-				addShape(shapeId)
-			}
-
 			let opacity: number | null = null
-			for (const shape of shapesToCheck) {
+			for (const shape of this._getSelectedShapesExpandingGroups()) {
 				if (opacity === null) {
 					opacity = shape.opacity
 				} else if (opacity !== shape.opacity) {
@@ -9441,40 +9246,41 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @param opacity - The opacity to set. Must be a number between 0 and 1 inclusive.
 	 */
 	setOpacityForSelectedShapes(opacity: number): this {
-		const selectedShapes = this.getSelectedShapes()
-
-		if (selectedShapes.length > 0) {
-			const shapesToUpdate: TLShape[] = []
-
-			// We can have many deep levels of grouped shape
-			// Making a recursive function to look through all the levels
-			const addShapeById = (shape: TLShape) => {
-				if (this.isShapeOfType(shape, 'group')) {
-					const childIds = this.getSortedChildIdsForParent(shape)
-					for (const childId of childIds) {
-						addShapeById(this.getShape(childId)!)
-					}
-				} else {
-					shapesToUpdate.push(shape)
-				}
-			}
-
-			for (const id of selectedShapes) {
-				addShapeById(id)
-			}
-
+		if (this.getSelectedShapes().length > 0) {
 			this.updateShapes(
-				shapesToUpdate.map((shape) => {
-					return {
-						id: shape.id,
-						type: shape.type,
-						opacity,
-					}
-				})
+				this._getSelectedShapesExpandingGroups().map((shape) => ({
+					id: shape.id,
+					type: shape.type,
+					opacity,
+				}))
 			)
 		}
 
 		return this
+	}
+
+	/**
+	 * The selected shapes with groups replaced by their (recursively expanded) children: the
+	 * shapes whose styles/opacity would actually change when the selection is styled.
+	 *
+	 * @internal
+	 */
+	private _getSelectedShapesExpandingGroups(): TLShape[] {
+		const result: TLShape[] = []
+		const visit = (shape: TLShape) => {
+			if (this.isShapeOfType(shape, 'group')) {
+				for (const childId of this.getSortedChildIdsForParent(shape.id)) {
+					const child = this.getShape(childId)
+					if (child) visit(child)
+				}
+			} else {
+				result.push(shape)
+			}
+		}
+		for (const shape of this.getSelectedShapes()) {
+			visit(shape)
+		}
+		return result
 	}
 
 	/**
@@ -9521,46 +9327,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setStyleForSelectedShapes<S extends StyleProp<any>>(style: S, value: StylePropValue<S>): this {
-		const selectedShapes = this.getSelectedShapes()
-
-		if (selectedShapes.length > 0) {
-			const updates: {
-				util: ShapeUtil
-				originalShape: TLShape
-				updatePartial: TLShapePartial
-			}[] = []
-
-			// We can have many deep levels of grouped shape
-			// Making a recursive function to look through all the levels
-			const addShapeById = (shape: TLShape) => {
-				if (this.isShapeOfType(shape, 'group')) {
-					const childIds = this.getSortedChildIdsForParent(shape.id)
-					for (const childId of childIds) {
-						addShapeById(this.getShape(childId)!)
-					}
-				} else {
-					const util = this.getShapeUtil(shape)
-					const stylePropKey = this.styleProps[shape.type].get(style)
-					if (stylePropKey) {
-						const shapePartial: TLShapePartial = {
-							id: shape.id,
-							type: shape.type,
-							props: { [stylePropKey]: value },
-						}
-						updates.push({
-							util,
-							originalShape: shape,
-							updatePartial: shapePartial,
-						})
-					}
+		if (this.getSelectedShapes().length > 0) {
+			const updates: TLShapePartial[] = []
+			for (const shape of this._getSelectedShapesExpandingGroups()) {
+				const stylePropKey = this.styleProps[shape.type].get(style)
+				if (stylePropKey) {
+					updates.push({ id: shape.id, type: shape.type, props: { [stylePropKey]: value } })
 				}
 			}
-
-			for (const shape of selectedShapes) {
-				addShapeById(shape)
-			}
-
-			this.updateShapes(updates.map(({ updatePartial }) => updatePartial))
+			this.updateShapes(updates)
 		}
 
 		return this
@@ -9772,7 +9547,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes as TLShape[]).map((s) => s.id)
 
-		if (!ids) return
 		if (ids.length === 0) return
 
 		const shapeIds = this.getShapeAndDescendantIds(ids)
@@ -10214,10 +9988,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			// Apply offset to move shapes to target point
-			const pageCenter = Box.Common(
-				compact(rootShapes.map(({ id }) => this.getShapePageBounds(id)))
-			).center
-			const offset = Vec.Sub(point, pageCenter)
+			const offset = Vec.Sub(point, rootBounds.center)
 
 			if (offset.x !== 0 || offset.y !== 0) {
 				this.updateShapes(
@@ -10877,16 +10648,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	_releaseShiftKey() {
 		this._shiftKeyTimeout = -1
 		this.inputs.setShiftKey(false)
+		this._dispatchModifierKeyUp('Shift', 'ShiftLeft')
+	}
+
+	private _dispatchModifierKeyUp(key: string, code: string) {
 		this.dispatch({
 			type: 'keyboard',
 			name: 'key_up',
-			key: 'Shift',
+			key,
 			shiftKey: this.inputs.getShiftKey(),
 			ctrlKey: this.inputs.getCtrlKey(),
 			altKey: this.inputs.getAltKey(),
 			metaKey: this.inputs.getMetaKey(),
 			accelKey: this.inputs.getAccelKey(),
-			code: 'ShiftLeft',
+			code,
 		})
 	}
 
@@ -10901,17 +10676,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	_releaseAltKey() {
 		this._altKeyTimeout = -1
 		this.inputs.setAltKey(false)
-		this.dispatch({
-			type: 'keyboard',
-			name: 'key_up',
-			key: 'Alt',
-			shiftKey: this.inputs.getShiftKey(),
-			ctrlKey: this.inputs.getCtrlKey(),
-			altKey: this.inputs.getAltKey(),
-			metaKey: this.inputs.getMetaKey(),
-			accelKey: this.inputs.getAccelKey(),
-			code: 'AltLeft',
-		})
+		this._dispatchModifierKeyUp('Alt', 'AltLeft')
 	}
 
 	/** @internal */
@@ -10925,17 +10690,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	_releaseCtrlKey() {
 		this._ctrlKeyTimeout = -1
 		this.inputs.setCtrlKey(false)
-		this.dispatch({
-			type: 'keyboard',
-			name: 'key_up',
-			key: 'Ctrl',
-			shiftKey: this.inputs.getShiftKey(),
-			ctrlKey: this.inputs.getCtrlKey(),
-			altKey: this.inputs.getAltKey(),
-			metaKey: this.inputs.getMetaKey(),
-			accelKey: this.inputs.getAccelKey(),
-			code: 'ControlLeft',
-		})
+		this._dispatchModifierKeyUp('Ctrl', 'ControlLeft')
 	}
 
 	/** @internal */
@@ -10949,17 +10704,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	_releaseMetaKey() {
 		this._metaKeyTimeout = -1
 		this.inputs.setMetaKey(false)
-		this.dispatch({
-			type: 'keyboard',
-			name: 'key_up',
-			key: 'Meta',
-			shiftKey: this.inputs.getShiftKey(),
-			ctrlKey: this.inputs.getCtrlKey(),
-			altKey: this.inputs.getAltKey(),
-			metaKey: this.inputs.getMetaKey(),
-			accelKey: this.inputs.getAccelKey(),
-			code: 'MetaLeft',
-		})
+		this._dispatchModifierKeyUp('Meta', 'MetaLeft')
 	}
 
 	/**
@@ -11856,9 +11601,7 @@ function withIsolatedShapes<T>(
 						const hasTo = shapeIds.has(binding.toId)
 						if (hasFrom && hasTo) {
 							bindingsWithBoth.add(binding.id)
-							continue
-						}
-						if (!hasFrom || !hasTo) {
+						} else {
 							bindingsToRemove.add(binding.id)
 						}
 					}
@@ -11882,6 +11625,41 @@ function withIsolatedShapes<T>(
 		return result.value
 	} else {
 		throw result.error
+	}
+}
+
+function getFitZoom(
+	mode: Exclude<TLCameraConstraints['initialZoom'], 'default'>,
+	{ zx, zy }: { zx: number; zy: number }
+) {
+	switch (mode) {
+		case 'fit-min': {
+			return Math.max(zx, zy)
+		}
+		case 'fit-max': {
+			return Math.min(zx, zy)
+		}
+		case 'fit-x': {
+			return zx
+		}
+		case 'fit-y': {
+			return zy
+		}
+		case 'fit-min-100': {
+			return Math.min(1, Math.max(zx, zy))
+		}
+		case 'fit-max-100': {
+			return Math.min(1, Math.min(zx, zy))
+		}
+		case 'fit-x-100': {
+			return Math.min(1, zx)
+		}
+		case 'fit-y-100': {
+			return Math.min(1, zy)
+		}
+		default: {
+			throw exhaustiveSwitchError(mode)
+		}
 	}
 }
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4164,7 +4164,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// When centering, capture the page center before the change so it can be restored after
 		const centerBefore =
-			!_willSetInitialBounds && center && !this.getInstanceState().followingUserId
+			center && !this.getInstanceState().followingUserId
 				? this.getViewportPageBounds().center
 				: null
 
@@ -6311,13 +6311,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	isShapeInPage(shape: TLShape | TLShapeId, pageId = this.getCurrentPageId()): boolean {
-		const id = typeof shape === 'string' ? shape : shape.id
-		let current = this.getShape(id)
-		while (current) {
-			if (current.parentId === pageId) return true
-			current = this.getShape(current.parentId)
-		}
-		return false
+		return this.getAncestorPageId(shape) === pageId
 	}
 
 	/**
@@ -9093,42 +9087,20 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/* --------------------- Styles --------------------- */
 
 	/**
-	 * Get all the current styles among the users selected shapes
-	 *
-	 * @internal
-	 */
-	private _extractSharedStyles(shape: TLShape, sharedStyleMap: SharedStyleMap) {
-		if (this.isShapeOfType(shape, 'group')) {
-			// For groups, ignore the styles of the group shape and instead include the styles of the
-			// group's children. These are the shapes that would have their styles changed if the
-			// user called `setStyle` on the current selection.
-			const childIds = this._parentIdsToChildIds.get()[shape.id]
-			if (!childIds) return
-
-			for (let i = 0, n = childIds.length; i < n; i++) {
-				this._extractSharedStyles(this.getShape(childIds[i])!, sharedStyleMap)
-			}
-		} else {
-			for (const [style, propKey] of this.styleProps[shape.type]) {
-				sharedStyleMap.applyValue(style, getOwnProperty(shape.props, propKey))
-			}
-		}
-	}
-
-	/**
 	 * A derived map containing all current styles among the user's selected shapes.
 	 *
 	 * @internal
 	 */
 	@computed
 	private _getSelectionSharedStyles(): ReadonlySharedStyleMap {
-		const selectedShapes = this.getSelectedShapes()
-
+		// Groups contribute their children's styles, since those are the shapes that would change
+		// if the user called `setStyle` on the current selection.
 		const sharedStyles = new SharedStyleMap()
-		for (const selectedShape of selectedShapes) {
-			this._extractSharedStyles(selectedShape, sharedStyles)
+		for (const shape of this._getSelectedShapesExpandingGroups()) {
+			for (const [style, propKey] of this.styleProps[shape.type]) {
+				sharedStyles.applyValue(style, getOwnProperty(shape.props, propKey))
+			}
 		}
-
 		return sharedStyles
 	}
 

--- a/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
+++ b/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
@@ -13,6 +13,7 @@ function fromScratch(
 	const shapeIds = shapeIdsQuery.get()
 	const sortedShapes = Array.from(shapeIds, (id) => store.get(id)!).sort(sortByIndex)
 
+	// Populate the result object with an array for each parent.
 	for (const shape of sortedShapes) {
 		result[shape.parentId] ??= []
 		result[shape.parentId].push(shape.id)
@@ -56,6 +57,7 @@ export function parentsToChildren(store: TLStore) {
 			const toSort = new Set<TLShapeId[]>()
 
 			for (const changes of diff) {
+				// Iterate through the added shapes, add them to the new value and mark them for sorting
 				for (const record of Object.values(changes.added)) {
 					if (!isShape(record)) continue
 					ensureNewArray(record.parentId)
@@ -63,23 +65,26 @@ export function parentsToChildren(store: TLStore) {
 					toSort.add(newValue![record.parentId])
 				}
 
+				// Iterate through the updated shapes, add them to their parents in the new value and mark them for sorting
 				for (const [from, to] of Object.values(changes.updated)) {
 					if (!isShape(to)) continue
 					if (!isShape(from)) continue
 
 					if (from.parentId !== to.parentId) {
+						// If the parents have changed, remove the new value from the old parent and add it to the new parent
 						ensureNewArray(from.parentId)
 						ensureNewArray(to.parentId)
 						newValue![from.parentId].splice(newValue![from.parentId].indexOf(to.id), 1)
 						newValue![to.parentId].push(to.id)
 						toSort.add(newValue![to.parentId])
 					} else if (from.index !== to.index) {
-						// Same parent, reordered: the array is already a fresh copy so just re-sort it.
+						// If the parent is the same but the index has changed (e.g. if they've been reordered), update the parent's array at the new index
 						ensureNewArray(to.parentId)
 						toSort.add(newValue![to.parentId])
 					}
 				}
 
+				// Iterate through the removed shapes, remove them from their parents in new value
 				for (const record of Object.values(changes.removed)) {
 					if (!isShape(record)) continue
 					ensureNewArray(record.parentId)

--- a/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
+++ b/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
@@ -1,6 +1,6 @@
 import { Computed, computed, isUninitialized, RESET_VALUE } from '@tldraw/state'
-import { CollectionDiff, RecordsDiff } from '@tldraw/store'
-import { isShape, TLParentId, TLRecord, TLShape, TLShapeId, TLStore } from '@tldraw/tlschema'
+import { CollectionDiff } from '@tldraw/store'
+import { isShape, TLParentId, TLShape, TLShapeId, TLStore } from '@tldraw/tlschema'
 import { sortByIndex } from '@tldraw/utils'
 
 type ParentShapeIdsToChildShapeIds = Record<TLParentId, TLShapeId[]>
@@ -13,11 +13,10 @@ function fromScratch(
 	const shapeIds = shapeIdsQuery.get()
 	const sortedShapes = Array.from(shapeIds, (id) => store.get(id)!).sort(sortByIndex)
 
-	// Populate the result object with an array for each parent.
-	sortedShapes.forEach((shape) => {
+	for (const shape of sortedShapes) {
 		result[shape.parentId] ??= []
 		result[shape.parentId].push(shape.id)
-	})
+	}
 
 	return result
 }
@@ -56,12 +55,7 @@ export function parentsToChildren(store: TLStore) {
 
 			const toSort = new Set<TLShapeId[]>()
 
-			let changes: RecordsDiff<TLRecord>
-
-			for (let i = 0, n = diff.length; i < n; i++) {
-				changes = diff[i]
-
-				// Iterate through the added shapes, add them to the new value and mark them for sorting
+			for (const changes of diff) {
 				for (const record of Object.values(changes.added)) {
 					if (!isShape(record)) continue
 					ensureNewArray(record.parentId)
@@ -69,28 +63,23 @@ export function parentsToChildren(store: TLStore) {
 					toSort.add(newValue![record.parentId])
 				}
 
-				// Iterate through the updated shapes, add them to their parents in the new value and mark them for sorting
 				for (const [from, to] of Object.values(changes.updated)) {
 					if (!isShape(to)) continue
 					if (!isShape(from)) continue
 
 					if (from.parentId !== to.parentId) {
-						// If the parents have changed, remove the new value from the old parent and add it to the new parent
 						ensureNewArray(from.parentId)
 						ensureNewArray(to.parentId)
 						newValue![from.parentId].splice(newValue![from.parentId].indexOf(to.id), 1)
 						newValue![to.parentId].push(to.id)
 						toSort.add(newValue![to.parentId])
 					} else if (from.index !== to.index) {
-						// If the parent is the same but the index has changed (e.g. if they've been reordered), update the parent's array at the new index
+						// Same parent, reordered: the array is already a fresh copy so just re-sort it.
 						ensureNewArray(to.parentId)
-						const idx = newValue![to.parentId].indexOf(to.id)
-						newValue![to.parentId][idx] = to.id
 						toSort.add(newValue![to.parentId])
 					}
 				}
 
-				// Iterate through the removed shapes, remove them from their parents in new value
 				for (const record of Object.values(changes.removed)) {
 					if (!isShape(record)) continue
 					ensureNewArray(record.parentId)

--- a/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
+++ b/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
@@ -64,9 +64,7 @@ export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: ()
 			return fromScratch()
 		}
 
-		const builder = new IncrementalSetConstructor<TLShapeId>(
-			prevValue
-		) as IncrementalSetConstructor<TLShapeId>
+		const builder = new IncrementalSetConstructor<TLShapeId>(prevValue)
 
 		for (const changes of diff) {
 			for (const record of Object.values(changes.added)) {

--- a/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
+++ b/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
@@ -29,19 +29,13 @@ export class ClickManager {
 		this._clickTimeout = this.editor.timers.setTimeout(
 			() => {
 				if (this._clickState === state && this._clickId === id) {
-					switch (this._clickState) {
-						case 'pendingOverflow': {
-							this.editor.dispatch({
-								...this.lastPointerInfo,
-								type: 'click',
-								name: 'double_click',
-								phase: this._isPressingWhilePending ? 'settle-down' : 'settle-up',
-							})
-							break
-						}
-						default: {
-							// noop
-						}
+					if (this._clickState === 'pendingOverflow') {
+						this.editor.dispatch({
+							...this.lastPointerInfo,
+							type: 'click',
+							name: 'double_click',
+							phase: this._isPressingWhilePending ? 'settle-down' : 'settle-up',
+						})
 					}
 
 					this._clickState = 'idle'
@@ -94,7 +88,7 @@ export class ClickManager {
 				switch (this._clickState) {
 					case 'pendingDouble': {
 						this._clickState = 'pendingOverflow'
-						this._clickTimeout = this._getClickTimeout(this._clickState)
+						this._getClickTimeout(this._clickState)
 						return {
 							...info,
 							type: 'click',
@@ -114,7 +108,7 @@ export class ClickManager {
 						// overflow
 					}
 				}
-				this._clickTimeout = this._getClickTimeout(this._clickState)
+				this._getClickTimeout(this._clickState)
 				return info
 			}
 			case 'pointer_up': {
@@ -124,17 +118,12 @@ export class ClickManager {
 
 				this._isPressingWhilePending = false
 
-				switch (this._clickState) {
-					case 'pendingOverflow': {
-						return {
-							...this.lastPointerInfo,
-							type: 'click',
-							name: 'double_click',
-							phase: 'up',
-						}
-					}
-					default: {
-						// idle, pendingDouble, overflow
+				if (this._clickState === 'pendingOverflow') {
+					return {
+						...this.lastPointerInfo,
+						type: 'click',
+						name: 'double_click',
+						phase: 'up',
 					}
 				}
 
@@ -164,7 +153,7 @@ export class ClickManager {
 	 */
 	@bind
 	cancelDoubleClickTimeout() {
-		this._clickTimeout = clearTimeout(this._clickTimeout)
+		clearTimeout(this._clickTimeout)
 		this._clickState = 'idle'
 		// when a double click is cancelled, we are no longer pending any further
 		// clicks, so we set this to false even if the user is still pressing

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -1,6 +1,6 @@
 import { EMPTY_ARRAY, atom, computed } from '@tldraw/state'
 import type { TLInstancePresence } from '@tldraw/tlschema'
-import { areArraysShallowEqual, maxBy } from '@tldraw/utils'
+import { areArraysShallowEqual } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
 
 /**
@@ -54,14 +54,17 @@ export class CollaboratorsManager {
 	getCollaborators(): TLInstancePresence[] {
 		const allPresenceRecords = this._getCollaboratorsQuery().get()
 		if (!allPresenceRecords.length) return EMPTY_ARRAY
-		const userIds = [...new Set(allPresenceRecords.map((c) => c.userId))].sort()
-		return userIds.map((id) => {
-			const latestPresence = maxBy(
-				allPresenceRecords.filter((c) => c.userId === id),
-				(p) => p.lastActivityTimestamp ?? 0
-			)
-			return latestPresence!
-		})
+		const latestByUserId = new Map<string, TLInstancePresence>()
+		for (const presence of allPresenceRecords) {
+			const existing = latestByUserId.get(presence.userId)
+			if (
+				!existing ||
+				(presence.lastActivityTimestamp ?? 0) > (existing.lastActivityTimestamp ?? 0)
+			) {
+				latestByUserId.set(presence.userId, presence)
+			}
+		}
+		return [...latestByUserId.keys()].sort().map((id) => latestByUserId.get(id)!)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -50,10 +50,7 @@ export class FontManager {
 				const fontFacesComputed = computed('font faces', () => this.getShapeFontFaces(id))
 				return computed(
 					'font load state',
-					() => {
-						const states = fontFacesComputed.get().map((face) => this.getFontState(face))
-						return states
-					},
+					() => fontFacesComputed.get().map((face) => this.getFontState(face)),
 					{ isEqual: areArraysShallowEqual }
 				)
 			}
@@ -158,15 +155,14 @@ export class FontManager {
 		}
 	}
 
+	private resolveUrl(font: TLFontFace) {
+		return this.assetUrls?.[font.src.url] ?? font.src.url
+	}
+
 	private findOrCreateFontFace(font: TLFontFace) {
 		const containerDocument = this.editor.getContainerDocument()
 
-		// `findOrCreateFontFace` runs for every font on every editor mount, and a fresh
-		// editor (e.g. switching documents) gets a fresh FontManager with no memory of the
-		// previous one. The dedup below is an O(n) scan of the document's whole FontFaceSet,
-		// so without a cache that scan re-ran on every mount (measurably expensive on mobile
-		// Safari). Cache the resolved FontFace per document so repeated lookups - and
-		// remounts - are O(1). Keyed per document for cross-window embedding.
+		// See `fontFaceCacheByDocument` for why this is cached across FontManager instances.
 		let cache = fontFaceCacheByDocument.get(containerDocument)
 		if (!cache) {
 			cache = new Map()
@@ -191,8 +187,7 @@ export class FontManager {
 			}
 		}
 
-		const url = this.assetUrls?.[font.src.url] ?? font.src.url
-		const instance = new FontFace(font.family, `url(${JSON.stringify(url)})`, {
+		const instance = new FontFace(font.family, `url(${JSON.stringify(this.resolveUrl(font))})`, {
 			...mapObjectMapValues(defaultFontFaceDescriptors, (key) => font[key]),
 			display: 'swap',
 		})
@@ -204,8 +199,7 @@ export class FontManager {
 	}
 
 	async toEmbeddedCssDeclaration(font: TLFontFace) {
-		const url = this.assetUrls?.[font.src.url] ?? font.src.url
-		const dataUrl = await FileHelpers.urlToDataUrl(url)
+		const dataUrl = await FileHelpers.urlToDataUrl(this.resolveUrl(font))
 
 		const src = compact([
 			`url("${dataUrl}")`,
@@ -242,10 +236,11 @@ const defaultFontFaceDescriptors = {
 }
 
 // A FontFace is fully determined by its family and descriptors, so resolved faces can be
-// cached per document and reused across FontManager instances (e.g. editor remounts),
-// turning the per-lookup FontFaceSet scan into an O(1) map lookup. Faces are never removed
-// from `document.fonts` (FontManager.dispose leaves them), so the cache stays valid for the
-// document's lifetime. Keyed per document for cross-window embedding.
+// cached per document and reused across FontManager instances (e.g. editor remounts,
+// switching documents), turning the per-lookup O(n) FontFaceSet scan — measurably expensive
+// on mobile Safari — into an O(1) map lookup. Faces are never removed from `document.fonts`
+// (FontManager.dispose leaves them), so the cache stays valid for the document's lifetime.
+// Keyed per document for cross-window embedding.
 let fontFaceCacheByDocument = new WeakMap<Document, Map<string, FontFace>>()
 
 function getFontFaceCacheKey(font: TLFontFace): string {

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -162,7 +162,12 @@ export class FontManager {
 	private findOrCreateFontFace(font: TLFontFace) {
 		const containerDocument = this.editor.getContainerDocument()
 
-		// See `fontFaceCacheByDocument` for why this is cached across FontManager instances.
+		// `findOrCreateFontFace` runs for every font on every editor mount, and a fresh
+		// editor (e.g. switching documents) gets a fresh FontManager with no memory of the
+		// previous one. The dedup below is an O(n) scan of the document's whole FontFaceSet,
+		// so without a cache that scan re-ran on every mount (measurably expensive on mobile
+		// Safari). Cache the resolved FontFace per document so repeated lookups - and
+		// remounts - are O(1). Keyed per document for cross-window embedding.
 		let cache = fontFaceCacheByDocument.get(containerDocument)
 		if (!cache) {
 			cache = new Map()
@@ -236,11 +241,10 @@ const defaultFontFaceDescriptors = {
 }
 
 // A FontFace is fully determined by its family and descriptors, so resolved faces can be
-// cached per document and reused across FontManager instances (e.g. editor remounts,
-// switching documents), turning the per-lookup O(n) FontFaceSet scan — measurably expensive
-// on mobile Safari — into an O(1) map lookup. Faces are never removed from `document.fonts`
-// (FontManager.dispose leaves them), so the cache stays valid for the document's lifetime.
-// Keyed per document for cross-window embedding.
+// cached per document and reused across FontManager instances (e.g. editor remounts),
+// turning the per-lookup FontFaceSet scan into an O(1) map lookup. Faces are never removed
+// from `document.fonts` (FontManager.dispose leaves them), so the cache stays valid for the
+// document's lifetime. Keyed per document for cross-window embedding.
 let fontFaceCacheByDocument = new WeakMap<Document, Map<string, FontFace>>()
 
 function getFontFaceCacheKey(font: TLFontFace): string {

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -125,7 +125,7 @@ export class HistoryManager<R extends UnknownRecord> {
 	}
 
 	// History
-	_undo({ pushToRedoStack, toMark = undefined }: { pushToRedoStack: boolean; toMark?: string }) {
+	_undo({ pushToRedoStack, toMark }: { pushToRedoStack: boolean; toMark?: string }) {
 		const previousState = this.state
 		const previousIsReplaying = this._isReplaying
 		this.state = HistoryRecorderState.Paused
@@ -278,7 +278,7 @@ export class HistoryManager<R extends UnknownRecord> {
 			top = top.tail
 		}
 
-		if (!top.head || top.head?.id !== id) {
+		if (!top.head) {
 			console.error('Could not find mark to squash to: ', id)
 			return this
 		}

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -474,10 +474,10 @@ export class InputsManager extends EditorManager {
 	 * @internal
 	 */
 	updatePointerVelocity(elapsed: number) {
+		if (elapsed === 0) return
+
 		const currentScreenPoint = this.getCurrentScreenPoint()
 		const pointerVelocity = this.getPointerVelocity()
-
-		if (elapsed === 0) return
 
 		const delta = Vec.Sub(currentScreenPoint, this._velocityPrevPoint)
 		this._velocityPrevPoint = currentScreenPoint.clone()
@@ -527,11 +527,14 @@ export class InputsManager extends EditorManager {
 		// The "screen point" is relative to the "screen bounds";
 		// it will be 0,0 when its actual screen position is equal
 		// to screenBounds.point. This is confusing!
-		this._currentScreenPoint.set(new Vec(sx, sy))
+		const nextScreenPoint = new Vec(sx, sy)
+		this._currentScreenPoint.set(nextScreenPoint)
 		const nx = sx / cz - cx
 		const ny = sy / cz - cy
+		let nextPagePoint = currentPagePoint
 		if (isFinite(nx) && isFinite(ny)) {
-			this._currentPagePoint.set(new Vec(nx, ny, sz))
+			nextPagePoint = new Vec(nx, ny, sz)
+			this._currentPagePoint.set(nextPagePoint)
 		}
 
 		this._isPen.set(info.type === 'pointer' && info.isPen)
@@ -539,20 +542,19 @@ export class InputsManager extends EditorManager {
 		// Reset velocity on pointer down, or when a pinch starts or ends
 		if (info.name === 'pointer_down' || isPinching) {
 			this._pointerVelocity.set(new Vec())
-			this._originScreenPoint.set(this._currentScreenPoint.__unsafe__getWithoutCapture())
-			this._originPagePoint.set(this._currentPagePoint.__unsafe__getWithoutCapture())
+			this._originScreenPoint.set(nextScreenPoint)
+			this._originPagePoint.set(nextPagePoint)
 		}
 
 		if (this._getHasCollaborators()) {
 			this.editor.run(
 				() => {
-					const pagePoint = this._currentPagePoint.__unsafe__getWithoutCapture()
 					this.editor.store.put([
 						{
 							id: TLPOINTER_ID,
 							typeName: 'pointer',
-							x: pagePoint.x,
-							y: pagePoint.y,
+							x: nextPagePoint.x,
+							y: nextPagePoint.y,
 							lastActivityTimestamp:
 								// If our pointer moved only because we're following some other user, then don't
 								// update our last activity timestamp; otherwise, update it to the current timestamp.

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
@@ -1,7 +1,8 @@
-import type { TLRecord, TLShapeId } from '@tldraw/tlschema'
+import type { TLRecord, TLShape, TLShapeId } from '@tldraw/tlschema'
 import { bind } from '@tldraw/utils'
 import EventEmitter from 'eventemitter3'
 import type { Editor } from '../../Editor'
+import type { TLEventMap, TLEventMapHandler } from '../../types/emit-types'
 import type {
 	TLCameraEndPerfEvent,
 	TLCameraStartPerfEvent,
@@ -9,28 +10,50 @@ import type {
 	TLInteractionEndPerfEvent,
 	TLInteractionStartPerfEvent,
 	TLPerfEventMap,
+	TLPerfFrameTimeStats,
 	TLPerfLongAnimationFrame,
 	TLShapeOperationPerfEvent,
 	TLUndoRedoPerfEvent,
 } from './perf-types'
+
+interface PerfSession {
+	startTime: number
+	frameTimes: number[]
+	loafEntries: TLPerfLongAnimationFrame[]
+}
 
 function percentile(sorted: number[], p: number): number {
 	const idx = Math.ceil(p * sorted.length) - 1
 	return sorted[Math.max(0, idx)]
 }
 
-function computeFrameTimeStats(frameTimes: number[]) {
-	if (frameTimes.length === 0) return { avg: 0, median: 0, p95: 0, p99: 0, min: 0, max: 0 }
+function computeFrameTimeStats(session: PerfSession): TLPerfFrameTimeStats {
+	const { frameTimes, loafEntries } = session
+	const duration = performance.now() - session.startTime
 	const sorted = [...frameTimes].sort((a, b) => a - b)
+	const n = sorted.length
 	const sum = sorted.reduce((a, b) => a + b, 0)
 	return {
-		avg: sum / sorted.length,
-		median: percentile(sorted, 0.5),
-		p95: percentile(sorted, 0.95),
-		p99: percentile(sorted, 0.99),
-		min: sorted[0],
-		max: sorted[sorted.length - 1],
+		duration,
+		fps: n > 0 ? (n / duration) * 1000 : 0,
+		frameCount: n,
+		avgFrameTime: n > 0 ? sum / n : 0,
+		medianFrameTime: n > 0 ? percentile(sorted, 0.5) : 0,
+		p95FrameTime: n > 0 ? percentile(sorted, 0.95) : 0,
+		p99FrameTime: n > 0 ? percentile(sorted, 0.99) : 0,
+		minFrameTime: n > 0 ? sorted[0] : 0,
+		maxFrameTime: n > 0 ? sorted[n - 1] : 0,
+		frameTimes,
+		longAnimationFrames: loafEntries.length > 0 ? loafEntries : undefined,
 	}
+}
+
+function countShapeTypes(shapes: Iterable<TLShape>): Record<string, number> {
+	const counts: Record<string, number> = {}
+	for (const shape of shapes) {
+		counts[shape.type] = (counts[shape.type] || 0) + 1
+	}
+	return counts
 }
 
 function toLoafEntry(entry: PerformanceEntry): TLPerfLongAnimationFrame | null {
@@ -56,6 +79,14 @@ function toLoafEntry(entry: PerformanceEntry): TLPerfLongAnimationFrame | null {
 	}
 }
 
+const SHAPE_PERF_EVENTS = ['shapes-created', 'shapes-updated', 'shapes-deleted'] as const
+
+type ShapePerfEvent = (typeof SHAPE_PERF_EVENTS)[number]
+
+function isShapePerfEvent(event: keyof TLPerfEventMap): event is ShapePerfEvent {
+	return (SHAPE_PERF_EVENTS as readonly string[]).includes(event)
+}
+
 /**
  * Manages performance event subscriptions for the editor. Available as `editor.performance`.
  *
@@ -77,32 +108,23 @@ export class PerformanceManager {
 
 	private editor: Editor
 
-	// Active interaction tracking
-	private activeInteraction: {
-		name: string
-		path: string
-		startTime: number
-		frameTimes: number[]
-		selectedShapeTypes: Record<string, number>
-		loafEntries: TLPerfLongAnimationFrame[]
-	} | null = null
+	private activeInteraction:
+		| (PerfSession & {
+				name: string
+				path: string
+				selectedShapeTypes: Record<string, number>
+		  })
+		| null = null
 
-	// Active camera tracking
-	private activeCamera: {
-		type: 'panning' | 'zooming'
-		startTime: number
-		frameTimes: number[]
-		timeout: number | null
-		loafEntries: TLPerfLongAnimationFrame[]
-	} | null = null
+	private activeCamera:
+		| (PerfSession & {
+				type: 'panning' | 'zooming'
+				timeout: number | null
+		  })
+		| null = null
 
-	// Lazy listener cleanup functions
 	private frameCleanup: (() => void) | null = null
-	private shapeCreatedCleanup: (() => void) | null = null
-	private shapeEditedCleanup: (() => void) | null = null
-	private shapeDeletedCleanup: (() => void) | null = null
-
-	// LoAF observer
+	private shapeEventCleanups: { [K in ShapePerfEvent]?: () => void } = {}
 	private loafObserver: PerformanceObserver | null = null
 
 	constructor(editor: Editor) {
@@ -163,17 +185,13 @@ export class PerformanceManager {
 		this.activeCamera = null
 		this.frameCleanup?.()
 		this.frameCleanup = null
-		this.shapeCreatedCleanup?.()
-		this.shapeCreatedCleanup = null
-		this.shapeEditedCleanup?.()
-		this.shapeEditedCleanup = null
-		this.shapeDeletedCleanup?.()
-		this.shapeDeletedCleanup = null
+		for (const event of SHAPE_PERF_EVENTS) {
+			this.shapeEventCleanups[event]?.()
+			delete this.shapeEventCleanups[event]
+		}
 		this._stopLoafObserver()
 		this.emitter.removeAllListeners()
 	}
-
-	// --- Internal notification methods ---
 
 	/** @internal */
 	_notifyInteractionStart(name: string, path: string) {
@@ -190,18 +208,12 @@ export class PerformanceManager {
 			)
 		}
 
-		// Capture selected shape types at start
-		const selectedShapeTypes: Record<string, number> = {}
-		for (const shape of this.editor.getSelectedShapes()) {
-			selectedShapeTypes[shape.type] = (selectedShapeTypes[shape.type] || 0) + 1
-		}
-
 		this.activeInteraction = {
 			name,
 			path,
 			startTime: performance.now(),
 			frameTimes: [],
-			selectedShapeTypes,
+			selectedShapeTypes: countShapeTypes(this.editor.getSelectedShapes()),
 			loafEntries: [],
 		}
 
@@ -221,26 +233,12 @@ export class PerformanceManager {
 
 		if (this.emitter.listenerCount('interaction-end') === 0) return
 
-		const duration = performance.now() - interaction.startTime
-		const stats = computeFrameTimeStats(interaction.frameTimes)
-
 		const event: TLInteractionEndPerfEvent = {
 			name: interaction.name,
 			path: interaction.path,
-			duration,
-			fps:
-				interaction.frameTimes.length > 0 ? (interaction.frameTimes.length / duration) * 1000 : 0,
-			frameCount: interaction.frameTimes.length,
-			avgFrameTime: stats.avg,
-			medianFrameTime: stats.median,
-			p95FrameTime: stats.p95,
-			p99FrameTime: stats.p99,
-			minFrameTime: stats.min,
-			maxFrameTime: stats.max,
-			frameTimes: interaction.frameTimes,
+			...computeFrameTimeStats(interaction),
 			shapeCount: this.editor.getCurrentPageShapeIds().size,
 			selectedShapeTypes: interaction.selectedShapeTypes,
-			longAnimationFrames: interaction.loafEntries.length > 0 ? interaction.loafEntries : undefined,
 			zoomLevel: this.editor.getCamera().z,
 			timestamp: performance.now(),
 		}
@@ -256,24 +254,17 @@ export class PerformanceManager {
 			return
 		}
 
-		if (this.activeCamera) {
-			// Extend existing camera session
-			if (this.activeCamera.timeout) {
-				clearTimeout(this.activeCamera.timeout)
-			}
-			// If type changed, end old and start new
-			if (this.activeCamera.type !== type) {
-				this._endCameraSession()
-				this._startCameraSession(type)
-			} else {
-				// Reset timeout
-				this.activeCamera.timeout = this.editor.timers.setTimeout(
-					() => this._endCameraSession(),
-					50
-				)
-			}
-		} else {
+		if (!this.activeCamera) {
 			this._startCameraSession(type)
+			return
+		}
+
+		if (this.activeCamera.timeout) clearTimeout(this.activeCamera.timeout)
+		if (this.activeCamera.type !== type) {
+			this._endCameraSession()
+			this._startCameraSession(type)
+		} else {
+			this.activeCamera.timeout = this._scheduleCameraSessionEnd()
 		}
 	}
 
@@ -289,14 +280,16 @@ export class PerformanceManager {
 		this.emitter.emit(type, event)
 	}
 
-	// --- Private helpers ---
+	private _scheduleCameraSessionEnd() {
+		return this.editor.timers.setTimeout(() => this._endCameraSession(), 50)
+	}
 
 	private _startCameraSession(type: 'panning' | 'zooming') {
 		this.activeCamera = {
 			type,
 			startTime: performance.now(),
 			frameTimes: [],
-			timeout: this.editor.timers.setTimeout(() => this._endCameraSession(), 50),
+			timeout: this._scheduleCameraSessionEnd(),
 			loafEntries: [],
 		}
 
@@ -317,28 +310,16 @@ export class PerformanceManager {
 
 		if (this.emitter.listenerCount('camera-end') === 0) return
 
-		const duration = performance.now() - camera.startTime
-		const stats = computeFrameTimeStats(camera.frameTimes)
 		const viewportBounds = this.editor.getViewportScreenBounds()
 		const totalShapes = this.editor.getCurrentPageShapeIds().size
 		const culledShapeCount = this.editor.getCulledShapes().size
 
 		const event: TLCameraEndPerfEvent = {
 			type: camera.type,
-			duration,
-			fps: camera.frameTimes.length > 0 ? (camera.frameTimes.length / duration) * 1000 : 0,
-			frameCount: camera.frameTimes.length,
-			avgFrameTime: stats.avg,
-			medianFrameTime: stats.median,
-			p95FrameTime: stats.p95,
-			p99FrameTime: stats.p99,
-			minFrameTime: stats.min,
-			maxFrameTime: stats.max,
-			frameTimes: camera.frameTimes,
+			...computeFrameTimeStats(camera),
 			shapeCount: totalShapes,
 			viewportWidth: viewportBounds.w,
 			viewportHeight: viewportBounds.h,
-			longAnimationFrames: camera.loafEntries.length > 0 ? camera.loafEntries : undefined,
 			visibleShapeCount: totalShapes - culledShapeCount,
 			culledShapeCount,
 			zoomLevel: this.editor.getCamera().z,
@@ -349,19 +330,12 @@ export class PerformanceManager {
 
 	@bind
 	private _onFrame(elapsed: number) {
-		// Record frame time for active interaction/camera
-		if (this.activeInteraction) {
-			this.activeInteraction.frameTimes.push(elapsed)
-		}
-		if (this.activeCamera) {
-			this.activeCamera.frameTimes.push(elapsed)
-		}
+		this.activeInteraction?.frameTimes.push(elapsed)
+		this.activeCamera?.frameTimes.push(elapsed)
 
-		// Emit standalone frame event if listeners exist
 		if (this.emitter.listenerCount('frame') > 0) {
 			const totalShapes = this.editor.getCurrentPageShapeIds().size
-			const culledShapes = this.editor.getCulledShapes()
-			const culledCount = culledShapes.size
+			const culledCount = this.editor.getCulledShapes().size
 			const event: TLFramePerfEvent = {
 				elapsed,
 				shapeCount: totalShapes,
@@ -372,67 +346,46 @@ export class PerformanceManager {
 		}
 	}
 
-	@bind
-	private _onShapesCreated(records: TLRecord[]) {
-		if (this.emitter.listenerCount('shapes-created') === 0) return
-		const shapeTypes: Record<string, number> = {}
-		for (const record of records) {
-			if (record.typeName === 'shape') {
-				shapeTypes[record.type] = (shapeTypes[record.type] || 0) + 1
-			}
-		}
-		const count = Object.values(shapeTypes).reduce((a, b) => a + b, 0)
-		if (count === 0) return
-		const event: TLShapeOperationPerfEvent = {
-			operation: 'create',
-			count,
-			shapeTypes,
+	private _emitShapeRecordsEvent(
+		event: 'shapes-created' | 'shapes-updated',
+		operation: 'create' | 'update',
+		records: TLRecord[]
+	) {
+		if (this.emitter.listenerCount(event) === 0) return
+		const shapes = records.filter((r): r is TLShape => r.typeName === 'shape')
+		if (shapes.length === 0) return
+		const perfEvent: TLShapeOperationPerfEvent = {
+			operation,
+			count: shapes.length,
+			shapeTypes: countShapeTypes(shapes),
 			timestamp: performance.now(),
 		}
-		this.emitter.emit('shapes-created', event)
+		this.emitter.emit(event, perfEvent)
+	}
+
+	@bind
+	private _onShapesCreated(records: TLRecord[]) {
+		this._emitShapeRecordsEvent('shapes-created', 'create', records)
 	}
 
 	@bind
 	private _onShapesEdited(records: TLRecord[]) {
-		if (this.emitter.listenerCount('shapes-updated') === 0) return
-		const shapeTypes: Record<string, number> = {}
-		for (const record of records) {
-			if (record.typeName === 'shape') {
-				shapeTypes[record.type] = (shapeTypes[record.type] || 0) + 1
-			}
-		}
-		const count = Object.values(shapeTypes).reduce((a, b) => a + b, 0)
-		if (count === 0) return
-		const event: TLShapeOperationPerfEvent = {
-			operation: 'update',
-			count,
-			shapeTypes,
-			timestamp: performance.now(),
-		}
-		this.emitter.emit('shapes-updated', event)
+		this._emitShapeRecordsEvent('shapes-updated', 'update', records)
 	}
 
 	@bind
 	private _onShapesDeleted(ids: TLShapeId[]) {
 		if (this.emitter.listenerCount('shapes-deleted') === 0) return
-		const shapeTypes: Record<string, number> = {}
-		for (const id of ids) {
-			// Works because 'deleted-shapes' fires before store.remove() in Editor.deleteShapes
-			const shape = this.editor.getShape(id)
-			if (shape) {
-				shapeTypes[shape.type] = (shapeTypes[shape.type] || 0) + 1
-			}
-		}
+		// Works because 'deleted-shapes' fires before store.remove() in Editor.deleteShapes
+		const shapes = ids.map((id) => this.editor.getShape(id)).filter((s): s is TLShape => !!s)
 		const event: TLShapeOperationPerfEvent = {
 			operation: 'delete',
 			count: ids.length,
-			shapeTypes,
+			shapeTypes: countShapeTypes(shapes),
 			timestamp: performance.now(),
 		}
 		this.emitter.emit('shapes-deleted', event)
 	}
-
-	// --- LoAF observer ---
 
 	private _startLoafObserver() {
 		if (typeof PerformanceObserver === 'undefined') return
@@ -445,21 +398,14 @@ export class PerformanceManager {
 		}
 
 		this.loafObserver = new PerformanceObserver((list) => {
-			const isInteractionActive = this.activeInteraction !== null
-			const isCameraActive = this.activeCamera !== null
-
-			if (!isInteractionActive && !isCameraActive) return
+			const { activeInteraction, activeCamera } = this
+			if (!activeInteraction && !activeCamera) return
 
 			for (const entry of list.getEntries()) {
 				const loaf = toLoafEntry(entry)
 				if (!loaf) continue
-
-				if (isInteractionActive) {
-					this.activeInteraction!.loafEntries.push(loaf)
-				}
-				if (isCameraActive) {
-					this.activeCamera!.loafEntries.push(loaf)
-				}
+				activeInteraction?.loafEntries.push(loaf)
+				activeCamera?.loafEntries.push(loaf)
 			}
 		})
 
@@ -473,8 +419,7 @@ export class PerformanceManager {
 		}
 	}
 
-	// --- Lazy listener management ---
-
+	// The frame listener also feeds interaction/camera frame-time tracking, not just 'frame'.
 	private _needsFrameListener(): boolean {
 		return (
 			this.emitter.listenerCount('frame') > 0 ||
@@ -492,92 +437,53 @@ export class PerformanceManager {
 		)
 	}
 
+	private _listen<K extends keyof TLEventMap>(event: K, fn: TLEventMapHandler<K>) {
+		this.editor.on(event, fn)
+		return () => this.editor.off(event, fn)
+	}
+
+	private _attachShapeListener(event: ShapePerfEvent) {
+		switch (event) {
+			case 'shapes-created':
+				return this._listen('created-shapes', this._onShapesCreated)
+			case 'shapes-updated':
+				return this._listen('edited-shapes', this._onShapesEdited)
+			case 'shapes-deleted':
+				return this._listen('deleted-shapes', this._onShapesDeleted)
+		}
+	}
+
 	private _maybeAttachLazyListeners(event: keyof TLPerfEventMap) {
-		// Frame listener needed for frame event + interaction/camera frame time tracking
-		if (
-			!this.frameCleanup &&
-			(event === 'frame' ||
-				event === 'interaction-start' ||
-				event === 'interaction-end' ||
-				event === 'camera-start' ||
-				event === 'camera-end')
-		) {
-			if (this._needsFrameListener()) {
-				this.editor.on('frame', this._onFrame)
-				this.frameCleanup = () => this.editor.off('frame', this._onFrame)
-			}
+		if (!this.frameCleanup && this._needsFrameListener()) {
+			this.frameCleanup = this._listen('frame', this._onFrame)
 		}
 
-		// LoAF observer needed when interaction-end or camera-end listeners exist
-		if (!this.loafObserver && (event === 'interaction-end' || event === 'camera-end')) {
-			if (this._needsLoafObserver()) {
-				this._startLoafObserver()
-			}
+		if (!this.loafObserver && this._needsLoafObserver()) {
+			this._startLoafObserver()
 		}
 
-		if (!this.shapeCreatedCleanup && event === 'shapes-created') {
-			this.editor.on('created-shapes', this._onShapesCreated)
-			this.shapeCreatedCleanup = () => this.editor.off('created-shapes', this._onShapesCreated)
-		}
-
-		if (!this.shapeEditedCleanup && event === 'shapes-updated') {
-			this.editor.on('edited-shapes', this._onShapesEdited)
-			this.shapeEditedCleanup = () => this.editor.off('edited-shapes', this._onShapesEdited)
-		}
-
-		if (!this.shapeDeletedCleanup && event === 'shapes-deleted') {
-			this.editor.on('deleted-shapes', this._onShapesDeleted)
-			this.shapeDeletedCleanup = () => this.editor.off('deleted-shapes', this._onShapesDeleted)
+		if (isShapePerfEvent(event) && !this.shapeEventCleanups[event]) {
+			this.shapeEventCleanups[event] = this._attachShapeListener(event)
 		}
 	}
 
 	private _maybeDetachLazyListeners(event: keyof TLPerfEventMap) {
-		if (
-			this.frameCleanup &&
-			(event === 'frame' ||
-				event === 'interaction-start' ||
-				event === 'interaction-end' ||
-				event === 'camera-start' ||
-				event === 'camera-end')
-		) {
-			if (!this._needsFrameListener()) {
-				this.frameCleanup()
-				this.frameCleanup = null
-			}
+		if (this.frameCleanup && !this._needsFrameListener()) {
+			this.frameCleanup()
+			this.frameCleanup = null
 		}
 
-		// Stop LoAF observer when no longer needed
-		if (this.loafObserver && (event === 'interaction-end' || event === 'camera-end')) {
-			if (!this._needsLoafObserver()) {
-				this._stopLoafObserver()
-			}
+		if (this.loafObserver && !this._needsLoafObserver()) {
+			this._stopLoafObserver()
 		}
 
 		if (
-			this.shapeCreatedCleanup &&
-			event === 'shapes-created' &&
-			this.emitter.listenerCount('shapes-created') === 0
+			isShapePerfEvent(event) &&
+			this.shapeEventCleanups[event] &&
+			this.emitter.listenerCount(event) === 0
 		) {
-			this.shapeCreatedCleanup()
-			this.shapeCreatedCleanup = null
-		}
-
-		if (
-			this.shapeEditedCleanup &&
-			event === 'shapes-updated' &&
-			this.emitter.listenerCount('shapes-updated') === 0
-		) {
-			this.shapeEditedCleanup()
-			this.shapeEditedCleanup = null
-		}
-
-		if (
-			this.shapeDeletedCleanup &&
-			event === 'shapes-deleted' &&
-			this.emitter.listenerCount('shapes-deleted') === 0
-		) {
-			this.shapeDeletedCleanup()
-			this.shapeDeletedCleanup = null
+			this.shapeEventCleanups[event]!()
+			delete this.shapeEventCleanups[event]
 		}
 	}
 }

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
@@ -114,6 +114,7 @@ export class PerformanceManager {
 
 	private editor: Editor
 
+	// Active interaction tracking
 	private activeInteraction:
 		| (PerfSession & {
 				name: string
@@ -122,6 +123,7 @@ export class PerformanceManager {
 		  })
 		| null = null
 
+	// Active camera tracking
 	private activeCamera:
 		| (PerfSession & {
 				type: 'panning' | 'zooming'
@@ -129,8 +131,11 @@ export class PerformanceManager {
 		  })
 		| null = null
 
+	// Lazy listener cleanup functions
 	private frameCleanup: (() => void) | null = null
 	private shapeEventCleanups: { [K in ShapePerfEvent]?: () => void } = {}
+
+	// LoAF observer
 	private loafObserver: PerformanceObserver | null = null
 
 	constructor(editor: Editor) {
@@ -199,6 +204,8 @@ export class PerformanceManager {
 		this.emitter.removeAllListeners()
 	}
 
+	// --- Internal notification methods ---
+
 	/** @internal */
 	_notifyInteractionStart(name: string, path: string) {
 		if (
@@ -265,11 +272,14 @@ export class PerformanceManager {
 			return
 		}
 
+		// Extend existing camera session
 		if (this.activeCamera.timeout) clearTimeout(this.activeCamera.timeout)
+		// If type changed, end old and start new
 		if (this.activeCamera.type !== type) {
 			this._endCameraSession()
 			this._startCameraSession(type)
 		} else {
+			// Reset timeout
 			this.activeCamera.timeout = this._scheduleCameraSessionEnd()
 		}
 	}
@@ -285,6 +295,8 @@ export class PerformanceManager {
 		}
 		this.emitter.emit(type, event)
 	}
+
+	// --- Private helpers ---
 
 	private _scheduleCameraSessionEnd() {
 		return this.editor.timers.setTimeout(() => this._endCameraSession(), 50)
@@ -336,9 +348,11 @@ export class PerformanceManager {
 
 	@bind
 	private _onFrame(elapsed: number) {
+		// Record frame time for active interaction/camera
 		this.activeInteraction?.frameTimes.push(elapsed)
 		this.activeCamera?.frameTimes.push(elapsed)
 
+		// Emit standalone frame event if listeners exist
 		if (this.emitter.listenerCount('frame') > 0) {
 			const totalShapes = this.editor.getCurrentPageShapeIds().size
 			const culledCount = this.editor.getCulledShapes().size
@@ -399,6 +413,8 @@ export class PerformanceManager {
 		this._emitShapeOperationEvent('shapes-deleted', 'delete', shapes, ids.length)
 	}
 
+	// --- LoAF observer ---
+
 	private _startLoafObserver() {
 		if (typeof PerformanceObserver === 'undefined') return
 
@@ -431,7 +447,8 @@ export class PerformanceManager {
 		}
 	}
 
-	// The frame listener also feeds interaction/camera frame-time tracking, not just 'frame'.
+	// --- Lazy listener management ---
+
 	private _needsFrameListener(): boolean {
 		return (
 			this.emitter.listenerCount('frame') > 0 ||
@@ -466,10 +483,12 @@ export class PerformanceManager {
 	}
 
 	private _maybeAttachLazyListeners(event: keyof TLPerfEventMap) {
+		// Frame listener needed for frame event + interaction/camera frame time tracking
 		if (!this.frameCleanup && this._needsFrameListener()) {
 			this.frameCleanup = this._listen('frame', this._onFrame)
 		}
 
+		// LoAF observer needed when interaction-end or camera-end listeners exist
 		if (!this.loafObserver && this._needsLoafObserver()) {
 			this._startLoafObserver()
 		}
@@ -485,6 +504,7 @@ export class PerformanceManager {
 			this.frameCleanup = null
 		}
 
+		// Stop LoAF observer when no longer needed
 		if (this.loafObserver && !this._needsLoafObserver()) {
 			this._stopLoafObserver()
 		}

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
@@ -1,4 +1,4 @@
-import type { TLRecord, TLShape, TLShapeId } from '@tldraw/tlschema'
+import { isShape, type TLRecord, type TLShape, type TLShapeId } from '@tldraw/tlschema'
 import { bind } from '@tldraw/utils'
 import EventEmitter from 'eventemitter3'
 import type { Editor } from '../../Editor'
@@ -45,6 +45,12 @@ function computeFrameTimeStats(session: PerfSession): TLPerfFrameTimeStats {
 		maxFrameTime: n > 0 ? sorted[n - 1] : 0,
 		frameTimes,
 		longAnimationFrames: loafEntries.length > 0 ? loafEntries : undefined,
+	}
+}
+
+function* shapeRecords(records: TLRecord[]): Generator<TLShape> {
+	for (const record of records) {
+		if (isShape(record)) yield record
 	}
 }
 
@@ -346,18 +352,30 @@ export class PerformanceManager {
 		}
 	}
 
-	private _emitShapeRecordsEvent(
-		event: 'shapes-created' | 'shapes-updated',
-		operation: 'create' | 'update',
-		records: TLRecord[]
+	/**
+	 * Counts shape records in a single pass. `count` overrides the emitted count (deletes report
+	 * the number of ids requested, even if some shapes are already gone); without it, an event
+	 * with no shapes is skipped.
+	 */
+	private _emitShapeOperationEvent(
+		event: ShapePerfEvent,
+		operation: TLShapeOperationPerfEvent['operation'],
+		shapes: Iterable<TLShape | undefined>,
+		count?: number
 	) {
 		if (this.emitter.listenerCount(event) === 0) return
-		const shapes = records.filter((r): r is TLShape => r.typeName === 'shape')
-		if (shapes.length === 0) return
+		const shapeTypes: Record<string, number> = {}
+		let shapeCount = 0
+		for (const shape of shapes) {
+			if (!shape) continue
+			shapeTypes[shape.type] = (shapeTypes[shape.type] || 0) + 1
+			shapeCount++
+		}
+		if (count === undefined && shapeCount === 0) return
 		const perfEvent: TLShapeOperationPerfEvent = {
 			operation,
-			count: shapes.length,
-			shapeTypes: countShapeTypes(shapes),
+			count: count ?? shapeCount,
+			shapeTypes,
 			timestamp: performance.now(),
 		}
 		this.emitter.emit(event, perfEvent)
@@ -365,26 +383,20 @@ export class PerformanceManager {
 
 	@bind
 	private _onShapesCreated(records: TLRecord[]) {
-		this._emitShapeRecordsEvent('shapes-created', 'create', records)
+		this._emitShapeOperationEvent('shapes-created', 'create', shapeRecords(records))
 	}
 
 	@bind
 	private _onShapesEdited(records: TLRecord[]) {
-		this._emitShapeRecordsEvent('shapes-updated', 'update', records)
+		this._emitShapeOperationEvent('shapes-updated', 'update', shapeRecords(records))
 	}
 
 	@bind
 	private _onShapesDeleted(ids: TLShapeId[]) {
 		if (this.emitter.listenerCount('shapes-deleted') === 0) return
 		// Works because 'deleted-shapes' fires before store.remove() in Editor.deleteShapes
-		const shapes = ids.map((id) => this.editor.getShape(id)).filter((s): s is TLShape => !!s)
-		const event: TLShapeOperationPerfEvent = {
-			operation: 'delete',
-			count: ids.length,
-			shapeTypes: countShapeTypes(shapes),
-			timestamp: performance.now(),
-		}
-		this.emitter.emit('shapes-deleted', event)
+		const shapes = ids.map((id) => this.editor.getShape(id))
+		this._emitShapeOperationEvent('shapes-deleted', 'delete', shapes, ids.length)
 	}
 
 	private _startLoafObserver() {

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -251,8 +251,12 @@ export class ScribbleManager {
 	 * @public
 	 */
 	addPoint(id: string, x: number, y: number, z = 0.5): ScribbleItem {
-		const { session, item } = this.findItem(id)
-		return this.setNextPoint(session, item, x, y, z)
+		// Runs on every pointer move, so search inline rather than allocating a {session, item} pair.
+		for (const session of this.sessions.values()) {
+			const item = session.items.find((i) => i.id === id)
+			if (item) return this.setNextPoint(session, item, x, y, z)
+		}
+		throw Error(`Scribble with id ${id} not found`)
 	}
 
 	/**
@@ -263,7 +267,7 @@ export class ScribbleManager {
 	 * @public
 	 */
 	complete(id: string): ScribbleItem {
-		const { item } = this.findItem(id)
+		const item = this.findItem(id)
 		if (item.scribble.state === 'starting' || item.scribble.state === 'active') {
 			item.scribble.state = 'complete'
 		}
@@ -277,7 +281,7 @@ export class ScribbleManager {
 	 * @public
 	 */
 	stop(id: string): ScribbleItem {
-		const { item } = this.findItem(id)
+		const item = this.findItem(id)
 		this.stopItem(item)
 		return item
 	}
@@ -333,10 +337,10 @@ export class ScribbleManager {
 		})
 	}
 
-	private findItem(id: string): { session: Session; item: ScribbleItem } {
+	private findItem(id: string): ScribbleItem {
 		for (const session of this.sessions.values()) {
 			const item = session.items.find((i) => i.id === id)
-			if (item) return { session, item }
+			if (item) return item
 		}
 		throw Error(`Scribble with id ${id} not found`)
 	}

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -44,6 +44,7 @@ export interface ScribbleSessionOptions {
 	fadeDurationMs?: number
 }
 
+// Internal session state (not exported)
 interface Session {
 	id: string
 	items: ScribbleItem[]
@@ -59,6 +60,8 @@ export class ScribbleManager {
 	private sessions = new Map<string, Session>()
 
 	constructor(private editor: Editor) {}
+
+	// ==================== SESSION API ====================
 
 	/**
 	 * Start a new session for grouping scribbles.
@@ -86,6 +89,8 @@ export class ScribbleManager {
 		}
 
 		this.sessions.set(id, session)
+
+		// Set up idle timeout if configured
 		this.resetIdleTimeout(session)
 
 		return id
@@ -128,6 +133,8 @@ export class ScribbleManager {
 		}
 
 		session.items.push(item)
+
+		// Reset idle timeout on activity
 		this.resetIdleTimeout(session)
 
 		return item
@@ -227,6 +234,8 @@ export class ScribbleManager {
 		return session?.state === 'active'
 	}
 
+	// ==================== SIMPLE API (for eraser, select, etc.) ====================
+
 	/**
 	 * Add a scribble using the default self-consuming behavior.
 	 * Creates an implicit session for the scribble.
@@ -310,10 +319,12 @@ export class ScribbleManager {
 		if (this.sessions.size === 0 && currentScribbles.length === 0) return
 
 		this.editor.run(() => {
+			// Tick all sessions
 			for (const session of this.sessions.values()) {
 				this.tickSession(session, elapsed)
 			}
 
+			// Remove completed sessions
 			for (const [id, session] of this.sessions) {
 				if (session.state === 'complete') {
 					this.clearIdleTimeout(session)
@@ -321,6 +332,7 @@ export class ScribbleManager {
 				}
 			}
 
+			// Collect scribbles from all sessions
 			const scribbles: TLScribble[] = []
 			for (const session of this.sessions.values()) {
 				for (const item of session.items) {
@@ -337,6 +349,8 @@ export class ScribbleManager {
 		})
 	}
 
+	// ==================== PRIVATE HELPERS ====================
+
 	private findItem(id: string): ScribbleItem {
 		for (const session of this.sessions.values()) {
 			const item = session.items.find((i) => i.id === id)
@@ -350,7 +364,10 @@ export class ScribbleManager {
 		if (!item.prev || Vec.Dist(item.prev, point) >= 1) {
 			item.next = point
 		}
+
+		// Reset idle timeout on activity
 		this.resetIdleTimeout(session)
+
 		return item
 	}
 
@@ -420,6 +437,7 @@ export class ScribbleManager {
 			}
 		}
 
+		// Remove completed items in individual fade mode
 		if (session.options.fadeMode === 'individual') {
 			for (let i = session.items.length - 1; i >= 0; i--) {
 				if (session.items[i].scribble.points.length === 0) {

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -44,7 +44,6 @@ export interface ScribbleSessionOptions {
 	fadeDurationMs?: number
 }
 
-// Internal session state (not exported)
 interface Session {
 	id: string
 	items: ScribbleItem[]
@@ -60,8 +59,6 @@ export class ScribbleManager {
 	private sessions = new Map<string, Session>()
 
 	constructor(private editor: Editor) {}
-
-	// ==================== SESSION API ====================
 
 	/**
 	 * Start a new session for grouping scribbles.
@@ -89,11 +86,7 @@ export class ScribbleManager {
 		}
 
 		this.sessions.set(id, session)
-
-		// Set up idle timeout if configured
-		if (session.options.idleTimeoutMs > 0) {
-			this.resetIdleTimeout(session)
-		}
+		this.resetIdleTimeout(session)
 
 		return id
 	}
@@ -135,11 +128,7 @@ export class ScribbleManager {
 		}
 
 		session.items.push(item)
-
-		// Reset idle timeout on activity
-		if (session.options.idleTimeoutMs > 0) {
-			this.resetIdleTimeout(session)
-		}
+		this.resetIdleTimeout(session)
 
 		return item
 	}
@@ -167,17 +156,7 @@ export class ScribbleManager {
 		const item = session.items.find((i) => i.id === scribbleId)
 		if (!item) throw Error(`Scribble ${scribbleId} not found in session ${sessionId}`)
 
-		const point = { x, y, z }
-		if (!item.prev || Vec.Dist(item.prev, point) >= 1) {
-			item.next = point
-		}
-
-		// Reset idle timeout on activity
-		if (session.options.idleTimeoutMs > 0) {
-			this.resetIdleTimeout(session)
-		}
-
-		return item
+		return this.setNextPoint(session, item, x, y, z)
 	}
 
 	/**
@@ -188,11 +167,7 @@ export class ScribbleManager {
 	 */
 	extendSession(sessionId: string): void {
 		const session = this.sessions.get(sessionId)
-		if (!session) return
-
-		if (session.options.idleTimeoutMs > 0) {
-			this.resetIdleTimeout(session)
-		}
+		if (session) this.resetIdleTimeout(session)
 	}
 
 	/**
@@ -219,8 +194,7 @@ export class ScribbleManager {
 			}
 		} else {
 			for (const item of session.items) {
-				item.delayRemaining = Math.min(item.delayRemaining, 200)
-				item.scribble.state = 'stopping'
+				this.stopItem(item)
 			}
 		}
 	}
@@ -253,8 +227,6 @@ export class ScribbleManager {
 		return session?.state === 'active'
 	}
 
-	// ==================== SIMPLE API (for eraser, select, etc.) ====================
-
 	/**
 	 * Add a scribble using the default self-consuming behavior.
 	 * Creates an implicit session for the scribble.
@@ -279,20 +251,8 @@ export class ScribbleManager {
 	 * @public
 	 */
 	addPoint(id: string, x: number, y: number, z = 0.5): ScribbleItem {
-		for (const session of this.sessions.values()) {
-			const item = session.items.find((i) => i.id === id)
-			if (item) {
-				const point = { x, y, z }
-				if (!item.prev || Vec.Dist(item.prev, point) >= 1) {
-					item.next = point
-				}
-				if (session.options.idleTimeoutMs > 0) {
-					this.resetIdleTimeout(session)
-				}
-				return item
-			}
-		}
-		throw Error(`Scribble with id ${id} not found`)
+		const { session, item } = this.findItem(id)
+		return this.setNextPoint(session, item, x, y, z)
 	}
 
 	/**
@@ -303,16 +263,11 @@ export class ScribbleManager {
 	 * @public
 	 */
 	complete(id: string): ScribbleItem {
-		for (const session of this.sessions.values()) {
-			const item = session.items.find((i) => i.id === id)
-			if (item) {
-				if (item.scribble.state === 'starting' || item.scribble.state === 'active') {
-					item.scribble.state = 'complete'
-				}
-				return item
-			}
+		const { item } = this.findItem(id)
+		if (item.scribble.state === 'starting' || item.scribble.state === 'active') {
+			item.scribble.state = 'complete'
 		}
-		throw Error(`Scribble with id ${id} not found`)
+		return item
 	}
 
 	/**
@@ -322,15 +277,9 @@ export class ScribbleManager {
 	 * @public
 	 */
 	stop(id: string): ScribbleItem {
-		for (const session of this.sessions.values()) {
-			const item = session.items.find((i) => i.id === id)
-			if (item) {
-				item.delayRemaining = Math.min(item.delayRemaining, 200)
-				item.scribble.state = 'stopping'
-				return item
-			}
-		}
-		throw Error(`Scribble with id ${id} not found`)
+		const { item } = this.findItem(id)
+		this.stopItem(item)
+		return item
 	}
 
 	/**
@@ -357,12 +306,10 @@ export class ScribbleManager {
 		if (this.sessions.size === 0 && currentScribbles.length === 0) return
 
 		this.editor.run(() => {
-			// Tick all sessions
 			for (const session of this.sessions.values()) {
 				this.tickSession(session, elapsed)
 			}
 
-			// Remove completed sessions
 			for (const [id, session] of this.sessions) {
 				if (session.state === 'complete') {
 					this.clearIdleTimeout(session)
@@ -370,7 +317,6 @@ export class ScribbleManager {
 				}
 			}
 
-			// Collect scribbles from all sessions
 			const scribbles: TLScribble[] = []
 			for (const session of this.sessions.values()) {
 				for (const item of session.items) {
@@ -387,10 +333,47 @@ export class ScribbleManager {
 		})
 	}
 
-	// ==================== PRIVATE HELPERS ====================
+	private findItem(id: string): { session: Session; item: ScribbleItem } {
+		for (const session of this.sessions.values()) {
+			const item = session.items.find((i) => i.id === id)
+			if (item) return { session, item }
+		}
+		throw Error(`Scribble with id ${id} not found`)
+	}
+
+	private setNextPoint(session: Session, item: ScribbleItem, x: number, y: number, z: number) {
+		const point = { x, y, z }
+		if (!item.prev || Vec.Dist(item.prev, point) >= 1) {
+			item.next = point
+		}
+		this.resetIdleTimeout(session)
+		return item
+	}
+
+	private stopItem(item: ScribbleItem): void {
+		item.delayRemaining = Math.min(item.delayRemaining, 200)
+		item.scribble.state = 'stopping'
+	}
+
+	/** Push the pending `next` point onto the scribble, if there is a new one. */
+	private consumeNextPoint(item: ScribbleItem): boolean {
+		const { next, prev } = item
+		if (!next || next === prev) return false
+		item.prev = next
+		item.scribble.points.push(next)
+		return true
+	}
+
+	private tickStartingItem(item: ScribbleItem): void {
+		this.consumeNextPoint(item)
+		if (item.scribble.points.length > 8) {
+			item.scribble.state = 'active'
+		}
+	}
 
 	private resetIdleTimeout(session: Session): void {
 		this.clearIdleTimeout(session)
+		if (session.options.idleTimeoutMs <= 0) return
 		session.idleTimeoutHandle = this.editor.timers.setTimeout(() => {
 			this.stopSession(session.id)
 		}, session.options.idleTimeoutMs)
@@ -433,7 +416,6 @@ export class ScribbleManager {
 			}
 		}
 
-		// Remove completed items in individual fade mode
 		if (session.options.fadeMode === 'individual') {
 			for (let i = session.items.length - 1; i >= 0; i--) {
 				if (session.items[i].scribble.points.length === 0) {
@@ -445,25 +427,10 @@ export class ScribbleManager {
 
 	private tickPersistentItem(item: ScribbleItem): void {
 		const { scribble } = item
-
 		if (scribble.state === 'starting') {
-			const { next, prev } = item
-			if (next && next !== prev) {
-				item.prev = next
-				scribble.points.push(next)
-			}
-			if (scribble.points.length > 8) {
-				scribble.state = 'active'
-			}
-			return
-		}
-
-		if (scribble.state === 'active') {
-			const { next, prev } = item
-			if (next && next !== prev) {
-				item.prev = next
-				scribble.points.push(next)
-			}
+			this.tickStartingItem(item)
+		} else if (scribble.state === 'active') {
+			this.consumeNextPoint(item)
 		}
 	}
 
@@ -471,14 +438,7 @@ export class ScribbleManager {
 		const { scribble } = item
 
 		if (scribble.state === 'starting') {
-			const { next, prev } = item
-			if (next && next !== prev) {
-				item.prev = next
-				scribble.points.push(next)
-			}
-			if (scribble.points.length > 8) {
-				scribble.state = 'active'
-			}
+			this.tickStartingItem(item)
 			return
 		}
 
@@ -491,23 +451,19 @@ export class ScribbleManager {
 			item.timeoutMs = 0
 		}
 
-		const { delayRemaining, timeoutMs, prev, next } = item
+		const { delayRemaining, timeoutMs } = item
 
 		switch (scribble.state) {
 			case 'active': {
-				if (next && next !== prev) {
-					item.prev = next
-					scribble.points.push(next)
+				if (this.consumeNextPoint(item)) {
 					if (delayRemaining === 0 && scribble.points.length > 8) {
 						scribble.points.shift()
 					}
-				} else {
-					if (timeoutMs === 0) {
-						if (scribble.points.length > 1) {
-							scribble.points.shift()
-						} else {
-							item.delayRemaining = scribble.delay
-						}
+				} else if (timeoutMs === 0) {
+					if (scribble.points.length > 1) {
+						scribble.points.shift()
+					} else {
+						item.delayRemaining = scribble.delay
 					}
 				}
 				break
@@ -534,11 +490,10 @@ export class ScribbleManager {
 	private tickGroupedFade(session: Session, elapsed: number): void {
 		session.fadeElapsed += elapsed
 
-		let remainingPoints = 0
-		for (const item of session.items) {
-			remainingPoints += item.scribble.points.length
-		}
-
+		const remainingPoints = session.items.reduce(
+			(sum, item) => sum + item.scribble.points.length,
+			0
+		)
 		if (remainingPoints === 0) return
 
 		if (session.fadeElapsed >= session.options.fadeDurationMs) {

--- a/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
@@ -175,6 +175,8 @@ function edgesEqual(a: [VecModel, VecModel], b: [VecModel, VecModel]) {
 function acceptNudge(nearestSnaps: NearestSnap[], minOffset: Vec, axis: 'x' | 'y', nudge: number) {
 	const offset = Math.abs(nudge)
 	if (round(offset) > round(minOffset[axis])) return false
+	// we found a point that is significantly closer than all previous points
+	// so wipe the slate clean and start over
 	if (round(offset) < round(minOffset[axis])) nearestSnaps.length = 0
 	minOffset[axis] = offset
 	return true
@@ -780,7 +782,46 @@ export class BoundsSnaps {
 					nudge: centerNudge,
 				}
 
-				// see the horizontal case above for why overlapping center snaps are collapsed
+				// we need to avoid creating visual noise with too many center snaps in situations
+				// where there are lots of adjacent items with even spacing
+				// so let's only show other center snaps where the gap's breadth does not overlap with this one
+				// i.e.
+				//                ┌───────────────┐
+				//                │               │
+				//                └──────┬────┬───┘
+				//                       ┼    │
+				//                 ┌─────┴┐   │
+				//                 │      │   ┼
+				//                 └─────┬┘   │
+				//                       ┼    │
+				//                   ┌───┴────┴───────┐
+				//                   │                │  ◄────  i'm dragging this one
+				//                   └───┬────┬───────┘
+				//            ─────►     ┼    │
+				//                 ┌─────┴┐   │                don't show these
+				// show these      │      │   ┼                larger gaps since
+				// smaller         └─────┬┘   │ ◄───────────── the smaller ones
+				// gaps                  ┼    │                cover the same
+				//              ─────►  ┌┴────┴─────┐          information
+				//                      │           │
+				//                      └───────────┘
+				//
+				// but we want to show all of these ones since the gap breadths don't overlap
+				//            ┌─────────────┐
+				//            │             │
+				// ┌────┐     └───┬─────────┘
+				// │    │         │
+				// └──┬─┘         ┼
+				//    ┼           │
+				// ┌──┴───────────┴─┐
+				// │                │ ◄───── i'm dragging this one
+				// └──┬───────────┬─┘
+				//    ┼           │
+				// ┌──┴────┐      ┼
+				// │       │      │
+				// └───────┘    ┌─┴───────┐
+				//              │         │
+				//              └─────────┘
 
 				const otherCenterSnap = nearestSnapsY.find(({ type }) => type === 'gap_center') as
 					| Extract<NearestSnap, { type: 'gap_center' }>

--- a/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
@@ -159,6 +159,27 @@ function findAdjacentGaps(
 	return matches
 }
 
+function edgesEqual(a: [VecModel, VecModel], b: [VecModel, VecModel]) {
+	return (
+		round(a[0].x) === round(b[0].x) &&
+		round(a[0].y) === round(b[0].y) &&
+		round(a[1].x) === round(b[1].x) &&
+		round(a[1].y) === round(b[1].y)
+	)
+}
+
+/**
+ * Records `nudge` as a candidate snap on one axis. Returns false if it is farther than the best
+ * so far; otherwise updates `minOffset` and clears the list first when it is strictly closer.
+ */
+function acceptNudge(nearestSnaps: NearestSnap[], minOffset: Vec, axis: 'x' | 'y', nudge: number) {
+	const offset = Math.abs(nudge)
+	if (round(offset) > round(minOffset[axis])) return false
+	if (round(offset) < round(minOffset[axis])) nearestSnaps.length = 0
+	minOffset[axis] = offset
+	return true
+}
+
 function dedupeGapSnaps(snaps: Array<Extract<SnapIndicator, { type: 'gaps' }>>) {
 	// sort by descending order of number of gaps
 	snaps.sort((a, b) => b.gaps.length - a.gaps.length)
@@ -172,20 +193,8 @@ function dedupeGapSnaps(snaps: Array<Extract<SnapIndicator, { type: 'gaps' }>>) 
 				otherSnap.direction === snap.direction &&
 				snap.gaps.every(
 					(gap) =>
-						otherSnap.gaps.some(
-							(otherGap) =>
-								round(gap.startEdge[0].x) === round(otherGap.startEdge[0].x) &&
-								round(gap.startEdge[0].y) === round(otherGap.startEdge[0].y) &&
-								round(gap.startEdge[1].x) === round(otherGap.startEdge[1].x) &&
-								round(gap.startEdge[1].y) === round(otherGap.startEdge[1].y)
-						) &&
-						otherSnap.gaps.some(
-							(otherGap) =>
-								round(gap.endEdge[0].x) === round(otherGap.endEdge[0].x) &&
-								round(gap.endEdge[0].y) === round(otherGap.endEdge[0].y) &&
-								round(gap.endEdge[1].x) === round(otherGap.endEdge[1].x) &&
-								round(gap.endEdge[1].y) === round(otherGap.endEdge[1].y)
-						)
+						otherSnap.gaps.some((otherGap) => edgesEqual(gap.startEdge, otherGap.startEdge)) &&
+						otherSnap.gaps.some((otherGap) => edgesEqual(gap.endEdge, otherGap.endEdge))
 				)
 			) {
 				snaps.splice(i, 1)
@@ -211,7 +220,6 @@ export class BoundsSnaps {
 			const snapPoints =
 				boundsSnapGeometry.points ?? editor.getShapeGeometry(shape).bounds.cornersAndCenter
 
-			if (!pageTransform || !snapPoints) return undefined
 			return snapPoints.map((point, i) => {
 				const { x, y } = Mat.applyToPoint(pageTransform, point)
 				return { x, y, id: `${shape.id}:${i}` }
@@ -250,17 +258,15 @@ export class BoundsSnaps {
 		const horizontal: Gap[] = []
 		const vertical: Gap[] = []
 
-		let startNode: GapNode, endNode: GapNode
-
 		const sortedShapesOnCurrentPageHorizontal = this.getSnappableGapNodes().sort((a, b) => {
 			return a.pageBounds.minX - b.pageBounds.minX
 		})
 
 		// Collect horizontal gaps
 		for (let i = 0; i < sortedShapesOnCurrentPageHorizontal.length; i++) {
-			startNode = sortedShapesOnCurrentPageHorizontal[i]
+			const startNode = sortedShapesOnCurrentPageHorizontal[i]
 			for (let j = i + 1; j < sortedShapesOnCurrentPageHorizontal.length; j++) {
-				endNode = sortedShapesOnCurrentPageHorizontal[j]
+				const endNode = sortedShapesOnCurrentPageHorizontal[j]
 
 				if (
 					// is there space between the boxes
@@ -302,9 +308,9 @@ export class BoundsSnaps {
 		})
 
 		for (let i = 0; i < sortedShapesOnCurrentPageVertical.length; i++) {
-			startNode = sortedShapesOnCurrentPageVertical[i]
+			const startNode = sortedShapesOnCurrentPageVertical[i]
 			for (let j = i + 1; j < sortedShapesOnCurrentPageVertical.length; j++) {
-				endNode = sortedShapesOnCurrentPageVertical[j]
+				const endNode = sortedShapesOnCurrentPageVertical[j]
 
 				if (
 					// is there space between the boxes
@@ -355,7 +361,7 @@ export class BoundsSnaps {
 		dragDelta: Vec
 	}): SnapData {
 		const snapThreshold = this.manager.getSnapThreshold()
-		const visibleSnapPointsNotInSelection = this.getSnappablePoints()
+		const otherNodeSnapPoints = this.getSnappablePoints()
 
 		const selectionPageBounds = initialSelectionPageBounds.clone().translate(dragDelta)
 
@@ -366,8 +372,6 @@ export class BoundsSnaps {
 				y: y + dragDelta.y,
 			})
 		)
-
-		const otherNodeSnapPoints = visibleSnapPointsNotInSelection
 
 		const nearestSnapsX: NearestSnap[] = []
 		const nearestSnapsY: NearestSnap[] = []
@@ -577,7 +581,7 @@ export class BoundsSnaps {
 			nearestSnapsY,
 		})
 
-		this.manager.setIndicators([...pointSnaps])
+		this.manager.setIndicators(pointSnaps)
 
 		return { nudge }
 	}
@@ -599,37 +603,23 @@ export class BoundsSnaps {
 		// which are closest to it in each axis
 		for (const thisSnapPoint of selectionSnapPoints) {
 			for (const otherSnapPoint of otherNodeSnapPoints) {
-				const offset = Vec.Sub(thisSnapPoint, otherSnapPoint)
-				const offsetX = Math.abs(offset.x)
-				const offsetY = Math.abs(offset.y)
+				const nudgeX = otherSnapPoint.x - thisSnapPoint.x
+				const nudgeY = otherSnapPoint.y - thisSnapPoint.y
 
-				if (round(offsetX) <= round(minOffset.x)) {
-					if (round(offsetX) < round(minOffset.x)) {
-						// we found a point that is significantly closer than all previous points
-						// so wipe the slate clean and start over
-						nearestSnapsX.length = 0
-					}
-
+				if (acceptNudge(nearestSnapsX, minOffset, 'x', nudgeX)) {
 					nearestSnapsX.push({
 						type: 'points',
 						points: { thisPoint: thisSnapPoint, otherPoint: otherSnapPoint },
-						nudge: otherSnapPoint.x - thisSnapPoint.x,
+						nudge: nudgeX,
 					})
-					minOffset.x = offsetX
 				}
 
-				if (round(offsetY) <= round(minOffset.y)) {
-					if (round(offsetY) < round(minOffset.y)) {
-						// we found a point that is significantly closer than all previous points
-						// so wipe the slate clean and start over
-						nearestSnapsY.length = 0
-					}
+				if (acceptNudge(nearestSnapsY, minOffset, 'y', nudgeY)) {
 					nearestSnapsY.push({
 						type: 'points',
 						points: { thisPoint: thisSnapPoint, otherPoint: otherSnapPoint },
-						nudge: otherSnapPoint.y - thisSnapPoint.y,
+						nudge: nudgeY,
 					})
-					minOffset.y = offsetY
 				}
 			}
 		}
@@ -666,13 +656,7 @@ export class BoundsSnaps {
 			const centerNudge = gapMidX - selectionPageBounds.center.x
 			const gapIsLargerThanSelection = gap.length > selectionPageBounds.width
 
-			if (gapIsLargerThanSelection && round(Math.abs(centerNudge)) <= round(minOffset.x)) {
-				if (round(Math.abs(centerNudge)) < round(minOffset.x)) {
-					// reset if we found a closer snap
-					nearestSnapsX.length = 0
-				}
-				minOffset.x = Math.abs(centerNudge)
-
+			if (gapIsLargerThanSelection && acceptNudge(nearestSnapsX, minOffset, 'x', centerNudge)) {
 				const snap: NearestSnap = {
 					type: 'gap_center',
 					gap,
@@ -746,13 +730,7 @@ export class BoundsSnaps {
 			const selectionRightX = selectionPageBounds.maxX
 
 			const duplicationLeftNudge = duplicationLeftX - selectionRightX
-			if (round(Math.abs(duplicationLeftNudge)) <= round(minOffset.x)) {
-				if (round(Math.abs(duplicationLeftNudge)) < round(minOffset.x)) {
-					// reset if we found a closer snap
-					nearestSnapsX.length = 0
-				}
-				minOffset.x = Math.abs(duplicationLeftNudge)
-
+			if (acceptNudge(nearestSnapsX, minOffset, 'x', duplicationLeftNudge)) {
 				nearestSnapsX.push({
 					type: 'gap_duplicate',
 					gap,
@@ -766,13 +744,7 @@ export class BoundsSnaps {
 			const selectionLeftX = selectionPageBounds.minX
 
 			const duplicationRightNudge = duplicationRightX - selectionLeftX
-			if (round(Math.abs(duplicationRightNudge)) <= round(minOffset.x)) {
-				if (round(Math.abs(duplicationRightNudge)) < round(minOffset.x)) {
-					// reset if we found a closer snap
-					nearestSnapsX.length = 0
-				}
-				minOffset.x = Math.abs(duplicationRightNudge)
-
+			if (acceptNudge(nearestSnapsX, minOffset, 'x', duplicationRightNudge)) {
 				nearestSnapsX.push({
 					type: 'gap_duplicate',
 					gap,
@@ -801,59 +773,14 @@ export class BoundsSnaps {
 
 			const gapIsLargerThanSelection = gap.length > selectionPageBounds.height
 
-			if (gapIsLargerThanSelection && round(Math.abs(centerNudge)) <= round(minOffset.y)) {
-				if (round(Math.abs(centerNudge)) < round(minOffset.y)) {
-					// reset if we found a closer snap
-					nearestSnapsY.length = 0
-				}
-				minOffset.y = Math.abs(centerNudge)
-
+			if (gapIsLargerThanSelection && acceptNudge(nearestSnapsY, minOffset, 'y', centerNudge)) {
 				const snap: NearestSnap = {
 					type: 'gap_center',
 					gap,
 					nudge: centerNudge,
 				}
 
-				// we need to avoid creating visual noise with too many center snaps in situations
-				// where there are lots of adjacent items with even spacing
-				// so let's only show other center snaps where the gap's breadth does not overlap with this one
-				// i.e.
-				//                ┌───────────────┐
-				//                │               │
-				//                └──────┬────┬───┘
-				//                       ┼    │
-				//                 ┌─────┴┐   │
-				//                 │      │   ┼
-				//                 └─────┬┘   │
-				//                       ┼    │
-				//                   ┌───┴────┴───────┐
-				//                   │                │  ◄────  i'm dragging this one
-				//                   └───┬────┬───────┘
-				//            ─────►     ┼    │
-				//                 ┌─────┴┐   │                don't show these
-				// show these      │      │   ┼                larger gaps since
-				// smaller         └─────┬┘   │ ◄───────────── the smaller ones
-				// gaps                  ┼    │                cover the same
-				//              ─────►  ┌┴────┴─────┐          information
-				//                      │           │
-				//                      └───────────┘
-				//
-				// but we want to show all of these ones since the gap breadths don't overlap
-				//            ┌─────────────┐
-				//            │             │
-				// ┌────┐     └───┬─────────┘
-				// │    │         │
-				// └──┬─┘         ┼
-				//    ┼           │
-				// ┌──┴───────────┴─┐
-				// │                │ ◄───── i'm dragging this one
-				// └──┬───────────┬─┘
-				//    ┼           │
-				// ┌──┴────┐      ┼
-				// │       │      │
-				// └───────┘    ┌─┴───────┐
-				//              │         │
-				//              └─────────┘
+				// see the horizontal case above for why overlapping center snaps are collapsed
 
 				const otherCenterSnap = nearestSnapsY.find(({ type }) => type === 'gap_center') as
 					| Extract<NearestSnap, { type: 'gap_center' }>
@@ -882,13 +809,7 @@ export class BoundsSnaps {
 			const selectionBottomY = selectionPageBounds.maxY
 
 			const duplicationTopNudge = duplicationTopY - selectionBottomY
-			if (round(Math.abs(duplicationTopNudge)) <= round(minOffset.y)) {
-				if (round(Math.abs(duplicationTopNudge)) < round(minOffset.y)) {
-					// reset if we found a closer snap
-					nearestSnapsY.length = 0
-				}
-				minOffset.y = Math.abs(duplicationTopNudge)
-
+			if (acceptNudge(nearestSnapsY, minOffset, 'y', duplicationTopNudge)) {
 				nearestSnapsY.push({
 					type: 'gap_duplicate',
 					gap,
@@ -902,13 +823,7 @@ export class BoundsSnaps {
 			const selectionTopY = selectionPageBounds.minY
 
 			const duplicationBottomNudge = duplicationBottomY - selectionTopY
-			if (round(Math.abs(duplicationBottomNudge)) <= round(minOffset.y)) {
-				if (round(Math.abs(duplicationBottomNudge)) < round(minOffset.y)) {
-					// reset if we found a closer snap
-					nearestSnapsY.length = 0
-				}
-				minOffset.y = Math.abs(duplicationBottomNudge)
-
+			if (acceptNudge(nearestSnapsY, minOffset, 'y', duplicationBottomNudge)) {
 				nearestSnapsY.push({
 					type: 'gap_duplicate',
 					gap,
@@ -928,36 +843,19 @@ export class BoundsSnaps {
 	}): PointsSnapIndicator[] {
 		// point snaps may align on multiple parallel lines so we need to split the pairs
 		// into groups based on where they are in their their snap axes
-		const snapGroupsX = {} as { [key: string]: SnapPair[] }
-		const snapGroupsY = {} as { [key: string]: SnapPair[] }
-
-		if (nearestSnapsX.length > 0) {
-			for (const snap of nearestSnapsX) {
-				if (snap.type === 'points') {
-					const key = round(snap.points.otherPoint.x)
-					if (!snapGroupsX[key]) {
-						snapGroupsX[key] = []
-					}
-					snapGroupsX[key].push(snap.points)
-				}
+		const groupPointSnaps = (snaps: NearestSnap[], axis: 'x' | 'y') => {
+			const groups: { [key: string]: SnapPair[] } = {}
+			for (const snap of snaps) {
+				if (snap.type !== 'points') continue
+				const key = round(snap.points.otherPoint[axis])
+				;(groups[key] ??= []).push(snap.points)
 			}
-		}
-
-		if (nearestSnapsY.length > 0) {
-			for (const snap of nearestSnapsY) {
-				if (snap.type === 'points') {
-					const key = round(snap.points.otherPoint.y)
-					if (!snapGroupsY[key]) {
-						snapGroupsY[key] = []
-					}
-					snapGroupsY[key].push(snap.points)
-				}
-			}
+			return Object.values(groups)
 		}
 
 		// and finally create all the snap lines for the UI to render
-		return Object.values(snapGroupsX)
-			.concat(Object.values(snapGroupsY))
+		return groupPointSnaps(nearestSnapsX, 'x')
+			.concat(groupPointSnaps(nearestSnapsY, 'y'))
 			.map((snapGroup) => ({
 				id: uniqueId(),
 				type: 'points',
@@ -992,120 +890,157 @@ export class BoundsSnaps {
 
 		const result: GapsSnapIndicator[] = []
 
-		if (nearestSnapsX.length > 0) {
-			for (const snap of nearestSnapsX) {
-				if (snap.type === 'points') continue
+		for (const snap of nearestSnapsX) {
+			if (snap.type === 'points') continue
 
-				const {
-					gap: { breadthIntersection, startEdge, startNode, endNode, length, endEdge },
-				} = snap
+			const {
+				gap: { breadthIntersection, startEdge, startNode, endNode, length, endEdge },
+			} = snap
 
-				switch (snap.type) {
-					case 'gap_center': {
-						// create
-						const newGapsLength = (length - selectionPageBounds.width) / 2
-						const gapBreadthIntersection = rangeIntersection(
-							breadthIntersection[0],
-							breadthIntersection[1],
-							selectionPageBounds.minY,
-							selectionPageBounds.maxY
-						)!
-						result.push({
-							type: 'gaps',
-							direction: 'horizontal',
-							id: uniqueId(),
-							gaps: [
-								...findAdjacentGaps(
-									horizontal,
-									startNode.id,
-									newGapsLength,
-									'backward',
-									gapBreadthIntersection
-								),
-								{
-									startEdge,
-									endEdge: selectionSides.left,
-								},
-								{
-									startEdge: selectionSides.right,
-									endEdge,
-								},
-								...findAdjacentGaps(
-									horizontal,
-									endNode.id,
-									newGapsLength,
-									'forward',
-									gapBreadthIntersection
-								),
-							],
-						})
-						break
-					}
-					case 'gap_duplicate': {
-						// create
-						const gapBreadthIntersection = rangeIntersection(
-							breadthIntersection[0],
-							breadthIntersection[1],
-							selectionPageBounds.minY,
-							selectionPageBounds.maxY
-						)!
-						result.push({
-							type: 'gaps',
-							direction: 'horizontal',
-							id: uniqueId(),
-							gaps:
-								snap.protrusionDirection === 'left'
-									? [
-											{
-												startEdge: selectionSides.right,
-												endEdge: startEdge.map((v) =>
-													v.clone().addXY(-startNode.pageBounds.width, 0)
-												) as [Vec, Vec],
-											},
-											{ startEdge, endEdge },
-											...findAdjacentGaps(
-												horizontal,
-												endNode.id,
-												length,
-												'forward',
-												gapBreadthIntersection
-											),
-										]
-									: [
-											...findAdjacentGaps(
-												horizontal,
-												startNode.id,
-												length,
-												'backward',
-												gapBreadthIntersection
-											),
-											{ startEdge, endEdge },
-											{
-												startEdge: endEdge.map((v) =>
-													v.clone().addXY(snap.gap.endNode.pageBounds.width, 0)
-												) as [Vec, Vec],
-												endEdge: selectionSides.left,
-											},
-										],
-						})
+			switch (snap.type) {
+				case 'gap_center': {
+					// create
+					const newGapsLength = (length - selectionPageBounds.width) / 2
+					const gapBreadthIntersection = rangeIntersection(
+						breadthIntersection[0],
+						breadthIntersection[1],
+						selectionPageBounds.minY,
+						selectionPageBounds.maxY
+					)!
+					result.push({
+						type: 'gaps',
+						direction: 'horizontal',
+						id: uniqueId(),
+						gaps: [
+							...findAdjacentGaps(
+								horizontal,
+								startNode.id,
+								newGapsLength,
+								'backward',
+								gapBreadthIntersection
+							),
+							{
+								startEdge,
+								endEdge: selectionSides.left,
+							},
+							{
+								startEdge: selectionSides.right,
+								endEdge,
+							},
+							...findAdjacentGaps(
+								horizontal,
+								endNode.id,
+								newGapsLength,
+								'forward',
+								gapBreadthIntersection
+							),
+						],
+					})
+					break
+				}
+				case 'gap_duplicate': {
+					// create
+					const gapBreadthIntersection = rangeIntersection(
+						breadthIntersection[0],
+						breadthIntersection[1],
+						selectionPageBounds.minY,
+						selectionPageBounds.maxY
+					)!
+					result.push({
+						type: 'gaps',
+						direction: 'horizontal',
+						id: uniqueId(),
+						gaps:
+							snap.protrusionDirection === 'left'
+								? [
+										{
+											startEdge: selectionSides.right,
+											endEdge: startEdge.map((v) =>
+												v.clone().addXY(-startNode.pageBounds.width, 0)
+											) as [Vec, Vec],
+										},
+										{ startEdge, endEdge },
+										...findAdjacentGaps(
+											horizontal,
+											endNode.id,
+											length,
+											'forward',
+											gapBreadthIntersection
+										),
+									]
+								: [
+										...findAdjacentGaps(
+											horizontal,
+											startNode.id,
+											length,
+											'backward',
+											gapBreadthIntersection
+										),
+										{ startEdge, endEdge },
+										{
+											startEdge: endEdge.map((v) =>
+												v.clone().addXY(snap.gap.endNode.pageBounds.width, 0)
+											) as [Vec, Vec],
+											endEdge: selectionSides.left,
+										},
+									],
+					})
 
-						break
-					}
+					break
 				}
 			}
 		}
 
-		if (nearestSnapsY.length > 0) {
-			for (const snap of nearestSnapsY) {
-				if (snap.type === 'points') continue
+		for (const snap of nearestSnapsY) {
+			if (snap.type === 'points') continue
 
-				const {
-					gap: { breadthIntersection, startEdge, startNode, endNode, length, endEdge },
-				} = snap
+			const {
+				gap: { breadthIntersection, startEdge, startNode, endNode, length, endEdge },
+			} = snap
 
-				switch (snap.type) {
-					case 'gap_center': {
-						const newGapsLength = (length - selectionPageBounds.height) / 2
+			switch (snap.type) {
+				case 'gap_center': {
+					const newGapsLength = (length - selectionPageBounds.height) / 2
+					const gapBreadthIntersection = rangeIntersection(
+						breadthIntersection[0],
+						breadthIntersection[1],
+						selectionPageBounds.minX,
+						selectionPageBounds.maxX
+					)!
+
+					result.push({
+						type: 'gaps',
+						direction: 'vertical',
+						id: uniqueId(),
+						gaps: [
+							...findAdjacentGaps(
+								vertical,
+								startNode.id,
+								newGapsLength,
+								'backward',
+								gapBreadthIntersection
+							),
+							{
+								startEdge,
+								endEdge: selectionSides.top,
+							},
+							{
+								startEdge: selectionSides.bottom,
+								endEdge,
+							},
+							...findAdjacentGaps(
+								vertical,
+								snap.gap.endNode.id,
+								newGapsLength,
+								'forward',
+								gapBreadthIntersection
+							),
+						],
+					})
+					break
+				}
+				case 'gap_duplicate':
+					{
 						const gapBreadthIntersection = rangeIntersection(
 							breadthIntersection[0],
 							breadthIntersection[1],
@@ -1117,84 +1052,43 @@ export class BoundsSnaps {
 							type: 'gaps',
 							direction: 'vertical',
 							id: uniqueId(),
-							gaps: [
-								...findAdjacentGaps(
-									vertical,
-									startNode.id,
-									newGapsLength,
-									'backward',
-									gapBreadthIntersection
-								),
-								{
-									startEdge,
-									endEdge: selectionSides.top,
-								},
-								{
-									startEdge: selectionSides.bottom,
-									endEdge,
-								},
-								...findAdjacentGaps(
-									vertical,
-									snap.gap.endNode.id,
-									newGapsLength,
-									'forward',
-									gapBreadthIntersection
-								),
-							],
+							gaps:
+								snap.protrusionDirection === 'top'
+									? [
+											{
+												startEdge: selectionSides.bottom,
+												endEdge: startEdge.map((v) =>
+													v.clone().addXY(0, -startNode.pageBounds.height)
+												) as [Vec, Vec],
+											},
+											{ startEdge, endEdge },
+											...findAdjacentGaps(
+												vertical,
+												endNode.id,
+												length,
+												'forward',
+												gapBreadthIntersection
+											),
+										]
+									: [
+											...findAdjacentGaps(
+												vertical,
+												startNode.id,
+												length,
+												'backward',
+												gapBreadthIntersection
+											),
+											{ startEdge, endEdge },
+											{
+												startEdge: endEdge.map((v) =>
+													v.clone().addXY(0, endNode.pageBounds.height)
+												) as [Vec, Vec],
+												endEdge: selectionSides.top,
+											},
+										],
 						})
-						break
 					}
-					case 'gap_duplicate':
-						{
-							const gapBreadthIntersection = rangeIntersection(
-								breadthIntersection[0],
-								breadthIntersection[1],
-								selectionPageBounds.minX,
-								selectionPageBounds.maxX
-							)!
-
-							result.push({
-								type: 'gaps',
-								direction: 'vertical',
-								id: uniqueId(),
-								gaps:
-									snap.protrusionDirection === 'top'
-										? [
-												{
-													startEdge: selectionSides.bottom,
-													endEdge: startEdge.map((v) =>
-														v.clone().addXY(0, -startNode.pageBounds.height)
-													) as [Vec, Vec],
-												},
-												{ startEdge, endEdge },
-												...findAdjacentGaps(
-													vertical,
-													endNode.id,
-													length,
-													'forward',
-													gapBreadthIntersection
-												),
-											]
-										: [
-												...findAdjacentGaps(
-													vertical,
-													startNode.id,
-													length,
-													'backward',
-													gapBreadthIntersection
-												),
-												{ startEdge, endEdge },
-												{
-													startEdge: endEdge.map((v) =>
-														v.clone().addXY(0, endNode.pageBounds.height)
-													) as [Vec, Vec],
-													endEdge: selectionSides.top,
-												},
-											],
-							})
-						}
-						break
-				}
+					break
 			}
 		}
 

--- a/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
@@ -179,13 +179,13 @@ export class HandleSnaps {
 	private getHandleSnapData({
 		handle,
 		currentShapeId,
+		handleInPageSpace,
 	}: {
 		handle: TLHandle
 		currentShapeId: TLShapeId
+		handleInPageSpace: Vec
 	}): AlignPointsSnap | null {
 		const snapThreshold = this.manager.getSnapThreshold()
-		const currentShapeTransform = assertExists(this.editor.getShapePageTransform(currentShapeId))
-		const handleInPageSpace = currentShapeTransform.applyToPoint(handle)
 
 		let nearestXSnap: Vec | null = null
 		let nearestYSnap: Vec | null = null
@@ -268,10 +268,7 @@ export class HandleSnaps {
 		}
 
 		if (snapType === 'align') {
-			const snapData = this.getHandleSnapData({
-				handle,
-				currentShapeId,
-			})
+			const snapData = this.getHandleSnapData({ handle, currentShapeId, handleInPageSpace })
 
 			if (!snapData) {
 				return null

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
@@ -65,7 +65,7 @@ export class SnapManager {
 	@computed getSnappableShapes(): Set<TLShapeId> {
 		const { editor } = this
 		const renderingBounds = editor.getViewportPageBounds()
-		const selectedShapeIds = editor.getSelectedShapeIds()
+		const selectedShapeIds = new Set(editor.getSelectedShapeIds())
 
 		const snappableShapes: Set<TLShapeId> = new Set()
 
@@ -79,7 +79,7 @@ export class SnapManager {
 			const sortedChildIds = editor.getSortedChildIdsForParent(parentId)
 			for (const childId of sortedChildIds) {
 				// Skip any selected ids
-				if (selectedShapeIds.includes(childId)) continue
+				if (selectedShapeIds.has(childId)) continue
 				const childShape = editor.getShape(childId)
 				if (!childShape) continue
 				const util = editor.getShapeUtil(childShape)

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
@@ -15,35 +15,19 @@ export interface SpatialElement {
 }
 
 /**
- * Custom RBush class for tldraw shapes.
- */
-class TldrawRBush extends RBush<SpatialElement> {}
-
-/**
  * Wrapper around RBush R-tree for efficient spatial queries.
  * Maintains a map of elements currently in the tree for efficient updates.
  */
 export class RBushIndex {
-	private rBush: TldrawRBush
-	private elementsInTree: Map<TLShapeId, SpatialElement>
-
-	constructor() {
-		this.rBush = new TldrawRBush()
-		this.elementsInTree = new Map()
-	}
+	private rBush = new RBush<SpatialElement>()
+	private elementsInTree = new Map<TLShapeId, SpatialElement>()
 
 	/**
 	 * Search for shapes within the given bounds.
 	 * Returns set of shape IDs that intersect with the bounds.
 	 */
 	search(bounds: Box): Set<TLShapeId> {
-		const results = this.rBush.search({
-			minX: bounds.minX,
-			minY: bounds.minY,
-			maxX: bounds.maxX,
-			maxY: bounds.maxY,
-		})
-		return new Set(results.map((e: SpatialElement) => e.id))
+		return new Set(this.rBush.search(bounds).map((e) => e.id))
 	}
 
 	/**
@@ -100,13 +84,6 @@ export class RBushIndex {
 	 */
 	has(id: TLShapeId): boolean {
 		return this.elementsInTree.has(id)
-	}
-
-	/**
-	 * Get the number of elements in the spatial index.
-	 */
-	getSize(): number {
-		return this.elementsInTree.size
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -6,12 +6,23 @@ import {
 	unsafe__withoutCapture,
 } from '@tldraw/state'
 import type { RecordsDiff } from '@tldraw/store'
-import { TLPageId, TLShape, TLShapeId, isBinding, isPageId, isShape } from '@tldraw/tlschema'
-import type { TLRecord } from '@tldraw/tlschema'
+import {
+	TLPageId,
+	TLRecord,
+	TLShape,
+	TLShapeId,
+	isBinding,
+	isPageId,
+	isShape,
+} from '@tldraw/tlschema'
 import { objectMapValues } from '@tldraw/utils'
 import { Box } from '../../../primitives/Box'
 import type { Editor } from '../../Editor'
 import { RBushIndex, type SpatialElement } from './RBushIndex'
+
+function toSpatialElement(id: TLShapeId, bounds: Box): SpatialElement {
+	return { minX: bounds.minX, minY: bounds.minY, maxX: bounds.maxX, maxY: bounds.maxY, id }
+}
 
 /**
  * Manages spatial indexing for efficient shape location queries.
@@ -102,17 +113,10 @@ export class SpatialIndexManager {
 		for (const shape of this.editor.getCurrentPageShapes()) {
 			const bounds = this.editor.getShapePageBounds(shape.id)
 			if (bounds && bounds.isValid()) {
-				elements.push({
-					minX: bounds.minX,
-					minY: bounds.minY,
-					maxX: bounds.maxX,
-					maxY: bounds.maxY,
-					id: shape.id,
-				})
+				elements.push(toSpatialElement(shape.id, bounds))
 			}
 		}
 
-		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
 	}
 
@@ -253,13 +257,7 @@ export class SpatialIndexManager {
 			if (bounds && bounds.isValid()) {
 				if (!this.areBoundsEqualToSpatialElement(bounds, indexedElement)) {
 					pendingRemoves.delete(id)
-					pendingUpserts.push({
-						minX: bounds.minX,
-						minY: bounds.minY,
-						maxX: bounds.maxX,
-						maxY: bounds.maxY,
-						id,
-					})
+					pendingUpserts.push(toSpatialElement(id, bounds))
 				}
 			} else if (this.rbush.has(id)) {
 				pendingRemoves.add(id)
@@ -272,12 +270,8 @@ export class SpatialIndexManager {
 		return true
 	}
 
-	private areBoundsEqualToSpatialElement(
-		a: Box | undefined,
-		b: SpatialElement | undefined
-	): boolean {
-		if (!a && !b) return true
-		if (!a || !b) return false
+	private areBoundsEqualToSpatialElement(a: Box, b: SpatialElement | undefined): boolean {
+		if (!b) return false
 		return a.minX === b.minX && a.minY === b.minY && a.maxX === b.maxX && a.maxY === b.maxY
 	}
 

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -117,6 +117,7 @@ export class SpatialIndexManager {
 			}
 		}
 
+		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
 	}
 

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -123,8 +123,7 @@ export class TextManager extends EditorManager {
 
 	private createMeasurementEl(): HTMLDivElement {
 		const elm = this.editor.getContainerDocument().createElement('div')
-		elm.classList.add('tl-text')
-		elm.classList.add('tl-text-measure')
+		elm.classList.add('tl-text', 'tl-text-measure')
 		elm.setAttribute('dir', 'auto')
 		elm.tabIndex = -1
 		for (const key of objectMapKeys(initialDefaultStyles)) {
@@ -190,6 +189,15 @@ export class TextManager extends EditorManager {
 		}
 	}
 
+	private measureElement(
+		el: HTMLElement,
+		measureScrollWidth: boolean | undefined
+	): TLMeasuredTextSize {
+		const scrollWidth = measureScrollWidth ? el.scrollWidth : 0
+		const rect = el.getBoundingClientRect()
+		return { x: 0, y: 0, w: rect.width, h: rect.height, scrollWidth }
+	}
+
 	private ensurePoolSize(size: number) {
 		if (this.poolElms.length >= size) return
 
@@ -231,21 +239,9 @@ export class TextManager extends EditorManager {
 			}
 		}
 
-		const results: TLMeasuredTextSize[] = []
-		for (let i = 0; i < requests.length; i++) {
-			const el = this.getPoolItem(i).el
-			const scrollWidth = requests[i].opts.measureScrollWidth ? el.scrollWidth : 0
-			const rect = el.getBoundingClientRect()
-			results.push({
-				x: 0,
-				y: 0,
-				w: rect.width,
-				h: rect.height,
-				scrollWidth,
-			})
-		}
-
-		return results
+		return requests.map((request, i) =>
+			this.measureElement(this.poolElms[i].el, request.opts.measureScrollWidth)
+		)
 	}
 
 	measureText(textToMeasure: string, opts: TLMeasureTextOpts): TLMeasuredTextSize {
@@ -261,17 +257,7 @@ export class TextManager extends EditorManager {
 
 		try {
 			elm.innerHTML = html
-
-			const scrollWidth = opts.measureScrollWidth ? elm.scrollWidth : 0
-			const rect = elm.getBoundingClientRect()
-
-			return {
-				x: 0,
-				y: 0,
-				w: rect.width,
-				h: rect.height,
-				scrollWidth,
-			}
+			return this.measureElement(elm, opts.measureScrollWidth)
 		} finally {
 			restoreStyles()
 		}

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
@@ -22,11 +22,7 @@ export class UserPreferencesManager {
 			this.systemColorScheme.set('dark')
 		}
 		const handleChange = (e: MediaQueryListEvent) => {
-			if (e.matches) {
-				this.systemColorScheme.set('dark')
-			} else {
-				this.systemColorScheme.set('light')
-			}
+			this.systemColorScheme.set(e.matches ? 'dark' : 'light')
 		}
 		darkModeMediaQuery?.addEventListener('change', handleChange)
 		this.disposables.add(() => darkModeMediaQuery?.removeEventListener('change', handleChange))

--- a/packages/editor/src/lib/editor/overlays/OverlayManager.ts
+++ b/packages/editor/src/lib/editor/overlays/OverlayManager.ts
@@ -75,12 +75,10 @@ export class OverlayManager {
 	 * @public
 	 */
 	@computed getOverlayUtilsInZOrder(): OverlayUtil[] {
-		const utils = Array.from(this._overlayUtils.values())
-		// Stable sort by zIndex (registration order breaks ties).
-		return utils
-			.map((util, i) => ({ util, i, z: util.options.zIndex ?? 0 }))
-			.sort((a, b) => a.z - b.z || a.i - b.i)
-			.map((entry) => entry.util)
+		// Array.prototype.sort is stable, so registration order breaks zIndex ties.
+		return Array.from(this._overlayUtils.values()).sort(
+			(a, b) => (a.options.zIndex ?? 0) - (b.options.zIndex ?? 0)
+		)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
@@ -82,10 +82,10 @@ export abstract class BaseFrameLikeShapeUtil<
 		const { editor } = this
 
 		if (draggingShapes.every((s) => s.parentId === shape.id)) return
+		// If any of the children are the ancestor of the frame, quit here
 		if (draggingShapes.some((s) => editor.hasAncestor(shape, s.id))) return
 
-		// Shapes that started out as children of this frame get their original index back, but only
-		// if none of those indices are now taken by a current child
+		// Check to see whether any of the shapes can have their old index restored
 		const previousChildren = draggingShapes.filter((s) => initialParentIds.get(s.id) === shape.id)
 		let canRestoreOriginalIndices = false
 		if (previousChildren.length > 0) {

--- a/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
@@ -1,4 +1,4 @@
-import { TLShape, TLShapeId } from '@tldraw/tlschema'
+import { TLShape } from '@tldraw/tlschema'
 import { IndexKey, compact } from '@tldraw/utils'
 import { Vec } from '../../primitives/Vec'
 import { BaseBoxShapeUtil, TLBaseBoxShape } from './BaseBoxShapeUtil'
@@ -82,24 +82,20 @@ export abstract class BaseFrameLikeShapeUtil<
 		const { editor } = this
 
 		if (draggingShapes.every((s) => s.parentId === shape.id)) return
-
-		// Check to see whether any of the shapes can have their old index restored
-		let canRestoreOriginalIndices = false
-		const previousChildren = draggingShapes.filter(
-			(s) => shape.id === (initialParentIds.get(s.id) as TLShapeId)
-		)
-
-		if (previousChildren.length > 0) {
-			const currentChildren = compact(
-				editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))
-			)
-			if (previousChildren.every((s) => !currentChildren.find((c) => c.index === s.index))) {
-				canRestoreOriginalIndices = true
-			}
-		}
-
-		// If any of the children are the ancestor of the frame, quit here
 		if (draggingShapes.some((s) => editor.hasAncestor(shape, s.id))) return
+
+		// Shapes that started out as children of this frame get their original index back, but only
+		// if none of those indices are now taken by a current child
+		const previousChildren = draggingShapes.filter((s) => initialParentIds.get(s.id) === shape.id)
+		let canRestoreOriginalIndices = false
+		if (previousChildren.length > 0) {
+			const currentIndices = new Set(
+				compact(editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))).map(
+					(c) => c.index
+				)
+			)
+			canRestoreOriginalIndices = previousChildren.every((s) => !currentIndices.has(s.index))
+		}
 
 		editor.reparentShapes(draggingShapes, shape.id)
 

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -4,6 +4,7 @@ import { LegacyMigrations, MigrationSequence } from '@tldraw/store'
 import {
 	RecordProps,
 	TLAsset,
+	TLFontFace,
 	TLHandle,
 	TLParentId,
 	TLPropsMigrations,
@@ -14,7 +15,6 @@ import {
 	TLUnknownShape,
 	VecModel,
 } from '@tldraw/tlschema'
-import { TLFontFace } from '@tldraw/tlschema'
 import { IndexKey } from '@tldraw/utils'
 import { ReactElement } from 'react'
 import { Box, SelectionHandle } from '../../primitives/Box'
@@ -649,8 +649,6 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 		return undefined
 	}
 
-	//  Events
-
 	/**
 	 * A callback called just before a shape is created. This method provides a last chance to modify
 	 * the created shape.
@@ -1130,8 +1128,6 @@ export interface TLResizeInfo<T extends TLShape> {
 	initialShape: T
 }
 
-/* -------------------- Dragging -------------------- */
-
 /** @public */
 export interface TLHandleDragInfo<T extends TLShape> {
 	handle: TLHandle
@@ -1139,8 +1135,6 @@ export interface TLHandleDragInfo<T extends TLShape> {
 	isCreatingShape: boolean
 	initial?: T | undefined
 }
-
-/* --------------------------------- Editing -------------------------------- */
 
 /** @public */
 export interface TLEditStartInfo {

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -649,6 +649,8 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 		return undefined
 	}
 
+	//  Events
+
 	/**
 	 * A callback called just before a shape is created. This method provides a last chance to modify
 	 * the created shape.
@@ -1128,6 +1130,8 @@ export interface TLResizeInfo<T extends TLShape> {
 	initialShape: T
 }
 
+/* -------------------- Dragging -------------------- */
+
 /** @public */
 export interface TLHandleDragInfo<T extends TLShape> {
 	handle: TLHandle
@@ -1135,6 +1139,8 @@ export interface TLHandleDragInfo<T extends TLShape> {
 	isCreatingShape: boolean
 	initial?: T | undefined
 }
+
+/* --------------------------------- Editing -------------------------------- */
 
 /** @public */
 export interface TLEditStartInfo {

--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -40,32 +40,27 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 		}
 
 		return new Group2d({
-			children: children.map((childId) => {
-				const shape = this.editor.getShape(childId)!
-				return this.editor
+			children: children.map((childId) =>
+				this.editor
 					.getShapeGeometry(childId)
-					.transform(this.editor.getShapeLocalTransform(shape)!, { isLabel: false })
-			}),
+					.transform(this.editor.getShapeLocalTransform(childId), { isLabel: false })
+			),
 		})
 	}
 
 	component(shape: TLGroupShape) {
 		const isErasing = this.editor.getErasingShapeIds().includes(shape.id)
 
-		const { hintingShapeIds } = this.editor.getCurrentPageState()
-		const isHintingOtherGroup =
-			hintingShapeIds.length > 0 &&
-			hintingShapeIds.some(
-				(id) => id !== shape.id && this.editor.isShapeOfType(this.editor.getShape(id)!, 'group')
-			)
-
-		const isFocused = this.editor.getCurrentPageState().focusedGroupId !== shape.id
+		const { hintingShapeIds, focusedGroupId } = this.editor.getCurrentPageState()
+		const isHintingOtherGroup = hintingShapeIds.some(
+			(id) => id !== shape.id && this.editor.isShapeOfType(this.editor.getShape(id)!, 'group')
+		)
 
 		if (
 			!isErasing && // always show the outline while we're erasing the group
 			// show the outline while the group is focused unless something outside of the group is being hinted
 			// this happens dropping shapes from a group onto some outside group
-			(isFocused || isHintingOtherGroup)
+			(focusedGroupId !== shape.id || isHintingOtherGroup)
 		) {
 			return null
 		}
@@ -123,19 +118,14 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 
 	override onChildrenChange(group: TLGroupShape) {
 		const children = this.editor.getSortedChildIdsForParent(group.id)
-		if (children.length === 0) {
-			if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
-				this.editor.popFocusedGroupId()
-			}
-			this.editor.deleteShapes([group.id])
-			return
-		} else if (children.length === 1) {
-			if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
-				this.editor.popFocusedGroupId()
-			}
-			this.editor.reparentShapes(children, group.parentId, group.index)
-			this.editor.deleteShapes([group.id])
-			return
+		if (children.length > 1) return
+
+		if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
+			this.editor.popFocusedGroupId()
 		}
+		if (children.length === 1) {
+			this.editor.reparentShapes(children, group.parentId, group.index)
+		}
+		this.editor.deleteShapes([group.id])
 	}
 }

--- a/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
@@ -30,25 +30,18 @@ export function getPerfectDashProps(
 		forceSolid = false,
 	} = opts
 
+	if (forceSolid || style === 'none') {
+		return {
+			strokeDasharray: 'none',
+			strokeDashoffset: 'none',
+		}
+	}
+
 	let dashLength = 0
 	let dashCount = 0
 	let ratio = 1
 	let gapLength = 0
 	let strokeDashoffset = 0
-
-	if (forceSolid) {
-		return {
-			strokeDasharray: 'none',
-			strokeDashoffset: 'none',
-		}
-	}
-
-	if (style === 'none') {
-		return {
-			strokeDasharray: 'none',
-			strokeDashoffset: 'none',
-		}
-	}
 
 	switch (style) {
 		case 'dashed': {

--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -15,7 +15,8 @@ export class Pointing extends StateNode {
 		if (editor.inputs.getIsDragging()) {
 			const originPagePoint = editor.inputs.getOriginPagePoint()
 
-			const shapeType = (this.parent as BaseBoxShapeTool)!.shapeType
+			const parent = this.parent as BaseBoxShapeTool
+			const shapeType = parent.shapeType
 
 			const id = createShapeId()
 
@@ -42,7 +43,6 @@ export class Pointing extends StateNode {
 			}
 			editor.select(id)
 
-			const parent = this.parent as BaseBoxShapeTool
 			this.editor.setCurrentTool(
 				'select.resizing',
 				{
@@ -85,7 +85,7 @@ export class Pointing extends StateNode {
 	complete() {
 		const originPagePoint = this.editor.inputs.getOriginPagePoint()
 
-		const shapeType = (this.parent as BaseBoxShapeTool)!.shapeType as TLBaseBoxShape['type']
+		const shapeType = (this.parent as BaseBoxShapeTool).shapeType
 
 		const id = createShapeId()
 
@@ -102,7 +102,7 @@ export class Pointing extends StateNode {
 			},
 		])
 
-		const shape = this.editor.getShape<TLBaseBoxShape>(id)!
+		const shape = this.editor.getShape<TLBaseBoxShape>(id)
 		if (!shape) {
 			this.cancel()
 			return

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -49,27 +49,14 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 
 		this.parent = parent ?? ({} as any)
 
-		if (parent) {
-			if (children && initial) {
-				this.type = 'branch'
-				this.initial = initial
-				this.children = Object.fromEntries(
-					children().map((Ctor) => [Ctor.id, new Ctor(this.editor, this)])
-				)
-				this._current.set(this.children[this.initial])
-			} else {
-				this.type = 'leaf'
-			}
-		} else {
-			this.type = 'root'
+		this.type = parent ? (children && initial ? 'branch' : 'leaf') : 'root'
 
-			if (children && initial) {
-				this.initial = initial
-				this.children = Object.fromEntries(
-					children().map((Ctor) => [Ctor.id, new Ctor(this.editor, this)])
-				)
-				this._current.set(this.children[this.initial])
-			}
+		if (children && initial) {
+			this.initial = initial
+			this.children = Object.fromEntries(
+				children().map((Ctor) => [Ctor.id, new Ctor(this.editor, this)])
+			)
+			this._current.set(this.children[this.initial])
 		}
 		this.isLockable = isLockable
 		this.useCoalescedEvents = useCoalescedEvents

--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -42,7 +42,7 @@ export class ExportDelay {
 
 		const result = await Promise.race([timeoutPromise, resolvePromise])
 		if (result === 'timeout') {
-			console.warn('[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms')
+			console.warn(`[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms`)
 		}
 
 		this.isResolved = true

--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -103,7 +103,7 @@ async function getDocumentFontFaces(doc: Document) {
 		}
 
 		if (cssRules) {
-			for (const rule of styleSheet.cssRules) {
+			for (const rule of cssRules) {
 				if (rule instanceof win.CSSFontFaceRule) {
 					fontFaces.push(parseCssFontFaces(rule.cssText, styleSheet.href ?? doc.baseURI))
 				} else if (rule instanceof win.CSSImportRule) {

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -53,7 +53,7 @@ export class StyleEmbedder {
 			? getDefaultStylesForTagName(element.ownerDocument, element.tagName.toLowerCase())
 			: NO_STYLES
 
-		const parentStyles = Object.assign({}, NO_STYLES) as Styles
+		const parentStyles: Styles = {}
 		if (shouldSkipInheritedParentStyles) {
 			let el = element.parentElement
 			// Keep going up the tree to find all the relevant styles
@@ -206,14 +206,14 @@ interface ReadStyleOpts {
 	parentStyles: ReadonlyStyles
 }
 
-function styleFromElement(element: Element, { defaultStyles, parentStyles }: ReadStyleOpts) {
+function styleFromElement(element: Element, opts: ReadStyleOpts) {
 	// `computedStyleMap` produces a more accurate representation of the styles, but it's not
 	// supported in firefox at the time of writing. So we fall back to `getComputedStyle` if it's
 	// not available.
 	if (element.computedStyleMap) {
-		return styleFromComputedStyleMap(element.computedStyleMap(), { defaultStyles, parentStyles })
+		return styleFromComputedStyleMap(element.computedStyleMap(), opts)
 	}
-	return styleFromComputedStyle(getComputedStyle(element), { defaultStyles, parentStyles })
+	return styleFromComputedStyle(getComputedStyle(element), opts)
 }
 
 function styleFromPseudoElement(element: Element, pseudo: string) {
@@ -229,51 +229,30 @@ function styleFromPseudoElement(element: Element, pseudo: string) {
 	return styleFromComputedStyle(style, { defaultStyles: NO_STYLES, parentStyles: NO_STYLES })
 }
 
-function styleFromComputedStyleMap(
-	style: StylePropertyMapReadOnly,
-	{ defaultStyles, parentStyles }: ReadStyleOpts
-) {
-	const styles: Record<string, string> = {}
-	const currentColor = style.get('color')?.toString() || ''
-	const ruleOptions = {
-		currentColor,
-		parentStyles,
-		defaultStyles,
-		getStyle: (property: string) => style.get(property)?.toString() ?? '',
-	}
-	for (const property of style.keys()) {
-		if (!shouldIncludeCssProperty(property)) continue
-
-		const value = style.get(property)!.toString()
-
-		if (defaultStyles[property] === value) continue
-
-		const rule = getOwnProperty(cssRules, property)
-		if (rule && rule(value, property, ruleOptions)) continue
-
-		styles[property] = value
-	}
-
-	return styles
+function styleFromComputedStyleMap(style: StylePropertyMapReadOnly, opts: ReadStyleOpts) {
+	return readStyles(style.keys(), (property) => style.get(property)?.toString() ?? '', opts)
 }
 
-function styleFromComputedStyle(
-	style: CSSStyleDeclaration,
+function styleFromComputedStyle(style: CSSStyleDeclaration, opts: ReadStyleOpts) {
+	return readStyles(forInKeys(style), (property) => style.getPropertyValue(property), opts)
+}
+
+function* forInKeys(obj: object) {
+	for (const key in obj) yield key
+}
+
+function readStyles(
+	properties: Iterable<string>,
+	getStyle: (property: string) => string,
 	{ defaultStyles, parentStyles }: ReadStyleOpts
 ) {
-	const styles: Record<string, string> = {}
-	const currentColor = style.color
-	const ruleOptions = {
-		currentColor,
-		parentStyles,
-		defaultStyles,
-		getStyle: (property: string) => style.getPropertyValue(property),
-	}
+	const styles: Styles = {}
+	const ruleOptions = { currentColor: getStyle('color'), parentStyles, defaultStyles, getStyle }
 
-	for (const property in style) {
+	for (const property of properties) {
 		if (!shouldIncludeCssProperty(property)) continue
 
-		const value = style.getPropertyValue(property)
+		const value = getStyle(property)
 
 		if (defaultStyles[property] === value) continue
 
@@ -282,6 +261,7 @@ function styleFromComputedStyle(
 
 		styles[property] = value
 	}
+
 	return styles
 }
 
@@ -345,9 +325,7 @@ function getDefaultStylesForTagName(ownerDoc: Document, tagName: string) {
 		const { foreignObject, document } = getDefaultStyleFrame(ownerDoc)
 		const element = document.createElement(tagName)
 		foreignObject.appendChild(element)
-		existing = element.computedStyleMap
-			? styleFromComputedStyleMap(element.computedStyleMap(), defaultStyleReadOptions)
-			: styleFromComputedStyle(getComputedStyle(element), defaultStyleReadOptions)
+		existing = styleFromElement(element, defaultStyleReadOptions)
 		foreignObject.removeChild(element)
 		defaultStylesByTagName[tagName] = existing
 	}

--- a/packages/editor/src/lib/exports/domUtils.ts
+++ b/packages/editor/src/lib/exports/domUtils.ts
@@ -42,16 +42,12 @@ function isDocument(node: Node | Document): node is Document {
 	return node.nodeType === Node.DOCUMENT_NODE
 }
 
-function getWindow(node: Node) {
-	return node.ownerDocument?.defaultView ?? globalThis
-}
-
 export function isElement(node: Node): node is Element {
-	return node instanceof getWindow(node).Element
+	return node instanceof getOwnerWindow(node).Element
 }
 
 function isShadowRoot(node: Node): node is ShadowRoot {
-	return node instanceof getWindow(node).ShadowRoot
+	return node instanceof getOwnerWindow(node).ShadowRoot
 }
 
 function isInShadowRoot(node: Node) {
@@ -59,7 +55,7 @@ function isInShadowRoot(node: Node) {
 }
 
 function isShadowSlotElement(node: Node): node is HTMLSlotElement {
-	return isInShadowRoot(node) && node instanceof getWindow(node).HTMLSlotElement
+	return isInShadowRoot(node) && node instanceof getOwnerWindow(node).HTMLSlotElement
 }
 
 export function elementStyle(element: Element) {
@@ -67,5 +63,5 @@ export function elementStyle(element: Element) {
 }
 
 export function getComputedStyle(element: Element, pseudoElement?: string) {
-	return getWindow(element).getComputedStyle(element, pseudoElement)
+	return getOwnerWindow(element).getComputedStyle(element, pseudoElement)
 }

--- a/packages/editor/src/lib/exports/embedMedia.ts
+++ b/packages/editor/src/lib/exports/embedMedia.ts
@@ -38,7 +38,7 @@ async function createImage(
 		copyAttrs(cloneAttributesFrom, image)
 	}
 
-	return await setImageSrc(image, dataUrl)
+	return setImageSrc(image, dataUrl)
 }
 
 async function getCanvasReplacement(canvas: HTMLCanvasElement) {
@@ -75,7 +75,7 @@ export async function embedMedia(node: HTMLElement) {
 	} else if (node instanceof win.HTMLVideoElement) {
 		return replace(node, await getVideoReplacement(node))
 	} else if (node instanceof win.HTMLImageElement) {
-		return await setImageSrc(node, await resourceToDataUrl(node.currentSrc || node.src))
+		return setImageSrc(node, await resourceToDataUrl(node.currentSrc || node.src))
 	} else if (node instanceof win.HTMLInputElement) {
 		node.setAttribute('value', node.value)
 	} else if (node instanceof win.HTMLTextAreaElement) {

--- a/packages/editor/src/lib/exports/embedMedia.ts
+++ b/packages/editor/src/lib/exports/embedMedia.ts
@@ -14,6 +14,19 @@ function replace(original: HTMLElement, replacement: HTMLElement) {
 	return replacement
 }
 
+async function setImageSrc(image: HTMLImageElement, dataUrl: string | null) {
+	image.setAttribute('src', dataUrl ?? 'data:')
+	image.setAttribute('decoding', 'sync')
+	image.setAttribute('loading', 'eager')
+
+	try {
+		await image.decode()
+	} catch {
+		// this is fine
+	}
+	return image
+}
+
 async function createImage(
 	doc: Document,
 	dataUrl: string | null,
@@ -25,16 +38,7 @@ async function createImage(
 		copyAttrs(cloneAttributesFrom, image)
 	}
 
-	image.setAttribute('src', dataUrl ?? 'data:')
-	image.setAttribute('decoding', 'sync')
-	image.setAttribute('loading', 'eager')
-
-	try {
-		await image.decode()
-	} catch {
-		// this is fine
-	}
-	return image
+	return await setImageSrc(image, dataUrl)
 }
 
 async function getCanvasReplacement(canvas: HTMLCanvasElement) {
@@ -71,21 +75,11 @@ export async function embedMedia(node: HTMLElement) {
 	} else if (node instanceof win.HTMLVideoElement) {
 		return replace(node, await getVideoReplacement(node))
 	} else if (node instanceof win.HTMLImageElement) {
-		const src = node.currentSrc || node.src
-		const dataUrl = await resourceToDataUrl(src)
-		node.setAttribute('src', dataUrl ?? 'data:')
-		node.setAttribute('decoding', 'sync')
-		node.setAttribute('loading', 'eager')
-		try {
-			await (node as HTMLImageElement).decode()
-		} catch {
-			// this is fine
-		}
-		return node
+		return await setImageSrc(node, await resourceToDataUrl(node.currentSrc || node.src))
 	} else if (node instanceof win.HTMLInputElement) {
-		node.setAttribute('value', (node as HTMLInputElement).value)
+		node.setAttribute('value', node.value)
 	} else if (node instanceof win.HTMLTextAreaElement) {
-		node.textContent = (node as HTMLTextAreaElement).value
+		node.textContent = node.value
 	}
 
 	await Promise.all(

--- a/packages/editor/src/lib/exports/getSvgAsImage.ts
+++ b/packages/editor/src/lib/exports/getSvgAsImage.ts
@@ -56,12 +56,7 @@ export async function getSvgAsImageWithOptions(
 
 	const blob = await new Promise<Blob | null>((resolve) =>
 		outputCanvas.canvas.toBlob(
-			(blob) => {
-				if (!blob || debugFlags.throwToBlob.get()) {
-					resolve(null)
-				}
-				resolve(blob)
-			},
+			(blob) => resolve(debugFlags.throwToBlob.get() ? null : blob),
 			'image/' + type,
 			quality
 		)
@@ -177,17 +172,17 @@ function measureContentBounds(
 	const declaredRight = w - extraPx
 	const declaredBottom = h - extraPx
 
+	function rowHasContent(y: number) {
+		for (let x = 0; x < w; x++) {
+			if (isContentPixel((y * w + x) * 4)) return true
+		}
+		return false
+	}
+
 	// Scan from top edge inward: find first row with content or declared bounds
 	let cropTop = declaredTop
 	for (let y = 0; y < declaredTop; y++) {
-		let hasContent = false
-		for (let x = 0; x < w; x++) {
-			if (isContentPixel((y * w + x) * 4)) {
-				hasContent = true
-				break
-			}
-		}
-		if (hasContent) {
+		if (rowHasContent(y)) {
 			cropTop = y
 			break
 		}
@@ -196,30 +191,24 @@ function measureContentBounds(
 	// Scan from bottom edge inward
 	let cropBottom = declaredBottom
 	for (let y = h - 1; y >= declaredBottom; y--) {
-		let hasContent = false
-		for (let x = 0; x < w; x++) {
-			if (isContentPixel((y * w + x) * 4)) {
-				hasContent = true
-				break
-			}
-		}
-		if (hasContent) {
+		if (rowHasContent(y)) {
 			cropBottom = y + 1
 			break
 		}
 	}
 
+	// Columns only need scanning within the rows we're keeping
+	function colHasContent(x: number) {
+		for (let y = cropTop; y < cropBottom; y++) {
+			if (isContentPixel((y * w + x) * 4)) return true
+		}
+		return false
+	}
+
 	// Scan from left edge inward
 	let cropLeft = declaredLeft
 	for (let x = 0; x < declaredLeft; x++) {
-		let hasContent = false
-		for (let y = cropTop; y < cropBottom; y++) {
-			if (isContentPixel((y * w + x) * 4)) {
-				hasContent = true
-				break
-			}
-		}
-		if (hasContent) {
+		if (colHasContent(x)) {
 			cropLeft = x
 			break
 		}
@@ -228,14 +217,7 @@ function measureContentBounds(
 	// Scan from right edge inward
 	let cropRight = declaredRight
 	for (let x = w - 1; x >= declaredRight; x--) {
-		let hasContent = false
-		for (let y = cropTop; y < cropBottom; y++) {
-			if (isContentPixel((y * w + x) * 4)) {
-				hasContent = true
-				break
-			}
-		}
-		if (hasContent) {
+		if (colHasContent(x)) {
 			cropRight = x + 1
 			break
 		}

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -1,6 +1,5 @@
 import { useAtom, useValue } from '@tldraw/state-react'
-import { TLFrameShape, TLShape, TLShapeId } from '@tldraw/tlschema'
-import { TLFontFace } from '@tldraw/tlschema'
+import { TLFontFace, TLFrameShape, TLShape, TLShapeId } from '@tldraw/tlschema'
 import { hasOwnProperty, promiseWithResolve, uniqueId } from '@tldraw/utils'
 import {
 	ComponentType,
@@ -51,7 +50,6 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 
 	const colorMode: 'light' | 'dark' =
 		opts.darkMode !== undefined ? (opts.darkMode ? 'dark' : 'light') : editor.getColorMode()
-	const isDarkMode = colorMode === 'dark'
 
 	// ---Figure out which shapes we need to include
 	const shapeIdsToInclude = editor.getShapeAndDescendantIds(ids)
@@ -113,14 +111,11 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 			bbox={bbox}
 			background={background}
 			singleFrameShapeId={singleFrameShapeId}
-			isDarkMode={isDarkMode}
 			colorMode={colorMode}
 			renderingShapes={renderingShapes}
 			onMount={initialEffectPromise.resolve}
 			waitUntil={exportDelay.waitUntil}
-		>
-			{}
-		</SvgExport>
+		/>
 	)
 
 	return { jsx: svg, width: w, height: h, exportDelay, trimPadding }
@@ -204,7 +199,6 @@ function SvgExport({
 	bbox,
 	background,
 	singleFrameShapeId,
-	isDarkMode,
 	colorMode,
 	renderingShapes,
 	onMount,
@@ -217,7 +211,6 @@ function SvgExport({
 	bbox: Box
 	background: boolean
 	singleFrameShapeId: TLShapeId | null
-	isDarkMode: boolean
 	colorMode: 'light' | 'dark'
 	renderingShapes: TLRenderingShape[]
 	onMount(): void
@@ -225,6 +218,7 @@ function SvgExport({
 }) {
 	const masksId = useUniqueSafeId()
 	const theme = editor.getCurrentTheme()
+	const isDarkMode = colorMode === 'dark'
 
 	const stateAtom = useAtom<{
 		defsById: Record<
@@ -307,22 +301,19 @@ function SvgExport({
 						])
 
 						const pageTransform = editor.getShapePageTransform(shape)
-						let pageTransformString = pageTransform!.toCssString()
+						let pageTransformString = pageTransform.toCssString()
 						let scale = 1
-						if ('scale' in shape.props) {
-							if (shape.props.scale !== 1) {
-								scale = shape.props.scale
-								pageTransformString = `${pageTransformString} scale(${shape.props.scale}, ${shape.props.scale})`
-							}
+						if ('scale' in shape.props && shape.props.scale !== 1) {
+							scale = shape.props.scale
+							pageTransformString = `${pageTransformString} scale(${scale}, ${scale})`
 						}
 
 						// Create svg mask if shape has a frame as parent
 						const pageMask = editor.getShapeMask(shape.id)
-						const shapeMask = pageMask
-							? Mat.From(Mat.Inverse(pageTransform)).applyToPoints(pageMask)
-							: null
 						const shapeMaskId = suffixSafeId(masksId, shape.id)
-						if (shapeMask) {
+						const clipPath = pageMask ? `url(#${shapeMaskId})` : undefined
+						if (pageMask) {
+							const shapeMask = Mat.From(Mat.Inverse(pageTransform)).applyToPoints(pageMask)
 							// Create a clip path and add it to defs
 							shapeDefs[shapeMaskId] = {
 								pending: false,
@@ -345,7 +336,7 @@ function SvgExport({
 										key={`fg_${shape.id}`}
 										transform={pageTransformString}
 										opacity={opacity}
-										clipPath={pageMask ? `url(#${shapeMaskId})` : undefined}
+										clipPath={clipPath}
 									>
 										{toSvgResult}
 									</g>
@@ -360,7 +351,7 @@ function SvgExport({
 										key={`bg_${shape.id}`}
 										transform={pageTransformString}
 										opacity={opacity}
-										clipPath={pageMask ? `url(#${shapeMaskId})` : undefined}
+										clipPath={clipPath}
 									>
 										{toBackgroundSvgResult}
 									</g>

--- a/packages/editor/src/lib/globals/menus.ts
+++ b/packages/editor/src/lib/globals/menus.ts
@@ -187,6 +187,7 @@ export const tlmenus = {
 			addOpenMenu: (id: string) => this.addOpenMenu(id, contextId),
 			deleteOpenMenu: (id: string) => this.deleteOpenMenu(id, contextId),
 			clearOpenMenus: () => this.clearOpenMenus(contextId),
+			// Gets whether any menus are open
 			isMenuOpen: (id: string) => this.isMenuOpen(id, contextId),
 			hasOpenMenus: () => this.hasOpenMenus(contextId),
 			hasAnyOpenMenus: () => this.hasAnyOpenMenus(),

--- a/packages/editor/src/lib/globals/menus.ts
+++ b/packages/editor/src/lib/globals/menus.ts
@@ -187,7 +187,6 @@ export const tlmenus = {
 			addOpenMenu: (id: string) => this.addOpenMenu(id, contextId),
 			deleteOpenMenu: (id: string) => this.deleteOpenMenu(id, contextId),
 			clearOpenMenus: () => this.clearOpenMenus(contextId),
-			// Gets whether any menus are open
 			isMenuOpen: (id: string) => this.isMenuOpen(id, contextId),
 			hasOpenMenus: () => this.hasOpenMenus(contextId),
 			hasAnyOpenMenus: () => this.hasAnyOpenMenus(),

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -91,18 +91,19 @@ export function useCanvasEvents() {
 				isSecondaryClickPointerDown = false
 			}
 
-			function onPointerEnter(e: React.PointerEvent) {
+			function setIsHoveringCanvas(e: React.PointerEvent, isHovering: boolean) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
 				const canHover = e.pointerType === 'mouse' || e.pointerType === 'pen'
-				editor.updateInstanceState({ isHoveringCanvas: canHover ? true : null })
+				editor.updateInstanceState({ isHoveringCanvas: canHover ? isHovering : null })
+			}
+
+			function onPointerEnter(e: React.PointerEvent) {
+				setIsHoveringCanvas(e, true)
 			}
 
 			function onPointerLeave(e: React.PointerEvent) {
-				if (editor.wasEventAlreadyHandled(e)) return
-				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
-				const canHover = e.pointerType === 'mouse' || e.pointerType === 'pen'
-				editor.updateInstanceState({ isHoveringCanvas: canHover ? false : null })
+				setIsHoveringCanvas(e, false)
 			}
 
 			function onTouchStart(e: React.TouchEvent) {

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -20,8 +20,8 @@ function getCursorCss(
 	const a = (-tr - r) * (PI / 180)
 	const s = Math.sin(a)
 	const c = Math.cos(a)
-	const dx = 1 * c - 1 * s
-	const dy = 1 * s + 1 * c
+	const dx = c - s
+	const dy = s + c
 
 	return (
 		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${color};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${

--- a/packages/editor/src/lib/hooks/useDarkMode.ts
+++ b/packages/editor/src/lib/hooks/useDarkMode.ts
@@ -12,19 +12,10 @@ export function useDarkMode() {
 	const forceSrgb = useValue(debugFlags.forceSrgb)
 
 	React.useEffect(() => {
-		if (colorMode === 'dark') {
-			container.setAttribute('data-color-mode', 'dark')
-			container.classList.remove('tl-theme__light')
-			container.classList.add('tl-theme__dark')
-		} else {
-			container.setAttribute('data-color-mode', 'light')
-			container.classList.remove('tl-theme__dark')
-			container.classList.add('tl-theme__light')
-		}
-		if (forceSrgb) {
-			container.classList.add('tl-theme__force-sRGB')
-		} else {
-			container.classList.remove('tl-theme__force-sRGB')
-		}
+		const isDark = colorMode === 'dark'
+		container.setAttribute('data-color-mode', colorMode)
+		container.classList.toggle('tl-theme__dark', isDark)
+		container.classList.toggle('tl-theme__light', !isDark)
+		container.classList.toggle('tl-theme__force-sRGB', forceSrgb)
 	}, [editor, container, forceSrgb, colorMode])
 }

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -174,9 +174,7 @@ export function useDocumentEvents() {
 					// Don't do anything if we open menus open
 					if (editor.menus.getOpenMenus().length > 0) return
 
-					if (editor.inputs.keys.has('Escape')) {
-						// noop
-					} else {
+					if (!editor.inputs.keys.has('Escape')) {
 						editor.inputs.keys.add('Escape')
 
 						editor.cancel()
@@ -196,19 +194,7 @@ export function useDocumentEvents() {
 				}
 			}
 
-			const info: TLKeyboardEventInfo = {
-				type: 'keyboard',
-				name: e.repeat ? 'key_repeat' : 'key_down',
-				key: e.key,
-				code: e.code,
-				shiftKey: e.shiftKey,
-				altKey: e.altKey,
-				ctrlKey: e.metaKey || e.ctrlKey,
-				metaKey: e.metaKey,
-				accelKey: isAccelKey(e),
-			}
-
-			editor.dispatch(info)
+			editor.dispatch(getKeyboardInfo(e, e.repeat ? 'key_repeat' : 'key_down'))
 		}
 
 		const handleKeyUp = (e: KeyboardEvent) => {
@@ -223,19 +209,7 @@ export function useDocumentEvents() {
 				return
 			}
 
-			const info: TLKeyboardEventInfo = {
-				type: 'keyboard',
-				name: 'key_up',
-				key: e.key,
-				code: e.code,
-				shiftKey: e.shiftKey,
-				altKey: e.altKey,
-				ctrlKey: e.metaKey || e.ctrlKey,
-				metaKey: e.metaKey,
-				accelKey: isAccelKey(e),
-			}
-
-			editor.dispatch(info)
+			editor.dispatch(getKeyboardInfo(e, 'key_up'))
 		}
 
 		function handleTouchStart(e: TouchEvent) {
@@ -305,4 +279,18 @@ function areShortcutsDisabled(editor: Editor) {
 		editor.menus.hasOpenMenus() ||
 		activeElementShouldCaptureKeys(true, editor.getContainerDocument())
 	)
+}
+
+function getKeyboardInfo(e: KeyboardEvent, name: TLKeyboardEventInfo['name']): TLKeyboardEventInfo {
+	return {
+		type: 'keyboard',
+		name,
+		key: e.key,
+		code: e.code,
+		shiftKey: e.shiftKey,
+		altKey: e.altKey,
+		ctrlKey: e.metaKey || e.ctrlKey,
+		metaKey: e.metaKey,
+		accelKey: isAccelKey(e),
+	}
 }

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -63,6 +63,8 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 		let pinchState = 'not sure' as 'not sure' | 'zooming' | 'panning'
 
+		// --- Wheel handling ---
+
 		function onWheel(event: WheelEvent) {
 			if (!editor.getInstanceState().isFocused) {
 				return
@@ -105,6 +107,8 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 			editor.dispatch(info)
 		}
+
+		// --- Touch pinch handling ---
 
 		let initDistanceBetweenFingers = 1 // the distance between the two fingers when the pinch starts
 		let initZoom = 1 // the zoom level when the pinch starts
@@ -279,6 +283,8 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 			}
 		}
 
+		// --- Safari trackpad pinch (GestureEvent) ---
+
 		let safariGestureInitialScale = 1
 
 		function onGestureStart(event: Event) {
@@ -357,6 +363,8 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 				)
 			})
 		}
+
+		// --- Attach event listeners ---
 
 		elm.addEventListener('wheel', onWheel, { passive: false })
 

--- a/packages/editor/src/lib/hooks/useGestureEvents.ts
+++ b/packages/editor/src/lib/hooks/useGestureEvents.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { TLWheelEventInfo } from '../editor/types/event-types'
 import { tlenv } from '../globals/environment'
+import { clamp } from '../primitives/utils'
 import { Vec } from '../primitives/Vec'
 import { preventDefault } from '../utils/dom'
 import { isAccelKey } from '../utils/keyboard'
@@ -62,8 +63,6 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 		let pinchState = 'not sure' as 'not sure' | 'zooming' | 'panning'
 
-		// --- Wheel handling ---
-
 		function onWheel(event: WheelEvent) {
 			if (!editor.getInstanceState().isFocused) {
 				return
@@ -106,8 +105,6 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 			editor.dispatch(info)
 		}
-
-		// --- Touch pinch handling ---
 
 		let initDistanceBetweenFingers = 1 // the distance between the two fingers when the pinch starts
 		let initZoom = 1 // the zoom level when the pinch starts
@@ -206,7 +203,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 		}
 
 		function onTouchStart(event: TouchEvent) {
-			if (!(event.target === elm || elm?.contains(event.target as Node))) return
+			if (!elm?.contains(event.target as Node)) return
 
 			activeTouches = Array.from(event.touches)
 
@@ -251,7 +248,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 			// very unstable zooming behavior.
 			const bounds = getScaleBounds()
 			const rawScale = initScaleFrom * (distance / initDistanceBetweenFingers)
-			scaleOffset = Math.min(bounds.max, Math.max(bounds.min, rawScale))
+			scaleOffset = clamp(rawScale, bounds.min, bounds.max)
 
 			switch (pinchState) {
 				case 'zooming': {
@@ -282,13 +279,11 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 			}
 		}
 
-		// --- Safari trackpad pinch (GestureEvent) ---
-
 		let safariGestureInitialScale = 1
 
 		function onGestureStart(event: Event) {
 			const e = event as GestureEvent
-			if (!(e.target === elm || elm?.contains(e.target as Node))) return
+			if (!elm?.contains(e.target as Node)) return
 
 			preventDefault(e)
 			e.stopPropagation()
@@ -316,7 +311,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 		function onGestureChange(event: Event) {
 			const e = event as GestureEvent
-			if (!(e.target === elm || elm?.contains(e.target as Node))) return
+			if (!elm?.contains(e.target as Node)) return
 
 			preventDefault(e)
 			e.stopPropagation()
@@ -330,7 +325,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 			// Safari GestureEvent.scale is a multiplier relative to gesture start
 			const bounds = getScaleBounds()
 			const rawScale = safariGestureInitialScale * e.scale
-			scaleOffset = Math.min(bounds.max, Math.max(bounds.min, rawScale))
+			scaleOffset = clamp(rawScale, bounds.min, bounds.max)
 
 			// Update distance tracking for pinch state (treat scale change as distance change)
 			currDistanceBetweenFingers = e.scale * initDistanceBetweenFingers
@@ -344,7 +339,7 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 
 		function onGestureEnd(event: Event) {
 			const e = event as GestureEvent
-			if (!(e.target === elm || elm?.contains(e.target as Node))) return
+			if (!elm?.contains(e.target as Node)) return
 
 			preventDefault(e)
 			e.stopPropagation()
@@ -362,8 +357,6 @@ export function useGestureEvents(ref: React.RefObject<HTMLDivElement | null>) {
 				)
 			})
 		}
-
-		// --- Attach event listeners ---
 
 		elm.addEventListener('wheel', onWheel, { passive: false })
 

--- a/packages/editor/src/lib/hooks/useZoomCss.ts
+++ b/packages/editor/src/lib/hooks/useZoomCss.ts
@@ -1,5 +1,4 @@
-import { EffectScheduler } from '@tldraw/state'
-import { debounce } from '@tldraw/utils'
+import { react } from '@tldraw/state'
 import * as React from 'react'
 import { useContainer } from './useContainer'
 import { useEditor } from './useEditor'
@@ -9,19 +8,8 @@ export function useZoomCss() {
 	const container = useContainer()
 
 	React.useEffect(() => {
-		const setScale = (s: number) => container.style.setProperty('--tl-zoom', s.toString())
-		const setScaleDebounced = debounce(setScale, 100)
-
-		const scheduler = new EffectScheduler('useZoomCss', () =>
-			setScale(editor.getEfficientZoomLevel())
-		)
-
-		scheduler.attach()
-		scheduler.execute()
-
-		return () => {
-			scheduler.detach()
-			setScaleDebounced.cancel()
-		}
+		return react('useZoomCss', () => {
+			container.style.setProperty('--tl-zoom', editor.getEfficientZoomLevel().toString())
+		})
 	}, [editor, container])
 }

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -442,7 +442,7 @@ export class LicenseManager {
 			Date.UTC(
 				expiryDate.getUTCFullYear(),
 				expiryDate.getUTCMonth(),
-				expiryDate.getUTCDate() + graceDays + 1
+				expiryDate.getUTCDate() + graceDays + 1 // Add 1 day to include the expiration day
 			)
 		)
 	}

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -304,10 +304,6 @@ export class LicenseManager {
 
 	async getLicenseFromKey(licenseKey?: string): Promise<LicenseFromKeyResult> {
 		if (!licenseKey) {
-			if (!this.isDevelopment) {
-				this.outputNoLicenseKeyProvided()
-			}
-
 			return { isLicenseParseable: false, reason: 'no-key-provided' }
 		}
 
@@ -438,42 +434,35 @@ export class LicenseManager {
 	}
 
 	private getExpirationDateWithoutGracePeriod(expiryDate: Date) {
-		// The named expiry date is the last day the license is fully usable, so the license
-		// expires at the end of that day, i.e. the start of the following day. We work in UTC
-		// (the expiry date is minted and parsed as a UTC date-only string) so the cutoff is a
-		// single predictable instant for every user regardless of their local timezone.
-		return new Date(
-			Date.UTC(
-				expiryDate.getUTCFullYear(),
-				expiryDate.getUTCMonth(),
-				expiryDate.getUTCDate() + 1 // Add 1 day so the named date is fully usable
-			)
-		)
+		return this.getExpirationDate(expiryDate, 0)
 	}
 
 	private getExpirationDateWithGracePeriod(expiryDate: Date) {
+		return this.getExpirationDate(expiryDate, GRACE_PERIOD_DAYS)
+	}
+
+	// The named expiry date is the last day the license is fully usable, so the license expires at
+	// the end of that day, i.e. the start of the following day (plus any grace period). We work in
+	// UTC (the expiry date is minted and parsed as a UTC date-only string) so the cutoff is a single
+	// predictable instant for every user regardless of their local timezone.
+	private getExpirationDate(expiryDate: Date, graceDays: number) {
 		return new Date(
 			Date.UTC(
 				expiryDate.getUTCFullYear(),
 				expiryDate.getUTCMonth(),
-				expiryDate.getUTCDate() + GRACE_PERIOD_DAYS + 1 // Add 1 day to include the expiration day
+				expiryDate.getUTCDate() + graceDays + 1
 			)
 		)
 	}
 
 	private isAnnualLicenseExpired(expiryDate: Date) {
-		const expiration = this.getExpirationDateWithGracePeriod(expiryDate)
-		return new Date() >= expiration
+		return new Date() >= this.getExpirationDateWithGracePeriod(expiryDate)
 	}
 
 	private isPerpetualLicenseExpired(expiryDate: Date) {
 		const expiration = this.getExpirationDateWithGracePeriod(expiryDate)
-		const dates = {
-			major: new Date(publishDates.major),
-			minor: new Date(publishDates.minor),
-		}
 		// We allow patch releases, but the major and minor releases should be within the expiration date
-		return dates.major >= expiration || dates.minor >= expiration
+		return new Date(publishDates.major) >= expiration || new Date(publishDates.minor) >= expiration
 	}
 
 	private getDaysSinceExpiry(expiryDate: Date): number {
@@ -486,21 +475,11 @@ export class LicenseManager {
 
 	private isEvaluationLicenseExpired(expiryDate: Date): boolean {
 		// Evaluation licenses have no grace period - they expire immediately
-		const now = new Date()
-		const expiration = this.getExpirationDateWithoutGracePeriod(expiryDate)
-		return now >= expiration
+		return new Date() >= this.getExpirationDateWithoutGracePeriod(expiryDate)
 	}
 
 	private isFlagEnabled(flags: number, flag: number) {
 		return (flags & flag) === flag
-	}
-
-	private outputNoLicenseKeyProvided() {
-		// Noop, we don't need to show this message.
-		// this.outputMessages([
-		// 	'No tldraw license key provided!',
-		// 	`Please reach out to ${LICENSE_EMAIL} if you would like to license tldraw or if you'd like a trial.`,
-		// ])
 	}
 
 	private outputInvalidLicenseKey(msg: string) {
@@ -522,28 +501,14 @@ export class LicenseManager {
 	}
 
 	private outputMessages(messages: string[], type: 'warning' | 'error' = 'error') {
-		if (this.isTest) return
-		if (this.verbose) {
-			this.outputDelimiter(type)
-			for (const message of messages) {
-				const bgColor = type === 'warning' ? 'orange' : 'crimson'
-				// eslint-disable-next-line no-console
-				console.log(
-					`%c${message}`,
-					`color: white; background: ${bgColor}; padding: 2px; border-radius: 3px;`
-				)
-			}
-			this.outputDelimiter(type)
-		}
-	}
-
-	private outputDelimiter(type: 'warning' | 'error' = 'error') {
+		if (this.isTest || !this.verbose) return
 		const bgColor = type === 'warning' ? 'orange' : 'crimson'
-		// eslint-disable-next-line no-console
-		console.log(
-			'%c-------------------------------------------------------------------',
-			`color: white; background: ${bgColor}; padding: 2px; border-radius: 3px;`
-		)
+		const style = `color: white; background: ${bgColor}; padding: 2px; border-radius: 3px;`
+		const delimiter = '-------------------------------------------------------------------'
+		for (const message of [delimiter, ...messages, delimiter]) {
+			// eslint-disable-next-line no-console
+			console.log(`%c${message}`, style)
+		}
 	}
 
 	static className = 'tl-watermark_SEE-LICENSE'
@@ -648,7 +613,7 @@ export function getLicenseState(
 
 	// Check if license is past expiry date but within grace period
 	const daysSinceExpiry = result.daysSinceExpiry
-	if (daysSinceExpiry > 0 && !result.isEvaluationLicense) {
+	if (daysSinceExpiry > 0) {
 		outputMessages([
 			'Your tldraw license has expired.',
 			`License expired ${daysSinceExpiry} days ago.`,

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -433,14 +433,6 @@ export class LicenseManager {
 		return this.isFlagEnabled(licenseInfo.flags, FLAGS.NATIVE_LICENSE)
 	}
 
-	private getExpirationDateWithoutGracePeriod(expiryDate: Date) {
-		return this.getExpirationDate(expiryDate, 0)
-	}
-
-	private getExpirationDateWithGracePeriod(expiryDate: Date) {
-		return this.getExpirationDate(expiryDate, GRACE_PERIOD_DAYS)
-	}
-
 	// The named expiry date is the last day the license is fully usable, so the license expires at
 	// the end of that day, i.e. the start of the following day (plus any grace period). We work in
 	// UTC (the expiry date is minted and parsed as a UTC date-only string) so the cutoff is a single
@@ -456,18 +448,18 @@ export class LicenseManager {
 	}
 
 	private isAnnualLicenseExpired(expiryDate: Date) {
-		return new Date() >= this.getExpirationDateWithGracePeriod(expiryDate)
+		return new Date() >= this.getExpirationDate(expiryDate, GRACE_PERIOD_DAYS)
 	}
 
 	private isPerpetualLicenseExpired(expiryDate: Date) {
-		const expiration = this.getExpirationDateWithGracePeriod(expiryDate)
+		const expiration = this.getExpirationDate(expiryDate, GRACE_PERIOD_DAYS)
 		// We allow patch releases, but the major and minor releases should be within the expiration date
 		return new Date(publishDates.major) >= expiration || new Date(publishDates.minor) >= expiration
 	}
 
 	private getDaysSinceExpiry(expiryDate: Date): number {
 		const now = new Date()
-		const expiration = this.getExpirationDateWithoutGracePeriod(expiryDate)
+		const expiration = this.getExpirationDate(expiryDate, 0)
 		const diffTime = now.getTime() - expiration.getTime()
 		const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 		return Math.max(0, diffDays)
@@ -475,7 +467,7 @@ export class LicenseManager {
 
 	private isEvaluationLicenseExpired(expiryDate: Date): boolean {
 		// Evaluation licenses have no grace period - they expire immediately
-		return new Date() >= this.getExpirationDateWithoutGracePeriod(expiryDate)
+		return new Date() >= this.getExpirationDate(expiryDate, 0)
 	}
 
 	private isFlagEnabled(flags: number, flag: number) {

--- a/packages/editor/src/lib/license/Watermark.tsx
+++ b/packages/editor/src/lib/license/Watermark.tsx
@@ -20,18 +20,26 @@ export const Watermark = memo(function Watermark() {
 	const isMobile = useValue('is mobile', () => editor.getViewportScreenBounds().width < 700, [
 		editor,
 	])
+	const isDebugMode = useValue('debug mode', () => editor.getInstanceState().isDebugMode, [editor])
 
 	const licenseManagerState = useLicenseManagerState(licenseManager)
 
-	if (!['licensed-with-watermark', 'unlicensed'].includes(licenseManagerState)) return null
+	if (licenseManagerState !== 'licensed-with-watermark' && licenseManagerState !== 'unlicensed') {
+		return null
+	}
 
 	return (
 		<>
 			<LicenseStyles />
-			<WatermarkInner
-				src={isMobile ? WATERMARK_MOBILE_LOCAL_SRC : WATERMARK_DESKTOP_LOCAL_SRC}
-				isUnlicensed={licenseManagerState === 'unlicensed'}
-			/>
+			{licenseManagerState === 'unlicensed' ? (
+				<UnlicensedWatermark isDebugMode={isDebugMode} isMobile={isMobile} />
+			) : (
+				<WatermarkInner
+					src={isMobile ? WATERMARK_MOBILE_LOCAL_SRC : WATERMARK_DESKTOP_LOCAL_SRC}
+					isDebugMode={isDebugMode}
+					isMobile={isMobile}
+				/>
+			)}
 		</>
 	)
 })
@@ -81,16 +89,14 @@ const UnlicensedWatermark = memo(function UnlicensedWatermark({
 
 const WatermarkInner = memo(function WatermarkInner({
 	src,
-	isUnlicensed,
+	isDebugMode,
+	isMobile,
 }: {
 	src: string
-	isUnlicensed: boolean
+	isDebugMode: boolean
+	isMobile: boolean
 }) {
 	const editor = useEditor()
-	const isDebugMode = useValue('debug mode', () => editor.getInstanceState().isDebugMode, [editor])
-	const isMobile = useValue('is mobile', () => editor.getViewportScreenBounds().width < 700, [
-		editor,
-	])
 	const events = useCanvasEvents()
 
 	const ref = useRef<HTMLDivElement>(null)
@@ -98,10 +104,6 @@ const WatermarkInner = memo(function WatermarkInner({
 
 	const maskCss = `url('${src}') center 100% / 100% no-repeat`
 	const url = 'https://tldraw.dev/?utm_source=sdk&utm_medium=organic&utm_campaign=watermark'
-
-	if (isUnlicensed) {
-		return <UnlicensedWatermark isDebugMode={isDebugMode} isMobile={isMobile} />
-	}
 
 	return (
 		<div

--- a/packages/editor/src/lib/primitives/Box.ts
+++ b/packages/editor/src/lib/primitives/Box.ts
@@ -306,63 +306,7 @@ export class Box {
 	}
 
 	resize(handle: SelectionCorner | SelectionEdge | string, dx: number, dy: number) {
-		const { minX: a0x, minY: a0y, maxX: a1x, maxY: a1y } = this
-		let { minX: b0x, minY: b0y, maxX: b1x, maxY: b1y } = this
-
-		// Use the delta to adjust the new box by changing its corners.
-		// The dragging handle (corner or edge) will determine which
-		// corners should change.
-		switch (handle) {
-			case 'left':
-			case 'top_left':
-			case 'bottom_left': {
-				b0x += dx
-				break
-			}
-			case 'right':
-			case 'top_right':
-			case 'bottom_right': {
-				b1x += dx
-				break
-			}
-		}
-		switch (handle) {
-			case 'top':
-			case 'top_left':
-			case 'top_right': {
-				b0y += dy
-				break
-			}
-			case 'bottom':
-			case 'bottom_left':
-			case 'bottom_right': {
-				b1y += dy
-				break
-			}
-		}
-
-		const scaleX = (b1x - b0x) / (a1x - a0x)
-		const scaleY = (b1y - b0y) / (a1y - a0y)
-
-		const flipX = scaleX < 0
-		const flipY = scaleY < 0
-
-		if (flipX) {
-			const t = b1x
-			b1x = b0x
-			b0x = t
-		}
-
-		if (flipY) {
-			const t = b1y
-			b1y = b0y
-			b0y = t
-		}
-
-		this.minX = b0x
-		this.minY = b0y
-		this.width = Math.abs(b1x - b0x)
-		this.height = Math.abs(b1y - b0y)
+		this.setTo(Box.Resize(this, handle, dx, dy).box)
 	}
 
 	union(box: BoxModel) {

--- a/packages/editor/src/lib/primitives/Mat.ts
+++ b/packages/editor/src/lib/primitives/Mat.ts
@@ -15,10 +15,6 @@ export interface MatModel {
 	f: number
 }
 
-// function getIdentity() {
-//   return new Mat(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
-// }
-
 /** @public */
 export class Mat {
 	constructor(a: number, b: number, c: number, d: number, e: number, f: number) {
@@ -60,14 +56,13 @@ export class Mat {
 	}
 
 	multiply(m: Mat | MatModel) {
-		const m2: MatModel = m
 		const { a, b, c, d, e, f } = this
-		this.a = a * m2.a + c * m2.b
-		this.c = a * m2.c + c * m2.d
-		this.e = a * m2.e + c * m2.f + e
-		this.b = b * m2.a + d * m2.b
-		this.d = b * m2.c + d * m2.d
-		this.f = b * m2.e + d * m2.f + f
+		this.a = a * m.a + c * m.b
+		this.c = a * m.c + c * m.d
+		this.e = a * m.e + c * m.f + e
+		this.b = b * m.a + d * m.b
+		this.d = b * m.c + d * m.d
+		this.f = b * m.e + d * m.f + f
 		return this
 	}
 
@@ -78,7 +73,7 @@ export class Mat {
 	}
 
 	translate(x: number, y: number): Mat {
-		return this.multiply(Mat.Translate(x, y!))
+		return this.multiply(Mat.Translate(x, y))
 	}
 
 	scale(x: number, y: number) {
@@ -134,8 +129,6 @@ export class Mat {
 		return new Mat(this.a, this.b, this.c, this.d, this.e, this.f)
 	}
 
-	/* --------------------- Static --------------------- */
-
 	static Identity() {
 		return new Mat(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
 	}
@@ -154,7 +147,7 @@ export class Mat {
 
 		if (cx === undefined) return rotationMatrix
 
-		return Mat.Compose(Mat.Translate(cx, cy!), rotationMatrix, Mat.Translate(-cx, -cy!))
+		return Mat.Translate(cx, cy!).multiply(rotationMatrix).translate(-cx, -cy!)
 	}
 
 	static Scale(x: number, y: number): Mat

--- a/packages/editor/src/lib/primitives/Mat.ts
+++ b/packages/editor/src/lib/primitives/Mat.ts
@@ -15,6 +15,10 @@ export interface MatModel {
 	f: number
 }
 
+// function getIdentity() {
+//   return new Mat(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+// }
+
 /** @public */
 export class Mat {
 	constructor(a: number, b: number, c: number, d: number, e: number, f: number) {
@@ -128,6 +132,8 @@ export class Mat {
 	clone() {
 		return new Mat(this.a, this.b, this.c, this.d, this.e, this.f)
 	}
+
+	/* --------------------- Static --------------------- */
 
 	static Identity() {
 		return new Mat(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -82,8 +82,6 @@ export class Vec {
 	subScalar(n: number) {
 		this.x -= n
 		this.y -= n
-		// this.z -= n
-
 		return this
 	}
 
@@ -102,8 +100,6 @@ export class Vec {
 	addScalar(n: number) {
 		this.x += n
 		this.y += n
-		// this.z += n
-
 		return this
 	}
 
@@ -120,28 +116,24 @@ export class Vec {
 	div(t: number) {
 		this.x /= t
 		this.y /= t
-		// this.z /= t
 		return this
 	}
 
 	divV(V: VecLike) {
 		this.x /= V.x
 		this.y /= V.y
-		// this.z /= V.z
 		return this
 	}
 
 	mul(t: number) {
 		this.x *= t
 		this.y *= t
-		// this.z *= t
 		return this
 	}
 
 	mulV(V: VecLike) {
 		this.x *= V.x
 		this.y *= V.y
-		// this.z *= V.z
 		return this
 	}
 
@@ -152,21 +144,24 @@ export class Vec {
 	}
 
 	nudge(B: VecLike, distance: number) {
-		const tan = Vec.Tan(B, this)
-		return this.add(tan.mul(distance))
+		const dx = B.x - this.x
+		const dy = B.y - this.y
+		const l = (dx * dx + dy * dy) ** 0.5
+		if (l === 0) return this
+		this.x += (dx / l) * distance
+		this.y += (dy / l) * distance
+		return this
 	}
 
 	neg() {
 		this.x *= -1
 		this.y *= -1
-		// this.z *= -1
 		return this
 	}
 
 	cross(V: VecLike) {
 		this.x = this.y * V.z! - this.z * V.y
 		this.y = this.z * V.x - this.x * V.z!
-		// this.z = this.x * V.y - this.y * V.x
 		return this
 	}
 
@@ -350,11 +345,7 @@ export class Vec {
 	}
 
 	static Cross(A: VecLike, V: VecLike) {
-		return new Vec(
-			A.y * V.z! - A.z! * V.y,
-			A.z! * V.x - A.x * V.z!
-			// A.z = A.x * V.y - A.y * V.x
-		)
+		return new Vec(A.y * V.z! - A.z! * V.y, A.z! * V.x - A.x * V.z!)
 	}
 
 	/**
@@ -582,7 +573,11 @@ export class Vec {
 	}
 
 	static Nudge(A: VecLike, B: VecLike, distance: number) {
-		return Vec.Add(A, Vec.Tan(B, A).mul(distance))
+		const dx = B.x - A.x
+		const dy = B.y - A.y
+		const l = (dx * dx + dy * dy) ** 0.5
+		if (l === 0) return new Vec(A.x, A.y)
+		return new Vec(A.x + (dx / l) * distance, A.y + (dy / l) * distance)
 	}
 
 	static ToString(A: VecLike) {
@@ -623,7 +618,7 @@ export class Vec {
 
 	static Clamp(A: Vec, min: number, max?: number) {
 		if (max === undefined) {
-			return new Vec(Math.min(Math.max(A.x, min)), Math.min(Math.max(A.y, min)))
+			return new Vec(Math.max(A.x, min), Math.max(A.y, min))
 		}
 
 		return new Vec(Math.min(Math.max(A.x, min), max), Math.min(Math.max(A.y, min), max))

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -82,6 +82,8 @@ export class Vec {
 	subScalar(n: number) {
 		this.x -= n
 		this.y -= n
+		// this.z -= n
+
 		return this
 	}
 
@@ -100,6 +102,8 @@ export class Vec {
 	addScalar(n: number) {
 		this.x += n
 		this.y += n
+		// this.z += n
+
 		return this
 	}
 
@@ -116,24 +120,28 @@ export class Vec {
 	div(t: number) {
 		this.x /= t
 		this.y /= t
+		// this.z /= t
 		return this
 	}
 
 	divV(V: VecLike) {
 		this.x /= V.x
 		this.y /= V.y
+		// this.z /= V.z
 		return this
 	}
 
 	mul(t: number) {
 		this.x *= t
 		this.y *= t
+		// this.z *= t
 		return this
 	}
 
 	mulV(V: VecLike) {
 		this.x *= V.x
 		this.y *= V.y
+		// this.z *= V.z
 		return this
 	}
 
@@ -156,12 +164,14 @@ export class Vec {
 	neg() {
 		this.x *= -1
 		this.y *= -1
+		// this.z *= -1
 		return this
 	}
 
 	cross(V: VecLike) {
 		this.x = this.y * V.z! - this.z * V.y
 		this.y = this.z * V.x - this.x * V.z!
+		// this.z = this.x * V.y - this.y * V.x
 		return this
 	}
 
@@ -345,7 +355,11 @@ export class Vec {
 	}
 
 	static Cross(A: VecLike, V: VecLike) {
-		return new Vec(A.y * V.z! - A.z! * V.y, A.z! * V.x - A.x * V.z!)
+		return new Vec(
+			A.y * V.z! - A.z! * V.y,
+			A.z! * V.x - A.x * V.z!
+			// A.z = A.x * V.y - A.y * V.x
+		)
 	}
 
 	/**

--- a/packages/editor/src/lib/primitives/geometry/Arc2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.ts
@@ -89,7 +89,7 @@ export class Arc2d extends Geometry2d {
 	getVertices(): Vec[] {
 		const { _center, _measure: measure, length, _radius: radius, _angleStart: angleStart } = this
 		const vertices: Vec[] = []
-		for (let i = 0, n = getVerticesCountForArcLength(Math.abs(length)); i < n + 1; i++) {
+		for (let i = 0, n = getVerticesCountForArcLength(length); i < n + 1; i++) {
 			const t = (i / n) * measure
 			const angle = angleStart + t
 			vertices.push(getPointOnCircle(_center, radius, angle))

--- a/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
@@ -30,23 +30,9 @@ export class CubicBezier2d extends Polyline2d {
 	}
 
 	override getVertices() {
-		const vertices = [] as Vec[]
-		const { _a: a, _b: b, _c: c, _d: d } = this
-		// we'll always use ten vertices for each bezier curve
+		const vertices: Vec[] = []
 		for (let i = 0, n = this._resolution; i <= n; i++) {
-			const t = i / n
-			vertices.push(
-				new Vec(
-					(1 - t) * (1 - t) * (1 - t) * a.x +
-						3 * ((1 - t) * (1 - t)) * t * b.x +
-						3 * (1 - t) * (t * t) * c.x +
-						t * t * t * d.x,
-					(1 - t) * (1 - t) * (1 - t) * a.y +
-						3 * ((1 - t) * (1 - t)) * t * b.y +
-						3 * (1 - t) * (t * t) * c.y +
-						t * t * t * d.y
-				)
-			)
+			vertices.push(CubicBezier2d.GetAtT(this, i / n))
 		}
 		return vertices
 	}
@@ -54,11 +40,9 @@ export class CubicBezier2d extends Polyline2d {
 	nearestPoint(A: VecLike): Vec {
 		let nearest: Vec | undefined
 		let dist = Infinity
-		let d: number
-		let p: Vec
 		for (const edge of this.segments) {
-			p = edge.nearestPoint(A)
-			d = Vec.Dist2(p, A)
+			const p = edge.nearestPoint(A)
+			const d = Vec.Dist2(p, A)
 			if (d < dist) {
 				nearest = p
 				dist = d

--- a/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
@@ -31,6 +31,7 @@ export class CubicBezier2d extends Polyline2d {
 
 	override getVertices() {
 		const vertices: Vec[] = []
+		// we'll always use ten vertices for each bezier curve
 		for (let i = 0, n = this._resolution; i <= n; i++) {
 			vertices.push(CubicBezier2d.GetAtT(this, i / n))
 		}

--- a/packages/editor/src/lib/primitives/geometry/CubicSpline2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicSpline2d.ts
@@ -51,9 +51,10 @@ export class CubicSpline2d extends Geometry2d {
 	}
 
 	getVertices() {
-		const vertices = this.segments.reduce((acc, segment) => {
-			return acc.concat(segment.vertices)
-		}, [] as Vec[])
+		const vertices: Vec[] = []
+		for (const segment of this.segments) {
+			vertices.push(...segment.vertices)
+		}
 		vertices.push(this._points[this._points.length - 1])
 		return vertices
 	}
@@ -61,11 +62,9 @@ export class CubicSpline2d extends Geometry2d {
 	nearestPoint(A: VecLike): Vec {
 		let nearest: Vec | undefined
 		let dist = Infinity
-		let d: number
-		let p: Vec
 		for (const segment of this.segments) {
-			p = segment.nearestPoint(A)
-			d = Vec.Dist2(p, A)
+			const p = segment.nearestPoint(A)
+			const d = Vec.Dist2(p, A)
 			if (d < dist) {
 				nearest = p
 				dist = d

--- a/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
@@ -1,5 +1,5 @@
 import { Box } from '../Box'
-import { PI, PI2, clamp, perimeterOfEllipse, pointInPolygon } from '../utils'
+import { PI2, clamp, perimeterOfEllipse, pointInPolygon } from '../utils'
 import { Vec, VecLike } from '../Vec'
 import { Edge2d } from './Edge2d'
 import { getVerticesCountForArcLength } from './geometry-constants'
@@ -39,34 +39,25 @@ export class Ellipse2d extends Geometry2d {
 	}
 
 	getVertices() {
-		// Perimeter of the ellipse
 		const w = Math.max(1, this._w)
 		const h = Math.max(1, this._h)
 		const cx = w / 2
 		const cy = h / 2
-		const q = Math.pow(cx - cy, 2) / Math.pow(cx + cy, 2)
-		const p = PI * (cx + cy) * (1 + (3 * q) / (10 + Math.sqrt(4 - 3 * q)))
-		// Number of points
-		const len = getVerticesCountForArcLength(p)
-		// Size of step
+		const len = getVerticesCountForArcLength(perimeterOfEllipse(cx, cy))
 		const step = PI2 / len
 
+		// Rotate a unit vector by `step` each iteration instead of calling sin/cos per vertex
 		const a = Math.cos(step)
 		const b = Math.sin(step)
-
 		let sin = 0
 		let cos = 1
-		let ts = 0
-		let tc = 1
 
 		const vertices = Array(len)
-
 		for (let i = 0; i < len; i++) {
 			vertices[i] = new Vec(clamp(cx + cx * cos, 0, w), clamp(cy + cy * sin, 0, h))
-			ts = b * cos + a * sin
-			tc = a * cos - b * sin
+			const ts = b * cos + a * sin
+			cos = a * cos - b * sin
 			sin = ts
-			cos = tc
 		}
 
 		return vertices
@@ -75,11 +66,9 @@ export class Ellipse2d extends Geometry2d {
 	nearestPoint(A: VecLike): Vec {
 		let nearest: Vec | undefined
 		let dist = Infinity
-		let d: number
-		let p: Vec
 		for (const edge of this.edges) {
-			p = edge.nearestPoint(A)
-			d = Vec.Dist2(p, A)
+			const p = edge.nearestPoint(A)
+			const d = Vec.Dist2(p, A)
 			if (d < dist) {
 				nearest = p
 				dist = d

--- a/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
@@ -39,11 +39,14 @@ export class Ellipse2d extends Geometry2d {
 	}
 
 	getVertices() {
+		// Perimeter of the ellipse
 		const w = Math.max(1, this._w)
 		const h = Math.max(1, this._h)
 		const cx = w / 2
 		const cy = h / 2
+		// Number of points
 		const len = getVerticesCountForArcLength(perimeterOfEllipse(cx, cy))
+		// Size of step
 		const step = PI2 / len
 
 		// Rotate a unit vector by `step` each iteration instead of calling sin/cos per vertex

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -100,9 +100,11 @@ export abstract class Geometry2d {
 	abstract nearestPoint(point: VecLike, _filters?: Geometry2dFilters): Vec
 
 	hitTestPoint(point: VecLike, margin = 0, hitInside = false, _filters?: Geometry2dFilters) {
+		// First check whether the point is inside
 		if (this.isClosed && (this.isFilled || hitInside) && pointInPolygon(point, this.vertices)) {
 			return true
 		}
+		// Then check whether the distance is within the margin
 		return Vec.Dist2(point, this.nearestPoint(point)) <= margin * margin
 	}
 
@@ -137,7 +139,7 @@ export abstract class Geometry2d {
 			}
 		}
 		if (!nearest) throw Error('nearest point not found')
-		dist = Math.sqrt(dist)
+		dist = Math.sqrt(dist) // return the actual distance, not the squared distance
 		return this.isClosed && this.isFilled && pointInPolygon(nearest, this.vertices) ? -dist : dist
 	}
 
@@ -240,30 +242,38 @@ export abstract class Geometry2d {
 	}
 
 	overlapsPolygon(polygon: VecLike[]): boolean {
+		// Skip empty labels
 		if (this.isEmptyLabel) return false
 
-		// Checks are ordered cheapest to most expensive
+		// We'll do things in order of cheapest to most expensive checks
 		const { vertices, isFilled, isClosed } = this
 
+		// If any of the geometry's vertices are inside the polygon, it's inside
 		if (vertices.some((v) => pointInPolygon(v, polygon))) {
 			return true
 		}
 
+		// If the geometry is filled and closed and its center is inside the polygon, it's inside
 		if (isClosed) {
 			if (isFilled) {
+				// If closed and filled, check if the center is inside the polygon
 				if (pointInPolygon(this.center, polygon)) {
 					return true
 				}
-				// The geometry may cover the entire polygon without containing its center
+
+				// ..then, slightly more expensive check, see the geometry covers the entire polygon but not its center
 				if (polygon.every((v) => pointInPolygon(v, vertices))) {
 					return true
 				}
 			}
-			// Edges can cross without any vertex being inside, e.g. a rotated rectangle
-			// moved over the corner of a parent rectangle
+
+			// If any the geometry's vertices intersect the edge of the polygon, it's inside.
+			// for example when a rotated rectangle is moved over the corner of a parent rectangle
+			// If the geometry is closed, intersect as a polygon
 			return polygonsIntersect(polygon, vertices)
 		}
 
+		// If the geometry is not closed, intersect as a polyline
 		return polygonIntersectsPolyline(polygon, vertices)
 	}
 
@@ -398,8 +408,10 @@ export abstract class Geometry2d {
 	abstract getSvgPathData(first: boolean): string
 }
 
-// Defined here rather than in its own file because Geometry2d.transform depends on it; a
-// separate file would create a circular import.
+// =================================================================================================
+// Because Geometry2d.transform depends on TransformedGeometry2d, we need to define it here instead
+// of in its own files. This prevents a circular import error.
+// =================================================================================================
 
 /** @public */
 export class TransformedGeometry2d extends Geometry2d {

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -100,11 +100,9 @@ export abstract class Geometry2d {
 	abstract nearestPoint(point: VecLike, _filters?: Geometry2dFilters): Vec
 
 	hitTestPoint(point: VecLike, margin = 0, hitInside = false, _filters?: Geometry2dFilters) {
-		// First check whether the point is inside
 		if (this.isClosed && (this.isFilled || hitInside) && pointInPolygon(point, this.vertices)) {
 			return true
 		}
-		// Then check whether the distance is within the margin
 		return Vec.Dist2(point, this.nearestPoint(point)) <= margin * margin
 	}
 
@@ -124,23 +122,22 @@ export abstract class Geometry2d {
 		if (vertices.length === 1) return Vec.Dist(A, vertices[0])
 		let nearest: Vec | undefined
 		let dist = Infinity
-		let d: number, p: Vec, q: Vec
 		const nextLimit = this.isClosed ? vertices.length : vertices.length - 1
 		for (let i = 0; i < vertices.length; i++) {
-			p = vertices[i]
+			const p = vertices[i]
 			if (i < nextLimit) {
 				const next = vertices[(i + 1) % vertices.length]
 				if (linesIntersect(A, B, p, next)) return 0
 			}
-			q = Vec.NearestPointOnLineSegment(A, B, p, true)
-			d = Vec.Dist2(p, q)
+			const q = Vec.NearestPointOnLineSegment(A, B, p, true)
+			const d = Vec.Dist2(p, q)
 			if (d < dist) {
 				dist = d
 				nearest = q
 			}
 		}
 		if (!nearest) throw Error('nearest point not found')
-		dist = Math.sqrt(dist) // return the actual distance, not the squared distance
+		dist = Math.sqrt(dist)
 		return this.isClosed && this.isFilled && pointInPolygon(nearest, this.vertices) ? -dist : dist
 	}
 
@@ -185,19 +182,15 @@ export abstract class Geometry2d {
 		const distanceToTravel = t * this.length
 		let distanceTraveled = 0
 
-		for (let i = 0; i < (this.isClosed ? vertices.length : vertices.length - 1); i++) {
+		const n = this.isClosed ? vertices.length : vertices.length - 1
+		for (let i = 0; i < n; i++) {
 			const curr = vertices[i]
 			const next = vertices[(i + 1) % vertices.length]
 			const dist = Vec.Dist(curr, next)
 			const newDistanceTraveled = distanceTraveled + dist
 			if (newDistanceTraveled >= distanceToTravel) {
 				if (dist === 0) return curr
-				const p = Vec.Lrp(
-					curr,
-					next,
-					invLerp(distanceTraveled, newDistanceTraveled, distanceToTravel)
-				)
-				return p
+				return Vec.Lrp(curr, next, invLerp(distanceTraveled, newDistanceTraveled, distanceToTravel))
 			}
 			distanceTraveled = newDistanceTraveled
 		}
@@ -211,38 +204,29 @@ export abstract class Geometry2d {
 	 */
 	uninterpolateAlongEdge(point: VecLike, _filters?: Geometry2dFilters): number {
 		const { vertices, length } = this
-		let closestSegment = null
-		let closestDistance = Infinity
+		if (vertices.length < 2 || length === 0) return 0
+
+		let closestDist2 = Infinity
+		let distanceAlongRoute = 0
 		let distanceTraveled = 0
 
-		if (vertices.length === 0 || vertices.length === 1) return 0
-
-		for (let i = 0; i < (this.isClosed ? vertices.length : vertices.length - 1); i++) {
+		const n = this.isClosed ? vertices.length : vertices.length - 1
+		for (let i = 0; i < n; i++) {
 			const curr = vertices[i]
 			const next = vertices[(i + 1) % vertices.length]
 
 			const nearestPoint = Vec.NearestPointOnLineSegment(curr, next, point, true)
-			const distance = Vec.Dist(nearestPoint, point)
+			const dist2 = Vec.Dist2(nearestPoint, point)
 
-			if (distance < closestDistance) {
-				closestDistance = distance
-				closestSegment = {
-					start: curr,
-					end: next,
-					nearestPoint,
-					distanceToStart: distanceTraveled,
-				}
+			if (dist2 < closestDist2) {
+				closestDist2 = dist2
+				distanceAlongRoute = distanceTraveled + Vec.Dist(curr, nearestPoint)
 			}
 
 			distanceTraveled += Vec.Dist(curr, next)
 		}
 
-		assert(closestSegment)
-
-		const distanceAlongRoute =
-			closestSegment.distanceToStart + Vec.Dist(closestSegment.start, closestSegment.nearestPoint)
-
-		return length === 0 ? 0 : distanceAlongRoute / length
+		return distanceAlongRoute / length
 	}
 
 	isPointInBounds(point: VecLike, margin = 0) {
@@ -255,51 +239,32 @@ export abstract class Geometry2d {
 		)
 	}
 
-	overlapsPolygon(_polygon: VecLike[]): boolean {
-		const polygon = _polygon.map((v) => Vec.From(v))
+	overlapsPolygon(polygon: VecLike[]): boolean {
+		if (this.isEmptyLabel) return false
 
-		// Otherwise, check if the geometry itself overlaps the polygon
-		const { vertices, center, isFilled, isEmptyLabel, isClosed } = this
+		// Checks are ordered cheapest to most expensive
+		const { vertices, isFilled, isClosed } = this
 
-		// We'll do things in order of cheapest to most expensive checks
-
-		// Skip empty labels
-		if (isEmptyLabel) return false
-
-		// If any of the geometry's vertices are inside the polygon, it's inside
 		if (vertices.some((v) => pointInPolygon(v, polygon))) {
 			return true
 		}
 
-		// If the geometry is filled and closed and its center is inside the polygon, it's inside
 		if (isClosed) {
 			if (isFilled) {
-				// If closed and filled, check if the center is inside the polygon
-				if (pointInPolygon(center, polygon)) {
+				if (pointInPolygon(this.center, polygon)) {
 					return true
 				}
-
-				// ..then, slightly more expensive check, see the geometry covers the entire polygon but not its center
+				// The geometry may cover the entire polygon without containing its center
 				if (polygon.every((v) => pointInPolygon(v, vertices))) {
 					return true
 				}
 			}
-
-			// If any the geometry's vertices intersect the edge of the polygon, it's inside.
-			// for example when a rotated rectangle is moved over the corner of a parent rectangle
-			// If the geometry is closed, intersect as a polygon
-			if (polygonsIntersect(polygon, vertices)) {
-				return true
-			}
-		} else {
-			// If the geometry is not closed, intersect as a polyline
-			if (polygonIntersectsPolyline(polygon, vertices)) {
-				return true
-			}
+			// Edges can cross without any vertex being inside, e.g. a rotated rectangle
+			// moved over the corner of a parent rectangle
+			return polygonsIntersect(polygon, vertices)
 		}
 
-		// If none of the above checks passed, the geometry is outside the polygon
-		return false
+		return polygonIntersectsPolyline(polygon, vertices)
 	}
 
 	transform(transform: MatModel, opts?: TransformedGeometry2dOptions): Geometry2d {
@@ -355,7 +320,7 @@ export abstract class Geometry2d {
 
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get area() {
-		if (!this._area) {
+		if (this._area === undefined) {
 			this._area = this.getArea()
 		}
 		return this._area
@@ -400,8 +365,9 @@ export abstract class Geometry2d {
 
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get length() {
-		if (this._length) return this._length
-		this._length = this.getLength(Geometry2dFilters.EXCLUDE_LABELS)
+		if (this._length === undefined) {
+			this._length = this.getLength(Geometry2dFilters.EXCLUDE_LABELS)
+		}
 		return this._length
 	}
 
@@ -432,10 +398,8 @@ export abstract class Geometry2d {
 	abstract getSvgPathData(first: boolean): string
 }
 
-// =================================================================================================
-// Because Geometry2d.transform depends on TransformedGeometry2d, we need to define it here instead
-// of in its own files. This prevents a circular import error.
-// =================================================================================================
+// Defined here rather than in its own file because Geometry2d.transform depends on it; a
+// separate file would create a circular import.
 
 /** @public */
 export class TransformedGeometry2d extends Geometry2d {

--- a/packages/editor/src/lib/primitives/geometry/Group2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.ts
@@ -49,19 +49,10 @@ export class Group2d extends Geometry2d {
 	override nearestPoint(point: VecLike, filters?: Geometry2dFilters): Vec {
 		let dist = Infinity
 		let nearest: Vec | undefined
-
-		const { children } = this
-
-		if (children.length === 0) {
-			throw Error('no children')
-		}
-
-		let p: Vec
-		let d: number
-		for (const child of children) {
+		for (const child of this.children) {
 			if (child.isExcludedByFilter(filters)) continue
-			p = child.nearestPoint(point, filters)
-			d = Vec.Dist2(p, point)
+			const p = child.nearestPoint(point, filters)
+			const d = Vec.Dist2(p, point)
 			if (d < dist) {
 				dist = d
 				nearest = p
@@ -109,11 +100,14 @@ export class Group2d extends Geometry2d {
 		return false
 	}
 
-	override intersectLineSegment(A: VecLike, B: VecLike, filters?: Geometry2dFilters) {
+	private collectFromChildren(
+		filters: Geometry2dFilters | undefined,
+		getHits: (child: Geometry2d) => VecLike[]
+	) {
 		const result: VecLike[] = []
 		for (const child of this.children) {
 			if (child.isExcludedByFilter(filters)) continue
-			const hits = child.intersectLineSegment(A, B, filters)
+			const hits = getHits(child)
 			for (let i = 0, n = hits.length; i < n; i++) {
 				result.push(hits[i])
 			}
@@ -121,16 +115,14 @@ export class Group2d extends Geometry2d {
 		return result
 	}
 
+	override intersectLineSegment(A: VecLike, B: VecLike, filters?: Geometry2dFilters) {
+		return this.collectFromChildren(filters, (child) => child.intersectLineSegment(A, B, filters))
+	}
+
 	override intersectCircle(center: VecLike, radius: number, filters?: Geometry2dFilters) {
-		const result: VecLike[] = []
-		for (const child of this.children) {
-			if (child.isExcludedByFilter(filters)) continue
-			const hits = child.intersectCircle(center, radius, filters)
-			for (let i = 0, n = hits.length; i < n; i++) {
-				result.push(hits[i])
-			}
-		}
-		return result
+		return this.collectFromChildren(filters, (child) =>
+			child.intersectCircle(center, radius, filters)
+		)
 	}
 
 	override getBoundsVertices(): Vec[] {
@@ -146,27 +138,11 @@ export class Group2d extends Geometry2d {
 	}
 
 	override intersectPolygon(polygon: VecLike[], filters?: Geometry2dFilters) {
-		const result: VecLike[] = []
-		for (const child of this.children) {
-			if (child.isExcludedByFilter(filters)) continue
-			const hits = child.intersectPolygon(polygon, filters)
-			for (let i = 0, n = hits.length; i < n; i++) {
-				result.push(hits[i])
-			}
-		}
-		return result
+		return this.collectFromChildren(filters, (child) => child.intersectPolygon(polygon, filters))
 	}
 
 	override intersectPolyline(polyline: VecLike[], filters?: Geometry2dFilters) {
-		const result: VecLike[] = []
-		for (const child of this.children) {
-			if (child.isExcludedByFilter(filters)) continue
-			const hits = child.intersectPolyline(polyline, filters)
-			for (let i = 0, n = hits.length; i < n; i++) {
-				result.push(hits[i])
-			}
-		}
-		return result
+		return this.collectFromChildren(filters, (child) => child.intersectPolyline(polyline, filters))
 	}
 
 	override interpolateAlongEdge(t: number, filters?: Geometry2dFilters): Vec {
@@ -193,23 +169,22 @@ export class Group2d extends Geometry2d {
 	override uninterpolateAlongEdge(point: VecLike, filters?: Geometry2dFilters): number {
 		const totalLength = this.getLength(filters)
 
-		let closestChild = null
+		let closestChild: Geometry2d | null = null
+		let closestStart = 0
+		let closestEnd = 0
 		let closestDistance = Infinity
 		let distanceTraveled = 0
 
 		for (const child of this.children) {
 			if (child.isExcludedByFilter(filters)) continue
-			const childLength = child.getLength(filters)
-			const newDistanceTraveled = distanceTraveled + childLength
+			const newDistanceTraveled = distanceTraveled + child.getLength(filters)
 
 			const distance = child.distanceToPoint(point, false, filters)
 			if (distance < closestDistance) {
 				closestDistance = distance
-				closestChild = {
-					startLength: distanceTraveled,
-					endLength: newDistanceTraveled,
-					child,
-				}
+				closestChild = child
+				closestStart = distanceTraveled
+				closestEnd = newDistanceTraveled
 			}
 
 			distanceTraveled = newDistanceTraveled
@@ -217,13 +192,8 @@ export class Group2d extends Geometry2d {
 
 		assert(closestChild)
 
-		const normalizedDistanceInChild = closestChild.child.uninterpolateAlongEdge(point, filters)
-		const childTLength = lerp(
-			closestChild.startLength,
-			closestChild.endLength,
-			normalizedDistanceInChild
-		)
-		return childTLength / totalLength
+		const normalizedDistanceInChild = closestChild.uninterpolateAlongEdge(point, filters)
+		return lerp(closestStart, closestEnd, normalizedDistanceInChild) / totalLength
 	}
 
 	override transform(transform: Mat): Geometry2d {
@@ -257,10 +227,9 @@ export class Group2d extends Geometry2d {
 			const nextDist = corner.dist(nextCorner)
 
 			const A = corner.clone().lrp(prevCorner, 4 / prevDist)
-			const B = corner
 			const C = corner.clone().lrp(nextCorner, 4 / nextDist)
 
-			path += `M${A.x},${A.y} L${B.x},${B.y} L${C.x},${C.y} `
+			path += `M${A.x},${A.y} L${corner.x},${corner.y} L${C.x},${C.y} `
 		}
 		return path
 	}

--- a/packages/editor/src/lib/primitives/geometry/Stadium2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Stadium2d.ts
@@ -9,10 +9,7 @@ import { Geometry2d, Geometry2dOptions } from './Geometry2d'
 export class Stadium2d extends Geometry2d {
 	private _w: number
 	private _h: number
-	private _a: Arc2d
-	private _b: Edge2d
-	private _c: Arc2d
-	private _d: Edge2d
+	private _parts: [Arc2d, Edge2d, Arc2d, Edge2d]
 
 	constructor(
 		public config: Omit<Geometry2dOptions, 'isClosed'> & {
@@ -27,56 +24,54 @@ export class Stadium2d extends Geometry2d {
 
 		if (h > w) {
 			const r = w / 2
-			this._a = new Arc2d({
+			const a = new Arc2d({
 				start: new Vec(0, r),
 				end: new Vec(w, r),
 				center: new Vec(w / 2, r),
 				sweepFlag: 1,
 				largeArcFlag: 1,
 			})
-			this._b = new Edge2d({ start: new Vec(w, r), end: new Vec(w, h - r) })
-			this._c = new Arc2d({
+			const b = new Edge2d({ start: new Vec(w, r), end: new Vec(w, h - r) })
+			const c = new Arc2d({
 				start: new Vec(w, h - r),
 				end: new Vec(0, h - r),
 				center: new Vec(w / 2, h - r),
 				sweepFlag: 1,
 				largeArcFlag: 1,
 			})
-			this._d = new Edge2d({ start: new Vec(0, h - r), end: new Vec(0, r) })
+			const d = new Edge2d({ start: new Vec(0, h - r), end: new Vec(0, r) })
+			this._parts = [a, b, c, d]
 		} else {
 			const r = h / 2
-			this._a = new Arc2d({
+			const a = new Arc2d({
 				start: new Vec(r, h),
 				end: new Vec(r, 0),
 				center: new Vec(r, r),
 				sweepFlag: 1,
 				largeArcFlag: 1,
 			})
-			this._b = new Edge2d({ start: new Vec(r, 0), end: new Vec(w - r, 0) })
-			this._c = new Arc2d({
+			const b = new Edge2d({ start: new Vec(r, 0), end: new Vec(w - r, 0) })
+			const c = new Arc2d({
 				start: new Vec(w - r, 0),
 				end: new Vec(w - r, h),
 				center: new Vec(w - r, r),
 				sweepFlag: 1,
 				largeArcFlag: 1,
 			})
-			this._d = new Edge2d({ start: new Vec(w - r, h), end: new Vec(r, h) })
+			const d = new Edge2d({ start: new Vec(w - r, h), end: new Vec(r, h) })
+			this._parts = [a, b, c, d]
 		}
 	}
 
 	nearestPoint(A: VecLike): Vec {
 		let nearest: Vec | undefined
 		let dist = Infinity
-		let _d: number
-		let p: Vec
-
-		const { _a: a, _b: b, _c: c, _d: d } = this
-		for (const part of [a, b, c, d]) {
-			p = part.nearestPoint(A)
-			_d = Vec.Dist2(p, A)
-			if (_d < dist) {
+		for (const part of this._parts) {
+			const p = part.nearestPoint(A)
+			const d = Vec.Dist2(p, A)
+			if (d < dist) {
 				nearest = p
-				dist = _d
+				dist = d
 			}
 		}
 		if (!nearest) throw Error('nearest point not found')
@@ -84,9 +79,8 @@ export class Stadium2d extends Geometry2d {
 	}
 
 	override distanceToPoint(point: VecLike, hitInside = false): number {
-		const { _a: a, _b: b, _c: c, _d: d } = this
 		let minDist = Infinity
-		for (const part of [a, b, c, d]) {
+		for (const part of this._parts) {
 			const dist = part.distanceToPoint(point)
 			if (dist < minDist) minDist = dist
 		}
@@ -97,16 +91,15 @@ export class Stadium2d extends Geometry2d {
 	}
 
 	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
-		const { _a: a, _b: b, _c: c, _d: d } = this
-		return [a, b, c, d].some((edge) => edge.hitTestLineSegment(A, B))
+		return this._parts.some((part) => part.hitTestLineSegment(A, B))
 	}
 
 	getVertices() {
-		const { _a: a, _b: b, _c: c, _d: d } = this
-		return [a, b, c, d].reduce<Vec[]>((a, p) => {
-			a.push(...p.vertices)
-			return a
-		}, [])
+		const vertices: Vec[] = []
+		for (const part of this._parts) {
+			vertices.push(...part.vertices)
+		}
+		return vertices
 	}
 
 	getBounds() {
@@ -120,7 +113,6 @@ export class Stadium2d extends Geometry2d {
 	}
 
 	getSvgPathData() {
-		const { _a: a, _b: b, _c: c, _d: d } = this
-		return [a, b, c, d].map((p, i) => p.getSvgPathData(i === 0)).join(' ') + ' Z'
+		return this._parts.map((p, i) => p.getSvgPathData(i === 0)).join(' ') + ' Z'
 	}
 }

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -221,7 +221,7 @@ export function radiansToDegrees(r: number): number {
  * @public
  */
 export function getPointOnCircle(center: VecLike, r: number, a: number) {
-	return new Vec(center.x, center.y).add(Vec.FromAngle(a, r))
+	return new Vec(center.x + Math.cos(a) * r, center.y + Math.sin(a) * r)
 }
 
 /** @public */
@@ -234,8 +234,8 @@ export function getPolygonVertices(width: number, height: number, sides: number)
 	let maxX = -Infinity
 	let minY = Infinity
 	let maxY = -Infinity
+	const step = PI2 / sides
 	for (let i = 0; i < sides; i++) {
-		const step = PI2 / sides
 		const t = -HALF_PI + i * step
 		const x = cx + cx * Math.cos(t)
 		const y = cy + cy * Math.sin(t)
@@ -376,11 +376,9 @@ export function isSafeFloat(n: number) {
  * @public
  */
 export function angleDistance(fromAngle: number, toAngle: number, direction: number) {
-	const dist =
-		direction < 0
-			? clockwiseAngleDist(fromAngle, toAngle)
-			: counterClockwiseAngleDist(fromAngle, toAngle)
-	return dist
+	return direction < 0
+		? clockwiseAngleDist(fromAngle, toAngle)
+		: counterClockwiseAngleDist(fromAngle, toAngle)
 }
 
 /**
@@ -396,28 +394,22 @@ export function angleDistance(fromAngle: number, toAngle: number, direction: num
  * @public
  */
 export function getPointInArcT(mAB: number, A: number, B: number, P: number): number {
-	let mAP: number
+	const mAP = shortAngleDist(A, P)
 	if (Math.abs(mAB) > PI) {
-		mAP = shortAngleDist(A, P)
 		const mPB = shortAngleDist(P, B)
-		if (Math.abs(mAP) < Math.abs(mPB)) {
-			return mAP / mAB
-		} else {
-			return (mAB - mPB) / mAB
-		}
-	} else {
-		mAP = shortAngleDist(A, P)
-		const t = mAP / mAB
-
-		// If the arc is something like -2.8 to 2.2, then we'll get a weird bug
-		// where the measurement to the center is negative but measure to points
-		// near the end are positive
-		if (Math.sign(mAP) !== Math.sign(mAB)) {
-			return Math.abs(t) > 0.5 ? 1 : 0
-		}
-
-		return t
+		return Math.abs(mAP) < Math.abs(mPB) ? mAP / mAB : (mAB - mPB) / mAB
 	}
+
+	const t = mAP / mAB
+
+	// If the arc is something like -2.8 to 2.2, then we'll get a weird bug
+	// where the measurement to the center is negative but measure to points
+	// near the end are positive
+	if (Math.sign(mAP) !== Math.sign(mAB)) {
+		return Math.abs(t) > 0.5 ? 1 : 0
+	}
+
+	return t
 }
 
 /**

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -143,8 +143,7 @@ export function elementShouldCaptureKeys(el: Element | null, includeButtonsAndMe
 		(el as HTMLElement).isContentEditable ||
 		tagName === 'input' ||
 		tagName === 'textarea' ||
-		(includeButtonsAndMenus && tagName === 'select') ||
-		(includeButtonsAndMenus && tagName === 'button') ||
+		(includeButtonsAndMenus && (tagName === 'select' || tagName === 'button')) ||
 		el.classList.contains('tlui-slider__thumb')
 	)
 }

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -63,13 +63,6 @@ export function getReorderingShapesChanges(
 	return changes
 }
 
-/**
- * Reorders the moving shapes to the back of the parent's children.
- *
- * @param moving The set of shapes that are moving
- * @param children The parent's children
- * @param changes The changes array to push changes to
- */
 function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
 	const len = children.length
 
@@ -97,28 +90,25 @@ function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLSha
 		}
 	}
 
-	if (moving.size === 0) {
-		// If our moving set is empty, there's nothing to do; all of our shapes were
-		// already at the back of the parent's children.
-		return
-	} else {
-		// Sort the moving shapes by their current index, then apply the new indices
-		const indices = getIndicesBetween(below, above, moving.size)
-		changes.push(
-			...Array.from(moving.values())
-				.sort(sortByIndex)
-				.map((shape, i) => ({ ...shape, index: indices[i] }))
-		)
-	}
+	// If our moving set is empty, all of our shapes were already at the back
+	if (moving.size > 0) pushMovedBetween(moving, below, above, changes)
 }
 
-/**
- * Reorders the moving shapes to the front of the parent's children.
- *
- * @param moving The set of shapes that are moving
- * @param children The parent's children
- * @param changes The changes array to push changes to
- */
+/** Sort the moving shapes by their current index, then re-index them between `below` and `above`. */
+function pushMovedBetween(
+	moving: Set<TLShape>,
+	below: IndexKey | undefined,
+	above: IndexKey | undefined,
+	changes: TLShapePartial[]
+) {
+	const indices = getIndicesBetween(below, above, moving.size)
+	changes.push(
+		...Array.from(moving.values())
+			.sort(sortByIndex)
+			.map((shape, i) => ({ ...shape, index: indices[i] }))
+	)
+}
+
 function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
 	const len = children.length
 
@@ -146,19 +136,8 @@ function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLSh
 		}
 	}
 
-	if (moving.size === 0) {
-		// If our moving set is empty, there's nothing to do; all of our shapes were
-		// already at the front of the parent's children.
-		return
-	} else {
-		// Sort the moving shapes by their current index, then apply the new indices
-		const indices = getIndicesBetween(below, above, moving.size)
-		changes.push(
-			...Array.from(moving.values())
-				.sort(sortByIndex)
-				.map((shape, i) => ({ ...shape, index: indices[i] }))
-		)
-	}
+	// If our moving set is empty, all of our shapes were already at the front
+	if (moving.size > 0) pushMovedBetween(moving, below, above, changes)
 }
 
 function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
@@ -180,15 +159,6 @@ function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
 	return isContaining
 }
 
-/**
- * Reorders the moving shapes forward in the parent's children.
- *
- * @param editor The editor
- * @param moving The set of shapes that are moving
- * @param children The parent's children
- * @param changes The changes array to push changes to
- * @param opts The options
- */
 function reorderForward(
 	editor: Editor,
 	moving: Set<TLShape>,
@@ -196,12 +166,12 @@ function reorderForward(
 	changes: TLShapePartial[],
 	opts?: { considerAllShapes?: boolean }
 ) {
-	const isContaining = getOverlapChecker(editor, moving)
-
 	const len = children.length
 
 	// If all of the children are moving, there's nothing to do
 	if (moving.size === len) return
+
+	const isContaining = opts?.considerAllShapes ? null : getOverlapChecker(editor, moving)
 
 	let state = { name: 'skipping' } as
 		| { name: 'skipping' }
@@ -220,7 +190,7 @@ function reorderForward(
 			}
 			case 'selecting': {
 				if (isMoving) continue
-				if (!opts?.considerAllShapes && !isContaining(children[i])) continue
+				if (isContaining && !isContaining(children[i])) continue
 				// if we find a non-moving and overlapping shape while selecting, move all selected
 				// shapes in front of the not moving shape; and start skipping
 				const { selectIndex } = state
@@ -239,15 +209,6 @@ function reorderForward(
 	}
 }
 
-/**
- * Reorders the moving shapes backward in the parent's children.
- *
- * @param editor The editor
- * @param moving The set of shapes that are moving
- * @param children The parent's children
- * @param changes The changes array to push changes to
- * @param opts The options
- */
 function reorderBackward(
 	editor: Editor,
 	moving: Set<TLShape>,
@@ -255,11 +216,12 @@ function reorderBackward(
 	changes: TLShapePartial[],
 	opts?: { considerAllShapes?: boolean }
 ) {
-	const isContaining = getOverlapChecker(editor, moving)
-
 	const len = children.length
 
+	// If all of the children are moving, there's nothing to do
 	if (moving.size === len) return
+
+	const isContaining = opts?.considerAllShapes ? null : getOverlapChecker(editor, moving)
 
 	let state = { name: 'skipping' } as
 		| { name: 'skipping' }
@@ -278,7 +240,7 @@ function reorderBackward(
 			}
 			case 'selecting': {
 				if (isMoving) continue
-				if (!opts?.considerAllShapes && !isContaining(children[i])) continue
+				if (isContaining && !isContaining(children[i])) continue
 				// if we find a non-moving and overlapping shape while selecting, move all selected
 				// shapes behind the non-moving shape; and start skipping
 				getIndicesBetween(children[i - 1]?.index, children[i].index, state.selectIndex - i).forEach(

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -63,6 +63,13 @@ export function getReorderingShapesChanges(
 	return changes
 }
 
+/**
+ * Reorders the moving shapes to the back of the parent's children.
+ *
+ * @param moving The set of shapes that are moving
+ * @param children The parent's children
+ * @param changes The changes array to push changes to
+ */
 function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
 	const len = children.length
 
@@ -90,7 +97,8 @@ function reorderToBack(moving: Set<TLShape>, children: TLShape[], changes: TLSha
 		}
 	}
 
-	// If our moving set is empty, all of our shapes were already at the back
+	// If our moving set is empty, there's nothing to do; all of our shapes were
+	// already at the back of the parent's children.
 	if (moving.size > 0) pushMovedBetween(moving, below, above, changes)
 }
 
@@ -109,6 +117,13 @@ function pushMovedBetween(
 	)
 }
 
+/**
+ * Reorders the moving shapes to the front of the parent's children.
+ *
+ * @param moving The set of shapes that are moving
+ * @param children The parent's children
+ * @param changes The changes array to push changes to
+ */
 function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLShapePartial[]) {
 	const len = children.length
 
@@ -136,7 +151,8 @@ function reorderToFront(moving: Set<TLShape>, children: TLShape[], changes: TLSh
 		}
 	}
 
-	// If our moving set is empty, all of our shapes were already at the front
+	// If our moving set is empty, there's nothing to do; all of our shapes were
+	// already at the front of the parent's children.
 	if (moving.size > 0) pushMovedBetween(moving, below, above, changes)
 }
 
@@ -159,6 +175,15 @@ function getOverlapChecker(editor: Editor, moving: Set<TLShape>) {
 	return isContaining
 }
 
+/**
+ * Reorders the moving shapes forward in the parent's children.
+ *
+ * @param editor The editor
+ * @param moving The set of shapes that are moving
+ * @param children The parent's children
+ * @param changes The changes array to push changes to
+ * @param opts The options
+ */
 function reorderForward(
 	editor: Editor,
 	moving: Set<TLShape>,
@@ -209,6 +234,15 @@ function reorderForward(
 	}
 }
 
+/**
+ * Reorders the moving shapes backward in the parent's children.
+ *
+ * @param editor The editor
+ * @param moving The set of shapes that are moving
+ * @param children The parent's children
+ * @param changes The changes array to push changes to
+ * @param opts The options
+ */
 function reorderBackward(
 	editor: Editor,
 	moving: Set<TLShape>,

--- a/packages/editor/src/lib/utils/reparenting.ts
+++ b/packages/editor/src/lib/utils/reparenting.ts
@@ -57,8 +57,9 @@ export function kickoutOccludedShapes(
 		}
 	}
 
-	// Get all of the shapes on the current page, sorted by their index
-	const sortedShapeIds = editor.getCurrentPageShapesSorted().map((s) => s.id)
+	// Position of each shape in the page's absolute (sorted) order, for ordering lookups below
+	const pageOrder = new Map(editor.getCurrentPageShapesSorted().map((s, i) => [s.id, i] as const))
+	const getPageOrder = (id: TLShapeId) => pageOrder.get(id) ?? -1
 
 	const parentsToNewChildren: Record<
 		TLParentId,
@@ -78,7 +79,7 @@ export function kickoutOccludedShapes(
 				if (opts?.filter && !opts.filter(maybeNewParent)) return false
 				return (
 					maybeNewParent.id !== prevParent.id &&
-					sortedShapeIds.indexOf(maybeNewParent.id) < sortedShapeIds.indexOf(shape.id)
+					getPageOrder(maybeNewParent.id) < getPageOrder(shape.id)
 				)
 			}
 		)
@@ -139,7 +140,7 @@ export function kickoutOccludedShapes(
 		Object.values(parentsToNewChildren).forEach(({ parentId, shapeIds, index }) => {
 			if (shapeIds.length === 0) return
 			// Before we reparent, sort the new shape ids by their place in the original absolute order on the page
-			shapeIds.sort((a, b) => (sortedShapeIds.indexOf(a) < sortedShapeIds.indexOf(b) ? -1 : 1))
+			shapeIds.sort((a, b) => (getPageOrder(a) < getPageOrder(b) ? -1 : 1))
 			editor.reparentShapes(shapeIds, parentId, index)
 		})
 	})
@@ -218,9 +219,7 @@ export function getDroppedShapesToNewParents(
 	for (const shape of shapes) {
 		const parent = editor.getShapeParent(shape)
 		if (parent && editor.isShapeOfType(parent, 'group')) {
-			if (!movingGroups.has(parent)) {
-				movingGroups.add(parent)
-			}
+			movingGroups.add(parent)
 		}
 	}
 
@@ -308,9 +307,7 @@ export function getDroppedShapesToNewParents(
 			// If the shape overlaps the parent polygon, reparent it to that parent
 			if (editor.getShapeGeometry(shape).overlapsPolygon(parentPolygonInShapeSpace)) {
 				// Use the util to check if the shape can be reparented to the parent
-				if (
-					!editor.getShapeUtil(parentShape).canReceiveNewChildrenOfType?.(parentShape, shape.type)
-				)
+				if (!editor.getShapeUtil(parentShape).canReceiveNewChildrenOfType(parentShape, shape.type))
 					continue shapeCheck
 
 				if (shape.parentId !== parentShape.id) {

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -1,7 +1,7 @@
 import { RecordsDiff, SerializedSchema, SerializedStore } from '@tldraw/store'
 import { TLRecord, TLStoreSchema } from '@tldraw/tlschema'
 import { assert, getFromLocalStorage, noop, setInLocalStorage } from '@tldraw/utils'
-import { IDBPDatabase, IDBPTransaction, deleteDB, openDB } from 'idb'
+import { IDBPDatabase, IDBPObjectStore, IDBPTransaction, deleteDB, openDB } from 'idb'
 import { TLSessionStateSnapshot } from '../../config/TLSessionStateSnapshot'
 
 // DO NOT CHANGE THESE WITHOUT ADDING MIGRATION LOGIC. DOING SO WOULD WIPE ALL EXISTING DATA.
@@ -27,17 +27,10 @@ async function openLocalDb(persistenceKey: string) {
 
 	return await openDB<StoreName>(storeId, 4, {
 		upgrade(database) {
-			if (!database.objectStoreNames.contains(Table.Records)) {
-				database.createObjectStore(Table.Records)
-			}
-			if (!database.objectStoreNames.contains(Table.Schema)) {
-				database.createObjectStore(Table.Schema)
-			}
-			if (!database.objectStoreNames.contains(Table.SessionState)) {
-				database.createObjectStore(Table.SessionState)
-			}
-			if (!database.objectStoreNames.contains(Table.Assets)) {
-				database.createObjectStore(Table.Assets)
+			for (const name of Object.values(Table)) {
+				if (!database.objectStoreNames.contains(name)) {
+					database.createObjectStore(name)
+				}
 			}
 		},
 	})
@@ -48,8 +41,7 @@ async function migrateLegacyAssetDbIfNeeded(persistenceKey: string) {
 		? (await window.indexedDB.databases()).map((db) => db.name)
 		: getAllIndexDbNames()
 	const oldStoreId = LEGACY_ASSET_STORE_PREFIX + persistenceKey
-	const existing = databases.find((dbName) => dbName === oldStoreId)
-	if (!existing) return
+	if (!databases.includes(oldStoreId)) return
 
 	const oldAssetDb = await openDB<StoreName>(oldStoreId, 1, {
 		upgrade(database) {
@@ -94,6 +86,25 @@ interface SessionStateSnapshotRow {
 	updatedAt: number
 }
 
+function putSessionState<Names extends StoreName[]>(
+	sessionStateStore: IDBPObjectStore<StoreName, Names, typeof Table.SessionState, 'readwrite'>,
+	sessionId: string | null | undefined,
+	sessionStateSnapshot: TLSessionStateSnapshot | null | undefined
+) {
+	if (sessionStateSnapshot && sessionId) {
+		sessionStateStore.put(
+			{
+				snapshot: sessionStateSnapshot,
+				updatedAt: Date.now(),
+				id: sessionId,
+			} satisfies SessionStateSnapshotRow,
+			sessionId
+		)
+	} else if (sessionStateSnapshot || sessionId) {
+		console.error('sessionStateSnapshot and instanceId must be provided together')
+	}
+}
+
 /** @internal */
 export class LocalIndexedDb {
 	private getDbPromise: Promise<IDBPDatabase<StoreName>>
@@ -111,10 +122,6 @@ export class LocalIndexedDb {
 		})()
 	}
 
-	private getDb() {
-		return this.getDbPromise
-	}
-
 	/**
 	 * Wait for any pending transactions to be completed. Useful for tests.
 	 *
@@ -128,7 +135,7 @@ export class LocalIndexedDb {
 		if (this.isClosed) return
 		this.isClosed = true
 		await this.pending()
-		;(await this.getDb()).close()
+		;(await this.getDbPromise).close()
 		LocalIndexedDb.connectedInstances.delete(this)
 	}
 
@@ -139,7 +146,7 @@ export class LocalIndexedDb {
 	): Promise<T> {
 		const txPromise = (async () => {
 			assert(!this.isClosed, 'db is closed')
-			const db = await this.getDb()
+			const db = await this.getDbPromise
 			const tx = db.transaction(names, mode)
 			// need to add a catch here early to prevent unhandled promise rejection
 			// during react-strict-mode where this tx.done promise can be rejected
@@ -181,13 +188,11 @@ export class LocalIndexedDb {
 					const all = (await sessionStateStore.getAll()) as SessionStateSnapshotRow[]
 					sessionStateSnapshot = all.sort((a, b) => a.updatedAt - b.updatedAt).pop()?.snapshot
 				}
-				const result = {
+				return {
 					records: await recordsStore.getAll(),
 					schema: await schemaStore.get(Table.Schema),
 					sessionStateSnapshot,
 				} satisfies LoadResult
-
-				return result
 			}
 		)
 	}
@@ -221,18 +226,7 @@ export class LocalIndexedDb {
 			}
 
 			schemaStore.put(schema.serialize(), Table.Schema)
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			putSessionState(sessionStateStore, sessionId, sessionStateSnapshot)
 		})
 	}
 
@@ -259,19 +253,7 @@ export class LocalIndexedDb {
 			}
 
 			schemaStore.put(schema.serialize(), Table.Schema)
-
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			putSessionState(sessionStateStore, sessionId, sessionStateSnapshot)
 		})
 	}
 
@@ -279,10 +261,7 @@ export class LocalIndexedDb {
 		await this.tx('readwrite', [Table.SessionState], async (tx) => {
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 			const all = (await sessionStateStore.getAll()).sort((a, b) => a.updatedAt - b.updatedAt)
-			if (all.length < 10) {
-				await tx.done
-				return
-			}
+			if (all.length < 10) return
 			const toDelete = all.slice(0, all.length - 10)
 			for (const { id } of toDelete) {
 				await sessionStateStore.delete(id)

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -43,8 +43,6 @@ interface AnnounceMessage {
 
 type Message = SyncMessage | AnnounceMessage
 
-type UnpackPromise<T> = T extends Promise<infer U> ? U : T
-
 const msg = (msg: Message) => msg
 
 /** @internal */
@@ -74,7 +72,6 @@ export class TLLocalSyncClient {
 	readonly sessionId: string
 	readonly serializedSchema: SerializedSchema
 	private isDebugging = false
-	private readonly documentTypes: ReadonlySet<string>
 	private readonly $sessionStateSnapshot: Signal<TLSessionStateSnapshot | null>
 	/** @internal */
 	readonly db: LocalIndexedDb
@@ -144,17 +141,11 @@ export class TLLocalSyncClient {
 		)
 
 		this.connect(onLoad, onLoadError)
-
-		this.documentTypes = new Set(
-			Object.values(this.store.schema.types)
-				.filter((t) => t.scope === 'document')
-				.map((t) => t.typeName)
-		)
 	}
 
 	private async connect(onLoad: (client: this) => void, onLoadError: (error: Error) => void) {
 		this.debug('connecting')
-		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
+		let data: Awaited<ReturnType<LocalIndexedDb['load']>> | undefined
 
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
@@ -185,7 +176,7 @@ export class TLLocalSyncClient {
 				}
 
 				const records = Object.values(migrationResult.value).filter((r) =>
-					this.documentTypes.has(r.typeName)
+					this.store.scopedTypes.document.has(r.typeName)
 				)
 				if (records.length > 0) {
 					// 3. Merge the changes into the REAL STORE


### PR DESCRIPTION
In order to make the editor package easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `packages/editor` and applies the fixes. It is the editor slice of #10068, split out so it can be reviewed on its own. The public API is unchanged and behavior is intended to be preserved: it deduplicates copy-pasted helpers, replaces switch/if chains with lookup tables, deletes dead code and never-read state, hoists repeated work out of hot paths, and trims narration, banner, and restatement comments per the comments guidance in `AGENTS.md`.

Worth a closer look, since they go slightly beyond mechanical cleanup:

- **`updateShapes` / `ClickManager`:** two latent bugs fell out (a sparse-array preallocation, and a click timeout id that was immediately overwritten with `undefined`). Both were observably no-ops before; the new code just does what the old code meant.
- **`api-report.api.md`:** only a parameter rename (`_polygon` → `polygon`) and an import alias.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` and the unit suites for the touched packages pass.

- [x] Unit tests

### Release notes

- Internal cleanup; no user-facing changes.

### API changes

- Renamed the `Geometry2d.overlapsPolygon` parameter from `_polygon` to `polygon` (docs only, no behavior change).

### Code changes

| Section         | LOC change    |
| --------------- | ------------- |
| Core code       | +1141 / -2181 |
| Automated files | +2 / -2       |
