### PR TITLE
refactor(tldraw): simplify pass over shapes, tools, overlays, and utils

### DIFF
--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -236,7 +236,8 @@ export function Tldraw(props: TldrawProps) {
 		acceptedVideoMimeTypes ?? DEFAULT_SUPPORT_VIDEO_TYPES
 	)
 
-	// options.text takes precedence over the deprecated textOptions prop
+	// Merge deprecated textOptions prop with options.textOptions
+	// options.textOptions takes precedence over the deprecated textOptions prop
 	const _mergedTextOptions = options?.text ?? _textOptions
 	const textOptionsWithDefaults = useMemo((): TLTextOptions => {
 		return {

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -1,6 +1,7 @@
 import {
 	DEFAULT_SUPPORTED_IMAGE_TYPES,
 	DEFAULT_SUPPORT_VIDEO_TYPES,
+	TLAnyAssetUtilConstructor,
 	TLEditorComponents,
 	TLOnMountHandler,
 	TLTextOptions,
@@ -15,7 +16,6 @@ import {
 	useShallowArrayIdentity,
 	useShallowObjectIdentity,
 } from '@tldraw/editor'
-import { TLAnyAssetUtilConstructor } from '@tldraw/editor'
 import { useMemo } from 'react'
 import { ImageAssetUtil } from './assets/ImageAssetUtil'
 import { VideoAssetUtil } from './assets/VideoAssetUtil'
@@ -236,8 +236,7 @@ export function Tldraw(props: TldrawProps) {
 		acceptedVideoMimeTypes ?? DEFAULT_SUPPORT_VIDEO_TYPES
 	)
 
-	// Merge deprecated textOptions prop with options.textOptions
-	// options.textOptions takes precedence over the deprecated textOptions prop
+	// options.text takes precedence over the deprecated textOptions prop
 	const _mergedTextOptions = options?.text ?? _textOptions
 	const textOptionsWithDefaults = useMemo((): TLTextOptions => {
 		return {
@@ -336,8 +335,7 @@ function InsideOfEditorAndUiContext({
 		editor.fonts.requestFonts(allDefaultFontFaces)
 
 		// Also preload any custom font faces defined in themes
-		const themes = editor.getThemes()
-		for (const theme of Object.values(themes)) {
+		for (const theme of Object.values(editor.getThemes())) {
 			for (const key of Object.keys(theme.fonts)) {
 				const font = theme.fonts[key as keyof typeof theme.fonts]
 				if (font.faces?.length) {

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -326,6 +326,7 @@ export function updateArrowTerminal({
 		},
 	} satisfies TLShapePartial<TLArrowShape>
 
+	// fix up the bend:
 	if (info.type === 'arc') {
 		const bend = getArcBendAfterTerminalMove(info, arrow, terminal, startPoint, endPoint)
 		// use `approximately` to avoid endless update loops
@@ -347,6 +348,7 @@ function getArcBendAfterTerminalMove(
 	startPoint: Vec,
 	endPoint: Vec
 ): number | undefined {
+	// find the new start/end points of the resulting arrow
 	const newStart =
 		terminal === 'start' ? startPoint : getValidTerminalPoint(info.start.handle, arrow.props.start)
 	const newEnd =
@@ -370,6 +372,7 @@ function getArcBendAfterTerminalMove(
 		return
 	}
 
+	// find the intersections with the old arrow arc:
 	const intersections = intersectLineSegmentCircle(
 		info.handleArc.center,
 		targetPoint,

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -22,6 +22,7 @@ import {
 	getIndexBetween,
 	intersectLineSegmentCircle,
 } from '@tldraw/editor'
+import { TLArcArrowInfo } from '../../shapes/arrow/arrow-types'
 import { getArrowInfo } from '../../shapes/arrow/getArrowInfo'
 import { getArrowBindings, removeArrowBinding } from '../../shapes/arrow/shared'
 
@@ -187,18 +188,15 @@ function reparentArrow(editor: Editor, arrowId: TLShapeId) {
 			parentPageId
 	} else if (startShape || endShape) {
 		const bindingParentId = (startShape || endShape)?.parentId
-		// If the arrow and the shape that it is bound to have the same parent, then keep that parent
-		if (bindingParentId && bindingParentId === arrow.parentId) {
-			nextParentId = arrow.parentId
-		} else {
-			// if arrow has one binding, keep arrow on its own page
-			nextParentId = parentPageId
-		}
+		// If the arrow and the shape that it is bound to have the same parent, then keep that parent;
+		// otherwise keep the arrow on its own page
+		nextParentId =
+			bindingParentId && bindingParentId === arrow.parentId ? arrow.parentId : parentPageId
 	} else {
 		return
 	}
 
-	if (nextParentId && nextParentId !== arrow.parentId) {
+	if (nextParentId !== arrow.parentId) {
 		editor.reparentShapes([arrowId], nextParentId)
 	}
 
@@ -208,24 +206,20 @@ function reparentArrow(editor: Editor, arrowId: TLShapeId) {
 	const startSibling = editor.getShapeNearestSibling(reparentedArrow, startShape)
 	const endSibling = editor.getShapeNearestSibling(reparentedArrow, endShape)
 
-	let highestSibling: TLShape | undefined
-
-	if (startSibling && endSibling) {
-		highestSibling = startSibling.index > endSibling.index ? startSibling : endSibling
-	} else if (startSibling && !endSibling) {
-		highestSibling = startSibling
-	} else if (endSibling && !startSibling) {
-		highestSibling = endSibling
-	} else {
-		return
-	}
+	const highestSibling =
+		startSibling && endSibling
+			? startSibling.index > endSibling.index
+				? startSibling
+				: endSibling
+			: (startSibling ?? endSibling)
+	if (!highestSibling) return
 
 	let finalIndex: IndexKey
 
 	const higherSiblings = editor
 		.getSortedChildIdsForParent(highestSibling.parentId)
 		.map((id) => editor.getShape(id)!)
-		.filter((sibling) => sibling.index > highestSibling!.index)
+		.filter((sibling) => sibling.index > highestSibling.index)
 
 	if (higherSiblings.length) {
 		// there are siblings above the highest bound sibling, we need to
@@ -285,9 +279,7 @@ function arrowDidUpdate(editor: Editor, arrow: TLArrowShape) {
 		const binding = bindings[handle]
 		if (!binding) continue
 		const boundShape = editor.getShape(binding.toId)
-		const isShapeInSamePageAsArrow =
-			editor.getAncestorPageId(arrow) === editor.getAncestorPageId(boundShape)
-		if (!boundShape || !isShapeInSamePageAsArrow) {
+		if (!boundShape || editor.getAncestorPageId(arrow) !== editor.getAncestorPageId(boundShape)) {
 			updateArrowTerminal({ editor, arrow, terminal: handle, unbind: true })
 		}
 	}
@@ -334,61 +326,11 @@ export function updateArrowTerminal({
 		},
 	} satisfies TLShapePartial<TLArrowShape>
 
-	// fix up the bend:
 	if (info.type === 'arc') {
-		// find the new start/end points of the resulting arrow
-		const newStart =
-			terminal === 'start'
-				? startPoint
-				: getValidTerminalPoint(info.start.handle, arrow.props.start)
-		const newEnd =
-			terminal === 'end' ? endPoint : getValidTerminalPoint(info.end.handle, arrow.props.end)
-		const newMidPoint = Vec.Med(newStart, newEnd)
-		const arrowDirection = Vec.Sub(newStart, newEnd)
-		if (approximately(Vec.Len2(arrowDirection), 0)) {
-			editor.updateShape(update)
-			if (unbind) {
-				removeArrowBinding(editor, arrow, terminal)
-			}
-			return
-		}
-
-		// intersect a line segment perpendicular to the new arrow with the old arrow arc to
-		// find the new mid-point
-		const lineSegment = arrowDirection
-			.per()
-			.uni()
-			.mul(info.handleArc.radius * 2 * Math.sign(arrow.props.bend))
-		const targetPoint = Vec.Add(newMidPoint, lineSegment)
-		if (
-			!Vec.IsFinite(info.handleArc.center) ||
-			!Number.isFinite(info.handleArc.radius) ||
-			!Vec.IsFinite(targetPoint)
-		) {
-			editor.updateShape(update)
-			if (unbind) {
-				removeArrowBinding(editor, arrow, terminal)
-			}
-			return
-		}
-
-		// find the intersections with the old arrow arc:
-		const intersections = intersectLineSegmentCircle(
-			info.handleArc.center,
-			targetPoint,
-			info.handleArc.center,
-			info.handleArc.radius
-		)
-
-		if (intersections?.length) {
-			const intersection = intersections.reduce((closest, candidate) =>
-				Vec.Dist2(candidate, targetPoint) < Vec.Dist2(closest, targetPoint) ? candidate : closest
-			)
-			const bend = Vec.Dist(newMidPoint, intersection) * Math.sign(arrow.props.bend)
-			// use `approximately` to avoid endless update loops
-			if (!approximately(bend, update.props.bend)) {
-				update.props.bend = bend
-			}
+		const bend = getArcBendAfterTerminalMove(info, arrow, terminal, startPoint, endPoint)
+		// use `approximately` to avoid endless update loops
+		if (bend !== undefined && !approximately(bend, update.props.bend)) {
+			update.props.bend = bend
 		}
 	}
 
@@ -396,6 +338,50 @@ export function updateArrowTerminal({
 	if (unbind) {
 		removeArrowBinding(editor, arrow, terminal)
 	}
+}
+
+function getArcBendAfterTerminalMove(
+	info: TLArcArrowInfo,
+	arrow: TLArrowShape,
+	terminal: 'start' | 'end',
+	startPoint: Vec,
+	endPoint: Vec
+): number | undefined {
+	const newStart =
+		terminal === 'start' ? startPoint : getValidTerminalPoint(info.start.handle, arrow.props.start)
+	const newEnd =
+		terminal === 'end' ? endPoint : getValidTerminalPoint(info.end.handle, arrow.props.end)
+	const newMidPoint = Vec.Med(newStart, newEnd)
+	const arrowDirection = Vec.Sub(newStart, newEnd)
+	if (approximately(Vec.Len2(arrowDirection), 0)) return
+
+	// intersect a line segment perpendicular to the new arrow with the old arrow arc to
+	// find the new mid-point
+	const lineSegment = arrowDirection
+		.per()
+		.uni()
+		.mul(info.handleArc.radius * 2 * Math.sign(arrow.props.bend))
+	const targetPoint = Vec.Add(newMidPoint, lineSegment)
+	if (
+		!Vec.IsFinite(info.handleArc.center) ||
+		!Number.isFinite(info.handleArc.radius) ||
+		!Vec.IsFinite(targetPoint)
+	) {
+		return
+	}
+
+	const intersections = intersectLineSegmentCircle(
+		info.handleArc.center,
+		targetPoint,
+		info.handleArc.center,
+		info.handleArc.radius
+	)
+	if (!intersections?.length) return
+
+	const intersection = intersections.reduce((closest, candidate) =>
+		Vec.Dist2(candidate, targetPoint) < Vec.Dist2(closest, targetPoint) ? candidate : closest
+	)
+	return Vec.Dist(newMidPoint, intersection) * Math.sign(arrow.props.bend)
 }
 
 function getValidTerminalPoint(

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -3,6 +3,22 @@ import { safeParseUrl } from '@tldraw/editor'
 // Only allow multiplayer embeds. If we add additional routes later for example '/help' this won't match
 const TLDRAW_APP_RE = /(^\/[f|p|r|ro|s|v]\/[^/]+\/?$)/
 
+function clearSearchParams(urlObj: URL) {
+	for (const key of Array.from(urlObj.searchParams.keys())) {
+		urlObj.searchParams.delete(key)
+	}
+}
+
+function youtubeEmbedSearch(searchParams: URLSearchParams) {
+	const timeStart = searchParams.get('t')
+	if (timeStart) {
+		searchParams.set('start', timeStart)
+		searchParams.delete('t')
+	}
+	const search = searchParams.toString()
+	return search ? '?' + search : ''
+}
+
 /** @public */
 export const DEFAULT_EMBED_DEFINITIONS = [
 	{
@@ -20,7 +36,6 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(TLDRAW_APP_RE)) {
-				// Add the "clean=true" search param to the URL to hide the sidebar
 				urlObj.searchParams.append('embed', 'true')
 				return url
 			}
@@ -29,7 +44,6 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(TLDRAW_APP_RE)) {
-				// Add the "clean=true" search param to the URL to hide the sidebar
 				urlObj.searchParams.delete('embed')
 				return url
 			}
@@ -175,7 +189,6 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		},
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
-			// e.g. extract "steveruizok/mathFact" from https://www.val.town/v/steveruizok/mathFact
 			const matches = urlObj && urlObj.pathname.match(/\/embed\/(.+)\/?/)
 			if (matches) {
 				return `https://www.val.town/v/${matches[1]}`
@@ -291,13 +304,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			if (hostname === 'youtu.be') {
 				const videoId = urlObj.pathname.split('/').filter(Boolean)[0]
 				const searchParams = new URLSearchParams(urlObj.search)
-				const timeStart = searchParams.get('t')
-				if (timeStart) {
-					searchParams.set('start', timeStart)
-					searchParams.delete('t')
-				}
-				const search = searchParams.toString() ? '?' + searchParams.toString() : ''
-				return `https://www.youtube.com/embed/${videoId}${search}`
+				return `https://www.youtube.com/embed/${videoId}${youtubeEmbedSearch(searchParams)}`
 			} else if (
 				(hostname === 'youtube.com' || hostname === 'm.youtube.com') &&
 				urlObj.pathname.match(/^\/watch/)
@@ -305,13 +312,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 				const videoId = urlObj.searchParams.get('v')
 				const searchParams = new URLSearchParams(urlObj.search)
 				searchParams.delete('v')
-				const timeStart = searchParams.get('t')
-				if (timeStart) {
-					searchParams.set('start', timeStart)
-					searchParams.delete('t')
-				}
-				const search = searchParams.toString() ? '?' + searchParams.toString() : ''
-				return `https://www.youtube.com/embed/${videoId}${search}`
+				return `https://www.youtube.com/embed/${videoId}${youtubeEmbedSearch(searchParams)}`
 			}
 			return
 		},
@@ -357,10 +358,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 			if (urlObj?.pathname.match(/\/calendar\/u\/0/) && cidQs) {
 				urlObj.pathname = '/calendar/embed'
 
-				const keys = Array.from(urlObj.searchParams.keys())
-				for (const key of keys) {
-					urlObj.searchParams.delete(key)
-				}
+				clearSearchParams(urlObj)
 				urlObj.searchParams.set('src', cidQs)
 				return urlObj.href
 			}
@@ -372,10 +370,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 
 			if (urlObj?.pathname.match(/\/calendar\/embed/) && srcQs) {
 				urlObj.pathname = '/calendar/u/0'
-				const keys = Array.from(urlObj.searchParams.keys())
-				for (const key of keys) {
-					urlObj.searchParams.delete(key)
-				}
+				clearSearchParams(urlObj)
 				urlObj.searchParams.set('cid', srcQs)
 				return urlObj.href
 			}
@@ -400,10 +395,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 
 			if (urlObj?.pathname.match(/^\/presentation/) && urlObj?.pathname.match(/\/pub\/?$/)) {
 				urlObj.pathname = urlObj.pathname.replace(/\/pub$/, '/embed')
-				const keys = Array.from(urlObj.searchParams.keys())
-				for (const key of keys) {
-					urlObj.searchParams.delete(key)
-				}
+				clearSearchParams(urlObj)
 				return urlObj.href
 			}
 			return
@@ -413,10 +405,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 
 			if (urlObj?.pathname.match(/^\/presentation/) && urlObj?.pathname.match(/\/embed\/?$/)) {
 				urlObj.pathname = urlObj.pathname.replace(/\/embed$/, '/pub')
-				const keys = Array.from(urlObj.searchParams.keys())
-				for (const key of keys) {
-					urlObj.searchParams.delete(key)
-				}
+				clearSearchParams(urlObj)
 				return urlObj.href
 			}
 			return
@@ -643,9 +632,6 @@ export const DEFAULT_EMBED_DEFINITIONS = [
  * @public
  */
 export const embedShapePermissionDefaults = {
-	// ========================================================================================
-	// Disabled permissions
-	// ========================================================================================
 	// [MDN] Experimental: Allows for downloads to occur without a gesture from the user.
 	// [REASON] Disabled because otherwise the <iframe/> can trick the user on behalf of us to perform an action.
 	'allow-downloads-without-user-activation': false,
@@ -679,9 +665,6 @@ export const embedShapePermissionDefaults = {
 	// [MDN] Lets the resource navigate the top-level browsing context, but only if initiated by a user gesture.
 	// [REASON] Prevents embed from navigating away from tldraw and pretending to be us.
 	'allow-top-navigation-by-user-activation': false,
-	// ========================================================================================
-	// Enabled permissions
-	// ========================================================================================
 	// [MDN] Lets the resource run scripts (but not create popup windows).
 	'allow-scripts': true,
 	// [MDN] If this token is not used, the resource is treated as being from a special origin that always fails the same-origin policy (potentially preventing access to data storage/cookies and some JavaScript APIs).

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -36,6 +36,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(TLDRAW_APP_RE)) {
+				// Add the "clean=true" search param to the URL to hide the sidebar
 				urlObj.searchParams.append('embed', 'true')
 				return url
 			}
@@ -44,6 +45,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.pathname.match(TLDRAW_APP_RE)) {
+				// Add the "clean=true" search param to the URL to hide the sidebar
 				urlObj.searchParams.delete('embed')
 				return url
 			}
@@ -189,6 +191,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		},
 		fromEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
+			// e.g. extract "steveruizok/mathFact" from https://www.val.town/v/steveruizok/mathFact
 			const matches = urlObj && urlObj.pathname.match(/\/embed\/(.+)\/?/)
 			if (matches) {
 				return `https://www.val.town/v/${matches[1]}`
@@ -632,6 +635,9 @@ export const DEFAULT_EMBED_DEFINITIONS = [
  * @public
  */
 export const embedShapePermissionDefaults = {
+	// ========================================================================================
+	// Disabled permissions
+	// ========================================================================================
 	// [MDN] Experimental: Allows for downloads to occur without a gesture from the user.
 	// [REASON] Disabled because otherwise the <iframe/> can trick the user on behalf of us to perform an action.
 	'allow-downloads-without-user-activation': false,
@@ -665,6 +671,9 @@ export const embedShapePermissionDefaults = {
 	// [MDN] Lets the resource navigate the top-level browsing context, but only if initiated by a user gesture.
 	// [REASON] Prevents embed from navigating away from tldraw and pretending to be us.
 	'allow-top-navigation-by-user-activation': false,
+	// ========================================================================================
+	// Enabled permissions
+	// ========================================================================================
 	// [MDN] Lets the resource run scripts (but not create popup windows).
 	'allow-scripts': true,
 	// [MDN] If this token is not used, the resource is treated as being from a special origin that always fails the same-origin policy (potentially preventing access to data storage/cookies and some JavaScript APIs).

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -92,52 +92,42 @@ export function registerDefaultExternalContentHandlers(
 	editor: Editor,
 	options: TLDefaultExternalContentHandlerOpts
 ) {
-	// files -> asset
 	editor.registerExternalAssetHandler('file', async (externalAsset) => {
 		return defaultHandleExternalFileAsset(editor, externalAsset, options)
 	})
 
-	// urls -> bookmark asset
 	editor.registerExternalAssetHandler('url', async (externalAsset) => {
 		return defaultHandleExternalUrlAsset(editor, externalAsset, options)
 	})
 
-	// svg text
 	editor.registerExternalContentHandler('svg-text', async (externalContent) => {
 		return defaultHandleExternalSvgTextContent(editor, externalContent)
 	})
 
-	// embeds
 	editor.registerExternalContentHandler<'embed', EmbedDefinition>('embed', (externalContent) => {
 		return defaultHandleExternalEmbedContent(editor, externalContent)
 	})
 
-	// files
 	editor.registerExternalContentHandler('files', async (externalContent) => {
 		return defaultHandleExternalFileContent(editor, externalContent, options)
 	})
 
-	// file-replace -> asset
 	editor.registerExternalContentHandler('file-replace', async (externalContent) => {
 		return defaultHandleExternalFileReplaceContent(editor, externalContent, options)
 	})
 
-	// text
 	editor.registerExternalContentHandler('text', async (externalContent) => {
 		return defaultHandleExternalTextContent(editor, externalContent)
 	})
 
-	// url
 	editor.registerExternalContentHandler('url', async (externalContent) => {
 		return defaultHandleExternalUrlContent(editor, externalContent, options)
 	})
 
-	// tldraw
 	editor.registerExternalContentHandler('tldraw', async (externalContent) => {
 		return defaultHandleExternalTldrawContent(editor, externalContent)
 	})
 
-	// excalidraw
 	editor.registerExternalContentHandler('excalidraw', async (externalContent) => {
 		return defaultHandleExternalExcalidrawContent(editor, externalContent)
 	})
@@ -187,45 +177,21 @@ export async function defaultHandleExternalFileReplaceContent(
 	if (!assetInfoPartial) return
 	editor.createAssets([assetInfoPartial])
 
-	// And update the shape
 	if (shape.type === 'image') {
 		const imageShape = shape as TLImageShape
-		const currentCrop = imageShape.props.crop
-
-		// Calculate new dimensions that preserve the current visual size of the cropped area
-		let newWidth = assetInfoPartial.props.w
-		let newHeight = assetInfoPartial.props.h
-		let newX = imageShape.x
-		let newY = imageShape.y
-		let finalCrop = currentCrop
-
-		if (currentCrop) {
-			// Use the dedicated function to calculate the new crop and dimensions
-			const result = getCroppedImageDataForReplacedImage(
-				imageShape,
-				assetInfoPartial.props.w,
-				assetInfoPartial.props.h
-			)
-
-			finalCrop = result.crop
-			newWidth = result.w
-			newHeight = result.h
-			newX = result.x
-			newY = result.y
-		}
+		const { w, h } = assetInfoPartial.props
+		// Preserve the visual size of the cropped area when the new image has different dimensions
+		const next = imageShape.props.crop
+			? getCroppedImageDataForReplacedImage(imageShape, w, h)
+			: { crop: imageShape.props.crop, w, h, x: imageShape.x, y: imageShape.y }
 
 		editor.updateShapes([
 			{
 				id: imageShape.id,
 				type: imageShape.type,
-				props: {
-					assetId: assetId,
-					crop: finalCrop,
-					w: newWidth,
-					h: newHeight,
-				},
-				x: newX,
-				y: newY,
+				props: { assetId, crop: next.crop, w: next.w, h: next.h },
+				x: next.x,
+				y: next.y,
 			},
 		])
 	} else if (shape.type === 'video') {
@@ -233,11 +199,7 @@ export async function defaultHandleExternalFileReplaceContent(
 			{
 				id: shape.id,
 				type: shape.type,
-				props: {
-					assetId: assetId,
-					w: assetInfoPartial.props.w,
-					h: assetInfoPartial.props.h,
-				},
+				props: { assetId, w: assetInfoPartial.props.w, h: assetInfoPartial.props.h },
 			},
 		])
 	}
@@ -293,7 +255,6 @@ export async function defaultHandleExternalUrlAsset(
 		meta = { image: '', favicon: '', title: '', description: '' }
 	}
 
-	// Create the bookmark asset from the meta
 	return {
 		id: AssetRecordType.createId(getHashForString(url)),
 		typeName: 'asset',
@@ -318,11 +279,7 @@ export async function defaultHandleExternalSvgTextContent(
 	text = sanitizeSvg(text)
 	if (!text) return
 
-	const position =
-		point ??
-		(editor.inputs.getShiftKey()
-			? editor.inputs.getCurrentPagePoint()
-			: editor.getViewportPageBounds().center)
+	const position = getExternalContentPoint(editor, point)
 
 	const svg = new DOMParser().parseFromString(text, 'image/svg+xml').querySelector('svg')
 	if (!svg) {
@@ -357,11 +314,7 @@ export function defaultHandleExternalEmbedContent<T>(
 	editor: Editor,
 	{ point, url, embed }: { point?: VecLike; url: string; embed: T }
 ) {
-	const position =
-		point ??
-		(editor.inputs.getShiftKey()
-			? editor.inputs.getCurrentPagePoint()
-			: editor.getViewportPageBounds().center)
+	const position = getExternalContentPoint(editor, point)
 
 	const { width, height } = embed as { width: number; height: number }
 
@@ -400,11 +353,7 @@ export async function defaultHandleExternalFileContent(
 		return
 	}
 
-	const position =
-		point ??
-		(editor.inputs.getShiftKey()
-			? editor.inputs.getCurrentPagePoint()
-			: editor.getViewportPageBounds().center)
+	const position = getExternalContentPoint(editor, point)
 
 	const pagePoint = new Vec(position.x, position.y)
 	const assetPartials: TLAsset[] = []
@@ -454,7 +403,6 @@ export async function defaultHandleExternalFileContent(
 				})
 				console.error(error)
 				editor.deleteAssets([assetAndFile.asset.id])
-				return
 			}
 		})
 	)
@@ -467,11 +415,7 @@ export async function defaultHandleExternalTextContent(
 	editor: Editor,
 	{ point, text, html }: { point?: VecLike; text: string; html?: string }
 ) {
-	const p =
-		point ??
-		(editor.inputs.getShiftKey()
-			? editor.inputs.getCurrentPagePoint()
-			: editor.getViewportPageBounds().center)
+	const p = getExternalContentPoint(editor, point)
 
 	const defaultProps = editor.getShapeUtil<TLTextShape>('text').getDefaultProps()
 
@@ -480,24 +424,6 @@ export async function defaultHandleExternalTextContent(
 		? renderRichTextFromHTML(editor, html)
 		: toRichText(cleanedUpPlaintext)
 
-	// todo: discuss
-	// If we have one shape with rich text selected, update the shape's text.
-	// const onlySelectedShape = editor.getOnlySelectedShape()
-	// if (onlySelectedShape && 'richText' in onlySelectedShape.props) {
-	// 	editor.updateShapes([
-	// 		{
-	// 			id: onlySelectedShape.id,
-	// 			type: onlySelectedShape.type,
-	// 			props: {
-	// 				richText: richTextToPaste,
-	// 			},
-	// 		},
-	// 	])
-
-	// 	return
-	// }
-
-	// Measure the text with default values
 	let w: number
 	let h: number
 	let autoSize: boolean
@@ -510,18 +436,18 @@ export async function defaultHandleExternalTextContent(
 	const isRtl = isRightToLeftLanguage(cleanedUpPlaintext)
 
 	if (isMultiLine) {
-		align = isMultiLine ? (isRtl ? 'end' : 'start') : 'middle'
+		align = isRtl ? 'end' : 'start'
 	}
 
 	const theme = editor.getCurrentTheme()
-
-	const rawSize = editor.textMeasure.measureHtml(htmlToMeasure, {
+	const measureOpts = {
 		...TEXT_PROPS,
 		lineHeight: theme.lineHeight,
 		fontFamily: getFontFamily(theme, defaultProps.font),
 		fontSize: theme.fontSize * FONT_SIZES[defaultProps.size],
-		maxWidth: null,
-	})
+	}
+
+	const rawSize = editor.textMeasure.measureHtml(htmlToMeasure, { ...measureOpts, maxWidth: null })
 
 	const minWidth = Math.min(
 		isMultiLine ? editor.getViewportPageBounds().width * 0.9 : 920,
@@ -530,10 +456,7 @@ export async function defaultHandleExternalTextContent(
 
 	if (rawSize.w > minWidth) {
 		const shrunkSize = editor.textMeasure.measureHtml(htmlToMeasure, {
-			...TEXT_PROPS,
-			lineHeight: theme.lineHeight,
-			fontFamily: getFontFamily(theme, defaultProps.font),
-			fontSize: theme.fontSize * FONT_SIZES[defaultProps.size],
+			...measureOpts,
 			maxWidth: minWidth,
 		})
 		w = shrunkSize.w
@@ -541,7 +464,6 @@ export async function defaultHandleExternalTextContent(
 		autoSize = false
 		align = isRtl ? 'end' : 'start'
 	} else {
-		// autosize is fine
 		w = Math.max(rawSize.w, 10)
 		h = Math.max(rawSize.h, 10)
 		autoSize = true
@@ -563,7 +485,6 @@ export async function defaultHandleExternalTextContent(
 			y: newPoint.y,
 			props: {
 				richText: richTextToPaste,
-				// if the text has more than one line, align it to the left
 				textAlign: align,
 				autoSize,
 				w,
@@ -607,13 +528,8 @@ export async function defaultHandleExternalUrlContent(
 		})
 	}
 
-	const position =
-		point ??
-		(editor.inputs.getShiftKey()
-			? editor.inputs.getCurrentPagePoint()
-			: editor.getViewportPageBounds().center)
+	const position = getExternalContentPoint(editor, point)
 
-	// Use the new function to create the bookmark
 	const result = await createBookmarkFromUrl(editor, { url, center: position })
 
 	if (!result.ok) {
@@ -668,7 +584,7 @@ export async function defaultHandleExternalTldrawContent(
 			!isMidInteraction &&
 			selectionBoundsBefore &&
 			selectedBoundsAfter &&
-			selectionBoundsBefore?.collides(selectedBoundsAfter)
+			selectionBoundsBefore.collides(selectedBoundsAfter)
 		) {
 			// Creates a 'puff' to show content has been pasted
 			editor.updateInstanceState({ isChangingStyle: true })
@@ -711,8 +627,7 @@ export async function createShapesForAssets(
 	const currentPoint = Vec.From(position)
 	const partials: TLShapePartial[] = []
 
-	for (let i = 0; i < assets.length; i++) {
-		const asset = assets[i]
+	for (const asset of assets) {
 		const shapeUtil = editor.getShapeUtilForAssetType(asset.type)
 		const partial = shapeUtil?.createShapeForAsset?.(asset, currentPoint) ?? null
 		if (partial) {
@@ -724,7 +639,6 @@ export async function createShapesForAssets(
 	}
 
 	editor.run(() => {
-		// Create any assets
 		const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
 
 		editor.store.atomic(() => {
@@ -733,10 +647,8 @@ export async function createShapesForAssets(
 					editor.createAssets(assetsToCreate)
 				}
 
-				// Create the shapes
 				editor.createShapes(partials).select(...partials.map((p) => p.id))
 
-				// Re-position shapes so that the center of the group is at the provided point
 				centerSelectionAroundPoint(editor, position)
 			}
 		})
@@ -756,12 +668,11 @@ export async function createShapesForAssets(
  * @public
  */
 export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
-	// Re-position shapes so that the center of the group is at the provided point
 	const viewportPageBounds = editor.getViewportPageBounds()
 	let selectionPageBounds = editor.getSelectionPageBounds()
 
 	if (selectionPageBounds) {
-		const offset = selectionPageBounds!.center.sub(position)
+		const offset = selectionPageBounds.center.sub(position)
 
 		editor.updateShapes(
 			editor.getSelectedShapes().map((shape) => {
@@ -770,8 +681,8 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 				return {
 					id: shape.id,
 					type: shape.type,
-					x: shape.x! - localDelta.x,
-					y: shape.y! - localDelta.y,
+					x: shape.x - localDelta.x,
+					y: shape.y - localDelta.y,
 				}
 			})
 		)
@@ -784,15 +695,12 @@ export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
 		const gridSnappedPoint = topLeft.clone().snapToGrid(gridSize)
 		const delta = Vec.Sub(topLeft, gridSnappedPoint)
 		editor.updateShapes(
-			editor.getSelectedShapes().map((shape) => {
-				const newPoint = { x: shape.x! - delta.x, y: shape.y! - delta.y }
-				return {
-					id: shape.id,
-					type: shape.type,
-					x: newPoint.x,
-					y: newPoint.y,
-				}
-			})
+			editor.getSelectedShapes().map((shape) => ({
+				id: shape.id,
+				type: shape.type,
+				x: shape.x - delta.x,
+				y: shape.y - delta.y,
+			}))
 		)
 	}
 	// Zoom out to fit the shapes, if necessary
@@ -831,6 +739,15 @@ export function createEmptyBookmarkShape(
 	return editor.getShape(partial.id) as TLBookmarkShape
 }
 
+function getExternalContentPoint(editor: Editor, point?: VecLike): VecLike {
+	return (
+		point ??
+		(editor.inputs.getShiftKey()
+			? editor.inputs.getCurrentPagePoint()
+			: editor.getViewportPageBounds().center)
+	)
+}
+
 async function maybeSanitizeSvgFile(file: File): Promise<File | null> {
 	if (file.type !== 'image/svg+xml') return file
 	try {
@@ -842,6 +759,19 @@ async function maybeSanitizeSvgFile(file: File): Promise<File | null> {
 	} catch {
 		return null
 	}
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 bytes'
+
+	const units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB']
+	const base = 1024
+	const unitIndex = Math.floor(Math.log(bytes) / Math.log(base))
+
+	const value = bytes / Math.pow(base, unitIndex)
+	const formatted = value % 1 === 0 ? value.toString() : value.toFixed(1)
+
+	return `${formatted} ${units[unitIndex]}`
 }
 
 /**
@@ -886,19 +816,6 @@ export function notifyIfFileNotAllowed(
 	}
 
 	if (file.size > maxAssetSize) {
-		const formatBytes = (bytes: number): string => {
-			if (bytes === 0) return '0 bytes'
-
-			const units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB']
-			const base = 1024
-			const unitIndex = Math.floor(Math.log(bytes) / Math.log(base))
-
-			const value = bytes / Math.pow(base, unitIndex)
-			const formatted = value % 1 === 0 ? value.toString() : value.toFixed(1)
-
-			return `${formatted} ${units[unitIndex]}`
-		}
-
 		toasts.addToast({
 			title: msg('assets.files.size-too-big'),
 			description: msg('assets.files.maximum-size').replace('{size}', formatBytes(maxAssetSize)),

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -23,12 +23,11 @@ import {
 	createShapeId,
 	fetch,
 	getHashForBuffer,
-	getHashForString,
 	maybeSnapToGrid,
 	toRichText,
 } from '@tldraw/editor'
 import { EmbedDefinition } from './defaultEmbedDefinitions'
-import { createBookmarkFromUrl } from './shapes/bookmark/bookmarks'
+import { createBookmarkFromUrl, getBookmarkAssetIdForUrl } from './shapes/bookmark/bookmarks'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
 import { getCroppedImageDataForReplacedImage } from './shapes/shared/crop'
 import { FONT_SIZES, TEXT_PROPS, getFontFamily } from './shapes/shared/default-shape-constants'
@@ -256,7 +255,7 @@ export async function defaultHandleExternalUrlAsset(
 	}
 
 	return {
-		id: AssetRecordType.createId(getHashForString(url)),
+		id: getBookmarkAssetIdForUrl(url),
 		typeName: 'asset',
 		type: 'bookmark',
 		props: {

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -91,42 +91,52 @@ export function registerDefaultExternalContentHandlers(
 	editor: Editor,
 	options: TLDefaultExternalContentHandlerOpts
 ) {
+	// files -> asset
 	editor.registerExternalAssetHandler('file', async (externalAsset) => {
 		return defaultHandleExternalFileAsset(editor, externalAsset, options)
 	})
 
+	// urls -> bookmark asset
 	editor.registerExternalAssetHandler('url', async (externalAsset) => {
 		return defaultHandleExternalUrlAsset(editor, externalAsset, options)
 	})
 
+	// svg text
 	editor.registerExternalContentHandler('svg-text', async (externalContent) => {
 		return defaultHandleExternalSvgTextContent(editor, externalContent)
 	})
 
+	// embeds
 	editor.registerExternalContentHandler<'embed', EmbedDefinition>('embed', (externalContent) => {
 		return defaultHandleExternalEmbedContent(editor, externalContent)
 	})
 
+	// files
 	editor.registerExternalContentHandler('files', async (externalContent) => {
 		return defaultHandleExternalFileContent(editor, externalContent, options)
 	})
 
+	// file-replace -> asset
 	editor.registerExternalContentHandler('file-replace', async (externalContent) => {
 		return defaultHandleExternalFileReplaceContent(editor, externalContent, options)
 	})
 
+	// text
 	editor.registerExternalContentHandler('text', async (externalContent) => {
 		return defaultHandleExternalTextContent(editor, externalContent)
 	})
 
+	// url
 	editor.registerExternalContentHandler('url', async (externalContent) => {
 		return defaultHandleExternalUrlContent(editor, externalContent, options)
 	})
 
+	// tldraw
 	editor.registerExternalContentHandler('tldraw', async (externalContent) => {
 		return defaultHandleExternalTldrawContent(editor, externalContent)
 	})
 
+	// excalidraw
 	editor.registerExternalContentHandler('excalidraw', async (externalContent) => {
 		return defaultHandleExternalExcalidrawContent(editor, externalContent)
 	})
@@ -176,6 +186,7 @@ export async function defaultHandleExternalFileReplaceContent(
 	if (!assetInfoPartial) return
 	editor.createAssets([assetInfoPartial])
 
+	// And update the shape
 	if (shape.type === 'image') {
 		const imageShape = shape as TLImageShape
 		const { w, h } = assetInfoPartial.props
@@ -254,6 +265,7 @@ export async function defaultHandleExternalUrlAsset(
 		meta = { image: '', favicon: '', title: '', description: '' }
 	}
 
+	// Create the bookmark asset from the meta
 	return {
 		id: getBookmarkAssetIdForUrl(url),
 		typeName: 'asset',
@@ -423,6 +435,24 @@ export async function defaultHandleExternalTextContent(
 		? renderRichTextFromHTML(editor, html)
 		: toRichText(cleanedUpPlaintext)
 
+	// todo: discuss
+	// If we have one shape with rich text selected, update the shape's text.
+	// const onlySelectedShape = editor.getOnlySelectedShape()
+	// if (onlySelectedShape && 'richText' in onlySelectedShape.props) {
+	// 	editor.updateShapes([
+	// 		{
+	// 			id: onlySelectedShape.id,
+	// 			type: onlySelectedShape.type,
+	// 			props: {
+	// 				richText: richTextToPaste,
+	// 			},
+	// 		},
+	// 	])
+
+	// 	return
+	// }
+
+	// Measure the text with default values
 	let w: number
 	let h: number
 	let autoSize: boolean
@@ -463,6 +493,7 @@ export async function defaultHandleExternalTextContent(
 		autoSize = false
 		align = isRtl ? 'end' : 'start'
 	} else {
+		// autosize is fine
 		w = Math.max(rawSize.w, 10)
 		h = Math.max(rawSize.h, 10)
 		autoSize = true
@@ -484,6 +515,7 @@ export async function defaultHandleExternalTextContent(
 			y: newPoint.y,
 			props: {
 				richText: richTextToPaste,
+				// if the text has more than one line, align it to the left
 				textAlign: align,
 				autoSize,
 				w,
@@ -529,6 +561,7 @@ export async function defaultHandleExternalUrlContent(
 
 	const position = getExternalContentPoint(editor, point)
 
+	// Use the new function to create the bookmark
 	const result = await createBookmarkFromUrl(editor, { url, center: position })
 
 	if (!result.ok) {
@@ -638,6 +671,7 @@ export async function createShapesForAssets(
 	}
 
 	editor.run(() => {
+		// Create any assets
 		const assetsToCreate = assets.filter((asset) => !editor.getAsset(asset.id))
 
 		editor.store.atomic(() => {
@@ -646,8 +680,10 @@ export async function createShapesForAssets(
 					editor.createAssets(assetsToCreate)
 				}
 
+				// Create the shapes
 				editor.createShapes(partials).select(...partials.map((p) => p.id))
 
+				// Re-position shapes so that the center of the group is at the provided point
 				centerSelectionAroundPoint(editor, position)
 			}
 		})
@@ -667,6 +703,7 @@ export async function createShapesForAssets(
  * @public
  */
 export function centerSelectionAroundPoint(editor: Editor, position: VecLike) {
+	// Re-position shapes so that the center of the group is at the provided point
 	const viewportPageBounds = editor.getViewportPageBounds()
 	let selectionPageBounds = editor.getSelectionPageBounds()
 

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -59,29 +59,18 @@ export function registerDefaultSideEffects(editor: Editor) {
 				if (prev.editingShapeId !== next.editingShapeId) {
 					if (!prev.editingShapeId && next.editingShapeId) {
 						if (!editor.isIn('select.editing_shape')) {
-							// Here's where we handle the special tool locking case for text
-							// If tool lock is enabled, and we just finished editing a text
-							// shape and are setting that shape as the new editing shape,
-							// then create the shape with a flag that will let it know to
-							// go back to the text tool once the edit is complete.
+							// With tool lock on, a text shape created from the text tool tells the editing
+							// state to return to the text tool once the edit is complete.
 							const shape = editor.getEditingShape()
-							if (
-								shape &&
-								shape.type === 'text' &&
+							const isCreatingTextWhileToolLocked =
+								shape?.type === 'text' &&
 								editor.isInAny('text.pointing', 'select.resizing') &&
 								editor.getInstanceState().isToolLocked
-							) {
-								editor.setCurrentTool('select.editing_shape', {
-									target: 'shape',
-									shape: shape,
-									isCreatingTextWhileToolLocked: true,
-								})
-							} else {
-								editor.setCurrentTool('select.editing_shape', {
-									target: 'shape',
-									shape: shape,
-								})
-							}
+							editor.setCurrentTool('select.editing_shape', {
+								target: 'shape',
+								shape,
+								...(isCreatingTextWhileToolLocked && { isCreatingTextWhileToolLocked: true }),
+							})
 						}
 					} else if (prev.editingShapeId && !next.editingShapeId) {
 						if (editor.isIn('select.editing_shape')) {

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -69,7 +69,7 @@ export function registerDefaultSideEffects(editor: Editor) {
 							editor.setCurrentTool('select.editing_shape', {
 								target: 'shape',
 								shape,
-								...(isCreatingTextWhileToolLocked && { isCreatingTextWhileToolLocked: true }),
+								isCreatingTextWhileToolLocked,
 							})
 						}
 					} else if (prev.editingShapeId && !next.editingShapeId) {

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -59,8 +59,11 @@ export function registerDefaultSideEffects(editor: Editor) {
 				if (prev.editingShapeId !== next.editingShapeId) {
 					if (!prev.editingShapeId && next.editingShapeId) {
 						if (!editor.isIn('select.editing_shape')) {
-							// With tool lock on, a text shape created from the text tool tells the editing
-							// state to return to the text tool once the edit is complete.
+							// Here's where we handle the special tool locking case for text
+							// If tool lock is enabled, and we just finished editing a text
+							// shape and are setting that shape as the new editing shape,
+							// then create the shape with a flag that will let it know to
+							// go back to the text tool once the edit is complete.
 							const shape = editor.getEditingShape()
 							const isCreatingTextWhileToolLocked =
 								shape?.type === 'text' &&

--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -186,11 +186,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				}
 			} else {
 				pathLength = dist - markerRadius
-				const t = markerRadius / dist
-				const trimmedHandle = {
-					x: handle.x + (point.x - handle.x) * t,
-					y: handle.y + (point.y - handle.y) * t,
-				}
+				const trimmedHandle = Vec.Lrp(handle, point, markerRadius / dist)
 				ctx.moveTo(trimmedHandle.x, trimmedHandle.y)
 				ctx.lineTo(point.x, point.y)
 			}

--- a/packages/tldraw/src/lib/overlays/ArrowHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowHintOverlayUtil.ts
@@ -1,6 +1,13 @@
-import { OverlayUtil, TLOverlay, TLShape, TLShapeId, createComputedCache } from '@tldraw/editor'
-import type { Editor } from '@tldraw/editor'
-import { TLIndicatorPath } from '@tldraw/editor'
+import {
+	Editor,
+	OverlayUtil,
+	PI2,
+	TLIndicatorPath,
+	TLOverlay,
+	TLShape,
+	TLShapeId,
+	createComputedCache,
+} from '@tldraw/editor'
 import { getArrowTargetState } from '../shapes/arrow/arrowTargetState'
 import { DraggingHandle } from '../tools/SelectTool/childStates/DraggingHandle'
 import { PointingHandle } from '../tools/SelectTool/childStates/PointingHandle'
@@ -57,18 +64,9 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		const editor = this.editor
 		if (editor.isInAny('arrow.idle', 'arrow.pointing')) return true
 
-		if (editor.isIn('select.pointing_handle')) {
-			const node: PointingHandle = editor.getStateDescendant('select.pointing_handle')!
-			if (
-				node.info.shape.type === 'arrow' &&
-				(node.info.handle.id === 'start' || node.info.handle.id === 'end')
-			) {
-				return true
-			}
-		}
-
-		if (editor.isIn('select.dragging_handle')) {
-			const node: DraggingHandle = editor.getStateDescendant('select.dragging_handle')!
+		for (const path of ['select.pointing_handle', 'select.dragging_handle'] as const) {
+			if (!editor.isIn(path)) continue
+			const node: PointingHandle | DraggingHandle = editor.getStateDescendant(path)!
 			if (
 				node.info.shape.type === 'arrow' &&
 				(node.info.handle.id === 'start' || node.info.handle.id === 'end')
@@ -137,7 +135,6 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
 		const { targetId, handles, anchorX, anchorY, snap, showEdgeHints } = overlay.props
 
-		// Draw the target shape indicator
 		const shape = editor.getShape(targetId)
 		if (shape) {
 			const pageTransform = editor.getShapePageTransform(shape)
@@ -163,17 +160,15 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 
 		if (!showEdgeHints) return
 
-		// Draw the anchor snap circle
 		if (snap === 'edge' || snap === 'edge-point') {
 			const snapRadius =
 				(snap === 'edge-point' ? this.options.edgePointRadius : this.options.edgeRadius) / zoom
 			ctx.beginPath()
-			ctx.arc(anchorX, anchorY, snapRadius, 0, Math.PI * 2)
+			ctx.arc(anchorX, anchorY, snapRadius, 0, PI2)
 			ctx.fillStyle = colors.selectionFill
 			ctx.fill()
 		}
 
-		// Draw edge handle circles using a single fill+stroke for all handles
 		const handleRadius = this.options.handleRadius / zoom
 		ctx.fillStyle = colors.selectedContrast
 		ctx.strokeStyle = colors.selectionStroke
@@ -181,15 +176,13 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		ctx.beginPath()
 		for (const handle of Object.values(handles)) {
 			if (!handle.isEnabled) continue
-			// Separate subpath for each circle
 			ctx.moveTo(handle.x + handleRadius, handle.y)
-			ctx.arc(handle.x, handle.y, handleRadius, 0, Math.PI * 2)
+			ctx.arc(handle.x, handle.y, handleRadius, 0, PI2)
 		}
 		ctx.fill()
 		ctx.stroke()
 	}
 
-	/** @internal */
 	private _renderIndicatorPath(ctx: CanvasRenderingContext2D, indicatorPath: TLIndicatorPath) {
 		if (indicatorPath instanceof Path2D) {
 			ctx.stroke(indicatorPath)

--- a/packages/tldraw/src/lib/overlays/ArrowHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowHintOverlayUtil.ts
@@ -135,6 +135,7 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
 		const { targetId, handles, anchorX, anchorY, snap, showEdgeHints } = overlay.props
 
+		// Draw the target shape indicator
 		const shape = editor.getShape(targetId)
 		if (shape) {
 			const pageTransform = editor.getShapePageTransform(shape)
@@ -160,6 +161,7 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 
 		if (!showEdgeHints) return
 
+		// Draw the anchor snap circle
 		if (snap === 'edge' || snap === 'edge-point') {
 			const snapRadius =
 				(snap === 'edge-point' ? this.options.edgePointRadius : this.options.edgeRadius) / zoom
@@ -169,6 +171,7 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 			ctx.fill()
 		}
 
+		// Draw edge handle circles using a single fill+stroke for all handles
 		const handleRadius = this.options.handleRadius / zoom
 		ctx.fillStyle = colors.selectedContrast
 		ctx.strokeStyle = colors.selectionStroke
@@ -176,6 +179,7 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		ctx.beginPath()
 		for (const handle of Object.values(handles)) {
 			if (!handle.isEnabled) continue
+			// Separate subpath for each circle
 			ctx.moveTo(handle.x + handleRadius, handle.y)
 			ctx.arc(handle.x, handle.y, handleRadius, 0, PI2)
 		}
@@ -183,6 +187,7 @@ export class ArrowHintOverlayUtil extends OverlayUtil<TLArrowHintOverlay> {
 		ctx.stroke()
 	}
 
+	/** @internal */
 	private _renderIndicatorPath(ctx: CanvasRenderingContext2D, indicatorPath: TLIndicatorPath) {
 		if (indicatorPath instanceof Path2D) {
 			ctx.stroke(indicatorPath)

--- a/packages/tldraw/src/lib/overlays/BrushOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/BrushOverlayUtil.ts
@@ -74,20 +74,7 @@ export class BrushOverlayUtil extends OverlayUtil<TLBrushOverlay> {
 	}
 
 	override render(ctx: CanvasRenderingContext2D, overlays: TLBrushOverlay[]): void {
-		const overlay = overlays[0]
-		if (!overlay) return
-
-		const { x, y, w, h } = overlay.props
-		const zoom = this.editor.getZoomLevel()
-		const dv = getOverlayDisplayValues(this, overlay)
-
-		// Use fillRect / strokeRect to avoid path construction overhead
-		ctx.fillStyle = dv.fillColor
-		ctx.fillRect(x, y, w, h)
-
-		ctx.lineWidth = dv.lineWidth / zoom
-		ctx.strokeStyle = dv.strokeColor
-		ctx.strokeRect(x, y, w, h)
+		this._draw(ctx, overlays[0], this.editor.getZoomLevel())
 	}
 
 	override renderMinimap(
@@ -95,12 +82,18 @@ export class BrushOverlayUtil extends OverlayUtil<TLBrushOverlay> {
 		overlays: TLBrushOverlay[],
 		zoom: number
 	): void {
-		const overlay = overlays[0]
+		this._draw(ctx, overlays[0], zoom)
+	}
+
+	private _draw(ctx: CanvasRenderingContext2D, overlay: TLBrushOverlay | undefined, zoom: number) {
 		if (!overlay) return
 		const { x, y, w, h } = overlay.props
 		const dv = getOverlayDisplayValues(this, overlay)
+
+		// Use fillRect / strokeRect to avoid path construction overhead
 		ctx.fillStyle = dv.fillColor
 		ctx.fillRect(x, y, w, h)
+
 		ctx.lineWidth = dv.lineWidth / zoom
 		ctx.strokeStyle = dv.strokeColor
 		ctx.strokeRect(x, y, w, h)

--- a/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
@@ -143,20 +143,25 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 			ctx.translate(x, y)
 			ctx.scale(scale, scale)
 
+			// Draw cursor arrow
 			paths ??= getCursorPaths()
 
+			// Shadow
 			ctx.fillStyle = 'rgba(0,0,0,0.2)'
 			ctx.fill(paths.shadowHead)
 			ctx.fill(paths.shadowTail)
 
+			// White outline
 			ctx.fillStyle = '#ffffff'
 			ctx.fill(paths.whiteHead)
 			ctx.fill(paths.whiteTail)
 
+			// Colored fill
 			ctx.fillStyle = color
 			ctx.fill(paths.fillHead)
 			ctx.fill(paths.fillTail)
 
+			// Draw name tag / chat
 			if (chatMessage) {
 				if (name) {
 					this._drawNameTitle(ctx, name, color, labelFontFamily)
@@ -190,6 +195,7 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 		ctx.textBaseline = 'top'
 		ctx.strokeText(text, x, y)
 
+		// Text fill
 		ctx.fillStyle = color
 		ctx.fillText(text, x, y)
 	}
@@ -213,11 +219,13 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 		const h = fontSize + py * 2
 		const w = textWidth + px * 2
 
+		// Background
 		ctx.fillStyle = color
 		ctx.beginPath()
 		ctx.roundRect(x, y, w, h, 4)
 		ctx.fill()
 
+		// Text
 		ctx.fillStyle = '#ffffff'
 		ctx.textBaseline = 'top'
 		ctx.fillText(text, x + px, y + py)

--- a/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
@@ -143,67 +143,31 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 			ctx.translate(x, y)
 			ctx.scale(scale, scale)
 
-			// Draw cursor arrow
 			paths ??= getCursorPaths()
 
-			// Shadow
 			ctx.fillStyle = 'rgba(0,0,0,0.2)'
 			ctx.fill(paths.shadowHead)
 			ctx.fill(paths.shadowTail)
 
-			// White outline
 			ctx.fillStyle = '#ffffff'
 			ctx.fill(paths.whiteHead)
 			ctx.fill(paths.whiteTail)
 
-			// Colored fill
 			ctx.fillStyle = color
 			ctx.fill(paths.fillHead)
 			ctx.fill(paths.fillTail)
 
-			// Draw name tag / chat
 			if (chatMessage) {
 				if (name) {
 					this._drawNameTitle(ctx, name, color, labelFontFamily)
 				}
-				this._drawChatBubble(ctx, chatMessage, color, labelFontFamily)
+				this._drawLabelBubble(ctx, chatMessage, color, labelFontFamily, this.options.chatMaxWidth)
 			} else if (name) {
-				this._drawNameTag(ctx, name, color, labelFontFamily)
+				this._drawLabelBubble(ctx, name, color, labelFontFamily, this.options.nameMaxWidth)
 			}
 
 			ctx.restore()
 		}
-	}
-
-	/** Name tag (no chat) - colored background with white text */
-	private _drawNameTag(
-		ctx: CanvasRenderingContext2D,
-		name: string,
-		color: string,
-		fontFamily: string
-	) {
-		const { fontSize, nameMaxWidth } = this.options
-		ctx.font = `${fontSize}px ${fontFamily}`
-		const text = this._truncateText(ctx, name, nameMaxWidth)
-		const metrics = ctx.measureText(text)
-		const textWidth = Math.min(metrics.width, nameMaxWidth)
-		const px = 6
-		const py = 3
-		const x = 13
-		const y = 16
-		const h = fontSize + py * 2
-		const w = textWidth + px * 2
-
-		// Background
-		ctx.fillStyle = color
-		ctx.beginPath()
-		ctx.roundRect(x, y, w, h, 4)
-		ctx.fill()
-
-		// Text
-		ctx.fillStyle = '#ffffff'
-		ctx.textBaseline = 'top'
-		ctx.fillText(text, x + px, y + py)
 	}
 
 	/** Name title (when chat is present) - text with shadow, no background */
@@ -226,23 +190,22 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 		ctx.textBaseline = 'top'
 		ctx.strokeText(text, x, y)
 
-		// Text fill
 		ctx.fillStyle = color
 		ctx.fillText(text, x, y)
 	}
 
-	/** Chat bubble - colored background with white text */
-	private _drawChatBubble(
+	/** Name tag (no chat) and chat bubble - colored background with white text */
+	private _drawLabelBubble(
 		ctx: CanvasRenderingContext2D,
-		chatMessage: string,
+		label: string,
 		color: string,
-		fontFamily: string
+		fontFamily: string,
+		maxWidth: number
 	) {
-		const { fontSize, chatMaxWidth } = this.options
+		const { fontSize } = this.options
 		ctx.font = `${fontSize}px ${fontFamily}`
-		const text = this._truncateText(ctx, chatMessage, chatMaxWidth)
-		const metrics = ctx.measureText(text)
-		const textWidth = Math.min(metrics.width, chatMaxWidth)
+		const text = this._truncateText(ctx, label, maxWidth)
+		const textWidth = Math.min(ctx.measureText(text).width, maxWidth)
 		const px = 6
 		const py = 3
 		const x = 13
@@ -250,13 +213,11 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
 		const h = fontSize + py * 2
 		const w = textWidth + px * 2
 
-		// Background
 		ctx.fillStyle = color
 		ctx.beginPath()
 		ctx.roundRect(x, y, w, h, 4)
 		ctx.fill()
 
-		// Text
 		ctx.fillStyle = '#ffffff'
 		ctx.textBaseline = 'top'
 		ctx.fillText(text, x + px, y + py)

--- a/packages/tldraw/src/lib/overlays/CollaboratorScribbleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorScribbleOverlayUtil.ts
@@ -1,5 +1,5 @@
-import { EASINGS, OverlayUtil, TLOverlay, TLScribble, getSvgPathFromPoints } from '@tldraw/editor'
-import { getStroke } from '../shapes/shared/freehand/getStroke'
+import { OverlayUtil, TLOverlay, TLScribble } from '@tldraw/editor'
+import { ScribblePathCache, getScribblePath } from './ScribbleOverlayUtil'
 
 /** @public */
 export interface TLCollaboratorScribbleOverlay extends TLOverlay {
@@ -7,18 +7,6 @@ export interface TLCollaboratorScribbleOverlay extends TLOverlay {
 		scribble: TLScribble
 		color: string
 	}
-}
-
-// Cache Path2D results for collaborator scribbles similarly to local scribbles
-interface CollaboratorScribbleCacheEntry {
-	len: number
-	lastX: number
-	lastY: number
-	zoom: number
-	size: number
-	taper: boolean
-	state: TLCollaboratorScribbleOverlay['props']['scribble']['state']
-	path: Path2D
 }
 
 /**
@@ -30,13 +18,8 @@ export class CollaboratorScribbleOverlayUtil extends OverlayUtil<TLCollaboratorS
 	static override type = 'collaborator_scribble'
 	override options = { zIndex: 800, streamline: 0.32, cacheSize: 500 }
 
-	// String-keyed (not a WeakMap) because the cache key is a logical identity
-	// — `${overlay.id}` derived from `scribble.id` — not the scribble object.
-	// Tldraw's store replaces record objects on every update, so a WeakMap
-	// keyed on the `TLScribble` instance would cache-miss every frame. Lifetime
-	// is bounded by the Util instance (so, by the editor) plus the `cacheSize`
-	// cap in `render` below.
-	private _collabScribblePathCache = new Map<string, CollaboratorScribbleCacheEntry>()
+	// Keyed by overlay id, not the scribble object — see ScribbleOverlayUtil for why.
+	private _collabScribblePathCache: ScribblePathCache = new Map()
 
 	override isActive(): boolean {
 		return this.editor.getVisibleCollaboratorsOnCurrentPage().some((c) => c.scribbles.length > 0)
@@ -62,56 +45,14 @@ export class CollaboratorScribbleOverlayUtil extends OverlayUtil<TLCollaboratorS
 
 		for (const overlay of overlays) {
 			const { scribble, color } = overlay.props
-			const ptsLen = scribble.points.length
-			if (!ptsLen) continue
-
-			const last = scribble.points[ptsLen - 1]
-			const cacheKey = overlay.id
-			const cached = this._collabScribblePathCache.get(cacheKey)
-			let path: Path2D
-			if (
-				cached &&
-				cached.len === ptsLen &&
-				cached.lastX === last.x &&
-				cached.lastY === last.y &&
-				cached.zoom === zoom &&
-				cached.size === scribble.size &&
-				cached.taper === scribble.taper &&
-				cached.state === scribble.state
-			) {
-				path = cached.path
-			} else {
-				const stroke = getStroke(scribble.points, {
-					size: scribble.size / zoom,
-					start: { taper: scribble.taper, easing: EASINGS.linear },
-					last: scribble.state === 'complete' || scribble.state === 'stopping',
-					simulatePressure: false,
-					streamline: this.options.streamline,
-				})
-
-				let d: string
-				if (stroke.length < 4) {
-					const r = scribble.size / zoom / 2
-					const { x, y } = last
-					d = `M ${x - r},${y} a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 ${-r * 2},0`
-				} else {
-					d = getSvgPathFromPoints(stroke)
-				}
-
-				path = new Path2D(d)
-				this._collabScribblePathCache.set(cacheKey, {
-					len: ptsLen,
-					lastX: last.x,
-					lastY: last.y,
-					zoom,
-					size: scribble.size,
-					taper: scribble.taper,
-					state: scribble.state,
-					path,
-				})
-				if (this._collabScribblePathCache.size > this.options.cacheSize)
-					this._collabScribblePathCache.clear()
-			}
+			const path = getScribblePath(
+				this._collabScribblePathCache,
+				overlay.id,
+				scribble,
+				zoom,
+				this.options
+			)
+			if (!path) continue
 
 			ctx.fillStyle = color
 			ctx.globalAlpha = scribble.color === 'laser' ? 0.5 : 0.1

--- a/packages/tldraw/src/lib/overlays/CollaboratorScribbleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorScribbleOverlayUtil.ts
@@ -18,7 +18,12 @@ export class CollaboratorScribbleOverlayUtil extends OverlayUtil<TLCollaboratorS
 	static override type = 'collaborator_scribble'
 	override options = { zIndex: 800, streamline: 0.32, cacheSize: 500 }
 
-	// Keyed by overlay id, not the scribble object — see ScribbleOverlayUtil for why.
+	// String-keyed (not a WeakMap) because the cache key is a logical identity
+	// — `${overlay.id}` derived from `scribble.id` — not the scribble object.
+	// Tldraw's store replaces record objects on every update, so a WeakMap
+	// keyed on the `TLScribble` instance would cache-miss every frame. Lifetime
+	// is bounded by the Util instance (so, by the editor) plus the `cacheSize`
+	// cap in `getScribblePath`.
 	private _collabScribblePathCache: ScribblePathCache = new Map()
 
 	override isActive(): boolean {

--- a/packages/tldraw/src/lib/overlays/ScribbleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ScribbleOverlayUtil.ts
@@ -29,6 +29,67 @@ interface ScribbleCacheEntry {
 	path: Path2D
 }
 
+/** @internal */
+export type ScribblePathCache = Map<string, ScribbleCacheEntry>
+
+/** @internal */
+export function getScribblePath(
+	cache: ScribblePathCache,
+	cacheKey: string,
+	scribble: TLScribble,
+	zoom: number,
+	options: { streamline: number; cacheSize: number }
+): Path2D | null {
+	const ptsLen = scribble.points.length
+	if (!ptsLen) return null
+
+	const last = scribble.points[ptsLen - 1]
+	const cached = cache.get(cacheKey)
+	if (
+		cached &&
+		cached.len === ptsLen &&
+		cached.lastX === last.x &&
+		cached.lastY === last.y &&
+		cached.zoom === zoom &&
+		cached.size === scribble.size &&
+		cached.taper === scribble.taper &&
+		cached.state === scribble.state
+	) {
+		return cached.path
+	}
+
+	const stroke = getStroke(scribble.points, {
+		size: scribble.size / zoom,
+		start: { taper: scribble.taper, easing: EASINGS.linear },
+		last: scribble.state === 'complete' || scribble.state === 'stopping',
+		simulatePressure: false,
+		streamline: options.streamline,
+	})
+
+	let d: string
+	if (stroke.length < 4) {
+		const r = scribble.size / zoom / 2
+		const { x, y } = last
+		d = `M ${x - r},${y} a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 ${-r * 2},0`
+	} else {
+		d = getSvgPathFromPoints(stroke)
+	}
+
+	const path = new Path2D(d)
+	cache.set(cacheKey, {
+		len: ptsLen,
+		lastX: last.x,
+		lastY: last.y,
+		zoom,
+		size: scribble.size,
+		taper: scribble.taper,
+		state: scribble.state,
+		path,
+	})
+	if (cache.size > options.cacheSize) cache.clear()
+	return path
+}
+
 /**
  * Overlay util for scribble strokes (eraser, lasso selection, etc.).
  *
@@ -43,8 +104,8 @@ export class ScribbleOverlayUtil extends OverlayUtil<TLScribbleOverlay> {
 	// cache key is a logical identity — `scribble.id` — not the scribble
 	// object. Tldraw's store replaces record objects on every update, so a
 	// WeakMap keyed on the `TLScribble` instance would cache-miss every frame.
-	// Lifetime is bounded by the Util instance plus the `cacheSize` cap below.
-	private _scribblePathCache = new Map<string, ScribbleCacheEntry>()
+	// Lifetime is bounded by the Util instance plus the `cacheSize` cap in `getScribblePath`.
+	private _scribblePathCache: ScribblePathCache = new Map()
 
 	override isActive(): boolean {
 		return this.editor.getInstanceState().scribbles.length > 0
@@ -64,54 +125,14 @@ export class ScribbleOverlayUtil extends OverlayUtil<TLScribbleOverlay> {
 
 		for (const overlay of overlays) {
 			const { scribble } = overlay.props
-			const ptsLen = scribble.points.length
-			if (!ptsLen) continue
-
-			const last = scribble.points[ptsLen - 1]
-			const cached = this._scribblePathCache.get(scribble.id)
-			let path: Path2D
-			if (
-				cached &&
-				cached.len === ptsLen &&
-				cached.lastX === last.x &&
-				cached.lastY === last.y &&
-				cached.zoom === zoom &&
-				cached.size === scribble.size &&
-				cached.taper === scribble.taper &&
-				cached.state === scribble.state
-			) {
-				path = cached.path
-			} else {
-				const stroke = getStroke(scribble.points, {
-					size: scribble.size / zoom,
-					start: { taper: scribble.taper, easing: EASINGS.linear },
-					last: scribble.state === 'complete' || scribble.state === 'stopping',
-					simulatePressure: false,
-					streamline: this.options.streamline,
-				})
-
-				let d: string
-				if (stroke.length < 4) {
-					const r = scribble.size / zoom / 2
-					const { x, y } = last
-					d = `M ${x - r},${y} a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 ${-r * 2},0`
-				} else {
-					d = getSvgPathFromPoints(stroke)
-				}
-
-				path = new Path2D(d)
-				this._scribblePathCache.set(scribble.id, {
-					len: ptsLen,
-					lastX: last.x,
-					lastY: last.y,
-					zoom,
-					size: scribble.size,
-					taper: scribble.taper,
-					state: scribble.state,
-					path,
-				})
-				if (this._scribblePathCache.size > this.options.cacheSize) this._scribblePathCache.clear()
-			}
+			const path = getScribblePath(
+				this._scribblePathCache,
+				scribble.id,
+				scribble,
+				zoom,
+				this.options
+			)
+			if (!path) continue
 
 			ctx.fillStyle = resolveCanvasUiColor(colors, scribble.color)
 			ctx.globalAlpha = scribble.opacity

--- a/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
@@ -3,6 +3,7 @@ import {
 	Geometry2d,
 	HALF_PI,
 	Mat,
+	PI2,
 	OverlayUtil,
 	Polygon2d,
 	Rectangle2d,
@@ -179,8 +180,6 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		}
 	}
 
-	// --- Overlay collection ---
-
 	private _collectResizeCornerOverlays(
 		state: SelectionState,
 		overlays: TLSelectionForegroundOverlay[]
@@ -242,8 +241,6 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		}
 	}
 
-	// --- Geometry builders ---
-
 	private _getResizeHandleGeometry(
 		handle: TLSelectionHandle,
 		state: SelectionState,
@@ -251,12 +248,7 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 	): Geometry2d {
 		if (handle === 'top' || handle === 'bottom' || handle === 'left' || handle === 'right') {
 			const rect = this._getEdgeLocalRect(handle, state)
-			return new Polygon2d({
-				points: this._localRectToPoints(rect.x, rect.y, rect.w, rect.h).map((p) =>
-					Mat.applyToPoint(transform, p)
-				),
-				isFilled: true,
-			})
+			return this._localRectToPolygon(rect.x, rect.y, rect.w, rect.h, transform)
 		}
 
 		const cornerPoint = this._getCornerLocalPoint(
@@ -265,15 +257,13 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 			state.height
 		)
 		const cornerHitHalfSize = Math.max(state.hitTargetSizeX, state.hitTargetSizeY) * 1.5
-		return new Polygon2d({
-			points: this._localRectToPoints(
-				cornerPoint.x - cornerHitHalfSize,
-				cornerPoint.y - cornerHitHalfSize,
-				cornerHitHalfSize * 2,
-				cornerHitHalfSize * 2
-			).map((p) => Mat.applyToPoint(transform, p)),
-			isFilled: true,
-		})
+		return this._localRectToPolygon(
+			cornerPoint.x - cornerHitHalfSize,
+			cornerPoint.y - cornerHitHalfSize,
+			cornerHitHalfSize * 2,
+			cornerHitHalfSize * 2,
+			transform
+		)
 	}
 
 	private _getRotateHandleGeometry(
@@ -294,17 +284,16 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 	}
 
 	private _getMobileRotateGeometry(state: SelectionState, transform: Mat): Geometry2d {
-		const bgRadius = Math.max(14 * (1 / state.zoom), 20 / Math.max(1, state.zoom))
+		const bgRadius = Math.max(14 / state.zoom, 20 / Math.max(1, state.zoom))
 		const { cx, cy } = this._getMobileRotateCenter(state)
-		return new Polygon2d({
-			points: this._localRectToPoints(cx - bgRadius, cy - bgRadius, bgRadius * 2, bgRadius * 2).map(
-				(p) => Mat.applyToPoint(transform, p)
-			),
-			isFilled: true,
-		})
+		return this._localRectToPolygon(
+			cx - bgRadius,
+			cy - bgRadius,
+			bgRadius * 2,
+			bgRadius * 2,
+			transform
+		)
 	}
-
-	// --- Rendering (all helpers assume ctx is in local selection space) ---
 
 	private _renderSelectionBox(
 		ctx: CanvasRenderingContext2D,
@@ -414,7 +403,7 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		ctx.strokeStyle = colors.strokeColor
 		ctx.lineWidth = this.options.lineWidth / state.zoom
 		ctx.beginPath()
-		ctx.arc(cx, cy, fgRadius, 0, Math.PI * 2)
+		ctx.arc(cx, cy, fgRadius, 0, PI2)
 		ctx.fill()
 		ctx.stroke()
 	}
@@ -452,8 +441,6 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		ctx.roundRect(width - hw / 2, height / 2 - textHandleHeight / 2, hw, textHandleHeight, r)
 		ctx.fill()
 	}
-
-	// --- Shared helpers ---
 
 	/**
 	 * Single source of truth for the derived state the selection foreground needs.
@@ -559,23 +546,22 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		const showSelectionBounds = !hideOnlyShapeSelectionBounds && !isChangingStyle
 
 		const shouldDisplayBox =
-			(showSelectionBounds &&
-				editor.isInAny(
-					'select.idle',
-					'select.brushing',
-					'select.scribble_brushing',
-					'select.pointing_canvas',
-					'select.pointing_selection',
-					'select.pointing_shape',
-					'select.crop.idle',
-					'select.crop.pointing_crop',
-					'select.crop.pointing_crop_handle',
-					'select.pointing_resize_handle',
-					'select.pointing_rotate_handle'
-				)) ||
-			(showSelectionBounds &&
-				editor.isIn('select.resizing') &&
-				!!(onlyShape && editor.isShapeOfType(onlyShape, 'text')))
+			showSelectionBounds &&
+			(editor.isInAny(
+				'select.idle',
+				'select.brushing',
+				'select.scribble_brushing',
+				'select.pointing_canvas',
+				'select.pointing_selection',
+				'select.pointing_shape',
+				'select.crop.idle',
+				'select.crop.pointing_crop',
+				'select.crop.pointing_crop_handle',
+				'select.pointing_resize_handle',
+				'select.pointing_rotate_handle'
+			) ||
+				(editor.isIn('select.resizing') &&
+					!!(onlyShape && editor.isShapeOfType(onlyShape, 'text'))))
 
 		return {
 			bounds,
@@ -694,7 +680,12 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		}
 	}
 
-	private _localRectToPoints(x: number, y: number, w: number, h: number): Vec[] {
-		return [new Vec(x, y), new Vec(x + w, y), new Vec(x + w, y + h), new Vec(x, y + h)]
+	private _localRectToPolygon(x: number, y: number, w: number, h: number, transform: Mat) {
+		return new Polygon2d({
+			points: [new Vec(x, y), new Vec(x + w, y), new Vec(x + w, y + h), new Vec(x, y + h)].map(
+				(p) => Mat.applyToPoint(transform, p)
+			),
+			isFilled: true,
+		})
 	}
 }

--- a/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
@@ -682,9 +682,7 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 
 	private _localRectToPolygon(x: number, y: number, w: number, h: number, transform: Mat) {
 		return new Polygon2d({
-			points: [new Vec(x, y), new Vec(x + w, y), new Vec(x + w, y + h), new Vec(x, y + h)].map(
-				(p) => Mat.applyToPoint(transform, p)
-			),
+			points: Mat.applyToPoints(transform, new Box(x, y, w, h).corners),
 			isFilled: true,
 		})
 	}

--- a/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
@@ -180,6 +180,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		}
 	}
 
+	// --- Overlay collection ---
+
 	private _collectResizeCornerOverlays(
 		state: SelectionState,
 		overlays: TLSelectionForegroundOverlay[]
@@ -241,6 +243,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		}
 	}
 
+	// --- Geometry builders ---
+
 	private _getResizeHandleGeometry(
 		handle: TLSelectionHandle,
 		state: SelectionState,
@@ -294,6 +298,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 			transform
 		)
 	}
+
+	// --- Rendering (all helpers assume ctx is in local selection space) ---
 
 	private _renderSelectionBox(
 		ctx: CanvasRenderingContext2D,
@@ -441,6 +447,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 		ctx.roundRect(width - hw / 2, height / 2 - textHandleHeight / 2, hw, textHandleHeight, r)
 		ctx.fill()
 	}
+
+	// --- Shared helpers ---
 
 	/**
 	 * Single source of truth for the derived state the selection foreground needs.

--- a/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
@@ -3,6 +3,7 @@ import {
 	Geometry2d,
 	Mat,
 	OverlayUtil,
+	PI2,
 	SIDES,
 	TLCursorType,
 	TLHandle,
@@ -61,10 +62,7 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 
 		if (editor.isShapeHidden(onlySelectedShape)) return []
 
-		const zoom = editor.getZoomLevel()
-		const isCoarse = editor.getInstanceState().isCoarsePointer
-		const minDist =
-			((isCoarse ? editor.options.coarseHandleRadius : editor.options.handleRadius) / zoom) * 2
+		const minDist = this._getHitRadius() * 2
 
 		const vertexHandles = handles.filter((handle) => handle.type === 'vertex')
 		const vertexHandlesForHitTest: TLHandle[] = []
@@ -107,12 +105,8 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 		const transform = editor.getShapePageTransform(shapeId)
 		if (!transform) return null
 
-		const zoom = editor.getZoomLevel()
-		const isCoarse = editor.getInstanceState().isCoarsePointer
-		const radius =
-			(isCoarse ? editor.options.coarseHandleRadius : editor.options.handleRadius) / zoom
+		const radius = this._getHitRadius()
 
-		// Transform handle position to page space
 		const pagePoint = Mat.applyToPoint(transform, { x: handle.x, y: handle.y })
 
 		return new Circle2d({
@@ -123,8 +117,17 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 		})
 	}
 
+	private _getHitRadius(): number {
+		const editor = this.editor
+		const isCoarse = editor.getInstanceState().isCoarsePointer
+		return (
+			(isCoarse ? editor.options.coarseHandleRadius : editor.options.handleRadius) /
+			editor.getZoomLevel()
+		)
+	}
+
 	override getCursor(_overlay: TLShapeHandleOverlay): TLCursorType | undefined {
-		return 'grab' as TLCursorType
+		return 'grab'
 	}
 
 	override render(ctx: CanvasRenderingContext2D, overlays: TLShapeHandleOverlay[]): void {
@@ -142,8 +145,7 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 		const strokeColor = themeColors.selectionStroke
 		const bgFill = themeColors.selectionFill
 		const hoveredOverlayId = editor.overlays.getHoveredOverlayId()
-		const bgRadius =
-			(isCoarse ? editor.options.coarseHandleRadius : editor.options.handleRadius) / zoom
+		const bgRadius = this._getHitRadius()
 
 		ctx.save()
 		ctx.transform(transform.a, transform.b, transform.c, transform.d, transform.e, transform.f)
@@ -167,7 +169,7 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 			if (isHovered) {
 				ctx.fillStyle = bgFill
 				ctx.beginPath()
-				ctx.arc(handle.x, handle.y, bgRadius, 0, Math.PI * 2)
+				ctx.arc(handle.x, handle.y, bgRadius, 0, PI2)
 				ctx.fill()
 			}
 
@@ -201,7 +203,7 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 
 			ctx.fillStyle = fgColor
 			ctx.beginPath()
-			ctx.arc(handle.x, handle.y, fr, 0, Math.PI * 2)
+			ctx.arc(handle.x, handle.y, fr, 0, PI2)
 			ctx.fill()
 			ctx.stroke()
 		}

--- a/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
@@ -107,6 +107,7 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 
 		const radius = this._getHitRadius()
 
+		// Transform handle position to page space
 		const pagePoint = Mat.applyToPoint(transform, { x: handle.x, y: handle.y })
 
 		return new Circle2d({

--- a/packages/tldraw/src/lib/overlays/SnapIndicatorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SnapIndicatorOverlayUtil.ts
@@ -71,33 +71,20 @@ export class SnapIndicatorOverlayUtil extends OverlayUtil<TLSnapIndicatorOverlay
 			if (point.y > maxY) maxY = point.y
 		}
 
-		let useNWtoSEdirection = false
-		for (const point of points) {
-			if (point.x === minX && point.y === minY) {
-				useNWtoSEdirection = true
-				break
-			}
-		}
-		let firstX: number, firstY: number, secondX: number, secondY: number
-		if (useNWtoSEdirection) {
-			firstX = minX
-			firstY = minY
-			secondX = maxX
-			secondY = maxY
-		} else {
-			firstX = minX
-			firstY = maxY
-			secondX = maxX
-			secondY = minY
-		}
+		const useNWtoSEdirection = points.some((point) => point.x === minX && point.y === minY)
 
 		ctx.strokeStyle = color
 		ctx.lineWidth = this.options.lineWidth / zoom
 
 		// Main snap line
 		ctx.beginPath()
-		ctx.moveTo(firstX, firstY)
-		ctx.lineTo(secondX, secondY)
+		if (useNWtoSEdirection) {
+			ctx.moveTo(minX, minY)
+			ctx.lineTo(maxX, maxY)
+		} else {
+			ctx.moveTo(minX, maxY)
+			ctx.lineTo(maxX, minY)
+		}
 		ctx.stroke()
 
 		// Batch-draw crosses for all points in a single stroke
@@ -125,30 +112,17 @@ export class SnapIndicatorOverlayUtil extends OverlayUtil<TLSnapIndicatorOverlay
 		const horizontal = direction === 'horizontal'
 
 		let edgeIntersection: number[] = [-Infinity, +Infinity]
-		let nextEdgeIntersection: number[] | null = null
 
 		for (const gap of gaps) {
-			nextEdgeIntersection = rangeIntersection(
-				edgeIntersection[0],
-				edgeIntersection[1],
-				horizontal ? gap.startEdge[0].y : gap.startEdge[0].x,
-				horizontal ? gap.startEdge[1].y : gap.startEdge[1].x
-			)
-			if (nextEdgeIntersection) {
+			for (const edge of [gap.startEdge, gap.endEdge]) {
+				const nextEdgeIntersection = rangeIntersection(
+					edgeIntersection[0],
+					edgeIntersection[1],
+					horizontal ? edge[0].y : edge[0].x,
+					horizontal ? edge[1].y : edge[1].x
+				)
+				if (!nextEdgeIntersection) break
 				edgeIntersection = nextEdgeIntersection
-			} else {
-				continue
-			}
-			nextEdgeIntersection = rangeIntersection(
-				edgeIntersection[0],
-				edgeIntersection[1],
-				horizontal ? gap.endEdge[0].y : gap.endEdge[0].x,
-				horizontal ? gap.endEdge[1].y : gap.endEdge[1].x
-			)
-			if (nextEdgeIntersection) {
-				edgeIntersection = nextEdgeIntersection
-			} else {
-				continue
 			}
 		}
 

--- a/packages/tldraw/src/lib/overlays/ZoomBrushOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ZoomBrushOverlayUtil.ts
@@ -41,20 +41,7 @@ export class ZoomBrushOverlayUtil extends OverlayUtil<TLZoomBrushOverlay> {
 	}
 
 	override render(ctx: CanvasRenderingContext2D, overlays: TLZoomBrushOverlay[]): void {
-		const overlay = overlays[0]
-		if (!overlay) return
-
-		const { x, y, w, h } = overlay.props
-		const zoom = this.editor.getZoomLevel()
-		const colors = this.editor.getCurrentTheme().colors[this.editor.getColorMode()]
-
-		// Use fillRect / strokeRect to avoid path construction overhead
-		ctx.fillStyle = colors.brushFill
-		ctx.fillRect(x, y, w, h)
-
-		ctx.lineWidth = this.options.lineWidth / zoom
-		ctx.strokeStyle = colors.brushStroke
-		ctx.strokeRect(x, y, w, h)
+		this._draw(ctx, overlays[0], this.editor.getZoomLevel())
 	}
 
 	override renderMinimap(
@@ -62,12 +49,22 @@ export class ZoomBrushOverlayUtil extends OverlayUtil<TLZoomBrushOverlay> {
 		overlays: TLZoomBrushOverlay[],
 		zoom: number
 	): void {
-		const overlay = overlays[0]
+		this._draw(ctx, overlays[0], zoom)
+	}
+
+	private _draw(
+		ctx: CanvasRenderingContext2D,
+		overlay: TLZoomBrushOverlay | undefined,
+		zoom: number
+	) {
 		if (!overlay) return
 		const { x, y, w, h } = overlay.props
 		const colors = this.editor.getCurrentTheme().colors[this.editor.getColorMode()]
+
+		// Use fillRect / strokeRect to avoid path construction overhead
 		ctx.fillStyle = colors.brushFill
 		ctx.fillRect(x, y, w, h)
+
 		ctx.lineWidth = this.options.lineWidth / zoom
 		ctx.strokeStyle = colors.brushStroke
 		ctx.strokeRect(x, y, w, h)

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowPath.tsx
@@ -1,4 +1,4 @@
-import { exhaustiveSwitchError, TLArrowShape } from '@tldraw/editor'
+import { exhaustiveSwitchError } from '@tldraw/editor'
 import { PathBuilder, PathBuilderOpts } from '../shared/PathBuilder'
 import { TLArrowInfo } from './arrow-types'
 import { getRouteHandlePath } from './elbow/getElbowArrowInfo'
@@ -41,7 +41,7 @@ export function getArrowBodyPathBuilder(info: TLArrowInfo): PathBuilder {
 	}
 }
 
-export function getArrowBodyPath(shape: TLArrowShape, info: TLArrowInfo, opts: PathBuilderOpts) {
+export function getArrowBodyPath(info: TLArrowInfo, opts: PathBuilderOpts) {
 	return getArrowBodyPathBuilder(info).toSvg(opts)
 }
 

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -367,6 +367,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 	private onArcMidpointHandleDrag(shape: TLArrowShape, { handle }: TLHandleDragInfo<TLArrowShape>) {
 		const bindings = getArrowBindings(this.editor, shape)
+
+		// Bending the arrow...
 		const { start, end } = getArrowTerminalsInArrowSpace(this.editor, shape, bindings)
 
 		const delta = Vec.Sub(end, start)
@@ -682,10 +684,13 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const { start, end } = structuredClone<TLArrowShape['props']>(shape.props)
 		let { bend } = shape.props
 
+		// Rescale start handle if it's not bound to a shape
 		if (!bindings.start) {
 			start.x = terminals.start.x * scaleX
 			start.y = terminals.start.y * scaleY
 		}
+
+		// Rescale end handle if it's not bound to a shape
 		if (!bindings.end) {
 			end.x = terminals.end.x * scaleX
 			end.y = terminals.end.y * scaleY
@@ -822,6 +827,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		const strokeWidth = dv.strokeWidth * shape.props.scale
 
+		// If editing and has label, just return the label rect
 		if (isEditing && labelGeometry) {
 			const labelBounds = labelGeometry.getBounds()
 			const path = new Path2D()
@@ -829,6 +835,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			return path
 		}
 
+		// Get arrow body path
 		const isForceSolid = this.editor.getEfficientZoomLevel() < 0.25 / shape.props.scale
 		const bodyPathBuilder = getArrowBodyPathBuilder(info)
 		const bodyPath2D = bodyPathBuilder.toPath2D(
@@ -844,14 +851,17 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				: { style: 'solid', strokeWidth: 1 }
 		)
 
+		// Get arrowhead paths
 		const as = info.start.arrowhead && getArrowheadPathForType(info, 'start', strokeWidth)
 		const ae = info.end.arrowhead && getArrowheadPathForType(info, 'end', strokeWidth)
 
+		// Check if we need clipping (label or complex arrowheads)
 		const clipStartArrowhead = !!(as && info.start.arrowhead !== 'arrow')
 		const clipEndArrowhead = !!(ae && info.end.arrowhead !== 'arrow')
 		const needsClipping = labelGeometry || clipStartArrowhead || clipEndArrowhead
 
 		if (needsClipping) {
+			// Create clip path using evenodd rule
 			const bounds = geometry.bounds
 			const clipPath = new Path2D()
 
@@ -864,6 +874,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				addRoundedRectPath(clipPath, labelBounds, dv.labelBorderRadius * shape.props.scale, true)
 			}
 
+			// Add arrowhead paths to clip path if needed
 			if (clipStartArrowhead && as) {
 				clipPath.addPath(new Path2D(as))
 			}
@@ -871,6 +882,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				clipPath.addPath(new Path2D(ae))
 			}
 
+			// Additional paths (arrowheads, label rect) to draw after clipped body
 			const additionalPaths: Path2D[] = []
 			if (as) additionalPaths.push(new Path2D(as))
 			if (ae) additionalPaths.push(new Path2D(ae))
@@ -888,6 +900,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			}
 		}
 
+		// No clipping needed - combine all paths into one
 		const combinedPath = new Path2D()
 		combinedPath.addPath(bodyPath2D)
 
@@ -1024,6 +1037,7 @@ const ArrowSvg = track(function ArrowSvg({
 
 	return (
 		<>
+			{/* Yep */}
 			<defs>
 				<clipPath id={clipPathId}>
 					<ArrowClipPath

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -1,15 +1,12 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {
-	Arc2d,
 	Box,
 	EMPTY_ARRAY,
-	Edge2d,
 	Editor,
 	Geometry2d,
 	Group2d,
 	IndexKey,
 	PI2,
-	Polyline2d,
 	Rectangle2d,
 	SVGContainer,
 	ShapeUtil,
@@ -66,7 +63,11 @@ import { RichTextLabel, RichTextSVG } from '../shared/RichTextLabel'
 import { useEfficientZoomThreshold } from '../shared/useEfficientZoomThreshold'
 import { ArrowShapeOptions, type ArrowShapeUtilDisplayValues } from './arrow-types'
 import { getArrowheadPathForType } from './arrowheads'
-import { getArrowLabelDefaultPosition, getArrowLabelPosition } from './arrowLabel'
+import {
+	getArrowBodyGeometry,
+	getArrowLabelDefaultPosition,
+	getArrowLabelPosition,
+} from './arrowLabel'
 import { getArrowBodyPath, getArrowBodyPathBuilder } from './ArrowPath'
 import { updateArrowTargetState } from './arrowTargetState'
 import { ElbowArrowAxes } from './elbow/definitions'
@@ -266,21 +267,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		const debugGeom: Geometry2d[] = []
 
-		const bodyGeom =
-			info.type === 'straight'
-				? new Edge2d({
-						start: Vec.From(info.start.point),
-						end: Vec.From(info.end.point),
-					})
-				: info.type === 'arc'
-					? new Arc2d({
-							center: Vec.Cast(info.handleArc.center),
-							start: Vec.Cast(info.start.point),
-							end: Vec.Cast(info.end.point),
-							sweepFlag: info.bodyArc.sweepFlag,
-							largeArcFlag: info.bodyArc.largeArcFlag,
-						})
-					: new Polyline2d({ points: info.route.points })
+		const bodyGeom = getArrowBodyGeometry(this.editor, shape)
 
 		let labelGeom
 		if (info.isValid && (isEditing || !isEmptyRichText(shape.props.richText))) {
@@ -380,8 +367,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 	private onArcMidpointHandleDrag(shape: TLArrowShape, { handle }: TLHandleDragInfo<TLArrowShape>) {
 		const bindings = getArrowBindings(this.editor, shape)
-
-		// Bending the arrow...
 		const { start, end } = getArrowTerminalsInArrowSpace(this.editor, shape, bindings)
 
 		const delta = Vec.Sub(end, start)
@@ -697,97 +682,37 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const { start, end } = structuredClone<TLArrowShape['props']>(shape.props)
 		let { bend } = shape.props
 
-		// Rescale start handle if it's not bound to a shape
 		if (!bindings.start) {
 			start.x = terminals.start.x * scaleX
 			start.y = terminals.start.y * scaleY
 		}
-
-		// Rescale end handle if it's not bound to a shape
 		if (!bindings.end) {
 			end.x = terminals.end.x * scaleX
 			end.y = terminals.end.y * scaleY
 		}
 
+		const flipX = scaleX < 0
+		const flipY = scaleY < 0
+
+		if (bend !== 0) {
+			if (flipX !== flipY) bend *= -1
+			bend *= Math.max(Math.abs(scaleX), Math.abs(scaleY))
+		}
+
 		// todo: we should only change the normalized anchor positions
 		// of the shape's handles if the bound shape is also being resized
-
-		const mx = Math.abs(scaleX)
-		const my = Math.abs(scaleY)
-
-		const startNormalizedAnchor = bindings?.start
-			? Vec.From(bindings.start.props.normalizedAnchor)
-			: null
-		const endNormalizedAnchor = bindings?.end ? Vec.From(bindings.end.props.normalizedAnchor) : null
-
-		if (scaleX < 0 && scaleY >= 0) {
-			if (bend !== 0) {
-				bend *= -1
-				bend *= Math.max(mx, my)
-			}
-
-			if (startNormalizedAnchor) {
-				startNormalizedAnchor.x = 1 - startNormalizedAnchor.x
-			}
-
-			if (endNormalizedAnchor) {
-				endNormalizedAnchor.x = 1 - endNormalizedAnchor.x
-			}
-		} else if (scaleX >= 0 && scaleY < 0) {
-			if (bend !== 0) {
-				bend *= -1
-				bend *= Math.max(mx, my)
-			}
-
-			if (startNormalizedAnchor) {
-				startNormalizedAnchor.y = 1 - startNormalizedAnchor.y
-			}
-
-			if (endNormalizedAnchor) {
-				endNormalizedAnchor.y = 1 - endNormalizedAnchor.y
-			}
-		} else if (scaleX >= 0 && scaleY >= 0) {
-			if (bend !== 0) {
-				bend *= Math.max(mx, my)
-			}
-		} else if (scaleX < 0 && scaleY < 0) {
-			if (bend !== 0) {
-				bend *= Math.max(mx, my)
-			}
-
-			if (startNormalizedAnchor) {
-				startNormalizedAnchor.x = 1 - startNormalizedAnchor.x
-				startNormalizedAnchor.y = 1 - startNormalizedAnchor.y
-			}
-
-			if (endNormalizedAnchor) {
-				endNormalizedAnchor.x = 1 - endNormalizedAnchor.x
-				endNormalizedAnchor.y = 1 - endNormalizedAnchor.y
-			}
-		}
-
-		if (bindings.start && startNormalizedAnchor) {
-			createOrUpdateArrowBinding(this.editor, shape, bindings.start.toId, {
-				...bindings.start.props,
-				normalizedAnchor: startNormalizedAnchor.toJson(),
-			})
-		}
-		if (bindings.end && endNormalizedAnchor) {
-			createOrUpdateArrowBinding(this.editor, shape, bindings.end.toId, {
-				...bindings.end.props,
-				normalizedAnchor: endNormalizedAnchor.toJson(),
+		for (const binding of [bindings.start, bindings.end]) {
+			if (!binding) continue
+			const normalizedAnchor = Vec.From(binding.props.normalizedAnchor)
+			if (flipX) normalizedAnchor.x = 1 - normalizedAnchor.x
+			if (flipY) normalizedAnchor.y = 1 - normalizedAnchor.y
+			createOrUpdateArrowBinding(this.editor, shape, binding.toId, {
+				...binding.props,
+				normalizedAnchor: normalizedAnchor.toJson(),
 			})
 		}
 
-		const next = {
-			props: {
-				start,
-				end,
-				bend,
-			},
-		}
-
-		return next
+		return { props: { start, end, bend } }
 	}
 
 	override onDoubleClickHandle(
@@ -887,7 +812,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const dv = getDisplayValues(this, shape)
 
 		const isEditing = this.editor.getEditingShapeId() === shape.id
-		const { start, end } = getArrowTerminalsInArrowSpace(this.editor, shape, info?.bindings)
+		const { start, end } = getArrowTerminalsInArrowSpace(this.editor, shape, info.bindings)
 		const geometry = this.editor.getShapeGeometry<Group2d>(shape)
 		const isEmpty = isEmptyRichText(shape.props.richText)
 
@@ -897,7 +822,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 		const strokeWidth = dv.strokeWidth * shape.props.scale
 
-		// If editing and has label, just return the label rect
 		if (isEditing && labelGeometry) {
 			const labelBounds = labelGeometry.getBounds()
 			const path = new Path2D()
@@ -905,7 +829,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			return path
 		}
 
-		// Get arrow body path
 		const isForceSolid = this.editor.getEfficientZoomLevel() < 0.25 / shape.props.scale
 		const bodyPathBuilder = getArrowBodyPathBuilder(info)
 		const bodyPath2D = bodyPathBuilder.toPath2D(
@@ -921,17 +844,14 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				: { style: 'solid', strokeWidth: 1 }
 		)
 
-		// Get arrowhead paths
 		const as = info.start.arrowhead && getArrowheadPathForType(info, 'start', strokeWidth)
 		const ae = info.end.arrowhead && getArrowheadPathForType(info, 'end', strokeWidth)
 
-		// Check if we need clipping (label or complex arrowheads)
 		const clipStartArrowhead = !!(as && info.start.arrowhead !== 'arrow')
 		const clipEndArrowhead = !!(ae && info.end.arrowhead !== 'arrow')
 		const needsClipping = labelGeometry || clipStartArrowhead || clipEndArrowhead
 
 		if (needsClipping) {
-			// Create clip path using evenodd rule
 			const bounds = geometry.bounds
 			const clipPath = new Path2D()
 
@@ -944,7 +864,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				addRoundedRectPath(clipPath, labelBounds, dv.labelBorderRadius * shape.props.scale, true)
 			}
 
-			// Add arrowhead paths to clip path if needed
 			if (clipStartArrowhead && as) {
 				clipPath.addPath(new Path2D(as))
 			}
@@ -952,7 +871,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 				clipPath.addPath(new Path2D(ae))
 			}
 
-			// Additional paths (arrowheads, label rect) to draw after clipped body
 			const additionalPaths: Path2D[] = []
 			if (as) additionalPaths.push(new Path2D(as))
 			if (ae) additionalPaths.push(new Path2D(ae))
@@ -970,7 +888,6 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 			}
 		}
 
-		// No clipping needed - combine all paths into one
 		const combinedPath = new Path2D()
 		combinedPath.addPath(bodyPath2D)
 
@@ -1107,7 +1024,6 @@ const ArrowSvg = track(function ArrowSvg({
 
 	return (
 		<>
-			{/* Yep */}
 			<defs>
 				<clipPath id={clipPathId}>
 					<ArrowClipPath
@@ -1141,7 +1057,7 @@ const ArrowSvg = track(function ArrowSvg({
 						height={toDomPrecision(bounds.height + 200)}
 						opacity={0}
 					/>
-					{getArrowBodyPath(shape, info, {
+					{getArrowBodyPath(info, {
 						style: shape.props.dash,
 						strokeWidth,
 						forceSolid: isForceSolid,

--- a/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowLabel.ts
@@ -60,33 +60,25 @@ const labelSizeCache = createComputedCache(
 	'arrow label size',
 	(editor: Editor, shape: TLArrowShape) => {
 		editor.fonts.trackFontsForShape(shape)
-		let width = 0
-		let height = 0
 
-		const bodyGeom = getArrowBodyGeometry(editor, shape)
+		const bodyBounds = getArrowBodyGeometry(editor, shape).bounds
 		// We use 'i' as a default label to measure against as a minimum width.
-		const isEmpty = isEmptyRichText(shape.props.richText)
 		const html = renderHtmlFromRichTextForMeasurement(
 			editor,
-			isEmpty ? toRichText('i') : shape.props.richText
+			isEmptyRichText(shape.props.richText) ? toRichText('i') : shape.props.richText
 		)
-
-		const bodyBounds = bodyGeom.bounds
 
 		const dv = getArrowDisplayValues(editor, shape)
 		const fontSize = dv.labelFontSize * shape.props.scale
 
 		// First we measure the text with no constraints
-		const { w, h } = editor.textMeasure.measureHtml(html, {
+		let { w: width, h: height } = editor.textMeasure.measureHtml(html, {
 			...TEXT_PROPS,
 			lineHeight: dv.labelLineHeight,
 			fontFamily: dv.labelFontFamily,
 			fontSize,
 			maxWidth: null,
 		})
-
-		width = w
-		height = h
 
 		let shouldSquish = false
 
@@ -100,7 +92,7 @@ const labelSizeCache = createComputedCache(
 				: 64
 
 		if (bodyBounds.width > bodyBounds.height) {
-			width = Math.max(Math.min(w, margin), Math.min(bodyBounds.width - margin, w))
+			width = Math.max(Math.min(width, margin), Math.min(bodyBounds.width - margin, width))
 			shouldSquish = true
 		} else if (width > 16 * fontSize) {
 			width = 16 * fontSize
@@ -141,13 +133,12 @@ function getLabelToArrowPadding(shape: TLArrowShape, theme: TLTheme) {
 	const strokeWidth = theme.strokeWidth * STROKE_SIZES[shape.props.size]
 	const smallStrokeWidth = theme.strokeWidth * STROKE_SIZES.s
 	const xlStrokeWidth = theme.strokeWidth * STROKE_SIZES.xl
-	const labelToArrowPadding =
+	return (
 		(LABEL_TO_ARROW_PADDING +
 			(strokeWidth - smallStrokeWidth) * 2 +
 			(strokeWidth >= xlStrokeWidth ? 20 : 0)) *
 		shape.props.scale
-
-	return labelToArrowPadding
+	)
 }
 
 /**
@@ -227,54 +218,27 @@ function getArrowLabelRange(editor: Editor, shape: TLArrowShape, info: TLArrowIn
 	return { start: startRelative, end: endRelative, dbg }
 }
 
-interface ArrowheadInfo {
-	hasStartBinding: boolean
-	hasEndBinding: boolean
-	hasStartArrowhead: boolean
-	hasEndArrowhead: boolean
-}
 export function getArrowLabelPosition(editor: Editor, shape: TLArrowShape, isEditing: boolean) {
+	const bodyGeom = getArrowBodyGeometry(editor, shape)
+
 	if (!isEditing && isEmptyRichText(shape.props.richText)) {
 		// Short-circuit for empty labels.
-		const bodyGeom = getArrowBodyGeometry(editor, shape)
 		const labelCenter = bodyGeom.interpolateAlongEdge(0.5)
 		return { box: Box.FromCenter(labelCenter, new Vec(0, 0)), debugGeom: [] }
 	}
 
-	const debugGeom: Geometry2d[] = []
 	const info = getArrowInfo(editor, shape)!
-
-	const arrowheadInfo: ArrowheadInfo = {
-		hasStartBinding: !!info.bindings.start,
-		hasEndBinding: !!info.bindings.end,
-		hasStartArrowhead: info.start.arrowhead !== 'none',
-		hasEndArrowhead: info.end.arrowhead !== 'none',
-	}
-
 	const range = getArrowLabelRange(editor, shape, info)
-	if (range.dbg) debugGeom.push(...range.dbg)
 
-	const clampedPosition = getClampedPosition(shape, range, arrowheadInfo)
-	const bodyGeom = getArrowBodyGeometry(editor, shape)
+	const clampedPosition = clamp(
+		shape.props.labelPosition,
+		info.start.arrowhead !== 'none' || info.bindings.start ? range.start : 0,
+		info.end.arrowhead !== 'none' || info.bindings.end ? range.end : 1
+	)
 	const labelCenter = bodyGeom.interpolateAlongEdge(clampedPosition)
 	const labelSize = getArrowLabelSize(editor, shape)
 
-	return { box: Box.FromCenter(labelCenter, labelSize), debugGeom }
-}
-
-function getClampedPosition(
-	shape: TLArrowShape,
-	range: { start: number; end: number },
-	arrowheadInfo: ArrowheadInfo
-) {
-	const { hasEndArrowhead, hasEndBinding, hasStartBinding, hasStartArrowhead } = arrowheadInfo
-	const clampedPosition = clamp(
-		shape.props.labelPosition,
-		hasStartArrowhead || hasStartBinding ? range.start : 0,
-		hasEndArrowhead || hasEndBinding ? range.end : 1
-	)
-
-	return clampedPosition
+	return { box: Box.FromCenter(labelCenter, labelSize), debugGeom: range.dbg }
 }
 
 function furthest(from: VecLike, candidates: VecLike[]): VecLike | null {
@@ -300,11 +264,8 @@ export function getArrowLabelDefaultPosition(editor: Editor, shape: TLArrowShape
 			return 0.5
 		case 'elbow': {
 			const midpointHandle = info.route.midpointHandle
-			const bodyGeom = getArrowBodyGeometry(editor, shape)
-			if (midpointHandle && bodyGeom) {
-				return bodyGeom.uninterpolateAlongEdge(midpointHandle.point)
-			}
-			return 0.5
+			if (!midpointHandle) return 0.5
+			return getArrowBodyGeometry(editor, shape).uninterpolateAlongEdge(midpointHandle.point)
 		}
 		default:
 			exhaustiveSwitchError(info, 'type')

--- a/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
@@ -217,6 +217,7 @@ export function updateArrowTargetState({
 	if (isExact) precise = true
 
 	const shouldSnapCenter = !isExact && precise && targetGeometryInTargetSpace.isClosed
+	// const shouldSnapEdges = !isExact && (precise || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdges =
 		!isExact && ((precise && arrowKind === 'elbow') || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdgePoints =

--- a/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowTargetState.ts
@@ -10,7 +10,7 @@ import {
 	invLerp,
 	mapObjectMapValues,
 	objectMapEntries,
-	objectMapKeys,
+	objectMapValues,
 	TLArrowBinding,
 	TLArrowShape,
 	TLArrowShapeKind,
@@ -186,8 +186,7 @@ export function updateArrowTargetState({
 	const minDistScaled = util.options.minElbowHandleDistance / zoomLevel
 
 	const targetCenterInPageSpace = targetTransform.applyToPoint(targetCenterInTargetSpace)
-	for (const side of objectMapKeys(handlesInPageSpace)) {
-		const handle = handlesInPageSpace[side]
+	for (const handle of objectMapValues(handlesInPageSpace)) {
 		if (Vec.DistMin(handle.point, targetCenterInPageSpace, minDistScaled)) {
 			handle.isEnabled = false
 		}
@@ -197,7 +196,7 @@ export function updateArrowTargetState({
 
 	if (!precise) {
 		// If we're switching to a new bound shape, then precise only if moving slowly
-		if (!currentBinding || (currentBinding && target.id !== currentBinding.toId)) {
+		if (!currentBinding || target.id !== currentBinding.toId) {
 			precise = editor.inputs.getPointerVelocity().len() < 0.5
 		}
 	}
@@ -218,7 +217,6 @@ export function updateArrowTargetState({
 	if (isExact) precise = true
 
 	const shouldSnapCenter = !isExact && precise && targetGeometryInTargetSpace.isClosed
-	// const shouldSnapEdges = !isExact && (precise || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdges =
 		!isExact && ((precise && arrowKind === 'elbow') || !targetGeometryInTargetSpace.isClosed)
 	const shouldSnapEdgePoints =

--- a/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/arrowheads.ts
@@ -140,7 +140,6 @@ export function getArrowheadPathForType(
 	if (type === 'none') return
 
 	const points = getArrowPoints(info, side, strokeWidth)
-	if (!points) return
 
 	switch (type) {
 		case 'bar':

--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -318,6 +318,7 @@ function getArcTerminalPointInBoundShape(
 	handleArc: TLArcInfo,
 	distFn: (a: number, b: number) => number
 ): Vec | undefined {
+	// get points in shape's coordinates?
 	const inverseTransform = Mat.Inverse(shapeInfo.transform)
 	const startInLocalSpace = Mat.applyToPoint(
 		inverseTransform,
@@ -385,6 +386,7 @@ function getArcTerminalPointInBoundShape(
 	}
 
 	if (!point) return
+	// target local point -> page point -> shape local point
 	return editor.getPointInShapeSpace(shape, Mat.applyToPoint(shapeInfo.transform, point))
 }
 

--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -15,6 +15,7 @@ import { STROKE_SIZES } from '../shared/default-shape-constants'
 import { TLArcInfo, TLArrowInfo } from './arrow-types'
 import {
 	BOUND_ARROW_OFFSET,
+	BoundShapeInfo,
 	MIN_ARROW_LENGTH,
 	TLArrowBindings,
 	WAY_TOO_BIG_ARROW_BEND_FACTOR,
@@ -22,6 +23,7 @@ import {
 	getArrowTerminalsInArrowSpace,
 	getBoundShapeInfoForTerminal,
 	getBoundShapeRelationships,
+	getBoundShapeStrokeOffset,
 } from './shared'
 import { getStraightArrowInfo } from './straight-arrow'
 
@@ -110,80 +112,23 @@ export function getCurvedArrowInfo(
 	let minLength = MIN_ARROW_LENGTH * shape.props.scale
 
 	if (startShapeInfo && !startShapeInfo.isExact) {
-		const startInPageSpace = Mat.applyToPoint(arrowPageTransform, tempA)
-		const centerInPageSpace = Mat.applyToPoint(arrowPageTransform, handleArc.center)
-		const endInPageSpace = Mat.applyToPoint(arrowPageTransform, tempB)
-
-		const inverseTransform = Mat.Inverse(startShapeInfo.transform)
-
-		const startInStartShapeLocalSpace = Mat.applyToPoint(inverseTransform, startInPageSpace)
-		const centerInStartShapeLocalSpace = Mat.applyToPoint(inverseTransform, centerInPageSpace)
-		const endInStartShapeLocalSpace = Mat.applyToPoint(inverseTransform, endInPageSpace)
-
-		const { isClosed } = startShapeInfo
-		let point: VecLike | undefined
-		let intersections = Array.from(
-			startShapeInfo.geometry.intersectCircle(centerInStartShapeLocalSpace, handleArc.radius, {
-				includeLabels: false,
-				includeInternal: false,
-			})
+		const point = getArcTerminalPointInBoundShape(
+			editor,
+			shape,
+			startShapeInfo,
+			'start',
+			arrowPageTransform,
+			tempA,
+			tempB,
+			handleArc,
+			distFn
 		)
-
-		if (intersections.length) {
-			const angleToStart = centerInStartShapeLocalSpace.angle(startInStartShapeLocalSpace)
-			const angleToEnd = centerInStartShapeLocalSpace.angle(endInStartShapeLocalSpace)
-			const dAB = distFn(angleToStart, angleToEnd)
-
-			// Filter out any intersections that aren't in the arc
-			intersections = intersections.filter(
-				(pt) => distFn(angleToStart, centerInStartShapeLocalSpace.angle(pt)) <= dAB
-			)
-
-			const targetDist = dAB * 0.25
-
-			intersections.sort(
-				isClosed
-					? (p0, p1) =>
-							Math.abs(distFn(angleToStart, centerInStartShapeLocalSpace.angle(p0)) - targetDist) <
-							Math.abs(distFn(angleToStart, centerInStartShapeLocalSpace.angle(p1)) - targetDist)
-								? -1
-								: 1
-					: (p0, p1) =>
-							distFn(angleToStart, centerInStartShapeLocalSpace.angle(p0)) <
-							distFn(angleToStart, centerInStartShapeLocalSpace.angle(p1))
-								? -1
-								: 1
-			)
-
-			point = intersections[0]
-		}
-		if (!point) {
-			if (isClosed) {
-				const nearestPoint = startShapeInfo.geometry.nearestPoint(startInStartShapeLocalSpace, {
-					includeInternal: false,
-					includeLabels: false,
-				})
-				if (Vec.DistMin(nearestPoint, startInStartShapeLocalSpace, 1)) {
-					point = nearestPoint
-				}
-			} else {
-				point = startInStartShapeLocalSpace
-			}
-		}
-
 		if (point) {
-			tempA.setTo(
-				editor.getPointInShapeSpace(shape, Mat.applyToPoint(startShapeInfo.transform, point))
-			)
-
+			tempA.setTo(point)
 			startShapeInfo.didIntersect = true
 
 			if (arrowheadStart !== 'none') {
-				const strokeOffset =
-					arrowSW / 2 +
-					('size' in startShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
-						: 0)
+				const strokeOffset = getBoundShapeStrokeOffset(theme, arrowSW, startShapeInfo)
 				offsetA = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale
 			}
@@ -191,82 +136,23 @@ export function getCurvedArrowInfo(
 	}
 
 	if (endShapeInfo && !endShapeInfo.isExact) {
-		// get points in shape's coordinates?
-		const startInPageSpace = Mat.applyToPoint(arrowPageTransform, tempA)
-		const endInPageSpace = Mat.applyToPoint(arrowPageTransform, tempB)
-		const centerInPageSpace = Mat.applyToPoint(arrowPageTransform, handleArc.center)
-
-		const inverseTransform = Mat.Inverse(endShapeInfo.transform)
-
-		const startInEndShapeLocalSpace = Mat.applyToPoint(inverseTransform, startInPageSpace)
-		const centerInEndShapeLocalSpace = Mat.applyToPoint(inverseTransform, centerInPageSpace)
-		const endInEndShapeLocalSpace = Mat.applyToPoint(inverseTransform, endInPageSpace)
-
-		const isClosed = endShapeInfo.isClosed
-		let point: VecLike | undefined
-		let intersections = Array.from(
-			endShapeInfo.geometry.intersectCircle(centerInEndShapeLocalSpace, handleArc.radius, {
-				includeLabels: false,
-				includeInternal: false,
-			})
+		const point = getArcTerminalPointInBoundShape(
+			editor,
+			shape,
+			endShapeInfo,
+			'end',
+			arrowPageTransform,
+			tempA,
+			tempB,
+			handleArc,
+			distFn
 		)
-
-		if (intersections.length) {
-			const angleToStart = centerInEndShapeLocalSpace.angle(startInEndShapeLocalSpace)
-			const angleToEnd = centerInEndShapeLocalSpace.angle(endInEndShapeLocalSpace)
-			const dAB = distFn(angleToStart, angleToEnd)
-			const targetDist = dAB * 0.75
-
-			// or simplified...
-
-			intersections = intersections.filter(
-				(pt) => distFn(angleToStart, centerInEndShapeLocalSpace.angle(pt)) <= dAB
-			)
-
-			intersections.sort(
-				isClosed
-					? (p0, p1) =>
-							Math.abs(distFn(angleToStart, centerInEndShapeLocalSpace.angle(p0)) - targetDist) <
-							Math.abs(distFn(angleToStart, centerInEndShapeLocalSpace.angle(p1)) - targetDist)
-								? -1
-								: 1
-					: (p0, p1) =>
-							distFn(angleToStart, centerInEndShapeLocalSpace.angle(p0)) <
-							distFn(angleToStart, centerInEndShapeLocalSpace.angle(p1))
-								? -1
-								: 1
-			)
-
-			point = intersections[0]
-		}
-		if (!point) {
-			if (isClosed) {
-				const nearestPoint = endShapeInfo.geometry.nearestPoint(endInEndShapeLocalSpace, {
-					includeInternal: false,
-					includeLabels: false,
-				})
-				if (Vec.DistMin(nearestPoint, endInEndShapeLocalSpace, 1)) {
-					point = nearestPoint
-				}
-			} else {
-				point = endInEndShapeLocalSpace
-			}
-		}
-
 		if (point) {
-			// Set b to target local point -> page point -> shape local point
-			tempB.setTo(
-				editor.getPointInShapeSpace(shape, Mat.applyToPoint(endShapeInfo.transform, point))
-			)
-
+			tempB.setTo(point)
 			endShapeInfo.didIntersect = true
 
 			if (arrowheadEnd !== 'none') {
-				const strokeOffset =
-					arrowSW / 2 +
-					('size' in endShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
-						: 0)
+				const strokeOffset = getBoundShapeStrokeOffset(theme, arrowSW, endShapeInfo)
 				offsetB = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale
 			}
@@ -415,6 +301,91 @@ export function getCurvedArrowInfo(
 		bodyArc,
 		isValid: bodyArc.length !== 0 && isFinite(bodyArc.center.x) && isFinite(bodyArc.center.y),
 	}
+}
+
+/**
+ * Find where the arc leaves the shape bound to one of the arrow's terminals. Returns the point in
+ * arrow space, or undefined if the arc doesn't reach the shape.
+ */
+function getArcTerminalPointInBoundShape(
+	editor: Editor,
+	shape: TLArrowShape,
+	shapeInfo: BoundShapeInfo,
+	terminal: 'start' | 'end',
+	arrowPageTransform: Mat,
+	tempA: Vec,
+	tempB: Vec,
+	handleArc: TLArcInfo,
+	distFn: (a: number, b: number) => number
+): Vec | undefined {
+	const inverseTransform = Mat.Inverse(shapeInfo.transform)
+	const startInLocalSpace = Mat.applyToPoint(
+		inverseTransform,
+		Mat.applyToPoint(arrowPageTransform, tempA)
+	)
+	const centerInLocalSpace = Mat.applyToPoint(
+		inverseTransform,
+		Mat.applyToPoint(arrowPageTransform, handleArc.center)
+	)
+	const endInLocalSpace = Mat.applyToPoint(
+		inverseTransform,
+		Mat.applyToPoint(arrowPageTransform, tempB)
+	)
+	const terminalInLocalSpace = terminal === 'start' ? startInLocalSpace : endInLocalSpace
+
+	const { isClosed } = shapeInfo
+	let point: VecLike | undefined
+	let intersections = Array.from(
+		shapeInfo.geometry.intersectCircle(centerInLocalSpace, handleArc.radius, {
+			includeLabels: false,
+			includeInternal: false,
+		})
+	)
+
+	if (intersections.length) {
+		const angleToStart = centerInLocalSpace.angle(startInLocalSpace)
+		const angleToEnd = centerInLocalSpace.angle(endInLocalSpace)
+		const dAB = distFn(angleToStart, angleToEnd)
+		const targetDist = dAB * (terminal === 'start' ? 0.25 : 0.75)
+
+		// Filter out any intersections that aren't in the arc
+		intersections = intersections.filter(
+			(pt) => distFn(angleToStart, centerInLocalSpace.angle(pt)) <= dAB
+		)
+
+		intersections.sort(
+			isClosed
+				? (p0, p1) =>
+						Math.abs(distFn(angleToStart, centerInLocalSpace.angle(p0)) - targetDist) <
+						Math.abs(distFn(angleToStart, centerInLocalSpace.angle(p1)) - targetDist)
+							? -1
+							: 1
+				: (p0, p1) =>
+						distFn(angleToStart, centerInLocalSpace.angle(p0)) <
+						distFn(angleToStart, centerInLocalSpace.angle(p1))
+							? -1
+							: 1
+		)
+
+		point = intersections[0]
+	}
+
+	if (!point) {
+		if (isClosed) {
+			const nearestPoint = shapeInfo.geometry.nearestPoint(terminalInLocalSpace, {
+				includeInternal: false,
+				includeLabels: false,
+			})
+			if (Vec.DistMin(nearestPoint, terminalInLocalSpace, 1)) {
+				point = nearestPoint
+			}
+		} else {
+			point = terminalInLocalSpace
+		}
+	}
+
+	if (!point) return
+	return editor.getPointInShapeSpace(shape, Mat.applyToPoint(shapeInfo.transform, point))
 }
 
 /**

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/elbowArrowSnapLines.tsx
@@ -120,10 +120,3 @@ export function perpDistanceToLineAngle(pointOnLine: VecLike, lineAngle: number)
 	// Project the point onto the perpendicular vector
 	return Vec.Dpr(pointOnLine, perpDir)
 }
-
-/**
- * Return the signed distance from the origin to the line segment defined by `A` and `B`.
- */
-export function perpDistanceToLine(A: VecLike, B: VecLike): number {
-	return perpDistanceToLineAngle(A, Vec.Angle(A, B))
-}

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
@@ -86,19 +86,8 @@ export function getElbowArrowInfo(
 
 	// We model each edge that an arrow might enter/exit from separately. If an edge is blocked,
 	// `getUsableEdge` might return null.
-	let edgesA = {
-		top: getUsableEdge(aTerminal, bTerminal, 'top', options),
-		right: getUsableEdge(aTerminal, bTerminal, 'right', options),
-		bottom: getUsableEdge(aTerminal, bTerminal, 'bottom', options),
-		left: getUsableEdge(aTerminal, bTerminal, 'left', options),
-	}
-
-	let edgesB = {
-		top: getUsableEdge(bTerminal, aTerminal, 'top', options),
-		right: getUsableEdge(bTerminal, aTerminal, 'right', options),
-		bottom: getUsableEdge(bTerminal, aTerminal, 'bottom', options),
-		left: getUsableEdge(bTerminal, aTerminal, 'left', options),
-	}
+	let edgesA = getUsableEdges(aTerminal, bTerminal, options)
+	let edgesB = getUsableEdges(bTerminal, aTerminal, options)
 
 	// We we don't have a usable edge because it's blocked, we can convert some of the terminals to
 	// points. Point terminals have less strict edge routing rules, but don't look as good
@@ -126,19 +115,8 @@ export function getElbowArrowInfo(
 	}
 
 	if (needsNewEdges) {
-		edgesA = {
-			top: getUsableEdge(aTerminal, bTerminal, 'top', options),
-			right: getUsableEdge(aTerminal, bTerminal, 'right', options),
-			bottom: getUsableEdge(aTerminal, bTerminal, 'bottom', options),
-			left: getUsableEdge(aTerminal, bTerminal, 'left', options),
-		}
-
-		edgesB = {
-			top: getUsableEdge(bTerminal, aTerminal, 'top', options),
-			right: getUsableEdge(bTerminal, aTerminal, 'right', options),
-			bottom: getUsableEdge(bTerminal, aTerminal, 'bottom', options),
-			left: getUsableEdge(bTerminal, aTerminal, 'left', options),
-		}
+		edgesA = getUsableEdges(aTerminal, bTerminal, options)
+		edgesB = getUsableEdges(bTerminal, aTerminal, options)
 	}
 
 	// We expand the bounds of the terminals so we can route arrows around them without the arrows
@@ -158,22 +136,18 @@ export function getElbowArrowInfo(
 	// Calculate the gaps between the two terminals. If gap is positive, B is to the right of A. If
 	// it's negative, the opposite is true. If it's 0, there's no gap between the shapes in that
 	// dimension.
-	let gapX = bTerminal.bounds.minX - aTerminal.bounds.maxX
-	if (gapX < 0) {
-		gapX = aTerminal.bounds.minX - bTerminal.bounds.maxX
-		if (gapX < 0) {
-			gapX = 0
-		}
-		gapX = -gapX
-	}
-	let gapY = bTerminal.bounds.minY - aTerminal.bounds.maxY
-	if (gapY < 0) {
-		gapY = aTerminal.bounds.minY - bTerminal.bounds.maxY
-		if (gapY < 0) {
-			gapY = 0
-		}
-		gapY = -gapY
-	}
+	const gapX = getGap(
+		aTerminal.bounds.minX,
+		aTerminal.bounds.maxX,
+		bTerminal.bounds.minX,
+		bTerminal.bounds.maxX
+	)
+	const gapY = getGap(
+		aTerminal.bounds.minY,
+		aTerminal.bounds.maxY,
+		bTerminal.bounds.minY,
+		bTerminal.bounds.maxY
+	)
 
 	// The midpoint of the gap is a useful point to route arrows through, but the user can also drag
 	// it to choose a new midpoint. First, we calculate some constraints we'll need to keep in mind
@@ -451,8 +425,9 @@ function getBindingGeometryInArrowSpace(
 
 	const targetGeometryInArrowSpace = targetGeometryInTargetSpace.transform(shapeToArrowTransform)
 
-	const center = { x: 0.5, y: 0.5 }
-	const normalizedAnchor = bindingProps.isPrecise ? bindingProps.normalizedAnchor : center
+	const normalizedAnchor = bindingProps.isPrecise
+		? bindingProps.normalizedAnchor
+		: { x: 0.5, y: 0.5 }
 
 	const targetInShapeSpace = {
 		x: lerp(
@@ -466,27 +441,11 @@ function getBindingGeometryInArrowSpace(
 			normalizedAnchor.y
 		),
 	}
-	const centerInShapeSpace = {
-		x: lerp(
-			targetGeometryInTargetSpace.bounds.minX,
-			targetGeometryInTargetSpace.bounds.maxX,
-			center.x
-		),
-		y: lerp(
-			targetGeometryInTargetSpace.bounds.minY,
-			targetGeometryInTargetSpace.bounds.maxY,
-			center.y
-		),
-	}
-
-	const targetInArrowSpace = Mat.applyToPoint(shapeToArrowTransform, targetInShapeSpace)
-	const centerInArrowSpace = Mat.applyToPoint(shapeToArrowTransform, centerInShapeSpace)
 
 	return {
 		bounds: targetGeometryInArrowSpace.bounds,
 		geometry: targetGeometryInArrowSpace,
-		target: targetInArrowSpace,
-		center: centerInArrowSpace,
+		target: Mat.applyToPoint(shapeToArrowTransform, targetInShapeSpace),
 		shapeToArrowTransform,
 	}
 }
@@ -533,6 +492,25 @@ const sideProps = {
 		crossAxis: 'y',
 	},
 } as const
+
+function getGap(aMin: number, aMax: number, bMin: number, bMax: number) {
+	const gap = bMin - aMax
+	if (gap >= 0) return gap
+	return -Math.max(0, aMin - bMax)
+}
+
+function getUsableEdges(
+	a: ElbowArrowTerminal,
+	b: ElbowArrowTerminal,
+	options: ElbowArrowOptions
+): ElbowArrowBoxEdges {
+	return {
+		top: getUsableEdge(a, b, 'top', options),
+		right: getUsableEdge(a, b, 'right', options),
+		bottom: getUsableEdge(a, b, 'bottom', options),
+		left: getUsableEdge(a, b, 'left', options),
+	}
+}
 
 export function getUsableEdge(
 	a: ElbowArrowTerminal,
@@ -709,7 +687,7 @@ function castPathSegmentIntoGeometry(
 
 	if (target.isExact) {
 		nearestIntersectionToPoint2 = target.target
-	} else if (target.geometry) {
+	} else {
 		const intersections = target.geometry.intersectLineSegment(point2, target.target, {
 			includeLabels: false,
 			includeInternal: false,
@@ -754,13 +732,11 @@ function castPathSegmentIntoGeometry(
 		let shouldAddExtraPointForNudge = false
 		if (!target.isExact && offset !== 0) {
 			const nudged = Vec.Nudge(nearestIntersectionToPoint2, point2, offset)
-			nudgedPoint = nudged
 			if (
 				offset < 0 &&
 				!target.geometry.hitTestPoint(nudged, 0, true, Geometry2dFilters.EXCLUDE_NON_STANDARD)
 			) {
 				// point has been nudged _out_ of the shape so lets not actually apply the nudge
-				nudgedPoint = nearestIntersectionToPoint2
 			} else {
 				if (offset < 0) {
 					shouldAddExtraPointForNudge = true
@@ -787,8 +763,6 @@ function fixTinyEndNubs(
 	aTerminal: ElbowArrowTerminal,
 	bTerminal: ElbowArrowTerminal
 ) {
-	if (!route) return
-
 	if (route.points.length >= 3) {
 		const a = route.points[0]
 		const b = route.points[1]
@@ -851,11 +825,8 @@ function adjustTerminalForUnclosedPathIfNeeded(
 		terminal.target[axis.cross]
 	)
 
-	let furthestIntersectionTowardsMin: VecLike | null = null
-	let furthestIntersectionTowardsMinDistance = 0
-	let furthestIntersectionTowardsMax: VecLike | null = null
-	let furthestIntersectionTowardsMaxDistance = 0
-	let side: ElbowArrowSideWithAxis = axis.self
+	let furthestDistanceTowardsMin = 0
+	let furthestDistanceTowardsMax = 0
 
 	for (const intersection of terminal.geometry.intersectLineSegment(
 		min,
@@ -865,35 +836,19 @@ function adjustTerminalForUnclosedPathIfNeeded(
 		if (Math.abs(intersection[axis.self] - terminal.target[axis.self]) < 1) {
 			continue
 		}
+		const distance = Vec.ManhattanDist(intersection, terminal.target)
 		if (intersection[axis.self] < terminal.target[axis.self]) {
-			if (
-				Vec.ManhattanDist(intersection, terminal.target) > furthestIntersectionTowardsMinDistance
-			) {
-				furthestIntersectionTowardsMinDistance = Vec.ManhattanDist(intersection, terminal.target)
-				furthestIntersectionTowardsMin = intersection
-			}
+			furthestDistanceTowardsMin = Math.max(furthestDistanceTowardsMin, distance)
 		} else {
-			if (
-				Vec.ManhattanDist(intersection, terminal.target) > furthestIntersectionTowardsMaxDistance
-			) {
-				furthestIntersectionTowardsMaxDistance = Vec.ManhattanDist(intersection, terminal.target)
-				furthestIntersectionTowardsMax = intersection
-			}
+			furthestDistanceTowardsMax = Math.max(furthestDistanceTowardsMax, distance)
 		}
 	}
 
-	if (furthestIntersectionTowardsMin && furthestIntersectionTowardsMax) {
-		if (furthestIntersectionTowardsMinDistance > furthestIntersectionTowardsMaxDistance) {
-			side = axis.hiEdge
-		} else {
-			side = axis.loEdge
-		}
-	} else if (furthestIntersectionTowardsMin && !furthestIntersectionTowardsMax) {
-		side = axis.hiEdge
-	} else if (!furthestIntersectionTowardsMin && furthestIntersectionTowardsMax) {
-		side = axis.loEdge
-	}
-
-	terminal.side = side
+	terminal.side =
+		furthestDistanceTowardsMin > 0 || furthestDistanceTowardsMax > 0
+			? furthestDistanceTowardsMin > furthestDistanceTowardsMax
+				? axis.hiEdge
+				: axis.loEdge
+			: axis.self
 	return terminal
 }

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/range.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/range.tsx
@@ -1,4 +1,4 @@
-import { assert, clamp } from '@tldraw/editor'
+import { assert } from '@tldraw/editor'
 
 export interface Range {
 	min: number
@@ -14,10 +14,6 @@ export function expandRange(range: Range, amount: number) {
 		return null
 	}
 	return newRange
-}
-
-export function clampToRange(value: number, range: Range) {
-	return clamp(value, range.min, range.max)
 }
 
 /**
@@ -64,18 +60,10 @@ export function createRange(a: number, b: number) {
 	return { min: Math.min(a, b), max: Math.max(a, b) }
 }
 
-export function doRangesOverlap(a: Range, b: Range) {
-	return a.min <= b.max && a.max >= b.min
-}
-
 export function isWithinRange(value: number, range: Range) {
 	return value >= range.min && value <= range.max
 }
 
 export function rangeSize(range: Range) {
 	return range.max - range.min
-}
-
-export function rangeCenter(range: Range) {
-	return (range.min + range.max) / 2
 }

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/routes/ElbowArrowWorkingInfo.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/routes/ElbowArrowWorkingInfo.ts
@@ -212,12 +212,8 @@ export class ElbowArrowWorkingInfo {
 		}
 
 		if (transform.transpose) {
-			let temp = this.midX
-			this.midX = this.midY
-			this.midY = temp
-			temp = this.gapX
-			this.gapX = this.gapY
-			this.gapY = temp
+			swap(this, 'midX', 'midY')
+			swap(this, 'gapX', 'gapY')
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/routes/routeArrowWithAutoEdgePicking.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/routes/routeArrowWithAutoEdgePicking.tsx
@@ -26,46 +26,16 @@ export function routeArrowWithAutoEdgePicking(
 		} else {
 			idealRoute = tryRouteArrow(info, 'left', 'right')
 		}
+	} else if (info.A.isPoint && info.B.isPoint) {
+		if (info.gapY > 0) {
+			idealRoute = tryRouteArrow(info, 'bottom', 'top')
+		} else {
+			idealRoute = tryRouteArrow(info, 'top', 'bottom')
+		}
 	} else {
-		const aRight = info.A.edges.right
-		const aLeft = info.A.edges.left
-		const bTop = info.B.edges.top
-		const bBottom = info.B.edges.bottom
-
-		if (info.A.isPoint && info.B.isPoint) {
-			if (info.gapY > 0) {
-				idealRoute = tryRouteArrow(info, 'bottom', 'top')
-			} else {
-				idealRoute = tryRouteArrow(info, 'top', 'bottom')
-			}
-		} else if (
-			aRight &&
-			bTop &&
-			(aRight.expanded ?? aRight.value) <= bTop.crossTarget &&
-			aRight.crossTarget <= (bTop.expanded ?? bTop.value)
-		) {
-			idealRoute = tryRouteArrow(info, 'right', 'top')
-		} else if (
-			aRight &&
-			bBottom &&
-			(aRight.expanded ?? aRight.value) <= bBottom.crossTarget &&
-			aRight.crossTarget >= (bBottom.expanded ?? bBottom.value)
-		) {
-			idealRoute = tryRouteArrow(info, 'right', 'bottom')
-		} else if (
-			aLeft &&
-			bTop &&
-			(aLeft.expanded ?? aLeft.value) >= bTop.crossTarget &&
-			aLeft.crossTarget <= (bTop.expanded ?? bTop.value)
-		) {
-			idealRoute = tryRouteArrow(info, 'left', 'top')
-		} else if (
-			aLeft &&
-			bBottom &&
-			(aLeft.expanded ?? aLeft.value) >= bBottom.crossTarget &&
-			aLeft.crossTarget >= (bBottom.expanded ?? bBottom.value)
-		) {
-			idealRoute = tryRouteArrow(info, 'left', 'bottom')
+		const cornerSides = pickCornerSides(info, ['right', 'left'])
+		if (cornerSides) {
+			idealRoute = tryRouteArrow(info, cornerSides[0], cornerSides[1])
 		} else if (info.gapY > 0 && info.midY !== null) {
 			idealRoute = tryRouteArrow(info, 'bottom', 'top')
 		} else if (info.gapY < 0 && info.midY !== null) {
@@ -95,50 +65,24 @@ export function routeArrowWithPartialEdgePicking(
 ) {
 	let idealRoute = null
 
-	const aRight = info.A.edges.right
-	const aLeft = info.A.edges.left
-	const bTop = info.B.edges.top
-	const bBottom = info.B.edges.bottom
-
 	switch (aSide) {
 		case 'right':
-			if (info.gapX > 0 && info.gapX > Math.abs(info.gapY) && info.midX !== null) {
-				idealRoute = tryRouteArrow(info, 'right', 'left')
-			} else if (
-				aRight &&
-				bTop &&
-				(aRight.expanded ?? aRight.value) <= bTop.crossTarget &&
-				aRight.crossTarget <= (bTop.expanded ?? bTop.value)
+		case 'left': {
+			const isRight = aSide === 'right'
+			if (
+				(isRight ? info.gapX > 0 : info.gapX < 0) &&
+				Math.abs(info.gapX) > Math.abs(info.gapY) &&
+				info.midX !== null
 			) {
-				idealRoute = tryRouteArrow(info, 'right', 'top')
-			} else if (
-				aRight &&
-				bBottom &&
-				(aRight.expanded ?? aRight.value) <= bBottom.crossTarget &&
-				aRight.crossTarget >= (bBottom.expanded ?? bBottom.value)
-			) {
-				idealRoute = tryRouteArrow(info, 'right', 'bottom')
+				idealRoute = tryRouteArrow(info, aSide, isRight ? 'left' : 'right')
+			} else {
+				const cornerSides = pickCornerSides(info, [aSide])
+				if (cornerSides) {
+					idealRoute = tryRouteArrow(info, cornerSides[0], cornerSides[1])
+				}
 			}
 			break
-		case 'left':
-			if (info.gapX < 0 && Math.abs(info.gapX) > Math.abs(info.gapY) && info.midX !== null) {
-				idealRoute = tryRouteArrow(info, 'left', 'right')
-			} else if (
-				aLeft &&
-				bTop &&
-				(aLeft.expanded ?? aLeft.value) >= bTop.crossTarget &&
-				aLeft.crossTarget <= (bTop.expanded ?? bTop.value)
-			) {
-				idealRoute = tryRouteArrow(info, 'left', 'top')
-			} else if (
-				aLeft &&
-				bBottom &&
-				(aLeft.expanded ?? aLeft.value) >= bBottom.crossTarget &&
-				aLeft.crossTarget >= (bBottom.expanded ?? bBottom.value)
-			) {
-				idealRoute = tryRouteArrow(info, 'left', 'bottom')
-			}
-			break
+		}
 		case 'top':
 		case 'bottom':
 			// top and bottom are handled by the pickShortest approach below - it automatically
@@ -208,6 +152,32 @@ export function routeArrowWithManualEdgePicking(
 
 	return null
 }
+/**
+ * Find the first horizontal side of A that can turn a corner into the top or bottom of B without
+ * doubling back on itself. Returns the pair of sides, or null if no corner works.
+ */
+function pickCornerSides(
+	info: ElbowArrowWorkingInfo,
+	aSides: ReadonlyArray<'right' | 'left'>
+): [ElbowArrowSide, ElbowArrowSide] | null {
+	for (const aSide of aSides) {
+		const aEdge = info.A.edges[aSide]
+		if (!aEdge) continue
+		const aExpanded = aEdge.expanded ?? aEdge.value
+		for (const bSide of ['top', 'bottom'] as const) {
+			const bEdge = info.B.edges[bSide]
+			if (!bEdge) continue
+			const bExpanded = bEdge.expanded ?? bEdge.value
+			const aClearsB =
+				aSide === 'right' ? aExpanded <= bEdge.crossTarget : aExpanded >= bEdge.crossTarget
+			const bClearsA =
+				bSide === 'top' ? aEdge.crossTarget <= bExpanded : aEdge.crossTarget >= bExpanded
+			if (aClearsB && bClearsA) return [aSide, bSide]
+		}
+	}
+	return null
+}
+
 function pickBest(
 	info: ElbowArrowWorkingInfo,
 	edges: ReadonlyArray<

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -1,4 +1,5 @@
 import {
+	clamp,
 	Editor,
 	Geometry2d,
 	intersectLineSegmentPolygon,
@@ -10,18 +11,21 @@ import {
 	TLArrowShape,
 	TLShape,
 	TLShapeId,
+	TLTheme,
 	Vec,
 } from '@tldraw/editor'
 import { createComputedCache } from '@tldraw/store'
+import { STROKE_SIZES } from '../shared/default-shape-constants'
 
 const MIN_ARROW_BEND = 8
 // Keep anchors off exact edges/corners to avoid degenerate arrow intersections.
 const NORMALIZED_ANCHOR_EPSILON = 1e-3
 
 function clampNormalizedAnchor(anchor: { x: number; y: number }) {
-	const clamp = (v: number) =>
-		Math.max(NORMALIZED_ANCHOR_EPSILON, Math.min(1 - NORMALIZED_ANCHOR_EPSILON, v))
-	return { x: clamp(anchor.x), y: clamp(anchor.y) }
+	return {
+		x: clamp(anchor.x, NORMALIZED_ANCHOR_EPSILON, 1 - NORMALIZED_ANCHOR_EPSILON),
+		y: clamp(anchor.y, NORMALIZED_ANCHOR_EPSILON, 1 - NORMALIZED_ANCHOR_EPSILON),
+	}
 }
 
 export function getIsArrowStraight(shape: TLArrowShape) {
@@ -43,12 +47,10 @@ export function getBoundShapeInfoForTerminal(
 	arrow: TLArrowShape,
 	terminalName: 'start' | 'end'
 ): BoundShapeInfo | undefined {
-	const binding = editor
-		.getBindingsFromShape(arrow, 'arrow')
-		.find((b) => b.props.terminal === terminalName)
+	const binding = getArrowBindings(editor, arrow)[terminalName]
 	if (!binding) return
 
-	const boundShape = editor.getShape(binding.toId)!
+	const boundShape = editor.getShape(binding.toId)
 	if (!boundShape) return
 	const transform = editor.getShapePageTransform(boundShape)!
 	const hasArrowhead =
@@ -68,6 +70,21 @@ export function getBoundShapeInfoForTerminal(
 		didIntersect: false,
 		geometry,
 	}
+}
+
+/**
+ * Half the arrow's stroke plus half the bound shape's stroke, so an arrowhead offset from the
+ * shape's geometry clears both strokes.
+ */
+export function getBoundShapeStrokeOffset(
+	theme: TLTheme,
+	arrowStrokeWidth: number,
+	info: BoundShapeInfo
+) {
+	return (
+		arrowStrokeWidth / 2 +
+		('size' in info.shape.props ? (theme.strokeWidth * STROKE_SIZES[info.shape.props.size]) / 2 : 0)
+	)
 }
 
 export function getArrowTerminalInArrowSpace(
@@ -282,7 +299,7 @@ export function clampArrowTerminalToMask(
 	// on the mask boundary.
 	const pageAnchor = Mat.applyToPoint(arrowPageTransform, terminalHandle)
 	const direction = Vec.Sub(pageAnchor, pagePoint).uni()
-	const extendedAnchor = Vec.Add(pageAnchor, Vec.Mul(direction, 1))
+	const extendedAnchor = Vec.Add(pageAnchor, direction)
 	const intersections = intersectLineSegmentPolygon(extendedAnchor, pagePoint, mask)
 	if (!intersections || intersections.length === 0) return
 

--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -49,19 +49,24 @@ export function getStraightArrowInfo(
 
 	const uAB = Vec.Sub(b, a).uni()
 
+	// Update the arrowhead points using intersections with the bound shapes, if any.
+
 	const startShapeInfo = getBoundShapeInfoForTerminal(editor, shape, 'start')
 	const endShapeInfo = getBoundShapeInfoForTerminal(editor, shape, 'end')
 
 	const arrowPageTransform = editor.getShapePageTransform(shape)!
 
+	// Update the position of the arrowhead's end point
 	updateArrowheadPointWithBoundShape(
-		b,
+		b, // <-- will be mutated
 		terminalsInArrowSpace.start,
 		arrowPageTransform,
 		endShapeInfo
 	)
+
+	// Then update the position of the arrowhead's end point
 	updateArrowheadPointWithBoundShape(
-		a,
+		a, // <-- will be mutated
 		terminalsInArrowSpace.end,
 		arrowPageTransform,
 		startShapeInfo
@@ -218,9 +223,11 @@ function updateArrowheadPointWithBoundShape(
 	// no binding, or an exact one: the arrowhead point stays at the arrow terminal
 	if (targetShapeInfo === undefined || targetShapeInfo.isExact) return
 
+	// From and To in page space
 	const pageFrom = Mat.applyToPoint(arrowPageTransform, opposite)
 	const pageTo = Mat.applyToPoint(arrowPageTransform, point)
 
+	// From and To in local space of the target shape
 	const targetTransformInverse = Mat.Inverse(targetShapeInfo.transform)
 	const targetFrom = Mat.applyToPoint(targetTransformInverse, pageFrom)
 	const targetTo = Mat.applyToPoint(targetTransformInverse, pageTo)

--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -10,6 +10,7 @@ import {
 	getArrowTerminalsInArrowSpace,
 	getBoundShapeInfoForTerminal,
 	getBoundShapeRelationships,
+	getBoundShapeStrokeOffset,
 } from './shared'
 
 export function getStraightArrowInfo(
@@ -48,24 +49,19 @@ export function getStraightArrowInfo(
 
 	const uAB = Vec.Sub(b, a).uni()
 
-	// Update the arrowhead points using intersections with the bound shapes, if any.
-
 	const startShapeInfo = getBoundShapeInfoForTerminal(editor, shape, 'start')
 	const endShapeInfo = getBoundShapeInfoForTerminal(editor, shape, 'end')
 
 	const arrowPageTransform = editor.getShapePageTransform(shape)!
 
-	// Update the position of the arrowhead's end point
 	updateArrowheadPointWithBoundShape(
-		b, // <-- will be mutated
+		b,
 		terminalsInArrowSpace.start,
 		arrowPageTransform,
 		endShapeInfo
 	)
-
-	// Then update the position of the arrowhead's end point
 	updateArrowheadPointWithBoundShape(
-		a, // <-- will be mutated
+		a,
 		terminalsInArrowSpace.end,
 		arrowPageTransform,
 		startShapeInfo
@@ -83,8 +79,6 @@ export function getStraightArrowInfo(
 
 	let offsetA = 0
 	let offsetB = 0
-	let strokeOffsetA = 0
-	let strokeOffsetB = 0
 	let minLength = MIN_ARROW_LENGTH * shape.props.scale
 
 	const theme = editor.getCurrentTheme()
@@ -136,11 +130,7 @@ export function getStraightArrowInfo(
 			arrowheadStart !== 'none' &&
 			!startShapeInfo.isExact
 		) {
-			strokeOffsetA =
-				arrowSW / 2 +
-				('size' in startShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
-					: 0)
+			const strokeOffsetA = getBoundShapeStrokeOffset(theme, arrowSW, startShapeInfo)
 			offsetA = (BOUND_ARROW_OFFSET + strokeOffsetA) * shape.props.scale
 			minLength += strokeOffsetA * shape.props.scale
 		}
@@ -153,11 +143,7 @@ export function getStraightArrowInfo(
 			arrowheadEnd !== 'none' &&
 			!endShapeInfo.isExact
 		) {
-			strokeOffsetB =
-				arrowSW / 2 +
-				('size' in endShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
-					: 0)
+			const strokeOffsetB = getBoundShapeStrokeOffset(theme, arrowSW, endShapeInfo)
 			offsetB = (BOUND_ARROW_OFFSET + strokeOffsetB) * shape.props.scale
 			minLength += strokeOffsetB * shape.props.scale
 		}
@@ -229,23 +215,15 @@ function updateArrowheadPointWithBoundShape(
 	arrowPageTransform: MatModel,
 	targetShapeInfo?: BoundShapeInfo
 ) {
-	if (targetShapeInfo === undefined) {
-		// No bound shape? The arrowhead point will be at the arrow terminal.
-		return
-	}
+	// no binding, or an exact one: the arrowhead point stays at the arrow terminal
+	if (targetShapeInfo === undefined || targetShapeInfo.isExact) return
 
-	if (targetShapeInfo.isExact) {
-		// Exact type binding? The arrowhead point will be at the arrow terminal.
-		return
-	}
-
-	// From and To in page space
 	const pageFrom = Mat.applyToPoint(arrowPageTransform, opposite)
 	const pageTo = Mat.applyToPoint(arrowPageTransform, point)
 
-	// From and To in local space of the target shape
-	const targetFrom = Mat.applyToPoint(Mat.Inverse(targetShapeInfo.transform), pageFrom)
-	const targetTo = Mat.applyToPoint(Mat.Inverse(targetShapeInfo.transform), pageTo)
+	const targetTransformInverse = Mat.Inverse(targetShapeInfo.transform)
+	const targetFrom = Mat.applyToPoint(targetTransformInverse, pageFrom)
+	const targetTo = Mat.applyToPoint(targetTransformInverse, pageTo)
 
 	const intersection = Array.from(
 		targetShapeInfo.geometry.intersectLineSegment(targetFrom, targetTo, {
@@ -257,9 +235,9 @@ function updateArrowheadPointWithBoundShape(
 	let targetInt: VecLike | undefined
 
 	if (intersection.length) {
-		targetInt =
-			intersection.sort((p1, p2) => Vec.Dist2(p1, targetFrom) - Vec.Dist2(p2, targetFrom))[0] ??
-			(targetShapeInfo.isClosed ? undefined : targetTo)
+		targetInt = intersection.sort(
+			(p1, p2) => Vec.Dist2(p1, targetFrom) - Vec.Dist2(p2, targetFrom)
+		)[0]
 	}
 
 	if (targetInt === undefined) {

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -138,8 +138,10 @@ export class Pointing extends StateNode {
 		const handles = this.editor.getShapeHandles(shape)
 		if (!handles) throw Error(`expected handles for arrow`)
 
+		// start update
 		this.dragHandle(shape, handles, 'start', { x: 0, y: 0 }, this.isPrecise)
 
+		// end update
 		const point = this.editor.getPointInShapeSpace(shape, this.editor.inputs.getCurrentPagePoint())
 		this.dragHandle(this.editor.getShape(shape)!, handles, 'end', point, this.isPrecise)
 

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -1,4 +1,11 @@
-import { StateNode, TLArrowShape, createShapeId, maybeSnapToGrid } from '@tldraw/editor'
+import {
+	StateNode,
+	TLArrowShape,
+	TLHandle,
+	VecLike,
+	createShapeId,
+	maybeSnapToGrid,
+} from '@tldraw/editor'
 import { ArrowShapeUtil } from '../ArrowShapeUtil'
 import { clearArrowTargetState, updateArrowTargetState } from '../arrowTargetState'
 
@@ -117,19 +124,7 @@ export class Pointing extends StateNode {
 		const handles = this.editor.getShapeHandles(shape)
 		if (!handles) throw Error(`expected handles for arrow`)
 
-		const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
-		const initial = this.shape
-		const startHandle = handles.find((h) => h.id === 'start')!
-		const change = util.onHandleDrag?.(shape, {
-			handle: { ...startHandle, x: 0, y: 0 },
-			isPrecise: true,
-			isCreatingShape: true,
-			initial: initial,
-		})
-
-		if (change) {
-			this.editor.updateShapes([change])
-		}
+		this.dragHandle(shape, handles, 'start', { x: 0, y: 0 }, true)
 
 		// Cache the current shape after those changes
 		this.shape = this.editor.getShape(id)
@@ -143,46 +138,34 @@ export class Pointing extends StateNode {
 		const handles = this.editor.getShapeHandles(shape)
 		if (!handles) throw Error(`expected handles for arrow`)
 
-		// start update
-		{
-			const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
-			const initial = this.shape
-			const startHandle = handles.find((h) => h.id === 'start')!
-			const change = util.onHandleDrag?.(shape, {
-				handle: { ...startHandle, x: 0, y: 0 },
-				isPrecise: this.isPrecise,
-				isCreatingShape: true,
-				initial: initial,
-			})
+		this.dragHandle(shape, handles, 'start', { x: 0, y: 0 }, this.isPrecise)
 
-			if (change) {
-				this.editor.updateShapes([change])
-			}
-		}
-
-		// end update
-		{
-			const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
-			const initial = this.shape
-			const point = this.editor.getPointInShapeSpace(
-				shape,
-				this.editor.inputs.getCurrentPagePoint()
-			)
-			const endHandle = handles.find((h) => h.id === 'end')!
-			const change = util.onHandleDrag?.(this.editor.getShape(shape)!, {
-				handle: { ...endHandle, x: point.x, y: point.y },
-				isPrecise: this.isPrecise,
-				isCreatingShape: true,
-				initial: initial,
-			})
-
-			if (change) {
-				this.editor.updateShapes([change])
-			}
-		}
+		const point = this.editor.getPointInShapeSpace(shape, this.editor.inputs.getCurrentPagePoint())
+		this.dragHandle(this.editor.getShape(shape)!, handles, 'end', point, this.isPrecise)
 
 		// Cache the current shape after those changes
 		this.shape = this.editor.getShape(shape.id)
+	}
+
+	private dragHandle(
+		shape: TLArrowShape,
+		handles: TLHandle[],
+		handleId: 'start' | 'end',
+		point: VecLike,
+		isPrecise: boolean
+	) {
+		const util = this.editor.getShapeUtil<TLArrowShape>('arrow')
+		const handle = handles.find((h) => h.id === handleId)!
+		const change = util.onHandleDrag?.(shape, {
+			handle: { ...handle, x: point.x, y: point.y },
+			isPrecise,
+			isCreatingShape: true,
+			initial: this.shape,
+		})
+
+		if (change) {
+			this.editor.updateShapes([change])
+		}
 	}
 
 	private startPreciseTimeout() {

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -195,8 +195,8 @@ export function BookmarkShapeComponent({
 								className="tl-bookmark__image"
 								draggable={false}
 								referrerPolicy="strict-origin-when-cross-origin"
-								src={asset?.props.image}
-								alt={asset?.props.title || ''}
+								src={asset.props.image}
+								alt={asset.props.title || ''}
 							/>
 						) : (
 							<div className="tl-bookmark__placeholder" />
@@ -208,7 +208,7 @@ export function BookmarkShapeComponent({
 					{asset?.props.title ? (
 						<a
 							className="tl-bookmark__link"
-							href={url || ''}
+							href={url}
 							target="_blank"
 							rel="noopener noreferrer"
 							draggable={false}
@@ -225,7 +225,7 @@ export function BookmarkShapeComponent({
 					) : null}
 					<a
 						className="tl-bookmark__link"
-						href={url || ''}
+						href={url}
 						target="_blank"
 						rel="noopener noreferrer"
 						draggable={false}

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -50,9 +50,11 @@ export function getHumanReadableAddress(url: string) {
 }
 
 export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
+	// Derive the asset id from the URL
 	const assetId = getBookmarkAssetIdForUrl(shape.props.url)
 
 	if (editor.getAsset(assetId)) {
+		// Existing asset for this URL?
 		if (shape.props.assetId !== assetId) {
 			editor.updateShapes([
 				{
@@ -63,7 +65,9 @@ export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 			])
 		}
 	} else {
-		// Clear the stale asset reference, then create a new one asynchronously
+		// No asset for this URL?
+
+		// First, clear out the existing asset reference
 		editor.updateShapes([
 			{
 				id: shape.id,
@@ -71,6 +75,8 @@ export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 				props: { assetId: null },
 			},
 		])
+
+		// Then try to asyncronously create a new one
 		createBookmarkAssetOnUrlChange(editor, shape)
 	}
 }
@@ -128,7 +134,10 @@ async function _createBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 	}
 
 	editor.run(() => {
+		// Create the new asset
 		editor.createAssets([asset])
+
+		// And update the shape
 		editor.updateShapes([
 			{
 				id: shape.id,

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -17,7 +17,7 @@ export const BOOKMARK_HEIGHT = 320
 export const BOOKMARK_JUST_URL_HEIGHT = 46
 const SHORT_BOOKMARK_HEIGHT = 101
 
-function getBookmarkAssetIdForUrl(url: string): TLAssetId {
+export function getBookmarkAssetIdForUrl(url: string): TLAssetId {
 	return AssetRecordType.createId(getHashForString(url))
 }
 

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -17,17 +17,15 @@ export const BOOKMARK_HEIGHT = 320
 export const BOOKMARK_JUST_URL_HEIGHT = 46
 const SHORT_BOOKMARK_HEIGHT = 101
 
+function getBookmarkAssetIdForUrl(url: string): TLAssetId {
+	return AssetRecordType.createId(getHashForString(url))
+}
+
 export function getBookmarkHeight(editor: Editor, assetId?: TLAssetId | null) {
 	const asset = (assetId ? editor.getAsset(assetId) : null) as TLBookmarkAsset | null
 
-	if (asset) {
-		if (!asset.props.image) {
-			if (!asset.props.title) {
-				return BOOKMARK_JUST_URL_HEIGHT
-			} else {
-				return SHORT_BOOKMARK_HEIGHT
-			}
-		}
+	if (asset && !asset.props.image) {
+		return asset.props.title ? SHORT_BOOKMARK_HEIGHT : BOOKMARK_JUST_URL_HEIGHT
 	}
 
 	return BOOKMARK_HEIGHT
@@ -52,13 +50,9 @@ export function getHumanReadableAddress(url: string) {
 }
 
 export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
-	const { url } = shape.props
-
-	// Derive the asset id from the URL
-	const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
+	const assetId = getBookmarkAssetIdForUrl(shape.props.url)
 
 	if (editor.getAsset(assetId)) {
-		// Existing asset for this URL?
 		if (shape.props.assetId !== assetId) {
 			editor.updateShapes([
 				{
@@ -69,9 +63,7 @@ export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 			])
 		}
 	} else {
-		// No asset for this URL?
-
-		// First, clear out the existing asset reference
+		// Clear the stale asset reference, then create a new one asynchronously
 		editor.updateShapes([
 			{
 				id: shape.id,
@@ -79,8 +71,6 @@ export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 				props: { assetId: null },
 			},
 		])
-
-		// Then try to asyncronously create a new one
 		createBookmarkAssetOnUrlChange(editor, shape)
 	}
 }
@@ -103,7 +93,7 @@ export function getResolvedBookmarkAssetId(
 	if (assetId) return assetId
 	if (!url) return null
 
-	const derivedId: TLAssetId = AssetRecordType.createId(getHashForString(url))
+	const derivedId = getBookmarkAssetIdForUrl(url)
 	return editor.getAsset(derivedId) ? derivedId : null
 }
 
@@ -138,10 +128,7 @@ async function _createBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 	}
 
 	editor.run(() => {
-		// Create the new asset
 		editor.createAssets([asset])
-
-		// And update the shape
 		editor.updateShapes([
 			{
 				id: shape.id,
@@ -192,8 +179,7 @@ export async function createBookmarkFromUrl(
 		// If we already have a bookmark asset for this URL (e.g. another bookmark
 		// shape was created from the same URL earlier), use it immediately rather
 		// than re-fetching.
-		const expectedAssetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
-		const existingAsset = editor.getAsset(expectedAssetId) as TLBookmarkAsset | null
+		const existingAsset = editor.getAsset(getBookmarkAssetIdForUrl(url)) as TLBookmarkAsset | null
 
 		const shapeId = createShapeId()
 		const shapePartial: TLShapePartial<TLBookmarkShape> = {
@@ -211,9 +197,7 @@ export async function createBookmarkFromUrl(
 			},
 		}
 
-		editor.run(() => {
-			editor.createShapes([shapePartial])
-		})
+		editor.createShapes([shapePartial])
 
 		const createdShape = editor.getShape<TLBookmarkShape>(shapeId)
 		if (!createdShape) {

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -25,7 +25,7 @@ import { STROKE_SIZES } from '../shared/default-shape-constants'
 import { DEFAULT_FILL_COLOR_NAMES } from '../shared/defaultFills'
 import { getFillDefForCanvas, getFillDefForExport } from '../shared/defaultStyleDefs'
 import { getStrokePoints } from '../shared/freehand/getStrokePoints'
-import { getSvgPathFromStrokePoints } from '../shared/freehand/svg'
+import { getSvgDotPath, getSvgPathFromStrokePoints } from '../shared/freehand/svg'
 import { svgInk } from '../shared/freehand/svgInk'
 import { ShapeOptionsWithDisplayValues, getDisplayValues } from '../shared/getDisplayValues'
 import { interpolateSegments } from '../shared/interpolate-props'
@@ -260,10 +260,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 }
 
 function getDot(point: VecLike, sw: number) {
-	const r = (sw + 1) * 0.5
-	return `M ${point.x} ${point.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${
-		r * 2
-	},0`
+	return getSvgDotPath(point, (sw + 1) * 0.5)
 }
 
 function getIsDot(shape: TLDrawShape) {

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -333,29 +333,22 @@ function DrawShapeSvg({
 	const options = getFreehandOptions(shape.props, sw, showAsComplete, forceSolid)
 
 	if (!forceSolid && shape.props.dash === 'draw') {
+		const fillPath =
+			shape.props.isClosed && shape.props.fill !== 'none' && allPointsFromSegments.length > 1
+				? getSvgPathFromStrokePoints(getStrokePoints(allPointsFromSegments, options), true)
+				: null
 		return (
 			<>
-				{shape.props.isClosed &&
-					shape.props.fill !== 'none' &&
-					allPointsFromSegments.length > 1 &&
+				{fillPath &&
 					(shape.props.fill === 'pattern' ? (
 						<PatternFill
-							d={getSvgPathFromStrokePoints(
-								getStrokePoints(allPointsFromSegments, options),
-								shape.props.isClosed
-							)}
+							d={fillPath}
 							fillColor={fillColor}
 							patternFillFallbackColor={patternFillFallbackColor}
 							scale={shape.props.scale}
 						/>
 					) : (
-						<path
-							fill={fillColor}
-							d={getSvgPathFromStrokePoints(
-								getStrokePoints(allPointsFromSegments, options),
-								shape.props.isClosed
-							)}
-						/>
+						<path fill={fillColor} d={fillPath} />
 					))}
 				<path d={svgInk(allPointsFromSegments, options)} strokeLinecap="round" fill={strokeColor} />
 			</>

--- a/packages/tldraw/src/lib/shapes/draw/getPath.ts
+++ b/packages/tldraw/src/lib/shapes/draw/getPath.ts
@@ -82,24 +82,16 @@ export function getFreehandOptions(
 	forceSolid: boolean
 ): StrokeOptions {
 	const last = shapeProps.isComplete || forceComplete
-
-	if (forceSolid) {
-		if (shapeProps.isPen) {
-			return { ...solidRealPressureSettings(strokeWidth), last }
-		} else {
-			return { ...solidSettings(strokeWidth), last }
-		}
-	}
-
-	if (shapeProps.dash === 'draw') {
-		if (shapeProps.isPen) {
-			return { ...realPressureSettings(strokeWidth), last }
-		} else {
-			return { ...simulatePressureSettings(strokeWidth), last }
-		}
-	}
-
-	return { ...solidSettings(strokeWidth), last }
+	const settings = forceSolid
+		? shapeProps.isPen
+			? solidRealPressureSettings
+			: solidSettings
+		: shapeProps.dash === 'draw'
+			? shapeProps.isPen
+				? realPressureSettings
+				: simulatePressureSettings
+			: solidSettings
+	return { ...settings(strokeWidth), last }
 }
 
 /** @public */
@@ -157,11 +149,12 @@ export function getDrawShapeStrokeDashArray(
 	strokeWidth: number,
 	dotAdjustment: number
 ) {
-	return {
-		draw: 'none',
-		solid: `none`,
-		dotted: `${dotAdjustment} ${strokeWidth * 2}`,
-		dashed: `${strokeWidth * 2} ${strokeWidth * 2}`,
-		none: `none`,
-	}[shape.props.dash]
+	switch (shape.props.dash) {
+		case 'dotted':
+			return `${dotAdjustment} ${strokeWidth * 2}`
+		case 'dashed':
+			return `${strokeWidth * 2} ${strokeWidth * 2}`
+		default:
+			return 'none'
+	}
 }

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -76,15 +76,13 @@ export class Drawing extends StateNode {
 		const { inputs } = this.editor
 		const isPen = inputs.getIsPen()
 
-		if (this.isPen && !isPen) {
+		if (this.isPen && !isPen && this.markId) {
 			// The user made a palm gesture before starting a pen gesture;
 			// ideally we'd start the new shape here but we could also just bail
 			// as the next interaction will work correctly
-			if (this.markId) {
-				this.editor.bailToMark(this.markId)
-				this.startShape()
-				return
-			}
+			this.editor.bailToMark(this.markId)
+			this.startShape()
+			return
 		}
 
 		if (this.isPenOrStylus) {
@@ -196,6 +194,40 @@ export class Drawing extends StateNode {
 		return this.segmentDim === DIM_2D ? { type, path, dim: DIM_2D } : { type, path }
 	}
 
+	private getStrokeWidth(shape: DrawableShape): number {
+		return (getDisplayValues(this.util as any, shape) as { strokeWidth: number }).strokeWidth
+	}
+
+	private refreshLineLengthIfShort(shape: DrawableShape, segments: TLDrawShapeSegment[]) {
+		if (this.currentLineLength < this.getStrokeWidth(shape) * 4) {
+			this.currentLineLength = this.getLineLength(segments)
+		}
+	}
+
+	private updateShapeSegments(
+		id: DrawableShape['id'],
+		segments: TLDrawShapeSegment[],
+		segmentsForClose: TLDrawShapeSegment[],
+		size: TLDefaultSizeStyle,
+		scale: number
+	) {
+		const shapePartial: TLShapePartial<DrawableShape> = {
+			id,
+			type: this.shapeType,
+			props: { segments },
+		}
+
+		if (this.canClose()) {
+			;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
+				segmentsForClose,
+				size,
+				scale
+			)
+		}
+
+		this.editor.updateShapes([shapePartial])
+	}
+
 	private startShape() {
 		const inputs = this.editor.inputs
 		const originPagePoint = inputs.getOriginPagePoint()
@@ -250,49 +282,23 @@ export class Drawing extends StateNode {
 					{ x, y, z: +pressure.toFixed(2) },
 				])
 
-				// Convert prevPoint to page space
-				const prevPointPageSpace = Mat.applyToPoint(
+				this.pagePointWhereCurrentSegmentChanged = Mat.applyToPoint(
 					this.editor.getShapePageTransform(shape.id)!,
 					prevPoint
 				)
-				this.pagePointWhereCurrentSegmentChanged = prevPointPageSpace
 				this.pagePointWhereNextSegmentChanged = null
 				const segments = [...shape.props.segments, newSegment]
 
-				const dvStrokeWidth = (getDisplayValues(this.util as any, shape) as { strokeWidth: number })
-					.strokeWidth
-				if (this.currentLineLength < dvStrokeWidth * 4) {
-					this.currentLineLength = this.getLineLength(segments)
-				}
-
-				const shapePartial: TLShapePartial<DrawableShape> = {
-					id: shape.id,
-					type: this.shapeType,
-					props: {
-						segments,
-					},
-				}
-
-				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-						segments,
-						shape.props.size,
-						shape.props.scale
-					)
-				}
-
-				this.editor.updateShapes([shapePartial])
+				this.refreshLineLengthIfShort(shape, segments)
+				this.updateShapeSegments(shape.id, segments, segments, shape.props.size, shape.props.scale)
 
 				return
 			}
 		}
 
-		// Create a new shape
-
 		this.pagePointWhereCurrentSegmentChanged = originPagePoint.clone()
 		const id = createShapeId()
 
-		// Initialize the segment points cache
 		const initialPoint = new Vec(0, 0, +pressure.toFixed(2))
 		this.currentSegmentPoints = [initialPoint]
 
@@ -314,7 +320,7 @@ export class Drawing extends StateNode {
 			return
 		}
 		this.currentLineLength = 0
-		this.initialShape = this.editor.getShape<DrawableShape>(id)
+		this.initialShape = shape
 	}
 
 	private updateDrawingShape() {
@@ -348,18 +354,14 @@ export class Drawing extends StateNode {
 				}
 
 				const hasMovedFarEnough =
-					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
+					Vec.Dist2(pagePointWhereNextSegmentChanged, currentPagePoint) >
 					this.editor.options.dragDistanceSquared
 
-				// Find the distance from where the pointer was when shift was released and
-				// where it is now; if it's far enough away, then update the page point where
-				// the current segment changed (to match the pagepoint where next segment changed)
-				// and set the pagepoint where next segment changed to null.
+				// Only switch modes once the pointer has moved far enough from where shift
+				// was pressed, so a tap of shift doesn't start a new segment.
 				if (hasMovedFarEnough) {
-					this.pagePointWhereCurrentSegmentChanged = this.pagePointWhereNextSegmentChanged!.clone()
+					this.pagePointWhereCurrentSegmentChanged = pagePointWhereNextSegmentChanged.clone()
 					this.pagePointWhereNextSegmentChanged = null
-
-					// Set the new mode
 					this.segmentMode = 'straight'
 
 					const prevSegment = last(segments)
@@ -387,23 +389,7 @@ export class Drawing extends StateNode {
 						newSegment = this.makeSegment('straight', [newLastPoint, newPoint])
 					}
 
-					const shapePartial: TLShapePartial<DrawableShape> = {
-						id,
-						type: this.shapeType,
-						props: {
-							segments: [...segments, newSegment],
-						},
-					}
-
-					if (this.canClose()) {
-						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-							segments,
-							size,
-							scale
-						)
-					}
-
-					this.editor.updateShapes([shapePartial])
+					this.updateShapeSegments(id, [...segments, newSegment], segments, size, scale)
 				}
 				break
 			}
@@ -415,22 +401,15 @@ export class Drawing extends StateNode {
 				}
 
 				const hasMovedFarEnough =
-					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
+					Vec.Dist2(pagePointWhereNextSegmentChanged, currentPagePoint) >
 					this.editor.options.dragDistanceSquared
 
-				// Find the distance from where the pointer was when shift was released and
-				// where it is now; if it's far enough away, then update the page point where
-				// the current segment changed (to match the pagepoint where next segment changed)
-				// and set the pagepoint where next segment changed to null.
 				if (hasMovedFarEnough) {
-					this.pagePointWhereCurrentSegmentChanged = this.pagePointWhereNextSegmentChanged!.clone()
+					this.pagePointWhereCurrentSegmentChanged = pagePointWhereNextSegmentChanged.clone()
 					this.pagePointWhereNextSegmentChanged = null
-
-					// Set the new mode
 					this.segmentMode = 'free'
 
-					const newSegments = segments.slice()
-					const prevStraightSegment = newSegments[newSegments.length - 1]
+					const prevStraightSegment = segments[segments.length - 1]
 					const prevPoint = b64Vecs.decodeLastPoint(
 						prevStraightSegment.path,
 						prevStraightSegment.dim
@@ -440,42 +419,16 @@ export class Drawing extends StateNode {
 						throw Error('No previous point!')
 					}
 
-					// Create the new free segment and interpolate the points between where the last line
-					// ended and where the pointer is now
+					// Interpolate the points between where the last line ended and where the pointer is now
 					const interpolatedPoints = Vec.PointsBetween(prevPoint, newPoint, 6).map(
 						(p) => new Vec(toFixed(p.x), toFixed(p.y), toFixed(p.z))
 					)
-					// Initialize cache for the new free segment
 					this.currentSegmentPoints = interpolatedPoints
 
-					const newFreeSegment = this.makeSegment('free', interpolatedPoints)
+					const finalSegments = [...segments, this.makeSegment('free', interpolatedPoints)]
 
-					const finalSegments = [...newSegments, newFreeSegment]
-
-					const dvStrokeWidth = (
-						getDisplayValues(this.util as any, shape) as { strokeWidth: number }
-					).strokeWidth
-					if (this.currentLineLength < dvStrokeWidth * 4) {
-						this.currentLineLength = this.getLineLength(finalSegments)
-					}
-
-					const shapePartial: TLShapePartial<DrawableShape> = {
-						id,
-						type: this.shapeType,
-						props: {
-							segments: finalSegments,
-						},
-					}
-
-					if (this.canClose()) {
-						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-							finalSegments,
-							size,
-							scale
-						)
-					}
-
-					this.editor.updateShapes([shapePartial])
+					this.refreshLineLengthIfShort(shape, finalSegments)
+					this.updateShapeSegments(id, finalSegments, finalSegments, size, scale)
 				}
 
 				break
@@ -485,9 +438,7 @@ export class Drawing extends StateNode {
 				const newSegment = newSegments[newSegments.length - 1]
 
 				const { pagePointWhereCurrentSegmentChanged } = this
-				const inputs = this.editor.inputs
 				const ctrlKey = inputs.getCtrlKey()
-				const currentPagePoint = inputs.getCurrentPagePoint()
 
 				if (!pagePointWhereCurrentSegmentChanged)
 					throw Error('We should have a point where the segment changed')
@@ -496,12 +447,10 @@ export class Drawing extends StateNode {
 				let shouldSnapToAngle = false
 
 				if (this.didJustShiftClickToExtendPreviousShapeLine) {
-					if (this.editor.inputs.getIsDragging()) {
+					if (inputs.getIsDragging()) {
 						// If we've just shift clicked to extend a line, only snap once we've started dragging
 						shouldSnapToAngle = !ctrlKey
 						this.didJustShiftClickToExtendPreviousShapeLine = false
-					} else {
-						// noop
 					}
 				} else {
 					// If we're not shift clicking to extend a line, but we're holding shift, then we should snap
@@ -591,44 +540,16 @@ export class Drawing extends StateNode {
 					newPoint = this.editor.getPointInShapeSpace(shape, pagePoint).toFixed().toJson()
 				}
 
-				// If the previous segment is a one point free shape and is the first segment of the line,
-				// then the user just did a click-and-immediately-press-shift to create a new straight line
-				// without continuing the previous line. In this case, we want to remove the previous segment.
-
-				this.currentLineLength +=
-					newSegments.length && b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)
-						? Vec.Dist(
-								b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!,
-								Vec.From(newPoint)
-							)
-						: 0
+				const segmentFirstPoint = b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)
+				this.currentLineLength += segmentFirstPoint ? Vec.Dist(segmentFirstPoint, newPoint) : 0
 
 				newSegments[newSegments.length - 1] = {
 					...newSegment,
 					type: 'straight',
-					path: b64Vecs.encodePoints(
-						[b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!, Vec.From(newPoint)],
-						newSegment.dim
-					),
+					path: b64Vecs.encodePoints([segmentFirstPoint!, Vec.From(newPoint)], newSegment.dim),
 				}
 
-				const shapePartial: TLShapePartial<DrawableShape> = {
-					id,
-					type: this.shapeType,
-					props: {
-						segments: newSegments,
-					},
-				}
-
-				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-						segments,
-						size,
-						scale
-					)
-				}
-
-				this.editor.updateShapes([shapePartial])
+				this.updateShapeSegments(id, newSegments, segments, size, scale)
 
 				break
 			}
@@ -657,29 +578,8 @@ export class Drawing extends StateNode {
 					path: b64Vecs.encodePoints(cachedPoints, newSegment.dim),
 				}
 
-				const dvStrokeWidth = (getDisplayValues(this.util as any, shape) as { strokeWidth: number })
-					.strokeWidth
-				if (this.currentLineLength < dvStrokeWidth * 4) {
-					this.currentLineLength = this.getLineLength(newSegments)
-				}
-
-				const shapePartial: TLShapePartial<DrawableShape> = {
-					id,
-					type: this.shapeType,
-					props: {
-						segments: newSegments,
-					},
-				}
-
-				if (this.canClose()) {
-					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-						newSegments,
-						size,
-						scale
-					)
-				}
-
-				this.editor.updateShapes([shapePartial])
+				this.refreshLineLengthIfShort(shape, newSegments)
+				this.updateShapeSegments(id, newSegments, newSegments, size, scale)
 
 				// Set a maximum length for the lines array; after 200 points, complete the line.
 				if (cachedPoints.length > this.util.options.maxPointsPerShape) {
@@ -692,7 +592,6 @@ export class Drawing extends StateNode {
 					if (!this.editor.canCreateShapes([newShapeId])) return this.cancel()
 					const currentPagePoint = inputs.getCurrentPagePoint()
 
-					// Reset cache for the new shape's segment
 					const initialPoint = new Vec(0, 0, this.isPenOrStylus ? +(z! * 1.25).toFixed() : 0.5)
 					this.currentSegmentPoints = [initialPoint]
 

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -282,6 +282,7 @@ export class Drawing extends StateNode {
 					{ x, y, z: +pressure.toFixed(2) },
 				])
 
+				// Convert prevPoint to page space
 				this.pagePointWhereCurrentSegmentChanged = Mat.applyToPoint(
 					this.editor.getShapePageTransform(shape.id)!,
 					prevPoint
@@ -296,9 +297,12 @@ export class Drawing extends StateNode {
 			}
 		}
 
+		// Create a new shape
+
 		this.pagePointWhereCurrentSegmentChanged = originPagePoint.clone()
 		const id = createShapeId()
 
+		// Initialize the segment points cache
 		const initialPoint = new Vec(0, 0, +pressure.toFixed(2))
 		this.currentSegmentPoints = [initialPoint]
 
@@ -357,11 +361,15 @@ export class Drawing extends StateNode {
 					Vec.Dist2(pagePointWhereNextSegmentChanged, currentPagePoint) >
 					this.editor.options.dragDistanceSquared
 
-				// Only switch modes once the pointer has moved far enough from where shift
-				// was pressed, so a tap of shift doesn't start a new segment.
+				// Find the distance from where the pointer was when shift was released and
+				// where it is now; if it's far enough away, then update the page point where
+				// the current segment changed (to match the pagepoint where next segment changed)
+				// and set the pagepoint where next segment changed to null.
 				if (hasMovedFarEnough) {
 					this.pagePointWhereCurrentSegmentChanged = pagePointWhereNextSegmentChanged.clone()
 					this.pagePointWhereNextSegmentChanged = null
+
+					// Set the new mode
 					this.segmentMode = 'straight'
 
 					const prevSegment = last(segments)
@@ -404,9 +412,15 @@ export class Drawing extends StateNode {
 					Vec.Dist2(pagePointWhereNextSegmentChanged, currentPagePoint) >
 					this.editor.options.dragDistanceSquared
 
+				// Find the distance from where the pointer was when shift was released and
+				// where it is now; if it's far enough away, then update the page point where
+				// the current segment changed (to match the pagepoint where next segment changed)
+				// and set the pagepoint where next segment changed to null.
 				if (hasMovedFarEnough) {
 					this.pagePointWhereCurrentSegmentChanged = pagePointWhereNextSegmentChanged.clone()
 					this.pagePointWhereNextSegmentChanged = null
+
+					// Set the new mode
 					this.segmentMode = 'free'
 
 					const prevStraightSegment = segments[segments.length - 1]
@@ -419,10 +433,12 @@ export class Drawing extends StateNode {
 						throw Error('No previous point!')
 					}
 
-					// Interpolate the points between where the last line ended and where the pointer is now
+					// Create the new free segment and interpolate the points between where the last line
+					// ended and where the pointer is now
 					const interpolatedPoints = Vec.PointsBetween(prevPoint, newPoint, 6).map(
 						(p) => new Vec(toFixed(p.x), toFixed(p.y), toFixed(p.z))
 					)
+					// Initialize cache for the new free segment
 					this.currentSegmentPoints = interpolatedPoints
 
 					const finalSegments = [...segments, this.makeSegment('free', interpolatedPoints)]
@@ -540,6 +556,10 @@ export class Drawing extends StateNode {
 					newPoint = this.editor.getPointInShapeSpace(shape, pagePoint).toFixed().toJson()
 				}
 
+				// If the previous segment is a one point free shape and is the first segment of the line,
+				// then the user just did a click-and-immediately-press-shift to create a new straight line
+				// without continuing the previous line. In this case, we want to remove the previous segment.
+
 				const segmentFirstPoint = b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)
 				this.currentLineLength += segmentFirstPoint ? Vec.Dist(segmentFirstPoint, newPoint) : 0
 
@@ -592,6 +612,7 @@ export class Drawing extends StateNode {
 					if (!this.editor.canCreateShapes([newShapeId])) return this.cancel()
 					const currentPagePoint = inputs.getCurrentPagePoint()
 
+					// Reset cache for the new shape's segment
 					const initialPoint = new Vec(0, 0, this.isPenOrStylus ? +(z! * 1.25).toFixed() : 0.5)
 					this.currentSegmentPoints = [initialPoint]
 

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -303,13 +303,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			typeof window !== 'undefined' && (window !== window.top || window.self !== window.parent)
 		if (isIframe && embedInfo?.definition.type === 'tldraw') return null
 
-		const sandbox = getSandboxPermissions({
-			...embedShapePermissionDefaults,
-			...(embedInfo
-				? (embedInfo.definition.overridePermissions ?? {})
-				: unknownEmbedShapePermissionOverrides),
-		})
-
 		if (embedInfo?.definition.type === 'github_gist') {
 			const idFromGistUrl = embedInfo.url.split('/').pop()
 			if (!idFromGistUrl) throw Error('No gist id!')
@@ -318,7 +311,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			// the embedded script shares the parent's origin and can escape the sandbox.
 			const gistSandbox = getSandboxPermissions({
 				...embedShapePermissionDefaults,
-				...(embedInfo?.definition?.overridePermissions ?? {}),
+				...embedInfo.definition.overridePermissions,
 				'allow-same-origin': false,
 			})
 
@@ -336,6 +329,13 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 				</HTMLContainer>
 			)
 		}
+
+		const sandbox = getSandboxPermissions({
+			...embedShapePermissionDefaults,
+			...(embedInfo
+				? embedInfo.definition.overridePermissions
+				: unknownEmbedShapePermissionOverrides),
+		})
 
 		const iframeSrc = embedInfo?.embedUrl ?? url
 

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
@@ -28,39 +28,20 @@ export function getEnclosedShapeIds(editor: Editor, shape: TLShape): TLShapeId[]
 	const bounds = editor.getShapePageBounds(shape)
 	if (!bounds) return []
 
-	const enclosedShapeIds: TLShapeId[] = []
-	const ancestorIds = editor.getShapeAncestors(shape).map((shape) => shape.id)
+	// We don't want to pull in shapes that are ancestors of the frame (can create a cycle)
+	const ancestorIds = new Set(editor.getShapeAncestors(shape).map((shape) => shape.id))
 
-	editor.getSortedChildIdsForParent(shape.parentId).map((siblingShapeId) => {
+	const enclosedShapeIds: TLShapeId[] = []
+	for (const siblingShapeId of editor.getSortedChildIdsForParent(shape.parentId)) {
+		if (siblingShapeId === shape.id || ancestorIds.has(siblingShapeId)) continue
 		const siblingShape = editor.getShape(siblingShapeId)
-		if (!siblingShape) return
-		// We don't want to frame the frame itself
-		if (siblingShape.id === shape.id) return
-		if (siblingShape.isLocked) return
+		if (!siblingShape || siblingShape.isLocked) continue
 
 		const pageShapeBounds = editor.getShapePageBounds(siblingShape)
-		if (!pageShapeBounds) return
-
-		// Frame shape encloses page shape
-		if (bounds.contains(pageShapeBounds)) {
-			if (canEnclose(siblingShape, ancestorIds, shape)) {
-				enclosedShapeIds.push(siblingShape.id)
-			}
+		if (pageShapeBounds && bounds.contains(pageShapeBounds)) {
+			enclosedShapeIds.push(siblingShape.id)
 		}
-	})
+	}
 
 	return enclosedShapeIds
-}
-
-/** @internal */
-function canEnclose(shape: TLShape, ancestorIds: TLShapeId[], frame: TLShape): boolean {
-	// We don't want to pull in shapes that are ancestors of the frame (can create a cycle)
-	if (ancestorIds.includes(shape.id)) {
-		return false
-	}
-	// We only want to pull in shapes that are siblings of the frame
-	if (shape.parentId === frame.parentId) {
-		return true
-	}
-	return false
 }

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
@@ -33,11 +33,13 @@ export function getEnclosedShapeIds(editor: Editor, shape: TLShape): TLShapeId[]
 
 	const enclosedShapeIds: TLShapeId[] = []
 	for (const siblingShapeId of editor.getSortedChildIdsForParent(shape.parentId)) {
+		// We don't want to frame the frame itself
 		if (siblingShapeId === shape.id || ancestorIds.has(siblingShapeId)) continue
 		const siblingShape = editor.getShape(siblingShapeId)
 		if (!siblingShape || siblingShape.isLocked) continue
 
 		const pageShapeBounds = editor.getShapePageBounds(siblingShape)
+		// Frame shape encloses page shape
 		if (pageShapeBounds && bounds.contains(pageShapeBounds)) {
 			enclosedShapeIds.push(siblingShape.id)
 		}

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -10,7 +10,6 @@ import {
 	TLEditStartInfo,
 	TLFrameShape,
 	TLFrameShapeProps,
-	TLShapePartial,
 	TLShapeUtilConstructor,
 	clamp,
 	compact,
@@ -30,11 +29,11 @@ import {
 import { ShapeOptionsWithDisplayValues, getDisplayValues } from '../shared/getDisplayValues'
 import { FrameHeading } from './components/FrameHeading'
 import {
-	defaultEmptyAs,
 	getFrameHeadingOpts,
 	getFrameHeadingSide,
 	getFrameHeadingSize,
 	getFrameHeadingTranslation,
+	getFrameTitle,
 } from './frameHelpers'
 
 // Some of these values are repeated in CSS and need to match
@@ -156,12 +155,11 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		const opts = getFrameHeadingOpts(rotatedTopEdgeWidth, false)
 		const headingSize = getFrameHeadingSize(editor, shape, opts)
 
-		// If NOT showing frame colors, we need to offset the label
-		// to the left so that the title is in line with the shape edge
-		// and add that extra width to the right side of the label
+		// If NOT showing frame colors, we offset the label to the left so that the title is in line
+		// with the shape edge and add that extra width to the right side of the label
 		const isShowingFrameColors = this.options.showColors
 
-		// Scale everything into **screen space**
+		// Scale everything into screen space
 		const extraWidth = FRAME_HEADING_EXTRA_WIDTH / z
 		const minWidth = FRAME_HEADING_MIN_WIDTH / z
 		const maxWidth = rotatedTopEdgeWidth + (isShowingFrameColors ? 1 : extraWidth)
@@ -178,11 +176,7 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		const width = isVertical ? labelHeight : clampedLabelWidth
 		const height = isVertical ? clampedLabelWidth : labelHeight
 
-		// Calculate label position based on side. The position needs to always appear
-		// at the top left of the shape, regardless of rotation. The label must be
-		// between a minimum and maximum. The minimum is arbitrary; the maximum is the
-		// width of the edge of the frame where the label will be shown.
-
+		// The label always appears at the top left of the shape, regardless of rotation.
 		let x: number, y: number
 
 		switch (labelSide) {
@@ -281,8 +275,8 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 						color={showFrameColors ? dv.showColorsHeadingTextColor : dv.headingTextColor}
 						width={shape.props.w}
 						height={shape.props.h}
-						offsetX={showFrameColors ? -1 : -7}
-						showColors={this.options.showColors}
+						offsetX={showFrameColors ? -1 : FRAME_HEADING_NOCOLORS_OFFSET_X}
+						showColors={showFrameColors}
 					/>
 				)}
 			</>
@@ -292,7 +286,6 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 	override toSvg(shape: TLFrameShape, ctx: SvgExportContext) {
 		const dv = getDisplayValues(this, shape, ctx.colorMode)
 
-		// rotate right 45 deg
 		const labelSide = getFrameHeadingSide(this.editor, shape)
 		const isVertical = labelSide % 2 === 1
 		const rotatedTopEdgeWidth = isVertical ? shape.props.h : shape.props.w
@@ -301,9 +294,8 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		// Truncate with ellipsis
 		const opts: TLCreateTextJsxFromSpansOpts = getFrameHeadingOpts(rotatedTopEdgeWidth - 12, true)
 
-		const frameTitle = defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203)
 		const labelBounds = getFrameHeadingSize(this.editor, shape, opts)
-		const spans = this.editor.textMeasure.measureTextSpans(frameTitle, opts)
+		const spans = this.editor.textMeasure.measureTextSpans(getFrameTitle(shape.props.name), opts)
 		const text = createTextJsxFromSpans(this.editor, spans, opts)
 
 		const showFrameColors = this.options.showColors
@@ -370,25 +362,21 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		const isHorizontalEdge = handle === 'left' || handle === 'right'
 		const isVerticalEdge = handle === 'top' || handle === 'bottom'
 
-		const childIds = this.editor.getSortedChildIdsForParent(shape.id)
-		const children = compact(childIds.map((id) => this.editor.getShape(id)))
+		const children = compact(
+			this.editor.getSortedChildIdsForParent(shape.id).map((id) => this.editor.getShape(id))
+		)
 		if (!children.length) return
 
 		const { dx, dy, w, h } = getFrameChildrenBounds(children, this.editor, { padding: 10 })
 
-		this.editor.run(() => {
-			const changes: TLShapePartial[] = childIds.map((childId) => {
-				const childShape = this.editor.getShape(childId)!
-				return {
-					id: childShape.id,
-					type: childShape.type,
-					x: isHorizontalEdge ? childShape.x + dx : childShape.x,
-					y: isVerticalEdge ? childShape.y + dy : childShape.y,
-				}
-			})
-
-			this.editor.updateShapes(changes)
-		})
+		this.editor.updateShapes(
+			children.map((childShape) => ({
+				id: childShape.id,
+				type: childShape.type,
+				x: isHorizontalEdge ? childShape.x + dx : childShape.x,
+				y: isVerticalEdge ? childShape.y + dy : childShape.y,
+			}))
+		)
 
 		return {
 			id: shape.id,

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -155,11 +155,12 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		const opts = getFrameHeadingOpts(rotatedTopEdgeWidth, false)
 		const headingSize = getFrameHeadingSize(editor, shape, opts)
 
-		// If NOT showing frame colors, we offset the label to the left so that the title is in line
-		// with the shape edge and add that extra width to the right side of the label
+		// If NOT showing frame colors, we need to offset the label
+		// to the left so that the title is in line with the shape edge
+		// and add that extra width to the right side of the label
 		const isShowingFrameColors = this.options.showColors
 
-		// Scale everything into screen space
+		// Scale everything into **screen space**
 		const extraWidth = FRAME_HEADING_EXTRA_WIDTH / z
 		const minWidth = FRAME_HEADING_MIN_WIDTH / z
 		const maxWidth = rotatedTopEdgeWidth + (isShowingFrameColors ? 1 : extraWidth)
@@ -176,7 +177,11 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 		const width = isVertical ? labelHeight : clampedLabelWidth
 		const height = isVertical ? clampedLabelWidth : labelHeight
 
-		// The label always appears at the top left of the shape, regardless of rotation.
+		// Calculate label position based on side. The position needs to always appear
+		// at the top left of the shape, regardless of rotation. The label must be
+		// between a minimum and maximum. The minimum is arbitrary; the maximum is the
+		// width of the edge of the frame where the label will be shown.
+
 		let x: number, y: number
 
 		switch (labelSide) {
@@ -286,6 +291,7 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 	override toSvg(shape: TLFrameShape, ctx: SvgExportContext) {
 		const dv = getDisplayValues(this, shape, ctx.colorMode)
 
+		// rotate right 45 deg
 		const labelSide = getFrameHeadingSide(this.editor, shape)
 		const isVertical = labelSide % 2 === 1
 		const rotatedTopEdgeWidth = isVertical ? shape.props.h : shape.props.w

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameHeading.tsx
@@ -29,20 +29,11 @@ export const FrameHeading = memo(function FrameHeading({
 		'shape rotation',
 		() => {
 			const shape = editor.getShape<TLFrameShape>(id)
-			if (!shape) {
-				// meh
-				return {
-					side: 0,
-					translation: 'translate(0, 0)',
-				}
-			}
-			const labelSide = getFrameHeadingSide(editor, shape)
-			return {
-				side: labelSide,
-				translation: getFrameHeadingTranslation(shape, labelSide, false),
-			}
+			if (!shape) return { side: 0, translation: 'translate(0, 0)' }
+			const side = getFrameHeadingSide(editor, shape)
+			return { side, translation: getFrameHeadingTranslation(shape, side, false) }
 		},
-		[editor, offsetX, id]
+		[editor, id]
 	)
 
 	const rInput = useRef<HTMLInputElement>(null)
@@ -55,16 +46,14 @@ export const FrameHeading = memo(function FrameHeading({
 			el.focus()
 			el.select()
 		}
-	}, [rInput, isEditing])
+	}, [isEditing])
 
 	return (
 		<div
 			className="tl-frame-heading"
 			style={{
 				overflow: isEditing ? 'visible' : 'hidden',
-				maxWidth: `calc(var(--tl-zoom) * ${
-					side === 0 || side === 2 ? Math.ceil(width) : Math.ceil(height)
-				}px + ${showColors ? '0px' : 'var(--tl-frame-offset-width)'})`,
+				maxWidth: `calc(var(--tl-zoom) * ${Math.ceil(side % 2 === 0 ? width : height)}px + ${showColors ? '0px' : 'var(--tl-frame-offset-width)'})`,
 				bottom: '100%',
 				transform: `${translation} scale(min(var(--tl-scale), 3.5)) translateX(${offsetX}px)`,
 			}}

--- a/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/components/FrameLabelInput.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useCallback, useEffect, useRef } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../../ui/constants'
 import { useBreakpoint } from '../../../ui/context/breakpoints'
 import { useTranslation } from '../../../ui/hooks/useTranslation/useTranslation'
-import { defaultEmptyAs } from '../frameHelpers'
+import { getFrameTitle } from '../frameHelpers'
 
 export const FrameLabelInput = forwardRef<
 	HTMLInputElement,
@@ -45,8 +45,7 @@ export const FrameLabelInput = forwardRef<
 			const shape = editor.getShape<TLFrameShape>(id)
 			if (!shape) return
 
-			const name = shape.props.name
-			if (name === value) return
+			if (shape.props.name === value) return
 
 			editor.updateShapes([
 				{
@@ -59,15 +58,8 @@ export const FrameLabelInput = forwardRef<
 		[id, editor]
 	)
 
-	const handleBlur = useCallback(
-		(e: React.FocusEvent<HTMLInputElement>) => {
-			renameFrame(e.currentTarget.value)
-		},
-		[renameFrame]
-	)
-
 	const handleChange = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
+		(e: React.SyntheticEvent<HTMLInputElement>) => {
 			renameFrame(e.currentTarget.value)
 		},
 		[renameFrame]
@@ -79,7 +71,7 @@ export const FrameLabelInput = forwardRef<
 			promptOpen.current = false
 			return
 		}
-		if (isEditing && shouldUseWindowPrompt && !promptOpen.current) {
+		if (shouldUseWindowPrompt && !promptOpen.current) {
 			promptOpen.current = true
 			const shape = editor.getShape<TLFrameShape>(id)
 			const currentName = shape?.props.name ?? ''
@@ -103,12 +95,12 @@ export const FrameLabelInput = forwardRef<
 				value={name}
 				autoFocus={!shouldUseWindowPrompt}
 				onKeyDown={handleKeyDown}
-				onBlur={handleBlur}
+				onBlur={handleChange}
 				onChange={handleChange}
 				onPointerDown={handlePointerDown}
 				draggable={false}
 			/>
-			{defaultEmptyAs(name, 'Frame') + String.fromCharCode(8203)}
+			{getFrameTitle(name)}
 		</div>
 	)
 })

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -9,10 +9,11 @@ import {
 import { TLCreateTextJsxFromSpansOpts } from '../shared/createTextJsxFromSpans'
 
 export function defaultEmptyAs(str: string, dflt: string) {
-	if (str.match(/^\s*$/)) {
-		return dflt
-	}
-	return str
+	return /^\s*$/.test(str) ? dflt : str
+}
+
+export function getFrameTitle(name: string) {
+	return defaultEmptyAs(name, 'Frame') + String.fromCharCode(8203)
 }
 
 export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 | 2 | 3 {
@@ -30,15 +31,6 @@ export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 
  */
 const measurementWeakmap = new WeakMap()
 
-/**
- * Get the frame heading info (size and text) for a frame shape.
- *
- * @param editor The editor instance.
- * @param shape The frame shape.
- * @param opts The text measurement options.
- *
- * @returns The frame heading's size (as a Box) and JSX text spans.
- */
 export function getFrameHeadingSize(
 	editor: Editor,
 	shape: TLFrameShape,
@@ -51,8 +43,7 @@ export function getFrameHeadingSize(
 
 	let width = measurementWeakmap.get(shape.props)
 	if (!width) {
-		const frameTitle = defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203)
-		const spans = editor.textMeasure.measureTextSpans(frameTitle, opts)
+		const spans = editor.textMeasure.measureTextSpans(getFrameTitle(shape.props.name), opts)
 		const firstSpan = spans[0]
 		const lastSpan = last(spans)
 
@@ -97,25 +88,18 @@ export function getFrameHeadingTranslation(
 ) {
 	const u = isSvg ? '' : 'px'
 	const r = isSvg ? '' : 'deg'
-	let labelTranslate: string
+	const w = toDomPrecision(shape.props.w)
+	const h = toDomPrecision(shape.props.h)
 	switch (side) {
 		case 0: // top
-			labelTranslate = ``
-			break
+			return ``
 		case 3: // right
-			labelTranslate = `translate(${toDomPrecision(shape.props.w)}${u}, 0${u}) rotate(90${r})`
-			break
+			return `translate(${w}${u}, 0${u}) rotate(90${r})`
 		case 2: // bottom
-			labelTranslate = `translate(${toDomPrecision(shape.props.w)}${u}, ${toDomPrecision(
-				shape.props.h
-			)}${u}) rotate(180${r})`
-			break
+			return `translate(${w}${u}, ${h}${u}) rotate(180${r})`
 		case 1: // left
-			labelTranslate = `translate(0${u}, ${toDomPrecision(shape.props.h)}${u}) rotate(270${r})`
-			break
+			return `translate(0${u}, ${h}${u}) rotate(270${r})`
 		default:
 			throw Error('labelSide out of bounds')
 	}
-
-	return labelTranslate
 }

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -31,6 +31,15 @@ export function getFrameHeadingSide(editor: Editor, shape: TLFrameShape): 0 | 1 
  */
 const measurementWeakmap = new WeakMap()
 
+/**
+ * Get the frame heading info (size and text) for a frame shape.
+ *
+ * @param editor The editor instance.
+ * @param shape The frame shape.
+ * @param opts The text measurement options.
+ *
+ * @returns The frame heading's size (as a Box) and JSX text spans.
+ */
 export function getFrameHeadingSize(
 	editor: Editor,
 	shape: TLFrameShape,

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -72,6 +72,9 @@ const GEO_SHAPE_MIN_WIDTHS = Object.freeze({
 	xl: 20,
 })
 
+// Extra padding for geo shape labels matches the stroke width
+// Computed dynamically in getDisplayValues via theme.strokeWidth * STROKE_SIZES[size]
+
 const GEO_SHAPE_HORIZONTAL_ALIGNS = Object.freeze({
 	start: 'start',
 	middle: 'center',
@@ -934,6 +937,7 @@ export function batchMeasureGeoLabels(
 	const requests: Array<{ id: TLShapeId; html: string; opts: TLMeasureTextOpts }> = []
 
 	for (const [id, snapshot] of shapeSnapshots) {
+		// Only process geo shapes with non-empty text labels
 		if (!editor.isShapeOfType<TLGeoShape>(snapshot.shape, 'geo')) continue
 		const geoShape = snapshot.shape
 		if (isEmptyRichText(geoShape.props.richText)) continue
@@ -955,8 +959,10 @@ export function batchMeasureGeoLabels(
 				? Math.max(Math.abs(scale.x), Math.abs(scale.y))
 				: Math.abs(areWidthAndHeightAlignedWithCorrectAxis ? scale.x : scale.y)
 
+		// Compute the target width for measurement (same logic as onResize)
 		const targetW = getGeoResizeTargetWidth(geoShape.props, effectiveScaleX)
 
+		// Build a temporary shape with the target width for measurement
 		const { html, opts } = getGeoLabelMeasurementRequest(editor, {
 			...geoShape,
 			props: { ...geoShape.props, w: targetW * geoShape.props.scale },
@@ -966,8 +972,10 @@ export function batchMeasureGeoLabels(
 
 	if (requests.length === 0) return
 
+	// Batch measure all labels in one DOM pass
 	const results = editor.textMeasure.measureHtmlBatch(requests)
 
+	// Build the cache map with label sizes (adding padding)
 	const cache = new Map<TLShapeId, { w: number; h: number }>()
 	for (let i = 0; i < requests.length; i++) {
 		cache.set(requests[i].id, {

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -72,9 +72,6 @@ const GEO_SHAPE_MIN_WIDTHS = Object.freeze({
 	xl: 20,
 })
 
-// Extra padding for geo shape labels matches the stroke width
-// Computed dynamically in getDisplayValues via theme.strokeWidth * STROKE_SIZES[size]
-
 const GEO_SHAPE_HORIZONTAL_ALIGNS = Object.freeze({
 	start: 'start',
 	middle: 'center',
@@ -91,6 +88,9 @@ const GEO_SHAPE_VERTICAL_ALIGNS = Object.freeze({
 } as const)
 
 const GEO_SHAPE_EMPTY_LABEL_SIZE = Object.freeze({ w: 0, h: 0 })
+
+// Minimum size of the shape to fit a label, based on font size and padding (in unscaled units)
+const MIN_SIZE_WITH_LABEL = (LABEL_PADDING + 1) * 3
 
 // Snapshot the built-in geo types at module init so that collision detection
 // in `configure()` only fires against the built-ins, not against keys added
@@ -218,8 +218,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 				labelPadding: LABEL_PADDING,
 				// Margin between label edge and shape edge (in unscaled units)
 				labelEdgeMargin: 8,
-				// Minimum size of the shape to fit a label, based on font size and padding (in unscaled units)
-				minSizeWithLabel: (LABEL_PADDING + 1) * 3,
+				minSizeWithLabel: MIN_SIZE_WITH_LABEL,
 			}
 		},
 		getCustomDisplayValues(_editor, _shape): Partial<GeoShapeUtilDisplayValues> {
@@ -325,7 +324,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					isFilled: true,
 					isLabel: true,
 					excludeFromShapeBounds: true,
-					isEmptyLabel: isEmptyLabel,
+					isEmptyLabel,
 				}),
 			],
 		})
@@ -341,9 +340,9 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 		// blobby shapes only snap to the center; polygon shapes snap to vertices + center.
 		if (def.snapType === 'blobby') {
-			return { outline: outline, points: [geometry.bounds.center] }
+			return { outline, points: [geometry.bounds.center] }
 		}
-		return { outline: outline, points: [...outline.vertices, geometry.bounds.center] }
+		return { outline, points: [...outline.vertices, geometry.bounds.center] }
 	}
 
 	override getText(shape: TLGeoShape) {
@@ -471,7 +470,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 
 		let textEl
 		if (!isEmptyRichText(richText)) {
-			const bounds = new Box(0, 0, newShape.props.w, (h + growY) / scale)
+			const bounds = new Box(0, 0, newShape.props.w, newShape.props.h)
 			textEl = (
 				<RichTextSVG
 					fontSize={dv.labelFontSize}
@@ -656,7 +655,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		// Text was added for the first time - expand shape to fit (if wasEmpty and now there's text...
 		// It might be just whitespace but it is faster to assume that it is NOT just whitespace and expand
 		// the shape in either case (a label with just spaces text will be less performant but that's acceptable)
-		if (wasEmpty && !isEmpty) {
+		if (wasEmpty) {
 			const expanded = this.expandShapeForFirstLabel(
 				next,
 				unscaledPrev.w,
@@ -815,9 +814,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const batchCached = getBatchLabelSizeCache(this.editor)?.get(shape.id)
 		if (batchCached) return batchCached
 
-		return this._labelSizesForGeoCache.get(shape, () => {
-			return this.measureUnscaledLabelSize(shape)
-		})
+		return this._labelSizesForGeoCache.get(shape, () => this.measureUnscaledLabelSize(shape))
 	}
 
 	/**
@@ -851,9 +848,6 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	}
 }
 
-const MIN_SIZE_WITH_LABEL = (LABEL_PADDING + 1) * 3
-const MIN_WIDTHS = GEO_SHAPE_MIN_WIDTHS
-
 // Per-editor batch cache, set by batchMeasureGeoLabels before the resize loop and cleared after.
 // When set, onResize will use pre-computed label sizes instead of measuring individually.
 // Uses a WeakMap keyed by editor to avoid issues with multiple editors on the same page.
@@ -885,7 +879,7 @@ function getGeoLabelMeasurementRequest(
 ): { html: string; opts: TLMeasureTextOpts } {
 	const { richText, font, size, w } = shape.props
 	const theme = editor.getCurrentTheme()
-	const minWidth = MIN_WIDTHS[size]
+	const minWidth = GEO_SHAPE_MIN_WIDTHS[size]
 	const html = renderHtmlFromRichTextForMeasurement(editor, richText)
 	const opts: TLMeasureTextOpts = {
 		...TEXT_PROPS,
@@ -940,9 +934,8 @@ export function batchMeasureGeoLabels(
 	const requests: Array<{ id: TLShapeId; html: string; opts: TLMeasureTextOpts }> = []
 
 	for (const [id, snapshot] of shapeSnapshots) {
-		// Only process geo shapes with non-empty text labels
 		if (!editor.isShapeOfType<TLGeoShape>(snapshot.shape, 'geo')) continue
-		const geoShape = snapshot.shape as TLGeoShape
+		const geoShape = snapshot.shape
 		if (isEmptyRichText(geoShape.props.richText)) continue
 
 		// Skip unaligned shapes — they take a different resize path (_resizeUnalignedShape)
@@ -956,39 +949,25 @@ export function batchMeasureGeoLabels(
 			0
 		)
 
-		let effectiveScaleX: number
-		if (isAspectRatioLocked || snapshot.isAspectRatioLocked) {
-			// When aspect ratio is locked, both axes get the same absolute scale
-			const uniformScale = Math.max(Math.abs(scale.x), Math.abs(scale.y))
-			effectiveScaleX = uniformScale
-		} else {
-			effectiveScaleX = Math.abs(areWidthAndHeightAlignedWithCorrectAxis ? scale.x : scale.y)
-		}
+		// When aspect ratio is locked, both axes get the same absolute scale
+		const effectiveScaleX =
+			isAspectRatioLocked || snapshot.isAspectRatioLocked
+				? Math.max(Math.abs(scale.x), Math.abs(scale.y))
+				: Math.abs(areWidthAndHeightAlignedWithCorrectAxis ? scale.x : scale.y)
 
-		// Compute the target width for measurement (same logic as onResize)
 		const targetW = getGeoResizeTargetWidth(geoShape.props, effectiveScaleX)
 
-		// Build a temporary shape with the target width for measurement
-		const tempShape = {
+		const { html, opts } = getGeoLabelMeasurementRequest(editor, {
 			...geoShape,
-			props: {
-				...geoShape.props,
-				w: targetW * geoShape.props.scale,
-			},
-		} as TLGeoShape
-
-		const { html, opts } = getGeoLabelMeasurementRequest(editor, tempShape)
+			props: { ...geoShape.props, w: targetW * geoShape.props.scale },
+		})
 		requests.push({ id, html, opts })
 	}
 
 	if (requests.length === 0) return
 
-	// Batch measure all labels in one DOM pass
-	const results = editor.textMeasure.measureHtmlBatch(
-		requests.map(({ html, opts }) => ({ html, opts }))
-	)
+	const results = editor.textMeasure.measureHtmlBatch(requests)
 
-	// Build the cache map with label sizes (adding padding)
 	const cache = new Map<TLShapeId, { w: number; h: number }>()
 	for (let i = 0; i < requests.length; i++) {
 		cache.set(requests[i].id, {

--- a/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
+++ b/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
@@ -515,6 +515,8 @@ function getStarPath(w: number, h: number, isFilled: boolean) {
 	).close()
 }
 
+/* ---------------------- Cloud --------------------- */
+
 function getOvalPerimeter(h: number, w: number) {
 	if (h > w) return (PI * (w / 2) + (h - w)) * 2
 	else return (PI * (h / 2) + (w - h)) * 2

--- a/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
+++ b/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
@@ -515,8 +515,6 @@ function getStarPath(w: number, h: number, isFilled: boolean) {
 	).close()
 }
 
-/* ---------------------- Cloud --------------------- */
-
 function getOvalPerimeter(h: number, w: number) {
 	if (h > w) return (PI * (w / 2) + (h - w)) * 2
 	else return (PI * (h / 2) + (w - h)) * 2
@@ -647,9 +645,9 @@ function getCloudPath(
 
 	const paddingX = (width - innerWidth) / 2
 	const paddingY = (height - innerHeight) / 2
-	const bumpPoints = getPillPoints(innerWidth, innerHeight, numBumps).map((p) => {
-		return p.addXY(paddingX, paddingY)
-	})
+	const bumpPoints = getPillPoints(innerWidth, innerHeight, numBumps).map((p) =>
+		p.addXY(paddingX, paddingY)
+	)
 	const maxWiggleX = width < 20 ? 0 : targetBumpProtrusion * 0.3
 	const maxWiggleY = height < 20 ? 0 : targetBumpProtrusion * 0.3
 
@@ -688,21 +686,13 @@ function getCloudPath(
 		const arcPoint = Vec.Lrp(leftPoint, rightPoint, 0.5).add(
 			Vec.Sub(rightPoint, leftPoint).uni().per().mul(finalDistance)
 		)
-		if (arcPoint.x < 0) {
-			arcPoint.x = 0
-		} else if (arcPoint.x > width) {
-			arcPoint.x = width
-		}
-		if (arcPoint.y < 0) {
-			arcPoint.y = 0
-		} else if (arcPoint.y > height) {
-			arcPoint.y = height
-		}
+		arcPoint.x = clamp(arcPoint.x, 0, width)
+		arcPoint.y = clamp(arcPoint.y, 0, height)
 
 		const center = centerOfCircleFromThreePoints(leftWigglePoint, rightWigglePoint, arcPoint)
 
 		const radius = Vec.Dist(
-			center ? center : Vec.Average([leftWigglePoint, rightWigglePoint]),
+			center ?? Vec.Average([leftWigglePoint, rightWigglePoint]),
 			leftWigglePoint
 		)
 

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -98,15 +98,11 @@ export class Pointing extends StateNode {
 				type: 'geo',
 				x: originPagePoint.x,
 				y: originPagePoint.y,
-				props: {
-					geo: this.editor.getStyleForNextShape(GeoShapeGeoStyle),
-					scale,
-					...size,
-				},
+				props: { geo, scale, ...size },
 			},
 		])
 
-		const shape = this.editor.getShape<TLGeoShape>(id)!
+		const shape = this.editor.getShape<TLGeoShape>(id)
 		if (!shape) {
 			this.cancel()
 			return
@@ -124,11 +120,7 @@ export class Pointing extends StateNode {
 			type: 'geo',
 			x: newPoint.x,
 			y: newPoint.y,
-			props: {
-				geo: this.editor.getStyleForNextShape(GeoShapeGeoStyle),
-				w: w * scale,
-				h: h * scale,
-			},
+			props: { geo, w: w * scale, h: h * scale },
 		})
 
 		if (this.editor.getInstanceState().isToolLocked) {

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -9,7 +9,6 @@ import {
 	TLHighlightShape,
 	TLHighlightShapeProps,
 	TLResizeInfo,
-	VecLike,
 	b64Vecs,
 	debugFlags,
 	getColorValue,
@@ -26,7 +25,7 @@ import { getHighlightFreehandSettings, getPointsFromDrawSegments } from '../draw
 import { FONT_SIZES } from '../shared/default-shape-constants'
 import { getStroke } from '../shared/freehand/getStroke'
 import { getStrokePoints } from '../shared/freehand/getStrokePoints'
-import { getSvgPathFromStrokePoints } from '../shared/freehand/svg'
+import { getSvgDotPath, getSvgPathFromStrokePoints } from '../shared/freehand/svg'
 import type { ShapeOptionsWithDisplayValues } from '../shared/getDisplayValues'
 import { getDisplayValues } from '../shared/getDisplayValues'
 import { interpolateSegments } from '../shared/interpolate-props'
@@ -177,7 +176,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 
 		const strokePath =
 			strokePoints.length < 2
-				? getDot(allPointsFromSegments[0], sw / 2)
+				? getSvgDotPath(allPointsFromSegments[0], sw / 2)
 				: getSvgPathFromStrokePoints(strokePoints, false)
 
 		return new Path2D(strokePath)
@@ -245,12 +244,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	}
 }
 
-function getDot(point: VecLike, r: number) {
-	return `M ${point.x} ${point.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${
-		r * 2
-	},0`
-}
-
 function getHighlightStrokePoints(
 	shape: TLHighlightShape,
 	strokeWidth: number,
@@ -307,7 +300,7 @@ function HighlightRenderer({
 	const solidStrokePath =
 		strokePoints.length > 1
 			? getSvgPathFromStrokePoints(strokePoints, false)
-			: getDot(allPointsFromSegments[0], 0.1)
+			: getSvgDotPath(allPointsFromSegments[0], 0.1)
 
 	return (
 		<path

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -169,19 +169,16 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 		const zoomLevel = this.editor.getEfficientZoomLevel()
 		const forceSolid = strokeWidth / zoomLevel < 1.5
 
-		const { strokePoints, sw } = getHighlightStrokePoints(shape, strokeWidth, forceSolid)
-		const allPointsFromSegments = getPointsFromDrawSegments(
-			shape.props.segments,
-			shape.props.scaleX,
-			shape.props.scaleY
+		const { strokePoints, sw, allPointsFromSegments } = getHighlightStrokePoints(
+			shape,
+			strokeWidth,
+			forceSolid
 		)
 
-		let strokePath
-		if (strokePoints.length < 2) {
-			strokePath = getIndicatorDot(allPointsFromSegments[0], sw)
-		} else {
-			strokePath = getSvgPathFromStrokePoints(strokePoints, false)
-		}
+		const strokePath =
+			strokePoints.length < 2
+				? getDot(allPointsFromSegments[0], sw / 2)
+				: getSvgPathFromStrokePoints(strokePoints, false)
 
 		return new Path2D(strokePath)
 	}
@@ -248,15 +245,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	}
 }
 
-function getShapeDot(point: VecLike) {
-	const r = 0.1
-	return `M ${point.x} ${point.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${
-		r * 2
-	},0`
-}
-
-function getIndicatorDot(point: VecLike, sw: number) {
-	const r = sw / 2
+function getDot(point: VecLike, r: number) {
 	return `M ${point.x} ${point.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${
 		r * 2
 	},0`
@@ -286,7 +275,7 @@ function getHighlightStrokePoints(
 
 	const strokePoints = getStrokePoints(allPointsFromSegments, options)
 
-	return { strokePoints, sw }
+	return { strokePoints, sw, allPointsFromSegments }
 }
 
 function getIsDot(shape: TLHighlightShape) {
@@ -309,28 +298,16 @@ function HighlightRenderer({
 	opacity: number
 	strokeColor: string
 }) {
-	const allPointsFromSegments = getPointsFromDrawSegments(
-		shape.props.segments,
-		shape.props.scaleX,
-		shape.props.scaleY
+	const { strokePoints, sw, allPointsFromSegments } = getHighlightStrokePoints(
+		shape,
+		strokeWidth,
+		forceSolid
 	)
-
-	let sw = strokeWidth
-	if (!forceSolid && !shape.props.isPen && allPointsFromSegments.length === 1) {
-		sw += rng(shape.id)() * (sw / 6)
-	}
-
-	const options = getHighlightFreehandSettings({
-		strokeWidth: sw,
-		showAsComplete: shape.props.isComplete || last(shape.props.segments)?.type === 'straight',
-	})
-
-	const strokePoints = getStrokePoints(allPointsFromSegments, options)
 
 	const solidStrokePath =
 		strokePoints.length > 1
 			? getSvgPathFromStrokePoints(strokePoints, false)
-			: getShapeDot(allPointsFromSegments[0])
+			: getDot(allPointsFromSegments[0], 0.1)
 
 	return (
 		<path

--- a/packages/tldraw/src/lib/shapes/image/ImageAlphaCache.ts
+++ b/packages/tldraw/src/lib/shapes/image/ImageAlphaCache.ts
@@ -1,4 +1,4 @@
-import { Image, LruCache, VecLike } from '@tldraw/editor'
+import { Image, LruCache, VecLike, clamp } from '@tldraw/editor'
 
 /** Mime types of image formats that support transparency / alpha channel. */
 export const TRANSPARENT_IMAGE_MIMETYPES: readonly string[] = [
@@ -34,8 +34,8 @@ function mapToImageCoords(
 	bounds: { minX: number; minY: number; w: number; h: number }
 ): { nx: number; ny: number } {
 	// Normalize point to [0,1] within the shape bounds, clamped for edge-margin hits
-	let nx = Math.max(0, Math.min(1, (point.x - bounds.minX) / bounds.w))
-	let ny = Math.max(0, Math.min(1, (point.y - bounds.minY) / bounds.h))
+	let nx = clamp((point.x - bounds.minX) / bounds.w, 0, 1)
+	let ny = clamp((point.y - bounds.minY) / bounds.h, 0, 1)
 
 	// Map from cropped shape space to full image space
 	if (config.crop) {

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -120,48 +120,25 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 	override getGeometry(shape: TLImageShape): Geometry2d {
 		const asset = shape.props.assetId ? this.editor.getAsset(shape.props.assetId) : null
-		const mimeType = asset && 'mimeType' in asset.props ? asset.props.mimeType : null
-		const supportsTransparency = mimeType != null && TRANSPARENT_IMAGE_MIMETYPES.includes(mimeType)
-		const assetSrc = asset && 'src' in asset.props ? asset.props.src : null
-
-		if (shape.props.crop?.isCircle) {
-			if (supportsTransparency && assetSrc) {
-				const src = assetSrc
-				return new ImageEllipse2d({
-					width: shape.props.w,
-					height: shape.props.h,
-					isFilled: true,
-					alphaDataGetter: () => getAlphaData(src),
-					crop: shape.props.crop,
-					flipX: shape.props.flipX,
-					flipY: shape.props.flipY,
-				})
-			}
-			return new Ellipse2d({
-				width: shape.props.w,
-				height: shape.props.h,
-				isFilled: true,
-			})
-		}
+		const { supportsTransparency, assetSrc } = getAssetTransparencyInfo(asset)
+		const { w: width, h: height, crop, flipX, flipY } = shape.props
 
 		if (supportsTransparency && assetSrc) {
-			const src = assetSrc
-			return new ImageRectangle2d({
-				width: shape.props.w,
-				height: shape.props.h,
+			const alphaConfig = {
+				width,
+				height,
 				isFilled: true,
-				alphaDataGetter: () => getAlphaData(src),
-				crop: shape.props.crop,
-				flipX: shape.props.flipX,
-				flipY: shape.props.flipY,
-			})
+				alphaDataGetter: () => getAlphaData(assetSrc),
+				crop,
+				flipX,
+				flipY,
+			}
+			return crop?.isCircle ? new ImageEllipse2d(alphaConfig) : new ImageRectangle2d(alphaConfig)
 		}
 
-		return new Rectangle2d({
-			width: shape.props.w,
-			height: shape.props.h,
-			isFilled: true,
-		})
+		return crop?.isCircle
+			? new Ellipse2d({ width, height, isFilled: true })
+			: new Rectangle2d({ width, height, isFilled: true })
 	}
 
 	override getAriaDescriptor(shape: TLImageShape) {
@@ -259,11 +236,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 	override onDoubleClickEdge(shape: TLImageShape) {
 		const props = shape.props
-		if (!props) return
-
-		if (this.editor.getCroppingShapeId() !== shape.id) {
-			return
-		}
+		if (this.editor.getCroppingShapeId() !== shape.id) return
 
 		const crop = structuredClone(props.crop) || {
 			topLeft: { x: 0, y: 0 },
@@ -354,9 +327,7 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 		return undefined
 	}, [editor, isAnimated, prefersReducedMotion, url])
 
-	const mimeType = asset && 'mimeType' in asset.props ? asset.props.mimeType : null
-	const supportsTransparency = mimeType != null && TRANSPARENT_IMAGE_MIMETYPES.includes(mimeType)
-	const assetSrc = asset && 'src' in asset.props ? asset.props.src : null
+	const { supportsTransparency, assetSrc } = getAssetTransparencyInfo(asset)
 
 	useEffect(() => {
 		if (url && supportsTransparency) {
@@ -404,7 +375,7 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 				>
 					{asset ? null : <BrokenAssetIcon />}
 				</div>
-				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
+				{shape.props.url && <HyperlinkButton url={shape.props.url} />}
 			</HTMLContainer>
 		)
 	}
@@ -475,6 +446,14 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 		</>
 	)
 })
+
+function getAssetTransparencyInfo(asset: TLAsset | null | undefined) {
+	const mimeType = asset && 'mimeType' in asset.props ? asset.props.mimeType : null
+	return {
+		supportsTransparency: mimeType != null && TRANSPARENT_IMAGE_MIMETYPES.includes(mimeType),
+		assetSrc: asset && 'src' in asset.props ? asset.props.src : null,
+	}
+}
 
 function getIsAnimated(editor: Editor, assetId: TLAssetId) {
 	const asset = assetId ? editor.getAsset(assetId) : undefined
@@ -589,7 +568,7 @@ function SvgImage({ shape, src }: { shape: TLImageShape; src: string }) {
 						width={width}
 						height={height}
 						aria-label={shape.props.altText}
-						style={flip ? { ...flip } : { transform: cropTransform }}
+						style={flip ?? { transform: cropTransform }}
 					/>
 				</g>
 			</>

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -106,13 +106,14 @@ export class Pointing extends StateNode {
 				},
 			])
 
-			if (!this.editor.getShape(id)) {
+			const shape = this.editor.getShape<TLLineShape>(id)
+			if (!shape) {
 				this.cancel()
 				return
 			}
 
 			this.editor.select(id)
-			this.shape = this.editor.getShape(id)!
+			this.shape = shape
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -300,7 +300,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 	}
 
 	override getFontFaces(shape: TLNoteShape) {
-		const fonts = isEmptyRichText(shape.props.richText)
+		const isEmpty = isEmptyRichText(shape.props.richText)
+		const fonts = isEmpty
 			? []
 			: getFontsFromRichText(this.editor, shape.props.richText, {
 					family: `tldraw_${shape.props.font}`,
@@ -308,7 +309,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					style: 'normal',
 				})
 
-		if (shape.props.textLastEditedBy && !isEmptyRichText(shape.props.richText)) {
+		if (shape.props.textLastEditedBy && !isEmpty) {
 			return [...fonts, DefaultFontFaces.tldraw_sans.normal.normal]
 		}
 		const themeFaces = getThemeFontFaces(this.editor.getCurrentTheme(), shape.props.font)
@@ -414,7 +415,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 						/>
 					)}
 				</div>
-				{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
+				{props.url && <HyperlinkButton url={props.url} />}
 			</>
 		)
 	}
@@ -634,10 +635,11 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		// of give.
 		const FUZZ = 1
 
+		const html = renderHtmlFromRichTextForMeasurement(this.editor, richText)
+
 		// We slightly make the font smaller if the text is too big for the note, width-wise.
 		do {
 			fontSizeAdjustment = Math.min(unadjustedFontSize, unadjustedFontSize - iterations)
-			const html = renderHtmlFromRichTextForMeasurement(this.editor, richText)
 			const nextTextSize = this.editor.textMeasure.measureHtml(html, {
 				...TEXT_PROPS,
 				lineHeight: dv.labelLineHeight,
@@ -654,7 +656,6 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 			if (fontSizeAdjustment <= 14) {
 				// Too small, just rely now on CSS `overflow-wrap: break-word`
 				// We need to recalculate the text measurement here with break-word enabled.
-				const html = renderHtmlFromRichTextForMeasurement(this.editor, richText)
 				const nextTextSizeWithOverflowBreak = this.editor.textMeasure.measureHtml(html, {
 					...TEXT_PROPS,
 					lineHeight: dv.labelLineHeight,
@@ -673,8 +674,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		} while (iterations++ < 50)
 
 		return {
-			labelHeight: labelHeight,
-			labelWidth: labelWidth,
+			labelHeight,
+			labelWidth,
 			fontSizeAdjustment:
 				fontSizeAdjustment === unadjustedFontSize ? 1 : fontSizeAdjustment / unadjustedFontSize,
 		}

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -14,41 +14,20 @@ export const CLONE_HANDLE_MARGIN = 0
 /** @internal */
 export const NOTE_ADJACENT_POSITION_SNAP_RADIUS = 10
 
-const BASE_NOTE_POSITIONS = (editor: Editor, noteWidth: number, noteHeight: number) =>
-	[
-		[
-			['a1' as IndexKey],
-			new Vec(noteWidth * 0.5, noteHeight * -0.5 - editor.options.adjacentShapeMargin),
-		], // t
-		[
-			['a2' as IndexKey],
-			new Vec(noteWidth * 1.5 + editor.options.adjacentShapeMargin, noteHeight * 0.5),
-		], // r
-		[
-			['a3' as IndexKey],
-			new Vec(noteWidth * 0.5, noteHeight * 1.5 + editor.options.adjacentShapeMargin),
-		], // b
-		[
-			['a4' as IndexKey],
-			new Vec(noteWidth * -0.5 - editor.options.adjacentShapeMargin, noteHeight * 0.5),
-		], // l
-	] as const
-
 function getBaseAdjacentNotePositions(
 	editor: Editor,
 	scale: number,
 	noteWidth: number,
 	noteHeight: number
 ) {
-	if (scale === 1) return BASE_NOTE_POSITIONS(editor, noteWidth, noteHeight)
 	const w = noteWidth * scale
 	const h = noteHeight * scale
 	const m = editor.options.adjacentShapeMargin * scale
 	return [
-		[['a1' as IndexKey], new Vec(w * 0.5, h * -0.5 - m)], // t
-		[['a2' as IndexKey], new Vec(w * 1.5 + m, h * 0.5)], // r
-		[['a3' as IndexKey], new Vec(w * 0.5, h * 1.5 + m)], // b
-		[['a4' as IndexKey], new Vec(w * -0.5 - m, h * 0.5)], // l
+		['a1' as IndexKey, new Vec(w * 0.5, h * -0.5 - m)], // t
+		['a2' as IndexKey, new Vec(w * 1.5 + m, h * 0.5)], // r
+		['a3' as IndexKey, new Vec(w * 0.5, h * 1.5 + m)], // b
+		['a4' as IndexKey, new Vec(w * -0.5 - m, h * 0.5)], // l
 	] as const
 }
 
@@ -73,12 +52,11 @@ export function getNoteAdjacentPositions(
 ): Record<IndexKey, Vec> {
 	const { pagePoint, pageRotation, growY, extraHeight, scale, noteWidth, noteHeight } = opts
 	return Object.fromEntries(
-		getBaseAdjacentNotePositions(editor, scale, noteWidth, noteHeight).map(([id, v], i) => {
-			const point = v.clone()
-			if (i === 0 && extraHeight) {
+		getBaseAdjacentNotePositions(editor, scale, noteWidth, noteHeight).map(([id, point], i) => {
+			if (i === 0) {
 				// apply top margin (the growY of the moving note shape)
 				point.y -= extraHeight
-			} else if (i === 2 && growY) {
+			} else if (i === 2) {
 				// apply bottom margin (the growY of this note shape)
 				point.y += growY
 			}

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -19,10 +19,6 @@ import type { NoteShapeUtil } from '../NoteShapeUtil'
 export class Pointing extends StateNode {
 	static override id = 'pointing'
 
-	dragged = false
-
-	info = {} as TLPointerEventInfo
-
 	markId = ''
 
 	shape = {} as TLNoteShape
@@ -40,7 +36,6 @@ export class Pointing extends StateNode {
 		this.shapeId = createShapeId()
 		this.markId = editor.markHistoryStoppingPoint(`creating_note:${this.shapeId}`)
 
-		// Resolve note dimensions from the util's defaults
 		const noteUtil = editor.getShapeUtil('note') as NoteShapeUtil
 		const dv = getDisplayValues(noteUtil, { props: noteUtil.getDefaultProps() } as TLNoteShape)
 
@@ -68,9 +63,7 @@ export class Pointing extends StateNode {
 		}
 	}
 
-	// Create the note now if it hasn't been created yet (idempotent). The deferred
-	// drag and release paths route through here; a max-shapes failure cancels the
-	// gesture, matching the original onEnter behaviour.
+	// A max-shapes failure cancels the gesture.
 	private ensureShapeCreated() {
 		if (this.hasCreatedShape) return
 
@@ -128,13 +121,13 @@ export class Pointing extends StateNode {
 		if (this.editor.getInstanceState().isToolLocked) {
 			this.parent.transition('idle')
 		} else {
-			startEditingShapeWithRichText(this.editor, this.shape.id, { info: this.info })
+			startEditingShapeWithRichText(this.editor, this.shape.id)
 		}
 	}
 
 	private cancel() {
 		this.editor.bailToMark(this.markId)
-		this.parent.transition('idle', this.info)
+		this.parent.transition('idle')
 	}
 }
 
@@ -177,8 +170,7 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 	})
 
 	const shape = editor.getShape<TLNoteShape>(id)
-	// Should never happen since we just checked, but just in case
-	if (!shape) return
+	if (!shape) return // may have hit max shapes
 
 	editor.select(id)
 	const bounds = editor.getShapeGeometry(shape).bounds

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -36,6 +36,7 @@ export class Pointing extends StateNode {
 		this.shapeId = createShapeId()
 		this.markId = editor.markHistoryStoppingPoint(`creating_note:${this.shapeId}`)
 
+		// Resolve note dimensions from the util's defaults
 		const noteUtil = editor.getShapeUtil('note') as NoteShapeUtil
 		const dv = getDisplayValues(noteUtil, { props: noteUtil.getDefaultProps() } as TLNoteShape)
 
@@ -63,7 +64,9 @@ export class Pointing extends StateNode {
 		}
 	}
 
-	// A max-shapes failure cancels the gesture.
+	// Create the note now if it hasn't been created yet (idempotent). The deferred
+	// drag and release paths route through here; a max-shapes failure cancels the
+	// gesture, matching the original onEnter behaviour.
 	private ensureShapeCreated() {
 		if (this.hasCreatedShape) return
 
@@ -170,7 +173,8 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 	})
 
 	const shape = editor.getShape<TLNoteShape>(id)
-	if (!shape) return // may have hit max shapes
+	// Should never happen since we just checked, but just in case
+	if (!shape) return
 
 	editor.select(id)
 	const bounds = editor.getShapeGeometry(shape).bounds

--- a/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/HyperlinkButton.tsx
@@ -1,10 +1,8 @@
 import { useEditor } from '@tldraw/editor'
 import classNames from 'classnames'
 import { PointerEventHandler, useCallback } from 'react'
+import { LINK_ICON } from './icons-editor'
 import { useEfficientZoomThreshold } from './useEfficientZoomThreshold'
-
-const LINK_ICON =
-	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' fill='none'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 5H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6M19 5h6m0 0v6m0-6L13 17'/%3E%3C/svg%3E"
 
 export function HyperlinkButton({ url }: { url: string }) {
 	const editor = useEditor()

--- a/packages/tldraw/src/lib/shapes/shared/PathBuilder.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/PathBuilder.tsx
@@ -518,9 +518,7 @@ export class PathBuilder {
 			const command = this.commands[i]
 			switch (command.type) {
 				case 'move': {
-					const isFilled =
-						command.opts?.geometry === false ? false : (command.opts?.geometry?.isFilled ?? false)
-					if (onlyFilled && !isFilled) {
+					if (onlyFilled && !isMoveFilled(command)) {
 						isSkippingCurrentLine = true
 					} else {
 						isSkippingCurrentLine = false
@@ -572,10 +570,8 @@ export class PathBuilder {
 			case 'dashed':
 			case 'dotted':
 				return this.toDashedSvg(opts)
-			case 'draw': {
-				const d = this.toDrawSvg(opts)
-				return d
-			}
+			case 'draw':
+				return this.toDrawSvg(opts)
 			default:
 				exhaustiveSwitchError(opts, 'style')
 		}
@@ -585,56 +581,38 @@ export class PathBuilder {
 		if (opts.style === 'none') {
 			return new Path2D()
 		}
-		if (opts.forceSolid || opts.style === 'solid') {
-			return new Path2D(this.toD({ onlyFilled: opts.onlyFilled }))
-		}
-		if (opts.style === 'draw') {
+		if (opts.style === 'draw' && !opts.forceSolid) {
 			return new Path2D(this.toDrawD(opts))
 		}
-
 		return new Path2D(this.toD({ onlyFilled: opts.onlyFilled }))
 	}
 
 	toGeometry(): PathBuilderGeometry2d | Group2d {
-		const geometries = []
+		const geometries: PathBuilderGeometry2d[] = []
 
-		let current: null | {
-			startIdx: number
-			moveCommand: MoveToPathBuilderCommand
-			isClosed: boolean
-			opts?: PathBuilderLineOpts
-		} = null
-		for (let i = 0; i < this.commands.length; i++) {
-			const command = this.commands[i]
-
-			if (command.type === 'move') {
-				if (current && current.opts?.geometry !== false) {
-					geometries.push(
-						new PathBuilderGeometry2d(this, current.startIdx, i, {
-							...current.opts?.geometry,
-							isFilled: current.opts?.geometry?.isFilled ?? false,
-							isClosed: current.moveCommand.closeIdx !== null,
-						})
-					)
-				}
-				current = { startIdx: i, moveCommand: command, opts: command.opts, isClosed: false }
-			}
-
-			if (command.isClose) {
-				assert(current, 'No current move command')
-				current.isClosed = true
-			}
-		}
-
-		if (current && current.opts?.geometry !== false) {
+		let current: { startIdx: number; moveCommand: MoveToPathBuilderCommand } | null = null
+		const flushCurrent = (endIdx: number) => {
+			if (!current) return
+			const { startIdx, moveCommand } = current
+			const geometry = moveCommand.opts?.geometry
+			if (geometry === false) return
 			geometries.push(
-				new PathBuilderGeometry2d(this, current.startIdx, this.commands.length, {
-					...current.opts?.geometry,
-					isFilled: current.opts?.geometry?.isFilled ?? false,
-					isClosed: current.moveCommand.closeIdx !== null,
+				new PathBuilderGeometry2d(this, startIdx, endIdx, {
+					...geometry,
+					isFilled: geometry?.isFilled ?? false,
+					isClosed: moveCommand.closeIdx !== null,
 				})
 			)
 		}
+
+		for (let i = 0; i < this.commands.length; i++) {
+			const command = this.commands[i]
+			if (command.type === 'move') {
+				flushCurrent(i)
+				current = { startIdx: i, moveCommand: command }
+			}
+		}
+		flushCurrent(this.commands.length)
 
 		assert(geometries.length > 0)
 		if (geometries.length === 1) return geometries[0]
@@ -709,9 +687,7 @@ export class PathBuilder {
 			const lastCommand = this.commands[i - 1]
 			if (command.type === 'move') {
 				isCurrentPathClosed = command.closeIdx !== null
-				const isFilled =
-					command.opts?.geometry === false ? false : (command.opts?.geometry?.isFilled ?? false)
-				if (opts.onlyFilled && !isFilled) {
+				if (opts.onlyFilled && !isMoveFilled(command)) {
 					isSkippingCurrentLine = true
 				} else {
 					isSkippingCurrentLine = false
@@ -841,19 +817,14 @@ export class PathBuilder {
 				offsetAmount,
 				roundnessBefore: roundnessBeforeClampedForLength,
 				roundnessAfter: roundnessAfterClampedForLength,
-				tangentToPrev: commandInfo[i]?.tangentEnd,
-				tangentToNext: nextInfo?.tangentStart,
-				moveDidClose: false,
+				tangentToPrev,
+				tangentToNext,
 			}
 
 			drawCommands.push(drawCommand)
 
 			if (command.isClose && lastMoveCommandIdx !== null) {
-				const lastMoveCommand = drawCommands[lastMoveCommandIdx]
-				lastMoveCommand.moveDidClose = true
-				lastMoveCommand.roundnessAfter = roundnessAfterClampedForLength
-			} else if (command.type === 'move') {
-				lastMoveCommandIdx = i
+				drawCommands[lastMoveCommandIdx].roundnessAfter = roundnessAfterClampedForLength
 			}
 		}
 
@@ -881,13 +852,7 @@ export class PathBuilder {
 
 				if (command.type === 'move') {
 					lastMoveToOffset = offset
-					const isFilled =
-						command.opts?.geometry === false ? false : (command.opts?.geometry?.isFilled ?? false)
-					if (onlyFilled && !isFilled) {
-						isSkippingCurrentLine = true
-					} else {
-						isSkippingCurrentLine = false
-					}
+					isSkippingCurrentLine = onlyFilled && !isMoveFilled(command)
 				}
 
 				if (isSkippingCurrentLine) continue
@@ -1046,6 +1011,11 @@ const commandsSupportingRoundness = {
 	cubic: false,
 } as const satisfies Record<PathBuilderCommand['type'], boolean>
 
+function isMoveFilled(command: MoveToPathBuilderCommand) {
+	const geometry = command.opts?.geometry
+	return geometry === false ? false : (geometry?.isFilled ?? false)
+}
+
 /** @public */
 export class PathBuilderGeometry2d extends Geometry2d {
 	constructor(
@@ -1176,7 +1146,6 @@ const CubicBezier = {
 		const n = 12
 
 		let sum = 0
-		sum = 0
 		for (let i = 0; i < n; i++) {
 			const ct = z2 * CubicBezier.Tvalues[i] + z2
 			const xbase = CubicBezier.base3(ct, x1, x2, x3, x4)

--- a/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/PlainTextLabel.tsx
@@ -60,13 +60,13 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 		useEditablePlainText(shapeId, type, plaintext)
 
 	const finalPlainText = TextHelpers.normalizeTextForDom(plaintext || '')
-	const hasText = finalPlainText.length > 0
-
 	const legacyAlign = isLegacyAlign(textAlign)
 
-	if (!isEditing && !hasText) {
+	if (!isEditing && finalPlainText.length === 0) {
 		return null
 	}
+
+	const lineHeightPx = `${resolveLineHeightPx(fontSize, lineHeight)}px`
 
 	// TODO: probably combine tl-text and tl-arrow eventually
 	// In case you're grepping for this, it breaks down as follows:
@@ -105,8 +105,8 @@ export const PlainTextLabel = React.memo(function PlainTextLabel({
 				className={`${cssPrefix}-label__inner tl-text-content__wrapper`}
 				style={{
 					fontSize,
-					lineHeight: `${resolveLineHeightPx(fontSize, lineHeight)}px`,
-					minHeight: `${resolveLineHeightPx(fontSize, lineHeight)}px`,
+					lineHeight: lineHeightPx,
+					minHeight: lineHeightPx,
 					minWidth: Math.ceil(textWidth || 0),
 					color: labelColor,
 					width: textWidth ? Math.ceil(textWidth) : undefined,

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -76,12 +76,10 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 	const { rInput, isEmpty, isEditing, isReadyForEditing, ...editableTextRest } =
 		useEditableRichText(shapeId, type, richText)
 
-	const html = useMemo(() => {
-		if (richText) {
-			return renderHtmlFromRichText(editor, richText)
-		}
-		return undefined
-	}, [editor, richText])
+	const html = useMemo(
+		() => (richText ? renderHtmlFromRichText(editor, richText) : undefined),
+		[editor, richText]
+	)
 
 	const selectToolActive = useValue(
 		'isSelectToolActive',
@@ -100,34 +98,33 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 
 	const handlePointerDown = (e: React.MouseEvent<HTMLDivElement>) => {
 		const HTMLElementCtor = editor.getContainerWindow().HTMLElement
-		if (
-			e.target instanceof HTMLElementCtor &&
-			(e.target.tagName === 'A' || e.target.closest('a'))
-		) {
-			// This mousedown prevent default is to let dragging when over a link work.
-			preventDefault(e)
+		if (!(e.target instanceof HTMLElementCtor)) return
+		const anchor = e.target.closest('a')
+		if (!anchor) return
 
-			if (!selectToolActive) return
-			const link = e.target.closest('a')?.getAttribute('href') ?? ''
-			// We don't get the mouseup event later because we preventDefault
-			// so we have to do it manually.
-			const handlePointerUp = (e: TLEventInfo) => {
-				if (e.name !== 'pointer_up' || !link) return
+		// Prevent default so that dragging works when the pointer is over a link.
+		preventDefault(e)
 
-				if (!isDragging.current) {
-					openWindow(link, '_blank', false)
-				}
-				editor.off('event', handlePointerUp)
+		if (!selectToolActive) return
+		const link = anchor.getAttribute('href') ?? ''
+		// We don't get the mouseup event later because we preventDefault
+		// so we have to do it manually.
+		const handlePointerUp = (e: TLEventInfo) => {
+			if (e.name !== 'pointer_up' || !link) return
+
+			if (!isDragging.current) {
+				openWindow(link, '_blank', false)
 			}
-			editor.on('event', handlePointerUp)
+			editor.off('event', handlePointerUp)
 		}
+		editor.on('event', handlePointerUp)
 	}
 
-	// Should be guarded higher up so that this doesn't render... but repeated here. This should never be true.
 	if (!isEditing && isEmpty) return null
 
 	// TODO: probably combine tl-text and tl-arrow eventually
 	const cssPrefix = classNamePrefix || 'tl-text'
+	const lineHeightPx = `${resolveLineHeightPx(fontSize, lineHeight)}px`
 	return (
 		<div
 			className={classNames(
@@ -163,8 +160,8 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 				style={
 					{
 						fontSize,
-						lineHeight: `${resolveLineHeightPx(fontSize, lineHeight)}px`,
-						minHeight: `${resolveLineHeightPx(fontSize, lineHeight)}px`,
+						lineHeight: lineHeightPx,
+						minHeight: lineHeightPx,
 						// Unitless multiplier consumed by the .tl-rich-text h1–h6 rule (see editor.css).
 						'--tl-rich-text-heading-line-height': lineHeight,
 						minWidth: Math.ceil(textWidth || 0),
@@ -179,7 +176,6 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 						<div
 							className="tl-rich-text"
 							data-is-select-tool-active={selectToolActive}
-							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}
 							data-is-ready-for-editing={isReadyForEditing}

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -102,7 +102,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 		const anchor = e.target.closest('a')
 		if (!anchor) return
 
-		// Prevent default so that dragging works when the pointer is over a link.
+		// This mousedown prevent default is to let dragging when over a link work.
 		preventDefault(e)
 
 		if (!selectToolActive) return
@@ -120,6 +120,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 		editor.on('event', handlePointerUp)
 	}
 
+	// Should be guarded higher up so that this doesn't render... but repeated here. This should never be true.
 	if (!isEditing && isEmpty) return null
 
 	// TODO: probably combine tl-text and tl-arrow eventually
@@ -176,6 +177,7 @@ export const RichTextLabel = React.memo(function RichTextLabel({
 						<div
 							className="tl-rich-text"
 							data-is-select-tool-active={selectToolActive}
+							// todo: see if I can abuse this
 							dangerouslySetInnerHTML={{ __html: html || '' }}
 							onPointerDown={handlePointerDown}
 							data-is-ready-for-editing={isReadyForEditing}

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -66,12 +66,10 @@ export function getUncroppedSize(
 	crop: TLShapeCrop | null
 ): { w: number; h: number } {
 	if (!crop) return { w: shapeSize.w, h: shapeSize.h }
-	const w = shapeSize.w / (crop.bottomRight.x - crop.topLeft.x)
-	const h = shapeSize.h / (crop.bottomRight.y - crop.topLeft.y)
-	return { w, h }
+	const { width, height } = getCropDimensions(crop)
+	return { w: shapeSize.w / width, h: shapeSize.h / height }
 }
 
-// Utility function to get crop dimensions
 function getCropDimensions(crop: TLShapeCrop) {
 	return {
 		width: crop.bottomRight.x - crop.topLeft.x,
@@ -79,7 +77,6 @@ function getCropDimensions(crop: TLShapeCrop) {
 	}
 }
 
-// Utility function to get crop center
 function getCropCenter(crop: TLShapeCrop) {
 	const { width, height } = getCropDimensions(crop)
 	return {
@@ -88,7 +85,11 @@ function getCropCenter(crop: TLShapeCrop) {
 	}
 }
 
-// Utility function to create crop with specified dimensions centered on given point
+function getShapeCenter(shape: TLImageShape) {
+	return { x: shape.x + shape.props.w / 2, y: shape.y + shape.props.h / 2 }
+}
+
+/** Create a crop of the given size centered on the given point, kept within the image bounds. */
 function createCropAroundCenter(
 	centerX: number,
 	centerY: number,
@@ -96,8 +97,8 @@ function createCropAroundCenter(
 	height: number,
 	isCircle?: boolean
 ) {
-	const topLeftX = Math.max(0, Math.min(1 - width, centerX - width / 2))
-	const topLeftY = Math.max(0, Math.min(1 - height, centerY - height / 2))
+	const topLeftX = clamp(centerX - width / 2, 0, 1 - width)
+	const topLeftY = clamp(centerY - height / 2, 0, 1 - height)
 
 	return {
 		topLeft: { x: topLeftX, y: topLeftY },
@@ -128,8 +129,7 @@ export function getCropBox<T extends ShapeWithCrop>(
 		return
 	}
 
-	// Lets get a box here in pixel space. For simplicity, we'll do all the math in
-	// pixel space, then convert to normalized space at the end.
+	// Do all the math in pixel space, then convert to normalized space at the end.
 	const prevCropBox = new Box(
 		crop.topLeft.x * w,
 		crop.topLeft.y * h,
@@ -198,8 +198,6 @@ export function getCropBox<T extends ShapeWithCrop>(
 		tempBox.w = halfW * 2
 		tempBox.h = halfH * 2
 	} else {
-		// Basic resizing logic based on the handles
-
 		if (movesLeft) {
 			tempBox.x = clamp(tempBox.x + change.x, 0, prevCropBox.maxX - minWidth)
 			tempBox.w = prevCropBox.maxX - tempBox.x
@@ -216,8 +214,6 @@ export function getCropBox<T extends ShapeWithCrop>(
 			tempBox.h = tempBottom - tempBox.y
 		}
 	}
-
-	// Aspect ratio locked resizing logic
 
 	if (aspectRatioLocked && !isResizingFromCenter) {
 		const isXLimiting = tempBox.aspectRatio > targetRatio
@@ -401,7 +397,6 @@ export function getCropBox<T extends ShapeWithCrop>(
 		newCrop.isCircle = crop.isCircle
 	}
 
-	// If the crop hasn't changed, we can return early
 	if (
 		newCrop.topLeft.x === crop.topLeft.x &&
 		newCrop.topLeft.y === crop.topLeft.y &&
@@ -442,41 +437,25 @@ interface CropChange {
 	y: number
 }
 
-// Base function for calculating crop changes
 function calculateCropChange(
 	imageShape: TLImageShape,
 	newCropWidth: number,
 	newCropHeight: number,
-	centerOnCurrentCrop: boolean = true,
 	isCircle: boolean = false
 ): CropChange {
-	const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
-	const currentCrop = imageShape.props.crop || getDefaultCrop()
+	const currentCrop = imageShape.props.crop ?? getDefaultCrop()
+	const { w, h } = getUncroppedSize(imageShape.props, currentCrop)
+	const imageCenter = getShapeCenter(imageShape)
+	const cropCenter = getCropCenter(currentCrop)
 
-	// Calculate image and crop centers
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
-
-	let cropCenterX, cropCenterY
-	if (centerOnCurrentCrop) {
-		const { x, y } = getCropCenter(currentCrop)
-		cropCenterX = x
-		cropCenterY = y
-	} else {
-		cropCenterX = 0.5
-		cropCenterY = 0.5
-	}
-
-	// Create new crop
 	const newCrop = createCropAroundCenter(
-		cropCenterX,
-		cropCenterY,
+		cropCenter.x,
+		cropCenter.y,
 		newCropWidth,
 		newCropHeight,
 		isCircle
 	)
 
-	// Calculate new dimensions
 	const croppedW = newCropWidth * w
 	const croppedH = newCropHeight * h
 
@@ -484,8 +463,8 @@ function calculateCropChange(
 		crop: newCrop,
 		w: croppedW,
 		h: croppedH,
-		x: imageCenterX - croppedW / 2,
-		y: imageCenterY - croppedH / 2,
+		x: imageCenter.x - croppedW / 2,
+		y: imageCenter.y - croppedH / 2,
 	}
 }
 
@@ -504,7 +483,6 @@ export function getCroppedImageDataWhenZooming(
 	const { width: oldWidth, height: oldHeight } = getCropDimensions(oldCrop)
 	const aspectRatio = oldWidth / oldHeight
 
-	// Calculate new crop size with zoom scale
 	const derivedMaxZoom = maxZoom ? 1 / (1 - maxZoom) : MAX_ZOOM
 	const zoomScale = 1 + zoom * (derivedMaxZoom - 1)
 	let newWidth, newHeight
@@ -517,19 +495,15 @@ export function getCroppedImageDataWhenZooming(
 		newWidth = newHeight * aspectRatio
 	}
 
-	// Calculate result with base function
-	const result = calculateCropChange(imageShape, newWidth, newHeight, true, oldCrop.isCircle)
+	const result = calculateCropChange(imageShape, newWidth, newHeight, oldCrop.isCircle)
 
-	// Apply zoom factor to display dimensions
+	// Apply zoom factor to display dimensions, keeping the image centered
 	const scaleFactor = Math.min(MAX_ZOOM, oldWidth / newWidth)
 	result.w *= scaleFactor
 	result.h *= scaleFactor
-
-	// Recenter
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
-	result.x = imageCenterX - result.w / 2
-	result.y = imageCenterY - result.h / 2
+	const imageCenter = getShapeCenter(imageShape)
+	result.x = imageCenter.x - result.w / 2
+	result.y = imageCenter.y - result.h / 2
 
 	return result
 }
@@ -549,73 +523,53 @@ export function getCroppedImageDataForReplacedImage(
 	const newImageAspectRatio = newImageWidth / newImageHeight
 
 	let crop = defaultCrop
-	let newDisplayW = origDisplayW
+	const newDisplayW = origDisplayW
 	let newDisplayH = origDisplayH
-	const isOriginalCrop = isEqual(imageShape.props.crop, defaultCrop)
 
-	if (isOriginalCrop) {
-		newDisplayW = origDisplayW
+	if (isEqual(imageShape.props.crop, defaultCrop)) {
 		newDisplayH = (origDisplayW * newImageHeight) / newImageWidth
 	} else {
-		const { w: uncroppedW, h: uncroppedH } = getUncroppedSize(
-			imageShape.props,
-			imageShape.props.crop || getDefaultCrop() // Use the ACTUAL current crop to correctly infer uncropped size
-		)
+		const { w: uncroppedW, h: uncroppedH } = getUncroppedSize(imageShape.props, currentCrop)
 		const { width: cropW, height: cropH } = getCropDimensions(currentCrop)
 		const targetRatio = cropW / cropH
 		const oldImageAspectRatio = uncroppedW / uncroppedH
-		let newRelativeWidth: number
-		let newRelativeHeight: number
-
 		const currentCropCenter = getCropCenter(currentCrop)
 
 		// Adjust the new crop dimensions to match the current crop zoom
-		newRelativeWidth = cropW
+		let newRelativeWidth = cropW
 		const ratioConversion = newImageAspectRatio / oldImageAspectRatio / targetRatio
-		newRelativeHeight = newRelativeWidth * ratioConversion
+		let newRelativeHeight = newRelativeWidth * ratioConversion
 
 		// Check that our new crop dimensions are within the MAX_ZOOM bounds
 		const maxRatioConversion = MAX_ZOOM / (MAX_ZOOM - 1)
 		if (ratioConversion > maxRatioConversion) {
 			const minDimension = 1 / MAX_ZOOM
-			if (1 / newRelativeHeight < 1 / newRelativeWidth) {
-				const scale = newRelativeHeight / minDimension
-				newRelativeHeight = newRelativeHeight / scale
-				newRelativeWidth = newRelativeWidth / scale
-			} else {
-				const scale = newRelativeWidth / minDimension
-				newRelativeWidth = newRelativeWidth / scale
-				newRelativeHeight = newRelativeHeight / scale
-			}
+			const scale =
+				1 / newRelativeHeight < 1 / newRelativeWidth
+					? newRelativeHeight / minDimension
+					: newRelativeWidth / minDimension
+			newRelativeHeight = newRelativeHeight / scale
+			newRelativeWidth = newRelativeWidth / scale
 		}
 
-		// Ensure dimensions are within [0, 1] bounds after adjustment
-		newRelativeWidth = Math.max(0, Math.min(1, newRelativeWidth))
-		newRelativeHeight = Math.max(0, Math.min(1, newRelativeHeight))
-
-		// Create the new crop object, centered around the CURRENT crop's center
 		crop = createCropAroundCenter(
 			currentCropCenter.x,
 			currentCropCenter.y,
-			newRelativeWidth,
-			newRelativeHeight,
+			clamp(newRelativeWidth, 0, 1),
+			clamp(newRelativeHeight, 0, 1),
 			currentCrop.isCircle
 		)
 	}
 
 	// Position so visual center stays put
-	const pageCenterX = imageShape.x + origDisplayW / 2
-	const pageCenterY = imageShape.y + origDisplayH / 2
-
-	const newX = pageCenterX - newDisplayW / 2
-	const newY = pageCenterY - newDisplayH / 2
+	const pageCenter = getShapeCenter(imageShape)
 
 	return {
 		crop,
 		w: newDisplayW,
 		h: newDisplayH,
-		x: newX,
-		y: newY,
+		x: pageCenter.x - newDisplayW / 2,
+		y: pageCenter.y - newDisplayH / 2,
 	}
 }
 
@@ -626,42 +580,30 @@ export function getCroppedImageDataForAspectRatio(
 	aspectRatioOption: ASPECT_RATIO_OPTION,
 	imageShape: TLImageShape
 ): CropChange {
-	// If original aspect ratio is requested, use default crop
-	if (aspectRatioOption === 'original') {
-		const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
-		const imageCenterX = imageShape.x + imageShape.props.w / 2
-		const imageCenterY = imageShape.y + imageShape.props.h / 2
+	const currentCrop = imageShape.props.crop ?? getDefaultCrop()
+	const { w: uncroppedW, h: uncroppedH } = getUncroppedSize(imageShape.props, currentCrop)
+	const imageCenter = getShapeCenter(imageShape)
 
+	if (aspectRatioOption === 'original') {
 		return {
 			crop: getDefaultCrop(),
-			w,
-			h,
-			x: imageCenterX - w / 2,
-			y: imageCenterY - h / 2,
+			w: uncroppedW,
+			h: uncroppedH,
+			x: imageCenter.x - uncroppedW / 2,
+			y: imageCenter.y - uncroppedH / 2,
 		}
 	}
 
-	// Get target ratio and uncropped image properties
-	const targetRatio = ASPECT_RATIO_TO_VALUE[aspectRatioOption] // Assume valid option
+	const targetRatio = ASPECT_RATIO_TO_VALUE[aspectRatioOption]
 	const isCircle = aspectRatioOption === 'circle'
-	// Use default crop to get uncropped size relative to the *original* image bounds
-	const { w: uncroppedW, h: uncroppedH } = getUncroppedSize(
-		imageShape.props,
-		imageShape.props.crop || getDefaultCrop() // Use the ACTUAL current crop to correctly infer uncropped size
-	)
-	// Calculate the original image aspect ratio
 	const imageAspectRatio = uncroppedW / uncroppedH
 
-	// Get the current crop and its relative dimensions
-	const currentCrop = imageShape.props.crop || getDefaultCrop()
 	const { width: cropW, height: cropH } = getCropDimensions(currentCrop)
 	const currentCropCenter = getCropCenter(currentCrop)
-
-	// Calculate the current crop zoom level
 	const currentCropZoom = Math.min(1 / cropW, 1 / cropH)
 
-	// Calculate the relative width and height of the crop rectangle (0-1 scale)
-	// Try to preserve the longest dimension of the current crop when changing aspect ratios
+	// The relative (0-1) size of the new crop rectangle. Preserve the longest dimension of the
+	// current crop when changing aspect ratios.
 	let newRelativeWidth: number
 	let newRelativeHeight: number
 
@@ -670,59 +612,42 @@ export function getCroppedImageDataForAspectRatio(
 		newRelativeWidth = 1
 		newRelativeHeight = 1
 	} else {
-		// Get current crop dimensions in absolute units
 		const currentAbsoluteWidth = cropW * uncroppedW
 		const currentAbsoluteHeight = cropH * uncroppedH
-
-		// Find the longest current dimension to preserve
 		const longestCurrentDimension = Math.max(currentAbsoluteWidth, currentAbsoluteHeight)
-		const isWidthLongest = currentAbsoluteWidth >= currentAbsoluteHeight
 
-		// Calculate new dimensions preserving the longest dimension
 		let newAbsoluteWidth: number
 		let newAbsoluteHeight: number
-
-		if (isWidthLongest) {
-			// Preserve width, calculate height based on target ratio
+		if (currentAbsoluteWidth >= currentAbsoluteHeight) {
 			newAbsoluteWidth = longestCurrentDimension
 			newAbsoluteHeight = newAbsoluteWidth / targetRatio
 		} else {
-			// Preserve height, calculate width based on target ratio
 			newAbsoluteHeight = longestCurrentDimension
 			newAbsoluteWidth = newAbsoluteHeight * targetRatio
 		}
 
-		// Convert back to relative coordinates
 		newRelativeWidth = newAbsoluteWidth / uncroppedW
 		newRelativeHeight = newAbsoluteHeight / uncroppedH
 
-		// Clamp to image bounds and adjust if necessary
+		// Clamp to image bounds, recalculating the other dimension to keep the ratio
 		if (newRelativeWidth > 1) {
-			// Width exceeds bounds, clamp and recalculate height
 			newRelativeWidth = 1
 			newRelativeHeight = imageAspectRatio / targetRatio
 		}
 		if (newRelativeHeight > 1) {
-			// Height exceeds bounds, clamp and recalculate width
 			newRelativeHeight = 1
 			newRelativeWidth = targetRatio / imageAspectRatio
 		}
 
-		// Final clamp to ensure we stay within bounds
-		newRelativeWidth = Math.max(0, Math.min(1, newRelativeWidth))
-		newRelativeHeight = Math.max(0, Math.min(1, newRelativeHeight))
+		newRelativeWidth = clamp(newRelativeWidth, 0, 1)
+		newRelativeHeight = clamp(newRelativeHeight, 0, 1)
 	}
 
-	const newCropZoom = Math.min(1 / newRelativeWidth, 1 / newRelativeHeight)
 	// Adjust the new crop dimensions to match the current crop zoom
-	newRelativeWidth *= newCropZoom / currentCropZoom
-	newRelativeHeight *= newCropZoom / currentCropZoom
+	const newCropZoom = Math.min(1 / newRelativeWidth, 1 / newRelativeHeight)
+	newRelativeWidth = clamp(newRelativeWidth * (newCropZoom / currentCropZoom), 0, 1)
+	newRelativeHeight = clamp(newRelativeHeight * (newCropZoom / currentCropZoom), 0, 1)
 
-	// Ensure dimensions are within [0, 1] bounds after adjustment
-	newRelativeWidth = Math.max(0, Math.min(1, newRelativeWidth))
-	newRelativeHeight = Math.max(0, Math.min(1, newRelativeHeight))
-
-	// Create the new crop object, centered around the CURRENT crop's center
 	const newCrop = createCropAroundCenter(
 		currentCropCenter.x,
 		currentCropCenter.y,
@@ -731,40 +656,27 @@ export function getCroppedImageDataForAspectRatio(
 		isCircle
 	)
 
-	// Get the actual relative dimensions from the new crop (after potential clamping)
-	const finalRelativeWidth = newCrop.bottomRight.x - newCrop.topLeft.x
-	const finalRelativeHeight = newCrop.bottomRight.y - newCrop.topLeft.y
-
-	// Calculate the base dimensions (as if applying the new crop to the uncropped image at scale 1)
+	// The base dimensions, as if applying the new crop to the uncropped image at scale 1
+	const { width: finalRelativeWidth, height: finalRelativeHeight } = getCropDimensions(newCrop)
 	const baseW = finalRelativeWidth * uncroppedW
 	const baseH = finalRelativeHeight * uncroppedH
 
-	// Determine the current effective scale of the shape
-	// This preserves the visual size when the crop changes
+	// Apply the shape's current effective scale so its visual size is preserved
 	let currentScale = 1.0
 	if (cropW > 0) {
 		currentScale = imageShape.props.w / (cropW * uncroppedW)
 	} else if (cropH > 0) {
-		// Fallback to height if width relative dimension is zero
 		currentScale = imageShape.props.h / (cropH * uncroppedH)
 	}
-
-	// Apply the current scale to the base dimensions to get the final dimensions
 	const newW = baseW * currentScale
 	const newH = baseH * currentScale
 
-	// Calculate the new top-left position (x, y) for the shape
-	// to keep the visual center of the cropped area fixed on the page.
-	const currentCenterXPage = imageShape.x + imageShape.props.w / 2
-	const currentCenterYPage = imageShape.y + imageShape.props.h / 2
-	const newX = currentCenterXPage - newW / 2
-	const newY = currentCenterYPage - newH / 2
-
+	// Keep the visual center of the cropped area fixed on the page
 	return {
 		crop: newCrop,
 		w: newW,
 		h: newH,
-		x: newX,
-		y: newY,
+		x: imageCenter.x - newW / 2,
+		y: imageCenter.y - newH / 2,
 	}
 }

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -70,6 +70,7 @@ export function getUncroppedSize(
 	return { w: shapeSize.w / width, h: shapeSize.h / height }
 }
 
+// Utility function to get crop dimensions
 function getCropDimensions(crop: TLShapeCrop) {
 	return {
 		width: crop.bottomRight.x - crop.topLeft.x,
@@ -77,6 +78,7 @@ function getCropDimensions(crop: TLShapeCrop) {
 	}
 }
 
+// Utility function to get crop center
 function getCropCenter(crop: TLShapeCrop) {
 	const { width, height } = getCropDimensions(crop)
 	return {
@@ -89,7 +91,7 @@ function getShapeCenter(shape: TLImageShape) {
 	return { x: shape.x + shape.props.w / 2, y: shape.y + shape.props.h / 2 }
 }
 
-/** Create a crop of the given size centered on the given point, kept within the image bounds. */
+// Utility function to create crop with specified dimensions centered on given point
 function createCropAroundCenter(
 	centerX: number,
 	centerY: number,
@@ -129,7 +131,8 @@ export function getCropBox<T extends ShapeWithCrop>(
 		return
 	}
 
-	// Do all the math in pixel space, then convert to normalized space at the end.
+	// Lets get a box here in pixel space. For simplicity, we'll do all the math in
+	// pixel space, then convert to normalized space at the end.
 	const prevCropBox = new Box(
 		crop.topLeft.x * w,
 		crop.topLeft.y * h,
@@ -198,6 +201,8 @@ export function getCropBox<T extends ShapeWithCrop>(
 		tempBox.w = halfW * 2
 		tempBox.h = halfH * 2
 	} else {
+		// Basic resizing logic based on the handles
+
 		if (movesLeft) {
 			tempBox.x = clamp(tempBox.x + change.x, 0, prevCropBox.maxX - minWidth)
 			tempBox.w = prevCropBox.maxX - tempBox.x
@@ -214,6 +219,8 @@ export function getCropBox<T extends ShapeWithCrop>(
 			tempBox.h = tempBottom - tempBox.y
 		}
 	}
+
+	// Aspect ratio locked resizing logic
 
 	if (aspectRatioLocked && !isResizingFromCenter) {
 		const isXLimiting = tempBox.aspectRatio > targetRatio
@@ -397,6 +404,7 @@ export function getCropBox<T extends ShapeWithCrop>(
 		newCrop.isCircle = crop.isCircle
 	}
 
+	// If the crop hasn't changed, we can return early
 	if (
 		newCrop.topLeft.x === crop.topLeft.x &&
 		newCrop.topLeft.y === crop.topLeft.y &&
@@ -437,6 +445,7 @@ interface CropChange {
 	y: number
 }
 
+// Base function for calculating crop changes
 function calculateCropChange(
 	imageShape: TLImageShape,
 	newCropWidth: number,
@@ -445,9 +454,11 @@ function calculateCropChange(
 ): CropChange {
 	const currentCrop = imageShape.props.crop ?? getDefaultCrop()
 	const { w, h } = getUncroppedSize(imageShape.props, currentCrop)
+	// Calculate image and crop centers
 	const imageCenter = getShapeCenter(imageShape)
 	const cropCenter = getCropCenter(currentCrop)
 
+	// Create new crop
 	const newCrop = createCropAroundCenter(
 		cropCenter.x,
 		cropCenter.y,
@@ -456,6 +467,7 @@ function calculateCropChange(
 		isCircle
 	)
 
+	// Calculate new dimensions
 	const croppedW = newCropWidth * w
 	const croppedH = newCropHeight * h
 
@@ -483,6 +495,7 @@ export function getCroppedImageDataWhenZooming(
 	const { width: oldWidth, height: oldHeight } = getCropDimensions(oldCrop)
 	const aspectRatio = oldWidth / oldHeight
 
+	// Calculate new crop size with zoom scale
 	const derivedMaxZoom = maxZoom ? 1 / (1 - maxZoom) : MAX_ZOOM
 	const zoomScale = 1 + zoom * (derivedMaxZoom - 1)
 	let newWidth, newHeight
@@ -495,12 +508,14 @@ export function getCroppedImageDataWhenZooming(
 		newWidth = newHeight * aspectRatio
 	}
 
+	// Calculate result with base function
 	const result = calculateCropChange(imageShape, newWidth, newHeight, oldCrop.isCircle)
 
-	// Apply zoom factor to display dimensions, keeping the image centered
+	// Apply zoom factor to display dimensions
 	const scaleFactor = Math.min(MAX_ZOOM, oldWidth / newWidth)
 	result.w *= scaleFactor
 	result.h *= scaleFactor
+	// Recenter
 	const imageCenter = getShapeCenter(imageShape)
 	result.x = imageCenter.x - result.w / 2
 	result.y = imageCenter.y - result.h / 2
@@ -552,6 +567,7 @@ export function getCroppedImageDataForReplacedImage(
 			newRelativeWidth = newRelativeWidth / scale
 		}
 
+		// Create the new crop object, centered around the CURRENT crop's center
 		crop = createCropAroundCenter(
 			currentCropCenter.x,
 			currentCropCenter.y,
@@ -584,6 +600,7 @@ export function getCroppedImageDataForAspectRatio(
 	const { w: uncroppedW, h: uncroppedH } = getUncroppedSize(imageShape.props, currentCrop)
 	const imageCenter = getShapeCenter(imageShape)
 
+	// If original aspect ratio is requested, use default crop
 	if (aspectRatioOption === 'original') {
 		return {
 			crop: getDefaultCrop(),
@@ -594,16 +611,21 @@ export function getCroppedImageDataForAspectRatio(
 		}
 	}
 
-	const targetRatio = ASPECT_RATIO_TO_VALUE[aspectRatioOption]
+	// Get target ratio and uncropped image properties
+	const targetRatio = ASPECT_RATIO_TO_VALUE[aspectRatioOption] // Assume valid option
 	const isCircle = aspectRatioOption === 'circle'
+	// Calculate the original image aspect ratio
 	const imageAspectRatio = uncroppedW / uncroppedH
 
+	// Get the current crop and its relative dimensions
 	const { width: cropW, height: cropH } = getCropDimensions(currentCrop)
 	const currentCropCenter = getCropCenter(currentCrop)
+
+	// Calculate the current crop zoom level
 	const currentCropZoom = Math.min(1 / cropW, 1 / cropH)
 
-	// The relative (0-1) size of the new crop rectangle. Preserve the longest dimension of the
-	// current crop when changing aspect ratios.
+	// Calculate the relative width and height of the crop rectangle (0-1 scale)
+	// Try to preserve the longest dimension of the current crop when changing aspect ratios
 	let newRelativeWidth: number
 	let newRelativeHeight: number
 
@@ -612,33 +634,42 @@ export function getCroppedImageDataForAspectRatio(
 		newRelativeWidth = 1
 		newRelativeHeight = 1
 	} else {
+		// Get current crop dimensions in absolute units
 		const currentAbsoluteWidth = cropW * uncroppedW
 		const currentAbsoluteHeight = cropH * uncroppedH
+		// Find the longest current dimension to preserve
 		const longestCurrentDimension = Math.max(currentAbsoluteWidth, currentAbsoluteHeight)
 
+		// Calculate new dimensions preserving the longest dimension
 		let newAbsoluteWidth: number
 		let newAbsoluteHeight: number
 		if (currentAbsoluteWidth >= currentAbsoluteHeight) {
+			// Preserve width, calculate height based on target ratio
 			newAbsoluteWidth = longestCurrentDimension
 			newAbsoluteHeight = newAbsoluteWidth / targetRatio
 		} else {
+			// Preserve height, calculate width based on target ratio
 			newAbsoluteHeight = longestCurrentDimension
 			newAbsoluteWidth = newAbsoluteHeight * targetRatio
 		}
 
+		// Convert back to relative coordinates
 		newRelativeWidth = newAbsoluteWidth / uncroppedW
 		newRelativeHeight = newAbsoluteHeight / uncroppedH
 
-		// Clamp to image bounds, recalculating the other dimension to keep the ratio
+		// Clamp to image bounds and adjust if necessary
 		if (newRelativeWidth > 1) {
+			// Width exceeds bounds, clamp and recalculate height
 			newRelativeWidth = 1
 			newRelativeHeight = imageAspectRatio / targetRatio
 		}
 		if (newRelativeHeight > 1) {
+			// Height exceeds bounds, clamp and recalculate width
 			newRelativeHeight = 1
 			newRelativeWidth = targetRatio / imageAspectRatio
 		}
 
+		// Final clamp to ensure we stay within bounds
 		newRelativeWidth = clamp(newRelativeWidth, 0, 1)
 		newRelativeHeight = clamp(newRelativeHeight, 0, 1)
 	}
@@ -648,6 +679,7 @@ export function getCroppedImageDataForAspectRatio(
 	newRelativeWidth = clamp(newRelativeWidth * (newCropZoom / currentCropZoom), 0, 1)
 	newRelativeHeight = clamp(newRelativeHeight * (newCropZoom / currentCropZoom), 0, 1)
 
+	// Create the new crop object, centered around the CURRENT crop's center
 	const newCrop = createCropAroundCenter(
 		currentCropCenter.x,
 		currentCropCenter.y,
@@ -656,22 +688,29 @@ export function getCroppedImageDataForAspectRatio(
 		isCircle
 	)
 
-	// The base dimensions, as if applying the new crop to the uncropped image at scale 1
+	// Get the actual relative dimensions from the new crop (after potential clamping)
 	const { width: finalRelativeWidth, height: finalRelativeHeight } = getCropDimensions(newCrop)
+
+	// Calculate the base dimensions (as if applying the new crop to the uncropped image at scale 1)
 	const baseW = finalRelativeWidth * uncroppedW
 	const baseH = finalRelativeHeight * uncroppedH
 
-	// Apply the shape's current effective scale so its visual size is preserved
+	// Determine the current effective scale of the shape
+	// This preserves the visual size when the crop changes
 	let currentScale = 1.0
 	if (cropW > 0) {
 		currentScale = imageShape.props.w / (cropW * uncroppedW)
 	} else if (cropH > 0) {
+		// Fallback to height if width relative dimension is zero
 		currentScale = imageShape.props.h / (cropH * uncroppedH)
 	}
+
+	// Apply the current scale to the base dimensions to get the final dimensions
 	const newW = baseW * currentScale
 	const newH = baseH * currentScale
 
-	// Keep the visual center of the cropped area fixed on the page
+	// Calculate the new top-left position (x, y) for the shape
+	// to keep the visual center of the cropped area fixed on the page.
 	return {
 		crop: newCrop,
 		w: newW,

--- a/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
@@ -31,7 +31,7 @@ const SIMPLIFY_WINDOW = 8
 const MIN_ROUNDED_CORNER_STEPS = 8
 const MAX_ROUNDED_CORNER_STEPS = 13
 
-// How many steps to take when rounding a corner
+// How many steps to take when drawing a cap
 const MIN_CAP_STEPS = 8
 const MAX_CAP_STEPS = 29
 

--- a/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/getStrokeOutlinePoints.ts
@@ -31,7 +31,7 @@ const SIMPLIFY_WINDOW = 8
 const MIN_ROUNDED_CORNER_STEPS = 8
 const MAX_ROUNDED_CORNER_STEPS = 13
 
-// How many steps to take when drawing a cap
+// How many steps to take when rounding a corner
 const MIN_CAP_STEPS = 8
 const MAX_CAP_STEPS = 29
 

--- a/packages/tldraw/src/lib/shapes/shared/freehand/svg.ts
+++ b/packages/tldraw/src/lib/shapes/shared/freehand/svg.ts
@@ -1,3 +1,4 @@
+import { VecLike } from '@tldraw/editor'
 import { finishPath, resetPath, toCenti, writeCPair, writeStr } from './fmt'
 import { StrokePoint } from './types'
 
@@ -98,4 +99,11 @@ export function getSvgPathFromStrokePoints(points: StrokePoint[], closed = false
 	}
 
 	return finishPath()
+}
+
+/** SVG path for a filled circle of radius `r` centred on `point`; the "dot" a single-point stroke renders as. */
+export function getSvgDotPath(point: VecLike, r: number): string {
+	return `M ${point.x} ${point.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${
+		r * 2
+	},0`
 }

--- a/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
+++ b/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
@@ -6,6 +6,7 @@ export function interpolateSegments(
 	endSegments: TLDrawShapeSegment[],
 	progress: number
 ): TLDrawShapeSegment[] {
+	// Extract all points from startSegments and endSegments
 	const startPoints = startSegments.flatMap((segment) =>
 		b64Vecs.decodePoints(segment.path, segment.dim)
 	)
@@ -26,6 +27,7 @@ export function interpolateSegments(
 		})
 	}
 
+	// Return all interpolated points in a single segment
 	return [
 		{
 			type: 'free',

--- a/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
+++ b/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
@@ -6,40 +6,26 @@ export function interpolateSegments(
 	endSegments: TLDrawShapeSegment[],
 	progress: number
 ): TLDrawShapeSegment[] {
-	const startPoints: VecModel[] = []
-	const endPoints: VecModel[] = []
-
-	// Extract all points from startSegments and endSegments
-	startSegments.forEach((segment) =>
-		startPoints.push(...b64Vecs.decodePoints(segment.path, segment.dim))
+	const startPoints = startSegments.flatMap((segment) =>
+		b64Vecs.decodePoints(segment.path, segment.dim)
 	)
-	endSegments.forEach((segment) =>
-		endPoints.push(...b64Vecs.decodePoints(segment.path, segment.dim))
+	const endPoints = endSegments.flatMap((segment) =>
+		b64Vecs.decodePoints(segment.path, segment.dim)
 	)
 
+	// Pad the shorter array by repeating its last point so both have the same length
 	const maxLength = Math.max(startPoints.length, endPoints.length)
-	const pointsToUseStart: VecModel[] = []
-	const pointsToUseEnd: VecModel[] = []
-
-	// Ensure both arrays have the same length
+	const interpolatedPoints: VecModel[] = []
 	for (let i = 0; i < maxLength; i++) {
-		pointsToUseStart.push(startPoints[i] || startPoints[startPoints.length - 1])
-		pointsToUseEnd.push(endPoints[i] || endPoints[endPoints.length - 1])
+		const start = startPoints[i] || startPoints[startPoints.length - 1]
+		const end = endPoints[i] || endPoints[endPoints.length - 1]
+		interpolatedPoints.push({
+			x: lerp(start.x, end.x, progress),
+			y: lerp(start.y, end.y, progress),
+			z: start.z !== undefined && end.z !== undefined ? lerp(start.z, end.z, progress) : 0.5,
+		})
 	}
 
-	// Interpolate points
-	const interpolatedPoints = pointsToUseStart.map((point, k) => {
-		let z = 0.5
-		if (pointsToUseEnd[k].z !== undefined && point.z !== undefined) {
-			z = lerp(point.z, pointsToUseEnd[k].z as number, progress)
-		}
-		return {
-			x: lerp(point.x, pointsToUseEnd[k].x, progress),
-			y: lerp(point.y, pointsToUseEnd[k].y, progress),
-			z,
-		}
-	})
-	// Return all interpolated points in a single segment
 	return [
 		{
 			type: 'free',

--- a/packages/tldraw/src/lib/shapes/shared/legacyProps.ts
+++ b/packages/tldraw/src/lib/shapes/shared/legacyProps.ts
@@ -11,11 +11,8 @@ export function getLegacyOffsetX(
 		for (const { box } of spans) {
 			spansBounds.union(box)
 		}
-		if (align === 'start-legacy') {
-			return (totalWidth - 2 * padding - spansBounds.width) / 2
-		} else if (align === 'end-legacy') {
-			return -(totalWidth - 2 * padding - spansBounds.width) / 2
-		}
+		const offset = (totalWidth - 2 * padding - spansBounds.width) / 2
+		return align === 'start-legacy' ? offset : -offset
 	}
 	return undefined
 }

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -59,15 +59,7 @@ export function useEditablePlainText(
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
 			if (editor.getEditingShapeId() !== shapeId) return
-
-			switch (e.key) {
-				case 'Enter': {
-					if (e.ctrlKey || e.metaKey) {
-						editor.complete()
-					}
-					break
-				}
-			}
+			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) editor.complete()
 		},
 		[editor, shapeId]
 	)
@@ -146,20 +138,14 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 	const handlePaste = useCallback(
 		(e: ClipboardEvent | React.ClipboardEvent<HTMLTextAreaElement>) => {
 			if (editor.getEditingShapeId() !== shapeId) return
-			if (e.clipboardData) {
-				// find html in the clipboard and look for the tldraw data
-				const html = e.clipboardData.getData('text/html')
-				if (html) {
-					if (html.includes('<div data-tldraw')) {
-						// Paste the plain text data instead of the tldraw data
-						const plainText = e.clipboardData.getData('text/plain')
-						preventDefault(e)
-						if (plainText) {
-							// eslint-disable-next-line @typescript-eslint/no-deprecated -- best way to insert text with undo support
-							editor.getContainerDocument().execCommand('insertText', false, plainText)
-						}
-					}
-				}
+			if (!e.clipboardData) return
+			// Paste tldraw's own clipboard html as plain text instead of shape data
+			if (!e.clipboardData.getData('text/html').includes('<div data-tldraw')) return
+			const plainText = e.clipboardData.getData('text/plain')
+			preventDefault(e)
+			if (plainText) {
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- best way to insert text with undo support
+				editor.getContainerDocument().execCommand('insertText', false, plainText)
 			}
 		},
 		[editor, shapeId]

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -139,8 +139,9 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 		(e: ClipboardEvent | React.ClipboardEvent<HTMLTextAreaElement>) => {
 			if (editor.getEditingShapeId() !== shapeId) return
 			if (!e.clipboardData) return
-			// Paste tldraw's own clipboard html as plain text instead of shape data
+			// find html in the clipboard and look for the tldraw data
 			if (!e.clipboardData.getData('text/html').includes('<div data-tldraw')) return
+			// Paste the plain text data instead of the tldraw data
 			const plainText = e.clipboardData.getData('text/plain')
 			preventDefault(e)
 			if (plainText) {

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -47,7 +47,7 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 	const exportInfo = useSvgExportContext()
 	const exportIsReady = useDelaySvgExport()
 
-	// Avoid updating this state whenever we can: every update re-renders the shape.
+	// We use a state to store the result of the asset resolution, and we're going to avoid updating this whenever we can
 	const [result, setResult] = useState<{
 		asset: (TLImageAsset | TLVideoAsset) | null
 		url: string | null
@@ -56,14 +56,21 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		url: null,
 	}))
 
-	// After the first resolution we can debounce subsequent ones
+	// A flag for whether we've resolved the asset URL at least once, after which we can debounce
 	const didAlreadyResolve = useRef(false)
+
+	// Track the previous assetId to detect when the asset itself changes
 	const previousAssetId = useRef<TLAssetId | null>(null)
-	// Skip debouncing for the next resolution (set when the asset itself changes)
+
+	// Track whether we should run immediately (skip debouncing) for the next resolution
 	const shouldRunImmediately = useRef(false)
+
+	// The last URL that we've seen for the shape
 	const previousUrl = useRef<string | null>(null)
 
 	useEffect(() => {
+		// Check if the assetId changed (not just resolution/scale updates)
+		// Set flag to run immediately (skip debouncing) for the next resolution
 		if (previousAssetId.current !== assetId) {
 			shouldRunImmediately.current = true
 		}
@@ -77,34 +84,37 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		const cleanupEffectScheduler = react('update state', () => {
 			if (!exportInfo && shapeId && editor.getCulledShapes().has(shapeId)) return
 
+			// Get the fresh asset
 			const asset = editor.getAsset<TLImageAsset | TLVideoAsset>(assetId)
 			if (!asset) {
-				// The asset was deleted, such as when an upload fails
+				// If the asset is deleted, such as when an upload fails, set the URL to null
 				setResult((prev) => ({ ...prev, asset: null, url: null }))
 				return
 			}
 
-			// Use the temporary preview while the asset has no source yet (e.g. still uploading)
+			// Set initial preview for the shape if it has no source (if it was pasted into a local project as base64)
 			if (!asset.props.src) {
 				const preview = editor.getTemporaryAssetPreview(asset.id)
 				if (preview) {
 					if (previousUrl.current !== preview) {
-						previousUrl.current = preview
-						setResult((prev) => ({ ...prev, isPlaceholder: true, url: preview }))
-						exportIsReady()
+						previousUrl.current = preview // just for kicks, let's save the url as the previous URL
+						setResult((prev) => ({ ...prev, isPlaceholder: true, url: preview })) // set the preview as the URL
+						exportIsReady() // let the SVG export know we're ready for export
 					}
 					return
 				}
 			}
 
+			// aside ...we could bail here if the only thing that has changed is the shape has changed from culled to not culled
+
 			const screenScale =
 				(exportInfo ? exportInfo.scale : editor.getEfficientZoomLevel()) * (width / asset.props.w)
 
 			function resolve(asset: TLImageAsset | TLVideoAsset, url: string | null) {
-				if (isCancelled) return // the hook has remounted
-				if (previousUrl.current === url) return
-				didAlreadyResolve.current = true
-				previousUrl.current = url
+				if (isCancelled) return // don't update if the hook has remounted
+				if (previousUrl.current === url) return // don't update the state if the url is the same
+				didAlreadyResolve.current = true // mark that we've resolved our first image
+				previousUrl.current = url // keep the url around to compare with the next one
 				setResult({ asset, url })
 				exportIsReady() // let the SVG export know we're ready for export
 			}

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -47,36 +47,27 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 	const exportInfo = useSvgExportContext()
 	const exportIsReady = useDelaySvgExport()
 
-	// We use a state to store the result of the asset resolution, and we're going to avoid updating this whenever we can
+	// Avoid updating this state whenever we can: every update re-renders the shape.
 	const [result, setResult] = useState<{
 		asset: (TLImageAsset | TLVideoAsset) | null
 		url: string | null
 	}>(() => ({
 		asset: assetId ? (editor.getAsset<TLImageAsset | TLVideoAsset>(assetId) ?? null) : null,
-		url: null as string | null,
+		url: null,
 	}))
 
-	// A flag for whether we've resolved the asset URL at least once, after which we can debounce
+	// After the first resolution we can debounce subsequent ones
 	const didAlreadyResolve = useRef(false)
-
-	// Track the previous assetId to detect when the asset itself changes
 	const previousAssetId = useRef<TLAssetId | null>(null)
-
-	// Track whether we should run immediately (skip debouncing) for the next resolution
+	// Skip debouncing for the next resolution (set when the asset itself changes)
 	const shouldRunImmediately = useRef(false)
-
-	// The last URL that we've seen for the shape
 	const previousUrl = useRef<string | null>(null)
 
 	useEffect(() => {
-		// Check if the assetId changed (not just resolution/scale updates)
-		const assetIdChanged = previousAssetId.current !== assetId
-		previousAssetId.current = assetId
-
-		// Set flag to run immediately (skip debouncing) for the next resolution
-		if (assetIdChanged) {
+		if (previousAssetId.current !== assetId) {
 			shouldRunImmediately.current = true
 		}
+		previousAssetId.current = assetId
 
 		if (!assetId) return
 
@@ -86,38 +77,34 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		const cleanupEffectScheduler = react('update state', () => {
 			if (!exportInfo && shapeId && editor.getCulledShapes().has(shapeId)) return
 
-			// Get the fresh asset
 			const asset = editor.getAsset<TLImageAsset | TLVideoAsset>(assetId)
 			if (!asset) {
-				// If the asset is deleted, such as when an upload fails, set the URL to null
+				// The asset was deleted, such as when an upload fails
 				setResult((prev) => ({ ...prev, asset: null, url: null }))
 				return
 			}
 
-			// Set initial preview for the shape if it has no source (if it was pasted into a local project as base64)
+			// Use the temporary preview while the asset has no source yet (e.g. still uploading)
 			if (!asset.props.src) {
 				const preview = editor.getTemporaryAssetPreview(asset.id)
 				if (preview) {
 					if (previousUrl.current !== preview) {
-						previousUrl.current = preview // just for kicks, let's save the url as the previous URL
-						setResult((prev) => ({ ...prev, isPlaceholder: true, url: preview })) // set the preview as the URL
-						exportIsReady() // let the SVG export know we're ready for export
+						previousUrl.current = preview
+						setResult((prev) => ({ ...prev, isPlaceholder: true, url: preview }))
+						exportIsReady()
 					}
 					return
 				}
 			}
 
-			// aside ...we could bail here if the only thing that has changed is the shape has changed from culled to not culled
-
-			const screenScale = exportInfo
-				? exportInfo.scale * (width / asset.props.w)
-				: editor.getEfficientZoomLevel() * (width / asset.props.w)
+			const screenScale =
+				(exportInfo ? exportInfo.scale : editor.getEfficientZoomLevel()) * (width / asset.props.w)
 
 			function resolve(asset: TLImageAsset | TLVideoAsset, url: string | null) {
-				if (isCancelled) return // don't update if the hook has remounted
-				if (previousUrl.current === url) return // don't update the state if the url is the same
-				didAlreadyResolve.current = true // mark that we've resolved our first image
-				previousUrl.current = url // keep the url around to compare with the next one
+				if (isCancelled) return // the hook has remounted
+				if (previousUrl.current === url) return
+				didAlreadyResolve.current = true
+				previousUrl.current = url
 				setResult({ asset, url })
 				exportIsReady() // let the SVG export know we're ready for export
 			}

--- a/packages/tldraw/src/lib/shapes/shared/usePrefersReducedMotion.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/usePrefersReducedMotion.tsx
@@ -11,7 +11,7 @@ export function usePrefersReducedMotion() {
 
 	useEffect(() => {
 		if (animationSpeed !== undefined) {
-			setPrefersReducedMotion(animationSpeed === 0 ? true : false)
+			setPrefersReducedMotion(animationSpeed === 0)
 			return
 		}
 

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -256,6 +256,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 // Also, insert a tab character at the front of the line if the shift key isn't pressed,
 // otherwise if shift is pressed, remove a tab character from the front of the line.
 function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
+	// Don't exit the editor.
 	event.preventDefault()
 
 	if (isEditingRichTextList(editor)) return
@@ -264,6 +265,7 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 	const { $from, $to } = state.selection
 	const isShift = event.shiftKey
 
+	// Create a new transaction
 	let tr = state.tr
 
 	// Iterate over each line in the selection in reverse so that the positions
@@ -277,6 +279,7 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		const lineEnd = line.end
 		const lineText = state.doc.textBetween(lineStart, lineEnd, '\n')
 
+		// Check if the current line or any of its parent nodes are part of a list
 		let isInList = false
 		state.doc.nodesBetween(lineStart, lineEnd, (node) => {
 			if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
@@ -290,8 +293,10 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		// sinkListItem and liftListItem from @tiptap/pm/schema-list
 		if (!isInList) {
 			if (!isShift) {
+				// Insert a tab character at the start of the line
 				tr = tr.insertText('\t', lineStart + 1)
 			} else if (lineText.startsWith('\t')) {
+				// Remove a tab character from the start of the line
 				tr = tr.delete(lineStart + 1, lineStart + 2)
 			}
 		}

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -1,10 +1,5 @@
 import { EditorView } from '@tiptap/pm/view'
-import {
-	EditorEvents,
-	JSONContent,
-	Editor as TextEditor,
-	type Editor as TTEditor,
-} from '@tiptap/react'
+import { EditorEvents, JSONContent, Editor as TextEditor } from '@tiptap/react'
 import {
 	Editor,
 	TLRichText,
@@ -67,7 +62,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 	const tipTapConfig = editor.getTextOptions().tipTapConfig
 
 	const rInitialRichText = useRef(richText)
-	const rTextEditor = useRef<TTEditor | null>(null)
+	const rTextEditor = useRef<TextEditor | null>(null)
 	const rTextEditorEl = useRef<HTMLDivElement>(null)
 
 	useLayoutEffect(() => {
@@ -175,8 +170,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 				},
 				handlePaste: (view: EditorView, event: ClipboardEvent) => {
 					onPaste(event)
-					if (event.defaultPrevented) return true
-					return false
+					return event.defaultPrevented
 				},
 				handleDoubleClick: (_view, _pos, event) => onDoubleClick(event),
 				...editorProps,
@@ -240,7 +234,7 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 			tabIndex={-1}
 			data-testid="rich-text-area"
 			className="tl-rich-text tl-text tl-text-input"
-			onContextMenu={isEditing ? (e) => e.stopPropagation() : undefined}
+			onContextMenu={(e) => e.stopPropagation()}
 			// N.B. When PointerStateExtension was introduced, this was moved there.
 			// However, that caused selecting over list items to break.
 			// The handleDOMEvents in TipTap don't seem to support the pointerDownCapture event.
@@ -262,7 +256,6 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 // Also, insert a tab character at the front of the line if the shift key isn't pressed,
 // otherwise if shift is pressed, remove a tab character from the front of the line.
 function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
-	// Don't exit the editor.
 	event.preventDefault()
 
 	if (isEditingRichTextList(editor)) return
@@ -271,7 +264,6 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 	const { $from, $to } = state.selection
 	const isShift = event.shiftKey
 
-	// Create a new transaction
 	let tr = state.tr
 
 	// Iterate over each line in the selection in reverse so that the positions
@@ -285,7 +277,6 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		const lineEnd = line.end
 		const lineText = state.doc.textBetween(lineStart, lineEnd, '\n')
 
-		// Check if the current line or any of its parent nodes are part of a list
 		let isInList = false
 		state.doc.nodesBetween(lineStart, lineEnd, (node) => {
 			if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
@@ -299,13 +290,9 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		// sinkListItem and liftListItem from @tiptap/pm/schema-list
 		if (!isInList) {
 			if (!isShift) {
-				// Insert a tab character at the start of the line
 				tr = tr.insertText('\t', lineStart + 1)
-			} else {
-				// Remove a tab character from the start of the line
-				if (lineText.startsWith('\t')) {
-					tr = tr.delete(lineStart + 1, lineStart + 2)
-				}
+			} else if (lineText.startsWith('\t')) {
+				tr = tr.delete(lineStart + 1, lineStart + 2)
 			}
 		}
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -148,7 +148,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	override isAspectRatioLocked(shape: TLTextShape) {
 		return true
-	}
+	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
 
 	component(shape: TLTextShape) {
 		const {
@@ -317,8 +317,31 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		return { ...next, x: next.x - delta.x, y: next.y - delta.y, props }
 	}
 
-	// onDoubleClickEdge (toggle autoSize / reset scale) was removed June 16 2024: it felt like a
-	// mistake more often than not, especially on multiline text.
+	// 	todo: The edge doubleclicking feels like a mistake more often than
+	//  not, especially on multiline text. Removed June 16 2024
+
+	// override onDoubleClickEdge = (shape: TLTextShape) => {
+	// 	// If the shape has a fixed width, set it to autoSize.
+	// 	if (!shape.props.autoSize) {
+	// 		return {
+	// 			id: shape.id,
+	// 			type: shape.type,
+	// 			props: {
+	// 				autoSize: true,
+	// 			},
+	// 		}
+	// 	}
+	// 	// If the shape is scaled, reset the scale to 1.
+	// 	if (shape.props.scale !== 1) {
+	// 		return {
+	// 			id: shape.id,
+	// 			type: shape.type,
+	// 			props: {
+	// 				scale: 1,
+	// 			},
+	// 		}
+	// 	}
+	// }
 }
 
 function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeUtilDisplayValues) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -116,19 +116,12 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	getGeometry(shape: TLTextShape, opts: TLGeometryOpts) {
 		const { scale } = shape.props
-		const { width, height } = this.getMinDimensions(shape)!
-		const context = opts?.context ?? 'none'
+		const { width, height } = this.getMinDimensions(shape)
+		const isArrowContext = opts?.context === '@tldraw/arrow-without-arrowhead'
+		const arrowPadding = this.options.extraArrowHorizontalPadding
 		return new Rectangle2d({
-			x:
-				(context === '@tldraw/arrow-without-arrowhead'
-					? -this.options.extraArrowHorizontalPadding
-					: 0) * scale,
-			width:
-				(width +
-					(context === '@tldraw/arrow-without-arrowhead'
-						? this.options.extraArrowHorizontalPadding * 2
-						: 0)) *
-				scale,
+			x: isArrowContext ? -arrowPadding * scale : 0,
+			width: (width + (isArrowContext ? arrowPadding * 2 : 0)) * scale,
 			height: height * scale,
 			isFilled: true,
 			isLabel: true,
@@ -155,7 +148,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	override isAspectRatioLocked(shape: TLTextShape) {
 		return true
-	} // WAIT NO THIS IS HARD CODED IN THE RESIZE HANDLER
+	}
 
 	component(shape: TLTextShape) {
 		const {
@@ -205,8 +198,8 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 	override toSvg(shape: TLTextShape, ctx: SvgExportContext) {
 		const bounds = this.editor.getShapeGeometry(shape).bounds
-		const width = bounds.width / (shape.props.scale ?? 1)
-		const height = bounds.height / (shape.props.scale ?? 1)
+		const width = bounds.width / shape.props.scale
+		const height = bounds.height / shape.props.scale
 
 		const dv = getDisplayValues(this, shape, ctx.colorMode)
 
@@ -316,49 +309,16 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 			}
 		}
 
-		if (delta) {
-			// account for shape rotation when writing text:
-			delta.rot(next.rotation)
-			const { x, y } = next
-			return {
-				...next,
-				x: x - delta.x,
-				y: y - delta.y,
-				props: { ...next.props, w: wB },
-			}
-		} else {
-			return {
-				...next,
-				props: { ...next.props, w: wB },
-			}
-		}
+		const props = { ...next.props, w: wB }
+		if (!delta) return { ...next, props }
+
+		// account for shape rotation when writing text:
+		delta.rot(next.rotation)
+		return { ...next, x: next.x - delta.x, y: next.y - delta.y, props }
 	}
 
-	// 	todo: The edge doubleclicking feels like a mistake more often than
-	//  not, especially on multiline text. Removed June 16 2024
-
-	// override onDoubleClickEdge = (shape: TLTextShape) => {
-	// 	// If the shape has a fixed width, set it to autoSize.
-	// 	if (!shape.props.autoSize) {
-	// 		return {
-	// 			id: shape.id,
-	// 			type: shape.type,
-	// 			props: {
-	// 				autoSize: true,
-	// 			},
-	// 		}
-	// 	}
-	// 	// If the shape is scaled, reset the scale to 1.
-	// 	if (shape.props.scale !== 1) {
-	// 		return {
-	// 			id: shape.id,
-	// 			type: shape.type,
-	// 			props: {
-	// 				scale: 1,
-	// 			},
-	// 		}
-	// 	}
-	// }
+	// onDoubleClickEdge (toggle autoSize / reset scale) was removed June 16 2024: it felt like a
+	// mistake more often than not, especially on multiline text.
 }
 
 function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeUtilDisplayValues) {
@@ -395,13 +355,8 @@ function useTextShapeKeydownHandler(id: TLShapeId) {
 		(e: KeyboardEvent) => {
 			if (editor.getEditingShapeId() !== id) return
 
-			switch (e.key) {
-				case 'Enter': {
-					if (e.ctrlKey || e.metaKey) {
-						editor.complete()
-					}
-					break
-				}
+			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+				editor.complete()
 			}
 		},
 		[editor, id]

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -28,8 +28,13 @@ export class Pointing extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		// Don't create a fixed width shape unless the drag is a little larger and longer than 150ms,
-		// otherwise you get a vertical column of single characters if you accidentally drag a bit.
+		// Create a fixed width shape if the user wants to do that.
+
+		// Don't create a fixed width shape unless the the drag is a little larger,
+		// otherwise you get a vertical column of single characters if you accidentally
+		// drag a bit unintentionally.
+
+		// If the user hasn't been pointing for more than 150ms, don't create a fixed width shape
 		if (Date.now() - this.enterTime < 150) return
 
 		const { editor } = this
@@ -48,6 +53,7 @@ export class Pointing extends StateNode {
 				: editor.options.dragDistanceSquared
 		)
 
+		// Ten times the base drag distance for fixed width
 		const minSquaredDragDist = (baseMinDragDistForFixedWidth * 6) / editor.getZoomLevel()
 
 		if (currentDragDist > minSquaredDragDist) {

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -28,13 +28,8 @@ export class Pointing extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		// Create a fixed width shape if the user wants to do that.
-
-		// Don't create a fixed width shape unless the the drag is a little larger,
-		// otherwise you get a vertical column of single characters if you accidentally
-		// drag a bit unintentionally.
-
-		// If the user hasn't been pointing for more than 150ms, don't create a fixed width shape
+		// Don't create a fixed width shape unless the drag is a little larger and longer than 150ms,
+		// otherwise you get a vertical column of single characters if you accidentally drag a bit.
 		if (Date.now() - this.enterTime < 150) return
 
 		const { editor } = this
@@ -53,7 +48,6 @@ export class Pointing extends StateNode {
 				: editor.options.dragDistanceSquared
 		)
 
-		// Ten times the base drag distance for fixed width
 		const minSquaredDragDist = (baseMinDragDistForFixedWidth * 6) / editor.getZoomLevel()
 
 		if (currentDragDist > minSquaredDragDist) {
@@ -150,14 +144,10 @@ export class Pointing extends StateNode {
 
 		const bounds = this.editor.getShapePageBounds(shape)!
 
-		const delta = new Vec()
+		const delta = new Vec(0, -bounds.height / 2)
 
 		if (autoSize) {
 			switch (shape.props.textAlign) {
-				case 'start': {
-					delta.x = 0
-					break
-				}
 				case 'middle': {
 					delta.x = -bounds.width / 2
 					break
@@ -167,11 +157,7 @@ export class Pointing extends StateNode {
 					break
 				}
 			}
-		} else {
-			delta.x = 0
 		}
-
-		delta.y = -bounds.height / 2
 
 		if (isShapeId(shape.parentId)) {
 			const transform = this.editor.getShapeParentTransform(shape)

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -147,9 +147,7 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 
 	const [isLoaded, setIsLoaded] = useState(false)
 
-	const handleLoadedData = useCallback<ReactEventHandler<HTMLVideoElement>>((e) => {
-		const video = e.currentTarget
-		if (!video) return
+	const handleLoadedData = useCallback<ReactEventHandler<HTMLVideoElement>>(() => {
 		setIsLoaded(true)
 	}, [])
 
@@ -166,12 +164,8 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 	// Focus the video when editing
 	useEffect(() => {
 		const video = rVideo.current
-		if (!video) return
-
-		if (isEditing) {
-			if (video.ownerDocument.activeElement !== video) {
-				video.focus()
-			}
+		if (isEditing && video && video.ownerDocument.activeElement !== video) {
+			video.focus()
 		}
 	}, [isEditing, isLoaded])
 
@@ -230,7 +224,7 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 					</div>
 				</div>
 			</HTMLContainer>
-			{'url' in shape.props && shape.props.url && <HyperlinkButton url={shape.props.url} />}
+			{shape.props.url && <HyperlinkButton url={shape.props.url} />}
 		</>
 	)
 })

--- a/packages/tldraw/src/lib/styles.tsx
+++ b/packages/tldraw/src/lib/styles.tsx
@@ -32,8 +32,9 @@ export function getColorStyleItems(colors: TLThemeColors): StyleValuesForUi<stri
 	const result: StyleValuesForUi<string>[number][] = []
 	const seen = new Set<string>()
 
+	// First, add colors in the preferred order from DefaultColorStyle
 	for (const name of DefaultColorStyle.values) {
-		// white is an easter egg color that the panel does not yet account for
+		// we remove white here temporarily, it's an easter egg color that the panel does not yet account for
 		if (name === 'white') continue
 		if (isPaletteColor(colors[name as keyof typeof colors])) {
 			result.push({ value: name, icon: 'color' })
@@ -41,6 +42,7 @@ export function getColorStyleItems(colors: TLThemeColors): StyleValuesForUi<stri
 		}
 	}
 
+	// Then, append any remaining palette colors from the theme
 	for (const [key, value] of Object.entries(colors)) {
 		if (!seen.has(key) && key !== 'white' && isPaletteColor(value)) {
 			result.push({ value: key, icon: 'color' })

--- a/packages/tldraw/src/lib/styles.tsx
+++ b/packages/tldraw/src/lib/styles.tsx
@@ -32,20 +32,18 @@ export function getColorStyleItems(colors: TLThemeColors): StyleValuesForUi<stri
 	const result: StyleValuesForUi<string>[number][] = []
 	const seen = new Set<string>()
 
-	// First, add colors in the preferred order from DefaultColorStyle
 	for (const name of DefaultColorStyle.values) {
-		if (name in colors && isPaletteColor(colors[name as keyof typeof colors])) {
-			// we remove white here temporarily, it's an easter egg color that the panel does not yet account for
-			if (name === 'white') continue
-			result.push({ value: name, icon: 'color' as const })
+		// white is an easter egg color that the panel does not yet account for
+		if (name === 'white') continue
+		if (isPaletteColor(colors[name as keyof typeof colors])) {
+			result.push({ value: name, icon: 'color' })
 			seen.add(name)
 		}
 	}
 
-	// Then, append any remaining palette colors from the theme
 	for (const [key, value] of Object.entries(colors)) {
 		if (!seen.has(key) && key !== 'white' && isPaletteColor(value)) {
-			result.push({ value: key, icon: 'color' as const })
+			result.push({ value: key, icon: 'color' })
 		}
 	}
 
@@ -74,7 +72,7 @@ export function getFontStyleItems(theme: TLTheme): StyleValuesForUi<string> {
 
 	for (const name of DefaultFontStyle.values) {
 		const entry = theme.fonts[name as keyof typeof theme.fonts]
-		if (name in theme.fonts && isFontEntry(entry)) {
+		if (isFontEntry(entry)) {
 			result.push({ value: name, icon: fontIcon(entry, name) })
 			seen.add(name)
 		}

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -20,8 +20,9 @@ export class Erasing extends StateNode {
 			this.editor
 				.getCurrentPageShapes()
 				.filter((shape) => {
+					//If the shape is locked, we shouldn't erase it
 					if (this.editor.isShapeOrAncestorLocked(shape)) return true
-					// Groups and frames the pointer started inside are containers, not targets
+					//If the shape is a group or frame-like, check we're inside it when we start erasing
 					if (this.editor.isShapeOfType(shape, 'group') || this.editor.isShapeFrameLike(shape)) {
 						const pointInShapeShape = this.editor.getPointInShapeSpace(shape, originPagePoint)
 						const geometry = this.editor.getShapeGeometry(shape)
@@ -85,13 +86,15 @@ export class Erasing extends StateNode {
 
 		this.pushPointToScribble()
 
+		// Otherwise, erasing shapes are all the shapes that were hit before plus any new shapes that are hit
 		const erasing = new Set<TLShapeId>(erasingShapeIds)
 		const minDist = editor.getHitTestMargin()
 
+		// Create bounds around line segment with margin
 		const lineBounds = Box.FromPoints([previousPagePoint, currentPagePoint]).expandBy(minDist)
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
-		// Skip the expensive getCurrentPageRenderingShapesSorted() when nothing is nearby
+		// Early return if no candidates - avoid expensive getCurrentPageRenderingShapesSorted()
 		if (candidateIds.size === 0) {
 			editor.setErasingShapes(Array.from(erasing))
 			return
@@ -109,6 +112,7 @@ export class Erasing extends StateNode {
 				continue
 			}
 
+			// Hit test the shape using a line segment
 			const geometry = editor.getShapeGeometry(shape)
 			const pageTransform = editor.getShapePageTransform(shape)
 			if (!geometry || !pageTransform) continue
@@ -116,7 +120,7 @@ export class Erasing extends StateNode {
 			const A = pt.applyToPoint(previousPagePoint)
 			const B = pt.applyToPoint(currentPagePoint)
 
-			// Cheap bounds rejection before the segment hit test
+			// If the line segment is entirely above / below / left / right of the shape's bounding box, skip the hit test
 			const { bounds } = geometry
 			if (
 				bounds.minX - minDist > Math.max(A.x, B.x) ||
@@ -127,7 +131,8 @@ export class Erasing extends StateNode {
 				continue
 			}
 
-			// Erase the outermost selectable shape, unless erasing started inside it (then erase its children)
+			// If a shape is hit and is part of a group, erase the group
+			// If we started erasing inside a group's bounds, erase child shapes (or nested groups) inside it
 			if (geometry.hitTestLineSegment(A, B, minDist)) {
 				const outermost = editor.getOutermostSelectableShape(shape)
 				if (excludedShapeIds.has(outermost.id)) {
@@ -141,6 +146,9 @@ export class Erasing extends StateNode {
 		}
 
 		this._erasingShapeIds = [...erasing]
+		// Remove the hit shapes, except if they're in the list of excluded shapes
+		// (these excluded shapes will be any frames or groups the pointer was inside of
+		// when the user started erasing)
 		editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
 	}
 

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -20,9 +20,8 @@ export class Erasing extends StateNode {
 			this.editor
 				.getCurrentPageShapes()
 				.filter((shape) => {
-					//If the shape is locked, we shouldn't erase it
 					if (this.editor.isShapeOrAncestorLocked(shape)) return true
-					//If the shape is a group or frame-like, check we're inside it when we start erasing
+					// Groups and frames the pointer started inside are containers, not targets
 					if (this.editor.isShapeOfType(shape, 'group') || this.editor.isShapeFrameLike(shape)) {
 						const pointInShapeShape = this.editor.getPointInShapeSpace(shape, originPagePoint)
 						const geometry = this.editor.getShapeGeometry(shape)
@@ -86,15 +85,13 @@ export class Erasing extends StateNode {
 
 		this.pushPointToScribble()
 
-		// Otherwise, erasing shapes are all the shapes that were hit before plus any new shapes that are hit
 		const erasing = new Set<TLShapeId>(erasingShapeIds)
-		const minDist = this.editor.getHitTestMargin()
+		const minDist = editor.getHitTestMargin()
 
-		// Create bounds around line segment with margin
 		const lineBounds = Box.FromPoints([previousPagePoint, currentPagePoint]).expandBy(minDist)
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
-		// Early return if no candidates - avoid expensive getCurrentPageRenderingShapesSorted()
+		// Skip the expensive getCurrentPageRenderingShapesSorted() when nothing is nearby
 		if (candidateIds.size === 0) {
 			editor.setErasingShapes(Array.from(erasing))
 			return
@@ -112,7 +109,6 @@ export class Erasing extends StateNode {
 				continue
 			}
 
-			// Hit test the shape using a line segment
 			const geometry = editor.getShapeGeometry(shape)
 			const pageTransform = editor.getShapePageTransform(shape)
 			if (!geometry || !pageTransform) continue
@@ -120,7 +116,7 @@ export class Erasing extends StateNode {
 			const A = pt.applyToPoint(previousPagePoint)
 			const B = pt.applyToPoint(currentPagePoint)
 
-			// If the line segment is entirely above / below / left / right of the shape's bounding box, skip the hit test
+			// Cheap bounds rejection before the segment hit test
 			const { bounds } = geometry
 			if (
 				bounds.minX - minDist > Math.max(A.x, B.x) ||
@@ -131,8 +127,7 @@ export class Erasing extends StateNode {
 				continue
 			}
 
-			// If a shape is hit and is part of a group, erase the group
-			// If we started erasing inside a group's bounds, erase child shapes (or nested groups) inside it
+			// Erase the outermost selectable shape, unless erasing started inside it (then erase its children)
 			if (geometry.hitTestLineSegment(A, B, minDist)) {
 				const outermost = editor.getOutermostSelectableShape(shape)
 				if (excludedShapeIds.has(outermost.id)) {
@@ -143,14 +138,10 @@ export class Erasing extends StateNode {
 					erasing.add(outermost.id)
 				}
 			}
-
-			this._erasingShapeIds = [...erasing]
 		}
 
-		// Remove the hit shapes, except if they're in the list of excluded shapes
-		// (these excluded shapes will be any frames or groups the pointer was inside of
-		// when the user started erasing)
-		this.editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
+		this._erasingShapeIds = [...erasing]
+		editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
 	}
 
 	complete(info?: TLPointerEventInfo) {

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -10,8 +10,6 @@ export class Pointing extends StateNode {
 
 		const erasing = new Set<TLShapeId>()
 
-		const initialSize = erasing.size
-
 		for (let n = currentPageShapesSorted.length, i = n - 1; i >= 0; i--) {
 			const shape = currentPageShapesSorted[i]
 			if (this.editor.isShapeOrAncestorLocked(shape) || this.editor.isShapeOfType(shape, 'group')) {
@@ -25,8 +23,7 @@ export class Pointing extends StateNode {
 				})
 			) {
 				const hitShape = this.editor.getOutermostSelectableShape(shape)
-				// If we've hit a frame-like shape after hitting any other shape, stop here
-				if (this.editor.isShapeFrameLike(hitShape) && erasing.size > initialSize) {
+				if (this.editor.isShapeFrameLike(hitShape) && erasing.size > 0) {
 					break
 				}
 

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -23,6 +23,7 @@ export class Pointing extends StateNode {
 				})
 			) {
 				const hitShape = this.editor.getOutermostSelectableShape(shape)
+				// If we've hit a frame-like shape after hitting any other shape, stop here
 				if (this.editor.isShapeFrameLike(hitShape) && erasing.size > 0) {
 					break
 				}

--- a/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
@@ -22,8 +22,9 @@ export class OneFingerZooming extends StateNode {
 
 		const currentScreenY = this.editor.inputs.getCurrentScreenPoint().y
 
-		// Dragging down zooms in, up zooms out (google maps default). The user's zoom
-		// direction preference is ignored because it only applies to mouse input.
+		// Dragging up = zoom out, dragging down = zoom in (same as google maps default)
+		// we won't respect the user's zoom direction preference because it only applies
+		// to mouse input
 		const dy = currentScreenY - this.originScreenY
 
 		// ~200px of drag ≈ 2x zoom change.

--- a/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLPointerEventInfo, Vec, clamp, last } from '@tldraw/editor'
+import { StateNode, Vec, clamp, last } from '@tldraw/editor'
 
 export class OneFingerZooming extends StateNode {
 	static override id = 'one_finger_zooming'
@@ -8,7 +8,7 @@ export class OneFingerZooming extends StateNode {
 	private initialZoom = 1
 	private originScreenY = 0
 
-	override onEnter(_info: TLPointerEventInfo) {
+	override onEnter() {
 		const camera = this.editor.getCamera()
 		this.initialCamera = Vec.From(camera)
 		this.initialZoom = camera.z
@@ -17,15 +17,14 @@ export class OneFingerZooming extends StateNode {
 		this.editor.setCursor({ type: 'grab', rotation: 0 })
 	}
 
-	override onPointerMove(_info: TLPointerEventInfo) {
+	override onPointerMove() {
 		this.editor.menus.clearOpenMenus()
 
 		const currentScreenY = this.editor.inputs.getCurrentScreenPoint().y
 
-		// Dragging up = zoom out, dragging down = zoom in (same as google maps default)
-		// we won't respect the user's zoom direction preference because it only applies
-		// to mouse input
-		const dy = (this.originScreenY - currentScreenY) * -1
+		// Dragging down zooms in, up zooms out (google maps default). The user's zoom
+		// direction preference is ignored because it only applies to mouse input.
+		const dy = currentScreenY - this.originScreenY
 
 		// ~200px of drag ≈ 2x zoom change.
 		const zoomFactor = Math.pow(2, dy / 200)
@@ -43,7 +42,7 @@ export class OneFingerZooming extends StateNode {
 		)
 	}
 
-	override onPointerUp(_info: TLPointerEventInfo) {
+	override onPointerUp() {
 		this.complete()
 	}
 

--- a/packages/tldraw/src/lib/tools/LaserTool/LaserTool.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/LaserTool.ts
@@ -35,12 +35,10 @@ export class LaserTool extends StateNode {
 	 * Get the current laser session ID, or create a new one if none exists or the current one is fading.
 	 */
 	getSessionId(): string {
-		// Reuse existing session if it's still active
 		if (this.sessionId && this.editor.scribbles.isSessionActive(this.sessionId)) {
 			return this.sessionId
 		}
 
-		// Create a new session
 		this.sessionId = this.editor.scribbles.startSession({
 			selfConsume: false,
 			idleTimeoutMs: this.editor.options.laserDelayMs,

--- a/packages/tldraw/src/lib/tools/LaserTool/LaserTool.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/LaserTool.ts
@@ -35,10 +35,12 @@ export class LaserTool extends StateNode {
 	 * Get the current laser session ID, or create a new one if none exists or the current one is fading.
 	 */
 	getSessionId(): string {
+		// Reuse existing session if it's still active
 		if (this.sessionId && this.editor.scribbles.isSessionActive(this.sessionId)) {
 			return this.sessionId
 		}
 
+		// Create a new session
 		this.sessionId = this.editor.scribbles.startSession({
 			selfConsume: false,
 			idleTimeoutMs: this.editor.options.laserDelayMs,

--- a/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
@@ -5,7 +5,6 @@ export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onPointerDown() {
-		// Get or create the shared laser session from the parent tool
 		const sessionId = (this.parent as LaserTool).getSessionId()
 		const scribble = this.editor.scribbles.addScribbleToSession(sessionId, {
 			color: 'laser',

--- a/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/childStates/Idle.ts
@@ -5,6 +5,7 @@ export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onPointerDown() {
+		// Get or create the shared laser session from the parent tool
 		const sessionId = (this.parent as LaserTool).getSessionId()
 		const scribble = this.editor.scribbles.addScribbleToSession(sessionId, {
 			color: 'laser',

--- a/packages/tldraw/src/lib/tools/LaserTool/childStates/Lasering.ts
+++ b/packages/tldraw/src/lib/tools/LaserTool/childStates/Lasering.ts
@@ -31,7 +31,7 @@ export class Lasering extends StateNode {
 	}
 
 	override onCancel() {
-		this.onComplete()
+		this.complete()
 	}
 
 	override onComplete() {

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -34,6 +34,7 @@ export class DragAndDropManager {
 	startDraggingShapes(movingShapes: TLShape[], point: Vec, cb: () => void) {
 		const { editor } = this
 
+		// Only start dragging if we're not already dragging
 		if (this.intervalTimerId !== -1) return
 
 		const shapesToActuallyMove = new Set(movingShapes)
@@ -145,6 +146,7 @@ export class DragAndDropManager {
 
 		if (!draggingShapes.length) return
 
+		// This is the shape under the pointer that can handle at least one of the dragging shapes
 		const nextDraggingOverShape = editor.getDraggingOverShape(point, this.shapesToActuallyMove)
 
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
@@ -159,6 +161,7 @@ export class DragAndDropManager {
 					isShapeId(nextDraggingOverShape.id) &&
 					!editor.inputs.getPreviousPagePoint().equals(currentPagePoint)
 				) {
+					// If the cursor moved, call onDragShapesOver for the previous dragging over shape
 					const util = editor.getShapeUtil(nextDraggingOverShape)
 					util.onDragShapesOver?.(nextDraggingOverShape, draggingShapes, {
 						initialDraggingOverShapeId: this.initialDraggingOverShape?.id ?? null,
@@ -211,6 +214,7 @@ export class DragAndDropManager {
 				editor.setHintingShapes([])
 			}
 
+			// This is the reparenting logic
 			cb?.()
 		})
 

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -21,9 +21,7 @@ export class DragAndDropManager {
 	}
 
 	shapesToActuallyMove: TLShape[] = []
-	draggedOverShapeIds = new Set<TLShapeId>()
 
-	initialGroupIds = new Map<TLShapeId, TLShapeId>()
 	initialParentIds = new Map<TLShapeId, TLParentId>()
 	initialIndices = new Map<TLShapeId, IndexKey>()
 
@@ -36,7 +34,6 @@ export class DragAndDropManager {
 	startDraggingShapes(movingShapes: TLShape[], point: Vec, cb: () => void) {
 		const { editor } = this
 
-		// Only start dragging if we're not already dragging
 		if (this.intervalTimerId !== -1) return
 
 		const shapesToActuallyMove = new Set(movingShapes)
@@ -45,9 +42,7 @@ export class DragAndDropManager {
 		for (const shape of shapesToActuallyMove) {
 			const parent = editor.getShapeParent(shape)
 			if (parent && editor.isShapeOfType(parent, 'group')) {
-				if (!movingGroups.has(parent)) {
-					movingGroups.add(parent)
-				}
+				movingGroups.add(parent)
 			}
 		}
 
@@ -69,11 +64,6 @@ export class DragAndDropManager {
 				this.initialParentIds.set(shape.id, parent.id)
 			}
 			this.initialIndices.set(shape.id, shape.index)
-
-			const group = editor.findShapeAncestor(shape, (s) => editor.isShapeOfType(s, 'group'))
-			if (group) {
-				this.initialGroupIds.set(shape.id, group.id)
-			}
 		}
 
 		const allShapes = editor.getCurrentPageShapesSorted()
@@ -155,7 +145,6 @@ export class DragAndDropManager {
 
 		if (!draggingShapes.length) return
 
-		// This is the shape under the pointer that can handle at least one of the dragging shapes
 		const nextDraggingOverShape = editor.getDraggingOverShape(point, this.shapesToActuallyMove)
 
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
@@ -170,7 +159,6 @@ export class DragAndDropManager {
 					isShapeId(nextDraggingOverShape.id) &&
 					!editor.inputs.getPreviousPagePoint().equals(currentPagePoint)
 				) {
-					// If the cursor moved, call onDragShapesOver for the previous dragging over shape
 					const util = editor.getShapeUtil(nextDraggingOverShape)
 					util.onDragShapesOver?.(nextDraggingOverShape, draggingShapes, {
 						initialDraggingOverShapeId: this.initialDraggingOverShape?.id ?? null,
@@ -223,7 +211,6 @@ export class DragAndDropManager {
 				editor.setHintingShapes([])
 			}
 
-			// This is the reparenting logic
 			cb?.()
 		})
 

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -48,6 +48,7 @@ export class SelectTool extends StateNode {
 		]
 	}
 
+	// We want to clean up the duplicate props when the selection changes
 	cleanUpDuplicateProps() {
 		const selectedShapeIds = this.editor.getSelectedShapeIds()
 		const instance = this.editor.getInstanceState()

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -48,7 +48,6 @@ export class SelectTool extends StateNode {
 		]
 	}
 
-	// We want to clean up the duplicate props when the selection changes
 	cleanUpDuplicateProps() {
 		const selectedShapeIds = this.editor.getSelectedShapeIds()
 		const instance = this.editor.getInstanceState()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -25,7 +25,7 @@ export class Brushing extends StateNode {
 	isWrapMode = false
 
 	viewportDidChange = false
-	cleanupViewportChangeReactor?: () => void
+	cleanupViewportChangeReactor?: () => void // cleanup function for the viewport reactor
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
 		const { editor } = this
@@ -121,21 +121,32 @@ export class Brushing extends StateNode {
 		const shiftKey = editor.inputs.getShiftKey()
 		const ctrlKey = editor.inputs.getCtrlKey()
 
+		// We'll be collecting shape ids of selected shapes; if we're holding shift key, we start from our initial shapes
 		const results = new Set(shiftKey ? this.initialSelectedShapeIds : [])
 
 		// In wrap mode, we need to completely enclose a shape to select it
 		const isWrapping = isWrapMode ? !ctrlKey : ctrlKey
 
+		// Set the brush to contain the current and origin points
 		const brush = Box.FromPoints([originPagePoint, currentPagePoint])
+
+		// We'll be testing the corners of the brush against the shapes
 		const { corners } = brush
 
-		// We could cache all of the shape positions at the start of the interaction and do very
-		// fast checks against them, but then changes introduced by other collaborators wouldn't
-		// be reflected: a user could select a shape by selecting where it _used_ to be.
-		//
-		// We still avoid hit tests as much as possible by testing only on-screen shapes UNLESS
-		// the user has scrolled their viewport or is dragging outside of the screen (e.g. in a
-		// window). On a page with ~5000 shapes, on-screen hit tests are about 2x faster.
+		// Some notes on optimization. We could easily cache all of the shape positions at
+		// the start of the interaction and then do very fast checks against them, but that
+		// would mean changes introduced by other collaborators wouldn't be reflected—a user
+		// could select a shape by selecting where it _used_ to be.
+
+		// We still want to avoid hit tests as much as possible, however, so we test only the
+		// shapes that are on screen UNLESS: the user has scrolled their viewpor; or the user
+		// is dragging outside of the screen (e.g. in a window). In those cases, we need to
+		// test all shapes.
+
+		// On a page with ~5000 shapes, on-screen hit tests are about 2x faster than
+		// testing all shapes.
+
+		// Use spatial index to filter candidates
 		const candidateIds = editor.getShapeIdsInsideBounds(brush)
 
 		if (candidateIds.size > 0) {
@@ -160,16 +171,19 @@ export class Brushing extends StateNode {
 					continue
 				}
 
-				// In wrap mode a partial overlap is a miss. Frame-like shapes are only selected
-				// when fully enclosed.
+				// If we're in wrap mode and the brush did not fully encloses the shape, it's a miss
+				// We also skip frame-like shapes unless we've completely selected them.
 				if (isWrapping || editor.isShapeFrameLike(shape)) continue
 
+				// If the brush collides the page bounds, then do hit tests against
+				// each of the brush's four sides.
 				if (brush.collides(pageBounds)) {
 					// Shapes expect to hit test line segments in their own coordinate system,
 					// so we first need to get the brush corners in the shape's local space.
 					const pageTransform = editor.getShapePageTransform(shape)
 					if (!pageTransform) continue
 					const localCorners = pageTransform.clone().invert().applyToPoints(corners)
+					// See if any of the edges intersect the shape's geometry
 					const geometry = editor.getShapeGeometry(shape)
 					for (let i = 0; i < 4; i++) {
 						if (geometry.hitTestLineSegment(localCorners[i], localCorners[(i + 1) % 4], 0)) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -1,6 +1,5 @@
 import {
 	Box,
-	Mat,
 	StateNode,
 	TLCancelEventInfo,
 	TLKeyboardEventInfo,
@@ -26,9 +25,7 @@ export class Brushing extends StateNode {
 	isWrapMode = false
 
 	viewportDidChange = false
-	cleanupViewportChangeReactor() {
-		void null
-	} // cleanup function for the viewport reactor
+	cleanupViewportChangeReactor?: () => void
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
 		const { editor } = this
@@ -74,7 +71,7 @@ export class Brushing extends StateNode {
 		this.initialSelectedShapeIds = []
 		this.editor.updateInstanceState({ brush: null })
 
-		this.cleanupViewportChangeReactor()
+		this.cleanupViewportChangeReactor?.()
 	}
 
 	override onTick({ elapsed }: TLTickEventInfo) {
@@ -124,100 +121,61 @@ export class Brushing extends StateNode {
 		const shiftKey = editor.inputs.getShiftKey()
 		const ctrlKey = editor.inputs.getCtrlKey()
 
-		// We'll be collecting shape ids of selected shapes; if we're holding shift key, we start from our initial shapes
 		const results = new Set(shiftKey ? this.initialSelectedShapeIds : [])
 
 		// In wrap mode, we need to completely enclose a shape to select it
 		const isWrapping = isWrapMode ? !ctrlKey : ctrlKey
 
-		// Set the brush to contain the current and origin points
 		const brush = Box.FromPoints([originPagePoint, currentPagePoint])
-
-		// We'll be testing the corners of the brush against the shapes
 		const { corners } = brush
 
-		let A: Vec,
-			B: Vec,
-			shape: TLShape,
-			pageBounds: Box | undefined,
-			pageTransform: Mat | undefined,
-			localCorners: Vec[]
-
-		// Some notes on optimization. We could easily cache all of the shape positions at
-		// the start of the interaction and then do very fast checks against them, but that
-		// would mean changes introduced by other collaborators wouldn't be reflected—a user
-		// could select a shape by selecting where it _used_ to be.
-
-		// We still want to avoid hit tests as much as possible, however, so we test only the
-		// shapes that are on screen UNLESS: the user has scrolled their viewpor; or the user
-		// is dragging outside of the screen (e.g. in a window). In those cases, we need to
-		// test all shapes.
-
-		// On a page with ~5000 shapes, on-screen hit tests are about 2x faster than
-		// testing all shapes.
-
-		const brushBoxIsInsideViewport = editor.getViewportPageBounds().contains(brush)
-		const currentPageId = editor.getCurrentPageId()
-
-		// Use spatial index to filter candidates
+		// We could cache all of the shape positions at the start of the interaction and do very
+		// fast checks against them, but then changes introduced by other collaborators wouldn't
+		// be reflected: a user could select a shape by selecting where it _used_ to be.
+		//
+		// We still avoid hit tests as much as possible by testing only on-screen shapes UNLESS
+		// the user has scrolled their viewport or is dragging outside of the screen (e.g. in a
+		// window). On a page with ~5000 shapes, on-screen hit tests are about 2x faster.
 		const candidateIds = editor.getShapeIdsInsideBounds(brush)
 
-		// Early return if no candidates - avoid expensive getCurrentPageShapesSorted()
-		// But still update brush visual and selection
-		if (candidateIds.size === 0) {
-			const currentBrush = editor.getInstanceState().brush
-			if (!currentBrush || !brush.equals(currentBrush)) {
-				editor.updateInstanceState({ brush: { ...brush.toJson() } })
-			}
+		if (candidateIds.size > 0) {
+			const brushBoxIsInsideViewport = editor.getViewportPageBounds().contains(brush)
+			const currentPageId = editor.getCurrentPageId()
 
-			const current = editor.getSelectedShapeIds()
-			if (current.length !== results.size || current.some((id) => !results.has(id))) {
-				editor.setSelectedShapes(Array.from(results))
-			}
-			return
-		}
+			const allShapes =
+				brushBoxIsInsideViewport && !this.viewportDidChange
+					? editor.getCurrentPageRenderingShapesSorted()
+					: editor.getCurrentPageShapesSorted()
 
-		const allShapes =
-			brushBoxIsInsideViewport && !this.viewportDidChange
-				? editor.getCurrentPageRenderingShapesSorted()
-				: editor.getCurrentPageShapesSorted()
-		const shapesToHitTest = allShapes.filter((shape) => candidateIds.has(shape.id))
+			for (const shape of allShapes) {
+				if (!candidateIds.has(shape.id)) continue
+				if (excludedShapeIds.has(shape.id) || results.has(shape.id)) continue
 
-		testAllShapes: for (let i = 0, n = shapesToHitTest.length; i < n; i++) {
-			shape = shapesToHitTest[i]
-			if (excludedShapeIds.has(shape.id) || results.has(shape.id)) continue testAllShapes
+				const pageBounds = editor.getShapePageBounds(shape)
+				if (!pageBounds) continue
 
-			pageBounds = editor.getShapePageBounds(shape)
-			if (!pageBounds) continue testAllShapes
+				// If the brush fully wraps a shape, it's almost certainly a hit
+				if (brush.contains(pageBounds)) {
+					this.handleHit(shape, currentPagePoint, currentPageId, results, corners)
+					continue
+				}
 
-			// If the brush fully wraps a shape, it's almost certainly a hit
-			if (brush.contains(pageBounds)) {
-				this.handleHit(shape, currentPagePoint, currentPageId, results, corners)
-				continue testAllShapes
-			}
+				// In wrap mode a partial overlap is a miss. Frame-like shapes are only selected
+				// when fully enclosed.
+				if (isWrapping || editor.isShapeFrameLike(shape)) continue
 
-			// If we're in wrap mode and the brush did not fully encloses the shape, it's a miss
-			// We also skip frame-like shapes unless we've completely selected them.
-			if (isWrapping || editor.isShapeFrameLike(shape)) {
-				continue testAllShapes
-			}
-
-			// If the brush collides the page bounds, then do hit tests against
-			// each of the brush's four sides.
-			if (brush.collides(pageBounds)) {
-				// Shapes expect to hit test line segments in their own coordinate system,
-				// so we first need to get the brush corners in the shape's local space.
-				pageTransform = editor.getShapePageTransform(shape)
-				if (!pageTransform) continue testAllShapes
-				localCorners = pageTransform.clone().invert().applyToPoints(corners)
-				// See if any of the edges intersect the shape's geometry
-				const geometry = editor.getShapeGeometry(shape)
-				hitTestBrushEdges: for (let i = 0; i < 4; i++) {
-					A = localCorners[i]
-					B = localCorners[(i + 1) % 4]
-					if (geometry.hitTestLineSegment(A, B, 0)) {
-						this.handleHit(shape, currentPagePoint, currentPageId, results, corners)
-						break hitTestBrushEdges
+				if (brush.collides(pageBounds)) {
+					// Shapes expect to hit test line segments in their own coordinate system,
+					// so we first need to get the brush corners in the shape's local space.
+					const pageTransform = editor.getShapePageTransform(shape)
+					if (!pageTransform) continue
+					const localCorners = pageTransform.clone().invert().applyToPoints(corners)
+					const geometry = editor.getShapeGeometry(shape)
+					for (let i = 0; i < 4; i++) {
+						if (geometry.hitTestLineSegment(localCorners[i], localCorners[(i + 1) % 4], 0)) {
+							this.handleHit(shape, currentPagePoint, currentPageId, results, corners)
+							break
+						}
 					}
 				}
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -11,6 +11,7 @@ import {
 	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getCropBox, getDefaultCrop, getUncroppedSize } from '../../../../../shapes/shared/crop'
+import { returnToInteractionEnd } from '../../../selectHelpers'
 import { CursorTypeMap } from '../../PointingResizeHandle'
 
 type Snapshot = ReturnType<Cropping['createSnapshot']>
@@ -203,17 +204,9 @@ export class Cropping extends StateNode {
 	}
 
 	private exitToPreviousTool() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-		} else {
-			this.editor.setCroppingShape(null)
-			this.editor.setCurrentTool('select.idle')
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, this.info)) return
+		this.editor.setCroppingShape(null)
+		this.editor.setCurrentTool('select.idle')
 	}
 
 	private createSnapshot() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -15,27 +15,23 @@ import { CursorTypeMap } from '../../PointingResizeHandle'
 
 type Snapshot = ReturnType<Cropping['createSnapshot']>
 
+type CroppingInfo = TLPointerEventInfo & {
+	target: 'selection'
+	handle: SelectionHandle
+	onInteractionEnd?: string | (() => void)
+}
+
 export class Cropping extends StateNode {
 	static override id = 'cropping'
 	static override trackPerformance = true
 
-	info = {} as TLPointerEventInfo & {
-		target: 'selection'
-		handle: SelectionHandle
-		onInteractionEnd?: string | (() => void)
-	}
+	info = {} as CroppingInfo
 
 	markId = ''
 
 	private snapshot = {} as any as Snapshot
 
-	override onEnter(
-		info: TLPointerEventInfo & {
-			target: 'selection'
-			handle: SelectionHandle
-			onInteractionEnd?: string | (() => void)
-		}
-	) {
+	override onEnter(info: CroppingInfo) {
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -198,21 +194,15 @@ export class Cropping extends StateNode {
 	private complete() {
 		this.updateShapes()
 		kickoutOccludedShapes(this.editor, [this.snapshot.shape.id])
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-		} else {
-			this.editor.setCroppingShape(null)
-			this.editor.setCurrentTool('select.idle')
-		}
+		this.exitToPreviousTool()
 	}
 
 	private cancel() {
 		this.editor.bailToMark(this.markId)
+		this.exitToPreviousTool()
+	}
+
+	private exitToPreviousTool() {
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -1,5 +1,4 @@
 import {
-	Editor,
 	ShapeWithCrop,
 	StateNode,
 	TLClickEventInfo,
@@ -9,6 +8,7 @@ import {
 } from '@tldraw/editor'
 import { getHitShapeOnCanvasPointerDown } from '../../../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { updateHoveredOverlayId } from '../../../../selection-logic/updateHoveredOverlayId'
+import { getHitSelectionHandleOverlay } from '../../../selectHelpers'
 import { getTranslateCroppedImageChange } from './crop_helpers'
 
 export class Idle extends StateNode {
@@ -54,7 +54,7 @@ export class Idle extends StateNode {
 					this.onPointerDown({
 						...info,
 						target: 'selection',
-						handle: hitOverlay.props.handle as any,
+						handle: hitOverlay.props.handle,
 					})
 					return
 				}
@@ -148,7 +148,7 @@ export class Idle extends StateNode {
 				this.onDoubleClick({
 					...info,
 					target: 'selection',
-					handle: hitOverlay.props.handle as any,
+					handle: hitOverlay.props.handle,
 				})
 				return
 			}
@@ -224,21 +224,4 @@ export class Idle extends StateNode {
 			this.editor.updateShapes([partial])
 		}
 	}
-}
-
-function getHitSelectionHandleOverlay(editor: Editor) {
-	const hitOverlay = editor.overlays.getOverlayAtPoint(
-		editor.inputs.getCurrentPagePoint(),
-		editor.getHitTestMargin()
-	)
-	if (!hitOverlay) return undefined
-	const overlayType = hitOverlay.props.overlayType as string | undefined
-	if (
-		overlayType === 'resize_handle' ||
-		overlayType === 'rotate_handle' ||
-		overlayType === 'mobile_rotate'
-	) {
-		return hitOverlay
-	}
-	return undefined
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -1,4 +1,5 @@
 import {
+	Editor,
 	ShapeWithCrop,
 	StateNode,
 	TLClickEventInfo,
@@ -34,8 +35,7 @@ export class Idle extends StateNode {
 	}
 
 	override onCancel() {
-		this.editor.setCroppingShape(null)
-		this.editor.setCurrentTool('select.idle', {})
+		this.cancel()
 	}
 
 	override onPointerDown(info: TLPointerEventInfo) {
@@ -49,25 +49,14 @@ export class Idle extends StateNode {
 		switch (info.target) {
 			case 'canvas': {
 				// Check overlays first — if we hit a crop/resize handle, re-dispatch
-				const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
-				const hitOverlay = this.editor.overlays.getOverlayAtPoint(
-					currentPagePoint,
-					this.editor.getHitTestMargin()
-				)
+				const hitOverlay = getHitSelectionHandleOverlay(this.editor)
 				if (hitOverlay) {
-					const overlayType = hitOverlay.props.overlayType as string | undefined
-					if (
-						overlayType === 'resize_handle' ||
-						overlayType === 'rotate_handle' ||
-						overlayType === 'mobile_rotate'
-					) {
-						this.onPointerDown({
-							...info,
-							target: 'selection',
-							handle: hitOverlay.props.handle as any,
-						})
-						return
-					}
+					this.onPointerDown({
+						...info,
+						target: 'selection',
+						handle: hitOverlay.props.handle as any,
+					})
+					return
 				}
 
 				const hitShape = getHitShapeOnCanvasPointerDown(this.editor)
@@ -154,25 +143,14 @@ export class Idle extends StateNode {
 		// Check overlays first — if we hit a resize/rotate handle, re-dispatch
 		// as a selection event so onDoubleClickEdge fires.
 		if (info.target === 'canvas') {
-			const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
-			const hitOverlay = this.editor.overlays.getOverlayAtPoint(
-				currentPagePoint,
-				this.editor.getHitTestMargin()
-			)
+			const hitOverlay = getHitSelectionHandleOverlay(this.editor)
 			if (hitOverlay) {
-				const overlayType = hitOverlay.props.overlayType as string | undefined
-				if (
-					overlayType === 'resize_handle' ||
-					overlayType === 'rotate_handle' ||
-					overlayType === 'mobile_rotate'
-				) {
-					this.onDoubleClick({
-						...info,
-						target: 'selection',
-						handle: hitOverlay.props.handle as any,
-					})
-					return
-				}
+				this.onDoubleClick({
+					...info,
+					target: 'selection',
+					handle: hitOverlay.props.handle as any,
+				})
+				return
 			}
 		}
 
@@ -198,8 +176,7 @@ export class Idle extends StateNode {
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		switch (info.key) {
 			case 'Enter': {
-				this.editor.setCroppingShape(null)
-				this.editor.setCurrentTool('select.idle', {})
+				this.cancel()
 				break
 			}
 		}
@@ -229,7 +206,7 @@ export class Idle extends StateNode {
 		if (keys.has('ArrowUp')) delta.y += 1
 		if (keys.has('ArrowDown')) delta.y -= 1
 
-		if (delta.equals(new Vec(0, 0))) return
+		if (delta.x === 0 && delta.y === 0) return
 
 		if (shiftKey) delta.mul(10)
 
@@ -247,4 +224,21 @@ export class Idle extends StateNode {
 			this.editor.updateShapes([partial])
 		}
 	}
+}
+
+function getHitSelectionHandleOverlay(editor: Editor) {
+	const hitOverlay = editor.overlays.getOverlayAtPoint(
+		editor.inputs.getCurrentPagePoint(),
+		editor.getHitTestMargin()
+	)
+	if (!hitOverlay) return undefined
+	const overlayType = hitOverlay.props.overlayType as string | undefined
+	if (
+		overlayType === 'resize_handle' ||
+		overlayType === 'rotate_handle' ||
+		overlayType === 'mobile_rotate'
+	) {
+		return hitOverlay
+	}
+	return undefined
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
@@ -1,4 +1,5 @@
 import { StateNode, TLClickEventInfo, TLPointerEventInfo } from '@tldraw/editor'
+import { returnToInteractionEnd } from '../../../selectHelpers'
 import { CursorTypeMap } from '../../PointingResizeHandle'
 
 type TLPointingCropHandleInfo = TLPointerEventInfo & {
@@ -75,15 +76,7 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	private exitToPreviousTool() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, this.info)) return
 		this.editor.setCroppingShape(null)
 		this.editor.setCurrentTool('select.idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
@@ -3,7 +3,6 @@ import { CursorTypeMap } from '../../PointingResizeHandle'
 
 type TLPointingCropHandleInfo = TLPointerEventInfo & {
 	target: 'selection'
-} & {
 	onInteractionEnd?: string | (() => void)
 }
 
@@ -42,24 +41,11 @@ export class PointingCropHandle extends StateNode {
 
 	private startCropping() {
 		if (this.editor.getIsReadonly()) return
-		this.parent.transition('cropping', {
-			...this.info,
-			onInteractionEnd: this.info.onInteractionEnd,
-		})
+		this.parent.transition('cropping', this.info)
 	}
 
 	override onPointerUp() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
-		this.editor.setCroppingShape(null)
-		this.editor.setCurrentTool('select.idle')
+		this.exitToPreviousTool()
 	}
 
 	override onDoubleClick(info: TLClickEventInfo) {
@@ -77,18 +63,18 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	override onCancel() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onComplete() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onInterrupt() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
-	private cancel() {
+	private exitToPreviousTool() {
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
@@ -3,26 +3,22 @@ import { getTranslateCroppedImageChange } from './crop_helpers'
 
 type Snapshot = ReturnType<TranslatingCrop['createSnapshot']>
 
+type TranslatingCropInfo = TLPointerEventInfo & {
+	target: 'shape'
+	isCreating?: boolean
+	onInteractionEnd?: string
+}
+
 export class TranslatingCrop extends StateNode {
 	static override id = 'translating_crop'
 
-	info = {} as TLPointerEventInfo & {
-		target: 'shape'
-		isCreating?: boolean
-		onInteractionEnd?: string
-	}
+	info = {} as TranslatingCropInfo
 
 	markId = ''
 
 	private snapshot = {} as any as Snapshot
 
-	override onEnter(
-		info: TLPointerEventInfo & {
-			target: 'shape'
-			isCreating?: boolean
-			onInteractionEnd?: string
-		}
-	) {
+	override onEnter(info: TranslatingCropInfo) {
 		this.info = info
 		this.snapshot = this.createSnapshot()
 
@@ -90,7 +86,7 @@ export class TranslatingCrop extends StateNode {
 	}
 
 	protected updateShapes() {
-		const shape = this.snapshot.shape as ShapeWithCrop
+		const { shape } = this.snapshot
 
 		if (!shape) return
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -94,6 +94,7 @@ export class DraggingHandle extends StateNode {
 			handles.slice().reverse().find(isAdjacentCandidate) ??
 			null
 
+		// <!-- Only relevant to arrows
 		if (this.editor.isShapeOfType(shape, 'arrow')) {
 			const initialBinding = getArrowBindings(this.editor, shape)[info.handle.id as 'start' | 'end']
 
@@ -108,7 +109,9 @@ export class DraggingHandle extends StateNode {
 				}
 			}
 		}
+		// -->
 
+		// Call onHandleDragStart callback
 		const handleDragInfo = {
 			handle: this.initialHandle,
 			isPrecise: this.isPrecise,
@@ -129,6 +132,7 @@ export class DraggingHandle extends StateNode {
 	// Only relevant to arrows
 	private exactTimeout = -1
 
+	// Only relevant to arrows
 	private resetExactTimeout() {
 		const arrowUtil = this.editor.getShapeUtil<ArrowShapeUtil>('arrow')
 		const timeoutValue = arrowUtil.options.pointingPreciseTimeout
@@ -145,6 +149,7 @@ export class DraggingHandle extends StateNode {
 		}, timeoutValue)
 	}
 
+	// Only relevant to arrows
 	private clearExactTimeout() {
 		if (this.exactTimeout !== -1) {
 			clearTimeout(this.exactTimeout)
@@ -189,6 +194,7 @@ export class DraggingHandle extends StateNode {
 		this.editor.snaps.clearIndicators()
 		kickoutOccludedShapes(this.editor, [this.shapeId])
 
+		// Call onHandleDragEnd callback before state transitions
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -204,6 +210,7 @@ export class DraggingHandle extends StateNode {
 			}
 		}
 
+		// Return to the tool that was active before this one but only if tool lock is turned on!
 		if (
 			returnToInteractionEnd(
 				this.editor,
@@ -218,6 +225,7 @@ export class DraggingHandle extends StateNode {
 	}
 
 	private cancel() {
+		// Call onHandleDragCancel callback before bailing to mark
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -233,6 +241,7 @@ export class DraggingHandle extends StateNode {
 		this.editor.bailToMark(this.markId)
 		this.editor.snaps.clearIndicators()
 
+		// Return to the tool that was active before this one, whether tool lock is turned on or not!
 		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, { shapeId: this.shapeId }))
 			return
 
@@ -273,6 +282,7 @@ export class DraggingHandle extends StateNode {
 			point = Vec.RotWith(point, initialAdjacentHandle, angleDifference)
 		}
 
+		// Clear any existing snaps
 		editor.snaps.clearIndicators()
 
 		let nextHandle = { ...initialHandle, x: point.x, y: point.y }
@@ -289,6 +299,7 @@ export class DraggingHandle extends StateNode {
 		}
 
 		if (canSnap && (isSnapMode ? !ctrlKey : ctrlKey)) {
+			// We're snapping
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -17,6 +17,7 @@ import {
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
 import { clearArrowTargetState } from '../../../shapes/arrow/arrowTargetState'
 import { getArrowBindings } from '../../../shapes/arrow/shared'
+import { returnToInteractionEnd } from '../selectHelpers'
 
 export type DraggingHandleInfo = TLPointerEventInfo & {
 	shape: TLArrowShape | TLLineShape
@@ -203,19 +204,15 @@ export class DraggingHandle extends StateNode {
 			}
 		}
 
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				if (this.editor.getInstanceState().isToolLocked) {
-					// Return to the tool that was active before this one but only if tool lock is turned on!
-					this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
-					return
-				}
-			} else {
-				onInteractionEnd()
-				return
-			}
-		}
+		if (
+			returnToInteractionEnd(
+				this.editor,
+				this.info.onInteractionEnd,
+				{ shapeId: this.shapeId },
+				{ onlyIfToolLocked: true }
+			)
+		)
+			return
 
 		this.parent.transition('idle')
 	}
@@ -236,16 +233,8 @@ export class DraggingHandle extends StateNode {
 		this.editor.bailToMark(this.markId)
 		this.editor.snaps.clearIndicators()
 
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				// Return to the tool that was active before this one, whether tool lock is turned on or not!
-				this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
-			} else {
-				onInteractionEnd()
-			}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, { shapeId: this.shapeId }))
 			return
-		}
 
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -81,41 +81,18 @@ export class DraggingHandle extends StateNode {
 		const handles = this.editor.getShapeHandles(shape)!.sort(sortByIndex)
 		const index = handles.findIndex((h) => h.id === info.handle.id)
 
-		// Find the adjacent handle
-		this.initialAdjacentHandle = null
+		// The adjacent handle is the custom reference handle if one is specified; otherwise the
+		// next vertex after this one, wrapping around to the last vertex before it.
+		const isAdjacentCandidate = (h: TLHandle) =>
+			h.type === 'vertex' && h.id !== 'middle' && h.id !== info.handle.id
+		this.initialAdjacentHandle =
+			(info.handle.snapReferenceHandleId
+				? handles.find((h) => h.id === info.handle.snapReferenceHandleId)
+				: undefined) ??
+			handles.slice(index + 1).find(isAdjacentCandidate) ??
+			handles.slice().reverse().find(isAdjacentCandidate) ??
+			null
 
-		// First, check if the handle specifies a custom reference handle
-		if (info.handle.snapReferenceHandleId) {
-			const customHandle = handles.find((h) => h.id === info.handle.snapReferenceHandleId)
-			if (customHandle) {
-				this.initialAdjacentHandle = customHandle
-			}
-		}
-
-		// If no custom reference handle, use default behavior
-		if (!this.initialAdjacentHandle) {
-			// Start from the handle and work forward
-			for (let i = index + 1; i < handles.length; i++) {
-				const handle = handles[i]
-				if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
-					this.initialAdjacentHandle = handle
-					break
-				}
-			}
-
-			// If still no handle, start from the end and work backward
-			if (!this.initialAdjacentHandle) {
-				for (let i = handles.length - 1; i >= 0; i--) {
-					const handle = handles[i]
-					if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
-						this.initialAdjacentHandle = handle
-						break
-					}
-				}
-			}
-		}
-
-		// <!-- Only relevant to arrows
 		if (this.editor.isShapeOfType(shape, 'arrow')) {
 			const initialBinding = getArrowBindings(this.editor, shape)[info.handle.id as 'start' | 'end']
 
@@ -130,9 +107,7 @@ export class DraggingHandle extends StateNode {
 				}
 			}
 		}
-		// -->
 
-		// Call onHandleDragStart callback
 		const handleDragInfo = {
 			handle: this.initialHandle,
 			isPrecise: this.isPrecise,
@@ -153,14 +128,11 @@ export class DraggingHandle extends StateNode {
 	// Only relevant to arrows
 	private exactTimeout = -1
 
-	// Only relevant to arrows
 	private resetExactTimeout() {
 		const arrowUtil = this.editor.getShapeUtil<ArrowShapeUtil>('arrow')
 		const timeoutValue = arrowUtil.options.pointingPreciseTimeout
 
-		if (this.exactTimeout !== -1) {
-			this.clearExactTimeout()
-		}
+		this.clearExactTimeout()
 
 		this.exactTimeout = this.editor.timers.setTimeout(() => {
 			if (this.getIsActive() && !this.isPrecise) {
@@ -172,7 +144,6 @@ export class DraggingHandle extends StateNode {
 		}, timeoutValue)
 	}
 
-	// Only relevant to arrows
 	private clearExactTimeout() {
 		if (this.exactTimeout !== -1) {
 			clearTimeout(this.exactTimeout)
@@ -217,7 +188,6 @@ export class DraggingHandle extends StateNode {
 		this.editor.snaps.clearIndicators()
 		kickoutOccludedShapes(this.editor, [this.shapeId])
 
-		// Call onHandleDragEnd callback before state transitions
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -236,13 +206,13 @@ export class DraggingHandle extends StateNode {
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {
-				if (this.editor.getInstanceState().isToolLocked && onInteractionEnd) {
+				if (this.editor.getInstanceState().isToolLocked) {
 					// Return to the tool that was active before this one but only if tool lock is turned on!
 					this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
 					return
 				}
 			} else {
-				onInteractionEnd?.()
+				onInteractionEnd()
 				return
 			}
 		}
@@ -251,7 +221,6 @@ export class DraggingHandle extends StateNode {
 	}
 
 	private cancel() {
-		// Call onHandleDragCancel callback before bailing to mark
 		const shape = this.editor.getShape(this.shapeId)
 		if (shape) {
 			const util = this.editor.getShapeUtil(shape)
@@ -273,7 +242,7 @@ export class DraggingHandle extends StateNode {
 				// Return to the tool that was active before this one, whether tool lock is turned on or not!
 				this.editor.setCurrentTool(onInteractionEnd, { shapeId: this.shapeId })
 			} else {
-				onInteractionEnd?.()
+				onInteractionEnd()
 			}
 			return
 		}
@@ -315,7 +284,6 @@ export class DraggingHandle extends StateNode {
 			point = Vec.RotWith(point, initialAdjacentHandle, angleDifference)
 		}
 
-		// Clear any existing snaps
 		editor.snaps.clearIndicators()
 
 		let nextHandle = { ...initialHandle, x: point.x, y: point.y }
@@ -332,7 +300,6 @@ export class DraggingHandle extends StateNode {
 		}
 
 		if (canSnap && (isSnapMode ? !ctrlKey : ctrlKey)) {
-			// We're snapping
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -62,8 +62,7 @@ export class EditingShape extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		// In the case where on pointer down we hit a shape's label, we need to check if the user is dragging.
-		// and if they are, we need to transition to translating instead.
+		// A pointer down on another shape's label starts translating it if the user drags
 		if (this.hitLabelOnShapeForPointerUp && this.editor.inputs.getIsDragging()) {
 			if (this.editor.getIsReadonly()) return
 			if (this.hitLabelOnShapeForPointerUp.isLocked) return
@@ -74,7 +73,6 @@ export class EditingShape extends StateNode {
 			return
 		}
 
-		// Check if dragging from editing shape with blurred input
 		if (this.didPointerDownOnEditingShape && this.editor.inputs.isDragging) {
 			if (this.editor.getIsReadonly()) return
 
@@ -148,9 +146,7 @@ export class EditingShape extends StateNode {
 						textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 						textLabel.hitTestPoint(pointInShapeSpace)
 					) {
-						// it's a hit to the label!
 						if (selectingShape.id === editingShape.id) {
-							// Track click on editing shape for drag detection
 							this.didPointerDownOnEditingShape = true
 							return
 						} else {
@@ -180,9 +176,8 @@ export class EditingShape extends StateNode {
 			}
 		}
 
-		// still here? Cancel editing and transition back to select idle
+		// Cancel editing and replay the pointer down in select idle
 		this.parent.transition('idle', info)
-		// then feed the pointer down event back into the state chart as if it happened in that state
 		this.editor.root.handleEvent(info)
 	}
 
@@ -220,10 +215,10 @@ export class EditingShape extends StateNode {
 		this.editor.setEditingShape(hitShape.id)
 
 		const isMobile = tlenv.isIos || tlenv.isAndroid
-		if (!isMobile || !isEditToEditAction) {
-			this.editor.emit('place-caret', { shapeId: hitShape.id, point: info.point })
-		} else if (isMobile && isEditToEditAction) {
+		if (isMobile && isEditToEditAction) {
 			this.editor.emit('select-all-text', { shapeId: hitShape.id })
+		} else {
+			this.editor.emit('place-caret', { shapeId: hitShape.id, point: info.point })
 		}
 		updateHoveredShapeId(this.editor)
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -62,7 +62,8 @@ export class EditingShape extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		// A pointer down on another shape's label starts translating it if the user drags
+		// In the case where on pointer down we hit a shape's label, we need to check if the user is dragging.
+		// and if they are, we need to transition to translating instead.
 		if (this.hitLabelOnShapeForPointerUp && this.editor.inputs.getIsDragging()) {
 			if (this.editor.getIsReadonly()) return
 			if (this.hitLabelOnShapeForPointerUp.isLocked) return
@@ -73,6 +74,7 @@ export class EditingShape extends StateNode {
 			return
 		}
 
+		// Check if dragging from editing shape with blurred input
 		if (this.didPointerDownOnEditingShape && this.editor.inputs.isDragging) {
 			if (this.editor.getIsReadonly()) return
 
@@ -146,7 +148,9 @@ export class EditingShape extends StateNode {
 						textLabel.bounds.containsPoint(pointInShapeSpace, 0) &&
 						textLabel.hitTestPoint(pointInShapeSpace)
 					) {
+						// it's a hit to the label!
 						if (selectingShape.id === editingShape.id) {
+							// Track click on editing shape for drag detection
 							this.didPointerDownOnEditingShape = true
 							return
 						} else {
@@ -176,8 +180,9 @@ export class EditingShape extends StateNode {
 			}
 		}
 
-		// Cancel editing and replay the pointer down in select idle
+		// still here? Cancel editing and transition back to select idle
 		this.parent.transition('idle', info)
+		// then feed the pointer down event back into the state chart as if it happened in that state
 		this.editor.root.handleEvent(info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -289,6 +289,7 @@ export class Idle extends StateNode {
 					return
 				}
 
+				// No hit shape, so double click on the canvas instead
 				this.handleDoubleClickOnCanvas(info)
 				break
 			}
@@ -387,6 +388,7 @@ export class Idle extends StateNode {
 				// Allow playing videos and embeds
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
+				// Call the shape's double click handler
 				const change = util.onDoubleClick?.(shape)
 				if (change) {
 					this.editor.updateShapes([change])
@@ -422,6 +424,8 @@ export class Idle extends StateNode {
 				if (changes) {
 					this.editor.updateShapes([changes])
 				} else if (this.editor.canEditShape(shape)) {
+					// If the shape's double click handler has not created a change,
+					// and if the shape can edit, then begin editing the shape.
 					this.startEditingShape(shape, info, true /* select all */)
 				}
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -15,7 +15,6 @@ import {
 	toRichText,
 	unsafe__withoutCapture,
 } from '@tldraw/editor'
-import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { updateHoveredOverlayId } from '../../selection-logic/updateHoveredOverlayId'
 import {
@@ -95,21 +94,12 @@ export class Idle extends StateNode {
 					return
 				}
 
-				const selectedShapeIds = this.editor.getSelectedShapeIds()
-				const onlySelectedShape = this.editor.getOnlySelectedShape()
-
-				if (
-					selectedShapeIds.length > 1 ||
-					(onlySelectedShape &&
-						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
-				) {
-					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
-						this.onPointerDown({
-							...info,
-							target: 'selection',
-						})
-						return
-					}
+				if (isPointInSelectionBoundsBg(this.editor, currentPagePoint)) {
+					this.onPointerDown({
+						...info,
+						target: 'selection',
+					})
+					return
 				}
 
 				this.parent.transition('pointing_canvas', info)
@@ -146,22 +136,8 @@ export class Idle extends StateNode {
 					}
 				} else {
 					switch (overlayType) {
-						case 'rotate_handle': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
-						case 'mobile_rotate': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
+						case 'rotate_handle':
+						case 'mobile_rotate':
 						case 'resize_handle': {
 							this.onPointerDown({
 								...info,
@@ -335,10 +311,7 @@ export class Idle extends StateNode {
 					return
 				}
 
-				// No hit shape, so double click on the canvas instead
-				if (!this.editor.inputs.getShiftKey()) {
-					this.handleDoubleClickOnCanvas(info)
-				}
+				this.handleDoubleClickOnCanvas(info)
 				break
 			}
 			case 'selection': {
@@ -436,19 +409,16 @@ export class Idle extends StateNode {
 				// Allow playing videos and embeds
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
-				if (util.onDoubleClick) {
-					// Call the shape's double click handler
-					const change = util.onDoubleClick?.(shape)
-					if (change) {
-						this.editor.updateShapes([change])
-						return
-					}
+				const change = util.onDoubleClick?.(shape)
+				if (change) {
+					this.editor.updateShapes([change])
+					return
 				}
 
 				if (util.canCrop(shape) && !this.editor.isShapeOrAncestorLocked(shape)) {
 					// crop image etc on double click
 					this.editor.markHistoryStoppingPoint('select and crop')
-					this.editor.select(info.shape?.id)
+					this.editor.select(shape.id)
 					this.parent.transition('crop', info)
 					return
 				}
@@ -473,12 +443,8 @@ export class Idle extends StateNode {
 
 				if (changes) {
 					this.editor.updateShapes([changes])
-				} else {
-					// If the shape's double click handler has not created a change,
-					// and if the shape can edit, then begin editing the shape.
-					if (this.editor.canEditShape(shape)) {
-						this.startEditingShape(shape, info, true /* select all */)
-					}
+				} else if (this.editor.canEditShape(shape)) {
+					this.startEditingShape(shape, info, true /* select all */)
 				}
 			}
 		}
@@ -487,24 +453,16 @@ export class Idle extends StateNode {
 	override onRightClick(info: TLPointerEventInfo) {
 		switch (info.target) {
 			case 'canvas': {
-				const selectedShapeIds = this.editor.getSelectedShapeIds()
-				const onlySelectedShape = this.editor.getOnlySelectedShape()
 				const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 
 				// Check selection bounds first so that right-clicking inside the
 				// selection preserves it, even when a filled shape sits behind it.
-				if (
-					selectedShapeIds.length > 1 ||
-					(onlySelectedShape &&
-						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
-				) {
-					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
-						this.onRightClick({
-							...info,
-							target: 'selection',
-						})
-						return
-					}
+				if (isPointInSelectionBoundsBg(this.editor, currentPagePoint)) {
+					this.onRightClick({
+						...info,
+						target: 'selection',
+					})
+					return
 				}
 
 				const hoveredShape = this.editor.getHoveredShape()
@@ -704,20 +662,13 @@ export class Idle extends StateNode {
 		info: TLClickEventInfo | (TLKeyboardEventInfo & { target: 'shape'; shape: TLShape }),
 		shouldSelectAll?: boolean
 	) {
-		const { editor } = this
 		this.editor.markHistoryStoppingPoint('editing shape')
 		if (hasRichText(shape)) {
-			startEditingShapeWithRichText(editor, shape, { selectAll: shouldSelectAll })
+			startEditingShapeWithRichText(this.editor, shape, { selectAll: shouldSelectAll })
 		} else {
-			editor.setEditingShape(shape)
+			this.editor.setEditingShape(shape)
 		}
 		this.parent.transition('editing_shape', info)
-	}
-
-	isOverArrowLabelTest(shape: TLShape | undefined) {
-		if (!shape) return false
-
-		return isOverArrowLabel(this.editor, shape)
 	}
 
 	handleDoubleClickOnCanvas(info: TLClickEventInfo) {
@@ -773,7 +724,7 @@ export class Idle extends StateNode {
 		if (keys.has('ArrowUp')) delta.y -= 1
 		if (keys.has('ArrowDown')) delta.y += 1
 
-		if (delta.equals(new Vec(0, 0))) return
+		if (delta.x === 0 && delta.y === 0) return
 
 		if (!ephemeral) this.editor.markHistoryStoppingPoint('nudge shapes')
 
@@ -800,7 +751,15 @@ export const MAJOR_NUDGE_FACTOR = 10
 export const MINOR_NUDGE_FACTOR = 1
 export const GRID_INCREMENT = 5
 
-function isPointInRotatedSelectionBounds(editor: Editor, point: VecLike) {
+function isPointInSelectionBoundsBg(editor: Editor, point: VecLike) {
+	const onlySelectedShape = editor.getOnlySelectedShape()
+	if (onlySelectedShape) {
+		if (editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+			return false
+	} else if (editor.getSelectedShapeIds().length <= 1) {
+		return false
+	}
+
 	const selectionBounds = editor.getSelectionRotatedPageBounds()
 	if (!selectionBounds) return false
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -21,7 +21,11 @@ import {
 	cancelUpdateHoveredShapeId,
 	updateHoveredShapeId,
 } from '../../selection-logic/updateHoveredShapeId'
-import { hasRichText, startEditingShapeWithRichText } from '../selectHelpers'
+import {
+	hasRichText,
+	isSelectionHandleOverlay,
+	startEditingShapeWithRichText,
+} from '../selectHelpers'
 
 const SKIPPED_KEYS_FOR_AUTO_EDITING = [
 	'Delete',
@@ -120,8 +124,6 @@ export class Idle extends StateNode {
 					if (result !== false) return
 				}
 
-				const overlayType = overlay.props.overlayType as string | undefined
-
 				// Check overlay type to determine how to route the event
 				if (overlay.type === 'shape_handle') {
 					// Re-dispatch as a handle event
@@ -134,25 +136,10 @@ export class Idle extends StateNode {
 							handle: overlay.props.handle as any,
 						})
 					}
+				} else if (isSelectionHandleOverlay(overlay)) {
+					this.onPointerDown({ ...info, target: 'selection', handle: overlay.props.handle })
 				} else {
-					switch (overlayType) {
-						case 'rotate_handle':
-						case 'mobile_rotate':
-						case 'resize_handle': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
-						default: {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-							})
-						}
-					}
+					this.onPointerDown({ ...info, target: 'selection' })
 				}
 				break
 			}
@@ -266,17 +253,8 @@ export class Idle extends StateNode {
 							return
 						}
 					}
-					const overlayType = hitOverlay.props.overlayType as string | undefined
-					if (
-						overlayType === 'resize_handle' ||
-						overlayType === 'rotate_handle' ||
-						overlayType === 'mobile_rotate'
-					) {
-						this.onDoubleClick({
-							...info,
-							target: 'selection',
-							handle: hitOverlay.props.handle as any,
-						})
+					if (isSelectionHandleOverlay(hitOverlay)) {
+						this.onDoubleClick({ ...info, target: 'selection', handle: hitOverlay.props.handle })
 						return
 					}
 				}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -13,6 +13,12 @@ import {
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
 import { startEditingShapeWithRichText } from '../selectHelpers'
 
+type PointingArrowLabelInfo = TLPointerEventInfo & {
+	shape: TLArrowShape
+	onInteractionEnd?: string | (() => void)
+	isCreating: boolean
+}
+
 export class PointingArrowLabel extends StateNode {
 	static override id = 'pointing_arrow_label'
 
@@ -22,23 +28,10 @@ export class PointingArrowLabel extends StateNode {
 	didDrag = false
 	didCtrlOnEnter = false
 
-	private info = {} as TLPointerEventInfo & {
-		shape: TLArrowShape
-		onInteractionEnd?: string | (() => void)
-		isCreating: boolean
-	}
+	private info = {} as PointingArrowLabelInfo
+	private _labelDragOffset = new Vec(0, 0)
 
-	private updateCursor() {
-		this.editor.setCursor({ type: 'grabbing', rotation: 0 })
-	}
-
-	override onEnter(
-		info: TLPointerEventInfo & {
-			shape: TLArrowShape
-			onInteractionEnd?: string | (() => void)
-			isCreating: boolean
-		}
-	) {
+	override onEnter(info: PointingArrowLabelInfo) {
 		const { shape } = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -48,7 +41,7 @@ export class PointingArrowLabel extends StateNode {
 		this.didDrag = false
 		this.didCtrlOnEnter = info.accelKey
 		this.wasAlreadySelected = this.editor.getOnlySelectedShapeId() === shape.id
-		this.updateCursor()
+		this.editor.setCursor({ type: 'grabbing', rotation: 0 })
 
 		const geometry = this.editor.getShapeGeometry<Group2d>(shape)
 		const labelGeometry = geometry.children[1]
@@ -63,14 +56,9 @@ export class PointingArrowLabel extends StateNode {
 		this.markId = this.editor.markHistoryStoppingPoint('label-drag start')
 
 		const additiveSelectionKey = info.shiftKey || info.accelKey
-		if (additiveSelectionKey) {
-			const selectedShapeIds = this.editor.getSelectedShapeIds()
-			this.editor.setSelectedShapes([...selectedShapeIds, this.shapeId])
-
-			return
-		}
-
-		this.editor.setSelectedShapes([this.shapeId])
+		this.editor.setSelectedShapes(
+			additiveSelectionKey ? [...this.editor.getSelectedShapeIds(), this.shapeId] : [this.shapeId]
+		)
 	}
 
 	override onExit() {
@@ -78,8 +66,6 @@ export class PointingArrowLabel extends StateNode {
 
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 	}
-
-	private _labelDragOffset = new Vec(0, 0)
 
 	override onPointerMove() {
 		const isDragging = this.editor.inputs.getIsDragging()
@@ -170,16 +156,6 @@ export class PointingArrowLabel extends StateNode {
 
 	private cancel() {
 		this.editor.bailToMark(this.markId)
-
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
-		this.parent.transition('idle')
+		this.complete()
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -11,7 +11,7 @@ import {
 	getArrowLabelDefaultPosition,
 } from '../../../shapes/arrow/arrowLabel'
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
-import { startEditingShapeWithRichText } from '../selectHelpers'
+import { returnToInteractionEnd, startEditingShapeWithRichText } from '../selectHelpers'
 
 type PointingArrowLabelInfo = TLPointerEventInfo & {
 	shape: TLArrowShape
@@ -142,15 +142,7 @@ export class PointingArrowLabel extends StateNode {
 	}
 
 	private complete() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle')
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -5,6 +5,7 @@ import {
 	TLPointerEventInfo,
 	TLSelectionHandle,
 } from '@tldraw/editor'
+import { returnToInteractionEnd } from '../selectHelpers'
 
 export const CursorTypeMap: Record<TLSelectionHandle, TLCursorType> = {
 	bottom: 'ns-resize',
@@ -92,15 +93,7 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	private exitToPreviousTool() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle')
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -31,20 +31,15 @@ export class PointingResizeHandle extends StateNode {
 
 	private info = {} as PointingResizeHandleInfo
 
-	private updateCursor() {
-		const cursorType = CursorTypeMap[this.info.handle!]
-		this.editor.setCursor({
-			type: cursorType,
-			rotation: this.editor.getSelectionRotation(),
-		})
-	}
-
 	override onEnter(info: PointingResizeHandleInfo) {
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
-		this.updateCursor()
+		this.editor.setCursor({
+			type: CursorTypeMap[info.handle!],
+			rotation: this.editor.getSelectionRotation(),
+		})
 	}
 
 	override onExit() {
@@ -67,7 +62,7 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	override onPointerUp() {
-		this.complete()
+		this.exitToPreviousTool()
 	}
 
 	override onDoubleClick(info: TLClickEventInfo) {
@@ -85,31 +80,18 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	override onCancel() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onComplete() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onInterrupt() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
-	private complete() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
-		this.parent.transition('idle')
-	}
-
-	private cancel() {
+	private exitToPreviousTool() {
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -10,19 +10,15 @@ export class PointingRotateHandle extends StateNode {
 
 	private info = {} as PointingRotateHandleInfo
 
-	private updateCursor() {
-		this.editor.setCursor({
-			type: CursorTypeMap[this.info.handle as RotateCorner],
-			rotation: this.editor.getSelectionRotation(),
-		})
-	}
-
 	override onEnter(info: PointingRotateHandleInfo) {
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
-		this.updateCursor()
+		this.editor.setCursor({
+			type: CursorTypeMap[info.handle as RotateCorner],
+			rotation: this.editor.getSelectionRotation(),
+		})
 	}
 
 	override onExit() {
@@ -46,7 +42,7 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	override onPointerUp() {
-		this.complete()
+		this.exitToPreviousTool()
 	}
 
 	override onDoubleClick(info: TLClickEventInfo) {
@@ -64,35 +60,22 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	override onCancel() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onComplete() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
 	override onInterrupt() {
-		this.cancel()
+		this.exitToPreviousTool()
 	}
 
-	private complete() {
+	private exitToPreviousTool() {
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {
 				// Return to the tool that was active before this one, whether tool lock is turned on or not!
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd?.()
-			}
-			return
-		}
-		this.parent.transition('idle')
-	}
-
-	private cancel() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
 				this.editor.setCurrentTool(onInteractionEnd, {})
 			} else {
 				onInteractionEnd()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -73,6 +73,7 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	private exitToPreviousTool() {
+		// Return to the tool that was active before this one, whether tool lock is turned on or not!
 		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -1,4 +1,5 @@
 import { RotateCorner, StateNode, TLClickEventInfo, TLPointerEventInfo } from '@tldraw/editor'
+import { returnToInteractionEnd } from '../selectHelpers'
 import { CursorTypeMap } from './PointingResizeHandle'
 
 type PointingRotateHandleInfo = Extract<TLPointerEventInfo, { target: 'selection' }> & {
@@ -72,16 +73,7 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	private exitToPreviousTool() {
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				// Return to the tool that was active before this one, whether tool lock is turned on or not!
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle')
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -82,33 +82,26 @@ export class PointingShape extends StateNode {
 			return
 		}
 
-		const selectingShape = hitShape
-			? this.editor.getOutermostSelectableShape(hitShape)
-			: this.hitShapeForPointerUp
+		const selectingShape = this.editor.getOutermostSelectableShape(hitShape)
 
-		if (selectingShape) {
-			// If the selecting shape has a click handler, call it instead of selecting the shape
-			const util = this.editor.getShapeUtil(selectingShape)
-			if (util.onClick) {
-				const change = util.onClick?.(selectingShape)
-				if (change) {
-					this.editor.markHistoryStoppingPoint('shape on click')
-					this.editor.updateShapes([change])
-					this.parent.transition('idle', info)
-					return
-				}
-			}
+		// If the selecting shape has a click handler, call it instead of selecting the shape
+		const change = this.editor.getShapeUtil(selectingShape).onClick?.(selectingShape)
+		if (change) {
+			this.editor.markHistoryStoppingPoint('shape on click')
+			this.editor.updateShapes([change])
+			this.parent.transition('idle', info)
+			return
+		}
 
-			if (selectingShape.id === focusedGroupId) {
-				if (selectedShapeIds.length > 0) {
-					this.editor.markHistoryStoppingPoint('clearing shape ids')
-					this.editor.setSelectedShapes([])
-				} else {
-					this.editor.popFocusedGroupId()
-				}
-				this.parent.transition('idle', info)
-				return
+		if (selectingShape.id === focusedGroupId) {
+			if (selectedShapeIds.length > 0) {
+				this.editor.markHistoryStoppingPoint('clearing shape ids')
+				this.editor.setSelectedShapes([])
+			} else {
+				this.editor.popFocusedGroupId()
 			}
+			this.parent.transition('idle', info)
+			return
 		}
 
 		if (!this.didSelectOnEnter) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -21,6 +21,7 @@ import {
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
+import { returnToInteractionEnd } from '../selectHelpers'
 
 export type ResizingInfo = TLPointerEventInfo & {
 	target: 'selection'
@@ -135,15 +136,7 @@ export class Resizing extends StateNode {
 
 		this.editor.bailToMark(this.markId)
 
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, {})
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle')
 	}
 
@@ -157,18 +150,15 @@ export class Resizing extends StateNode {
 			return
 		}
 
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				if (this.editor.getInstanceState().isToolLocked) {
-					this.editor.setCurrentTool(onInteractionEnd, {})
-					return
-				}
-			} else {
-				onInteractionEnd()
-				return
-			}
-		}
+		if (
+			returnToInteractionEnd(
+				this.editor,
+				this.info.onInteractionEnd,
+				{},
+				{ onlyIfToolLocked: true }
+			)
+		)
+			return
 
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -41,6 +41,7 @@ export class Resizing extends StateNode {
 
 	markId = ''
 
+	// A switch to detect when the user is holding ctrl
 	private didHoldCommand = false
 
 	// we transition into the resizing state from the geo pointing state, which starts with a shape of size w: 1, h: 1,
@@ -305,6 +306,9 @@ export class Resizing extends StateNode {
 
 		// calculate the scale by measuring the current distance between the drag handle and the scale origin
 		// and dividing by the original distance between the drag handle and the scale origin
+
+		// bug: for edges, the page point doesn't matter, the
+
 		const distanceFromScaleOriginNow = Vec.Sub(currentPagePoint, scaleOriginPage).rot(
 			-selectionRotation
 		)
@@ -477,6 +481,8 @@ export class Resizing extends StateNode {
 
 		this.editor.setHintingShapes(hintingShapeIds)
 	}
+
+	// ---
 
 	private updateCursor({
 		dragHandle,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -2,8 +2,6 @@ import {
 	Box,
 	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,6 +17,7 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -41,7 +40,6 @@ export class Resizing extends StateNode {
 
 	markId = ''
 
-	// A switch to detect when the user is holding ctrl
 	private didHoldCommand = false
 
 	// we transition into the resizing state from the geo pointing state, which starts with a shape of size w: 1, h: 1,
@@ -85,12 +83,9 @@ export class Resizing extends StateNode {
 					this.markId = markId
 				}
 			}
+			this.editor.setCursor({ type: 'cross', rotation: 0 })
 		} else {
 			this.markId = this.editor.markHistoryStoppingPoint('starting resizing')
-		}
-
-		if (isCreating) {
-			this.editor.setCursor({ type: 'cross', rotation: 0 })
 		}
 
 		this.handleResizeStart()
@@ -158,7 +153,7 @@ export class Resizing extends StateNode {
 		this.handleResizeEnd()
 
 		if (this.info.isCreating && this.info.onCreate) {
-			this.info.onCreate?.(this.editor.getOnlySelectedShape())
+			this.info.onCreate(this.editor.getOnlySelectedShape())
 			return
 		}
 
@@ -320,9 +315,6 @@ export class Resizing extends StateNode {
 
 		// calculate the scale by measuring the current distance between the drag handle and the scale origin
 		// and dividing by the original distance between the drag handle and the scale origin
-
-		// bug: for edges, the page point doesn't matter, the
-
 		const distanceFromScaleOriginNow = Vec.Sub(currentPagePoint, scaleOriginPage).rot(
 			-selectionRotation
 		)
@@ -496,8 +488,6 @@ export class Resizing extends StateNode {
 		this.editor.setHintingShapes(hintingShapeIds)
 	}
 
-	// ---
-
 	private updateCursor({
 		dragHandle,
 		isFlippedX,
@@ -670,23 +660,3 @@ export class Resizing extends StateNode {
 }
 
 type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
-}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -10,6 +10,7 @@ import {
 	shortAngleDist,
 	snapAngle,
 } from '@tldraw/editor'
+import { returnToInteractionEnd } from '../selectHelpers'
 import { CursorTypeMap } from './PointingResizeHandle'
 
 const ONE_DEGREE = Math.PI / 180
@@ -111,15 +112,7 @@ export class Rotating extends StateNode {
 		})
 
 		this.editor.bailToMark(this.markId)
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, this.info)) return
 		this.parent.transition('idle', this.info)
 	}
 
@@ -134,15 +127,7 @@ export class Rotating extends StateNode {
 			this.editor,
 			this.snapshot.shapeSnapshots.map((s) => s.shape.id)
 		)
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd, this.info)
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd, this.info)) return
 		this.parent.transition('idle', this.info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -30,6 +30,7 @@ export class Rotating extends StateNode {
 	markId = ''
 
 	override onEnter(info: RotatingInfo) {
+		// Store the event information
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -47,6 +48,7 @@ export class Rotating extends StateNode {
 		}
 		this.snapshot = snapshot
 
+		// Trigger a pointer move
 		this.applyRotation('start')
 	}
 
@@ -81,6 +83,8 @@ export class Rotating extends StateNode {
 		this.cancel()
 	}
 
+	// ---
+
 	private applyRotation(stage: 'start' | 'update') {
 		const newSelectionRotation = this._getRotationFromPointerPosition({
 			snapToNearestDegree: false,
@@ -93,6 +97,7 @@ export class Rotating extends StateNode {
 			stage,
 		})
 
+		// Update cursor
 		this.editor.setCursor({
 			type: CursorTypeMap[this.info.handle as RotateCorner],
 			rotation: newSelectionRotation + this.snapshot.initialShapesRotation,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -14,22 +14,21 @@ import { CursorTypeMap } from './PointingResizeHandle'
 
 const ONE_DEGREE = Math.PI / 180
 
+type RotatingInfo = Extract<TLPointerEventInfo, { target: 'selection' }> & {
+	onInteractionEnd?: string | (() => void)
+}
+
 export class Rotating extends StateNode {
 	static override id = 'rotating'
 	static override trackPerformance = true
 
 	snapshot = {} as TLRotationSnapshot
 
-	info = {} as Extract<TLPointerEventInfo, { target: 'selection' }> & {
-		onInteractionEnd?: string | (() => void)
-	}
+	info = {} as RotatingInfo
 
 	markId = ''
 
-	override onEnter(
-		info: TLPointerEventInfo & { target: 'selection'; onInteractionEnd?: string | (() => void) }
-	) {
-		// Store the event information
+	override onEnter(info: RotatingInfo) {
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -47,23 +46,7 @@ export class Rotating extends StateNode {
 		}
 		this.snapshot = snapshot
 
-		// Trigger a pointer move
-		const newSelectionRotation = this._getRotationFromPointerPosition({
-			snapToNearestDegree: false,
-		})
-
-		applyRotationToSnapshotShapes({
-			editor: this.editor,
-			delta: this._getRotationFromPointerPosition({ snapToNearestDegree: false }),
-			snapshot: this.snapshot,
-			stage: 'start',
-		})
-
-		// Update cursor
-		this.editor.setCursor({
-			type: CursorTypeMap[this.info.handle as RotateCorner],
-			rotation: newSelectionRotation + this.snapshot.initialShapesRotation,
-		})
+		this.applyRotation('start')
 	}
 
 	override onExit() {
@@ -74,15 +57,15 @@ export class Rotating extends StateNode {
 	}
 
 	override onPointerMove() {
-		this.update()
+		this.applyRotation('update')
 	}
 
 	override onKeyDown() {
-		this.update()
+		this.applyRotation('update')
 	}
 
 	override onKeyUp() {
-		this.update()
+		this.applyRotation('update')
 	}
 
 	override onPointerUp() {
@@ -97,9 +80,7 @@ export class Rotating extends StateNode {
 		this.cancel()
 	}
 
-	// ---
-
-	private update() {
+	private applyRotation(stage: 'start' | 'update') {
 		const newSelectionRotation = this._getRotationFromPointerPosition({
 			snapToNearestDegree: false,
 		})
@@ -108,10 +89,9 @@ export class Rotating extends StateNode {
 			editor: this.editor,
 			delta: newSelectionRotation,
 			snapshot: this.snapshot,
-			stage: 'update',
+			stage,
 		})
 
-		// Update cursor
 		this.editor.setCursor({
 			type: CursorTypeMap[this.info.handle as RotateCorner],
 			rotation: newSelectionRotation + this.snapshot.initialShapesRotation,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -86,6 +86,7 @@ export class ScribbleBrushing extends StateNode {
 
 		const minDist = 0 // this.editor.options.hitTestMargin / zoomLevel
 
+		// Create bounds around line segment with margin
 		const lineBounds = Box.FromPoints([previousPagePoint, currentPagePoint]).expandBy(minDist)
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
@@ -113,6 +114,7 @@ export class ScribbleBrushing extends StateNode {
 					continue
 				}
 
+				// Hit test the shape using a line segment
 				const pageTransform = editor.getShapePageTransform(shape)
 				if (!geometry || !pageTransform) continue
 				const pt = pageTransform.clone().invert()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -1,10 +1,7 @@
 import {
 	Box,
-	Geometry2d,
 	StateNode,
-	TLShape,
 	TLShapeId,
-	Vec,
 	intersectLineSegmentPolygon,
 	pointInPolygon,
 } from '@tldraw/editor'
@@ -12,10 +9,6 @@ import {
 export class ScribbleBrushing extends StateNode {
 	static override id = 'scribble_brushing'
 	static override trackPerformance = true
-
-	hits = new Set<TLShapeId>()
-
-	size = 0
 
 	scribbleId = 'id'
 
@@ -27,8 +20,6 @@ export class ScribbleBrushing extends StateNode {
 			this.editor.inputs.getShiftKey() ? this.editor.getSelectedShapeIds() : []
 		)
 		this.newlySelectedShapeIds = new Set<TLShapeId>()
-		this.size = 0
-		this.hits.clear()
 
 		const scribbleItem = this.editor.scribbles.addScribble({
 			color: 'selection-stroke',
@@ -95,88 +86,67 @@ export class ScribbleBrushing extends StateNode {
 
 		const minDist = 0 // this.editor.options.hitTestMargin / zoomLevel
 
-		// Create bounds around line segment with margin
 		const lineBounds = Box.FromPoints([previousPagePoint, currentPagePoint]).expandBy(minDist)
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
-		// Early return if no candidates - avoid expensive getCurrentPageRenderingShapesSorted()
-		// But still update selection based on current state
-		if (candidateIds.size === 0) {
-			const current = editor.getSelectedShapeIds()
-			const next = new Set<TLShapeId>(
-				shiftKey
-					? [...newlySelectedShapeIds, ...initialSelectedShapeIds]
-					: [...newlySelectedShapeIds]
-			)
-			if (current.length !== next.size || current.some((id) => !next.has(id))) {
-				this.editor.setSelectedShapes(Array.from(next))
-			}
-			return
-		}
+		if (candidateIds.size > 0) {
+			for (const shape of this.editor.getCurrentPageRenderingShapesSorted()) {
+				if (!candidateIds.has(shape.id)) continue
 
-		const allShapes = this.editor.getCurrentPageRenderingShapesSorted()
-		const currentPageShapes = allShapes.filter((shape) => candidateIds.has(shape.id))
-
-		const shapes = currentPageShapes
-		let shape: TLShape, geometry: Geometry2d, A: Vec, B: Vec
-
-		for (let i = 0, n = shapes.length; i < n; i++) {
-			shape = shapes[i]
-
-			// If the shape is a group or is already selected, don't select it.
-			// Also skip locked shapes unless the selectLockedShapes option is enabled.
-			if (
-				editor.isShapeOfType(shape, 'group') ||
-				newlySelectedShapeIds.has(shape.id) ||
-				(!editor.options.selectLockedShapes && editor.isShapeOrAncestorLocked(shape))
-			) {
-				continue
-			}
-
-			geometry = editor.getShapeGeometry(shape)
-
-			// If the scribble started inside of a frame-like shape, don't select it
-			if (
-				editor.isShapeFrameLike(shape) &&
-				geometry.bounds.containsPoint(editor.getPointInShapeSpace(shape, originPagePoint))
-			) {
-				continue
-			}
-
-			// Hit test the shape using a line segment
-			const pageTransform = editor.getShapePageTransform(shape)
-			if (!geometry || !pageTransform) continue
-			const pt = pageTransform.clone().invert()
-			A = pt.applyToPoint(previousPagePoint)
-			B = pt.applyToPoint(currentPagePoint)
-
-			// If the line segment is entirely above / below / left / right of the shape's bounding box, skip the hit test
-			const { bounds } = geometry
-			if (
-				bounds.minX - minDist > Math.max(A.x, B.x) ||
-				bounds.minY - minDist > Math.max(A.y, B.y) ||
-				bounds.maxX + minDist < Math.min(A.x, B.x) ||
-				bounds.maxY + minDist < Math.min(A.y, B.y)
-			) {
-				continue
-			}
-
-			if (geometry.hitTestLineSegment(A, B, minDist)) {
-				const outermostShape = this.editor.getOutermostSelectableShape(shape)
-				const pageMask = this.editor.getShapeMask(outermostShape.id)
-				if (pageMask) {
-					const intersection = intersectLineSegmentPolygon(
-						previousPagePoint,
-						currentPagePoint,
-						pageMask
-					)
-					if (intersection !== null) {
-						const isInMask = pointInPolygon(currentPagePoint, pageMask)
-						if (!isInMask) continue
-					}
+				// If the shape is a group or is already selected, don't select it.
+				// Also skip locked shapes unless the selectLockedShapes option is enabled.
+				if (
+					editor.isShapeOfType(shape, 'group') ||
+					newlySelectedShapeIds.has(shape.id) ||
+					(!editor.options.selectLockedShapes && editor.isShapeOrAncestorLocked(shape))
+				) {
+					continue
 				}
 
-				newlySelectedShapeIds.add(outermostShape.id)
+				const geometry = editor.getShapeGeometry(shape)
+
+				// If the scribble started inside of a frame-like shape, don't select it
+				if (
+					editor.isShapeFrameLike(shape) &&
+					geometry.bounds.containsPoint(editor.getPointInShapeSpace(shape, originPagePoint))
+				) {
+					continue
+				}
+
+				const pageTransform = editor.getShapePageTransform(shape)
+				if (!geometry || !pageTransform) continue
+				const pt = pageTransform.clone().invert()
+				const A = pt.applyToPoint(previousPagePoint)
+				const B = pt.applyToPoint(currentPagePoint)
+
+				// If the line segment is entirely above / below / left / right of the shape's bounding box, skip the hit test
+				const { bounds } = geometry
+				if (
+					bounds.minX - minDist > Math.max(A.x, B.x) ||
+					bounds.minY - minDist > Math.max(A.y, B.y) ||
+					bounds.maxX + minDist < Math.min(A.x, B.x) ||
+					bounds.maxY + minDist < Math.min(A.y, B.y)
+				) {
+					continue
+				}
+
+				if (geometry.hitTestLineSegment(A, B, minDist)) {
+					const outermostShape = this.editor.getOutermostSelectableShape(shape)
+					const pageMask = this.editor.getShapeMask(outermostShape.id)
+					if (pageMask) {
+						const intersection = intersectLineSegmentPolygon(
+							previousPagePoint,
+							currentPagePoint,
+							pageMask
+						)
+						if (intersection !== null) {
+							const isInMask = pointInPolygon(currentPagePoint, pageMask)
+							if (!isInMask) continue
+						}
+					}
+
+					newlySelectedShapeIds.add(outermostShape.id)
+				}
 			}
 		}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -3,7 +3,6 @@ import {
 	Editor,
 	Mat,
 	MatModel,
-	PageRecordType,
 	StateNode,
 	TLNoteShape,
 	TLPointerEventInfo,
@@ -87,7 +86,6 @@ export class Translating extends StateNode {
 		this.onCreate = onCreate
 
 		this.isCloning = false
-		this.info = info
 
 		this.editor.setCursor({ type: 'move', rotation: 0 })
 		this.selectionSnapshot = getTranslatingSnapshot(this.editor)
@@ -158,7 +156,7 @@ export class Translating extends StateNode {
 
 	protected startCloning() {
 		if (this.isCreating) return
-		const shapeIds = Array.from(this.editor.getSelectedShapeIds())
+		const shapeIds = this.editor.getSelectedShapeIds()
 
 		// If we can't create the shapes, don't even start cloning
 		if (!this.editor.canCreateShapes(shapeIds)) return
@@ -167,7 +165,7 @@ export class Translating extends StateNode {
 		this.reset()
 		this.markId = this.editor.markHistoryStoppingPoint('translate cloning')
 
-		this.editor.duplicateShapes(Array.from(this.editor.getSelectedShapeIds()))
+		this.editor.duplicateShapes(shapeIds)
 
 		this.snapshot = getTranslatingSnapshot(this.editor)
 		this.handleStart()
@@ -209,7 +207,7 @@ export class Translating extends StateNode {
 		}
 
 		if (this.isCreating) {
-			this.onCreate?.(this.editor.getOnlySelectedShape())
+			this.onCreate(this.editor.getOnlySelectedShape())
 		} else {
 			this.parent.transition('idle')
 		}
@@ -341,18 +339,14 @@ export class Translating extends StateNode {
 			editor,
 			snapshot: { shapeSnapshots },
 		} = this
-		const movingShapes: TLShape[] = []
 
 		shapeSnapshots.forEach((shapeSnapshot) => {
 			const shape = editor.getShape(shapeSnapshot.shape.id)
 			if (!shape) return
-			movingShapes.push(shape)
 
-			const parentTransform = isPageId(shape.parentId)
+			shapeSnapshot.parentTransform = isPageId(shape.parentId)
 				? null
 				: Mat.Inverse(editor.getShapePageTransform(shape.parentId)!)
-
-			shapeSnapshot.parentTransform = parentTransform
 		})
 	}
 }
@@ -374,7 +368,7 @@ function getTranslatingSnapshot(editor: Editor) {
 
 			pagePoints.push(pagePoint)
 
-			const parentTransform = PageRecordType.isId(shape.parentId)
+			const parentTransform = isPageId(shape.parentId)
 				? null
 				: Mat.Inverse(editor.getShapePageTransform(shape.parentId)!)
 
@@ -414,12 +408,9 @@ function getTranslatingSnapshot(editor: Editor) {
 		(s) => editor.isShapeOfType(s.shape, 'note') && editor.isPointInShape(s.shape, originPagePoint)
 	) as (MovingShapeSnapshot & { shape: TLNoteShape })[]
 
-	if (allHoveredNotes.length === 0) {
-		// noop
-	} else if (allHoveredNotes.length === 1) {
-		// just one, easy
+	if (allHoveredNotes.length === 1) {
 		noteSnapshot = allHoveredNotes[0]
-	} else {
+	} else if (allHoveredNotes.length > 1) {
 		// More than one under the cursor, so we need to find the highest shape in z-order
 		const allShapesSorted = editor.getCurrentPageShapesSorted()
 		noteSnapshot = allHoveredNotes
@@ -559,21 +550,19 @@ export function moveShapesToPoint({
 	const averageSnap = Vec.Sub(averageSnappedPoint, averagePagePoint)
 
 	editor.updateShapes(
-		compact(
-			shapeSnapshots.map(({ shape, pagePoint, parentTransform }): TLShapePartial | null => {
-				const newPagePoint = Vec.Add(pagePoint, averageSnap)
+		shapeSnapshots.map(({ shape, pagePoint, parentTransform }): TLShapePartial => {
+			const newPagePoint = Vec.Add(pagePoint, averageSnap)
 
-				const newLocalPoint = parentTransform
-					? Mat.applyToPoint(parentTransform, newPagePoint)
-					: newPagePoint
+			const newLocalPoint = parentTransform
+				? Mat.applyToPoint(parentTransform, newPagePoint)
+				: newPagePoint
 
-				return {
-					id: shape.id,
-					type: shape.type,
-					x: newLocalPoint.x,
-					y: newLocalPoint.y,
-				}
-			})
-		)
+			return {
+				id: shape.id,
+				type: shape.type,
+				x: newLocalPoint.x,
+				y: newLocalPoint.y,
+			}
+		})
 	)
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -22,6 +22,7 @@ import {
 import type { NoteShapeUtil } from '../../../shapes/note/NoteShapeUtil'
 import { getDisplayValues } from '../../../shapes/shared/getDisplayValues'
 import { DragAndDropManager } from '../DragAndDropManager'
+import { returnToInteractionEnd } from '../selectHelpers'
 
 export type TranslatingInfo = TLPointerEventInfo & {
 	target: 'shape'
@@ -193,18 +194,15 @@ export class Translating extends StateNode {
 			this.snapshot.movingShapes.map((s) => s.id)
 		)
 
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				if (this.editor.getInstanceState().isToolLocked) {
-					this.editor.setCurrentTool(onInteractionEnd)
-					return
-				}
-			} else {
-				onInteractionEnd()
-				return
-			}
-		}
+		if (
+			returnToInteractionEnd(
+				this.editor,
+				this.info.onInteractionEnd,
+				{},
+				{ onlyIfToolLocked: true }
+			)
+		)
+			return
 
 		if (this.isCreating) {
 			this.onCreate(this.editor.getOnlySelectedShape())
@@ -226,15 +224,7 @@ export class Translating extends StateNode {
 		})
 
 		this.reset()
-		const { onInteractionEnd } = this.info
-		if (onInteractionEnd) {
-			if (typeof onInteractionEnd === 'string') {
-				this.editor.setCurrentTool(onInteractionEnd)
-			} else {
-				onInteractionEnd()
-			}
-			return
-		}
+		if (returnToInteractionEnd(this.editor, this.info.onInteractionEnd)) return
 		this.parent.transition('idle', this.info)
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -399,6 +399,7 @@ function getTranslatingSnapshot(editor: Editor) {
 	) as (MovingShapeSnapshot & { shape: TLNoteShape })[]
 
 	if (allHoveredNotes.length === 1) {
+		// just one, easy
 		noteSnapshot = allHoveredNotes[0]
 	} else if (allHoveredNotes.length > 1) {
 		// More than one under the cursor, so we need to find the highest shape in z-order

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -39,6 +39,7 @@ export function startEditingShapeWithRichText(
 	if (!hasRichText(shape)) {
 		throw new Error('Shape does not have rich text')
 	}
+	// Finish this shape and start editing the next one
 	editor.setEditingShape(shape)
 	editor.setCurrentTool('select.editing_shape', {
 		...options.info,

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -37,7 +37,6 @@ export function startEditingShapeWithRichText(
 	if (!hasRichText(shape)) {
 		throw new Error('Shape does not have rich text')
 	}
-	// Finish this shape and start editing the next one
 	editor.setEditingShape(shape)
 	editor.setCurrentTool('select.editing_shape', {
 		...options.info,

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -3,10 +3,12 @@ import {
 	ExtractShapeByProps,
 	richTextValidator,
 	TLEventInfo,
+	TLOverlay,
 	TLRichText,
 	TLShape,
 	TLShapeId,
 } from '@tldraw/editor'
+import { TLSelectionForegroundOverlay } from '../../overlays/SelectionForegroundOverlayUtil'
 
 /** @internal */
 export function hasRichText(
@@ -46,4 +48,44 @@ export function startEditingShapeWithRichText(
 	if (options.selectAll) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
+}
+
+const SELECTION_HANDLE_OVERLAY_TYPES = new Set(['resize_handle', 'rotate_handle', 'mobile_rotate'])
+
+/** Whether an overlay is one of the selection-box resize/rotate handles. */
+export function isSelectionHandleOverlay(
+	overlay: TLOverlay
+): overlay is TLSelectionForegroundOverlay {
+	return SELECTION_HANDLE_OVERLAY_TYPES.has(overlay.props.overlayType as string)
+}
+
+/** The selection-box handle overlay under the pointer, if any. */
+export function getHitSelectionHandleOverlay(editor: Editor) {
+	const hitOverlay = editor.overlays.getOverlayAtPoint(
+		editor.inputs.getCurrentPagePoint(),
+		editor.getHitTestMargin()
+	)
+	return hitOverlay && isSelectionHandleOverlay(hitOverlay) ? hitOverlay : undefined
+}
+
+/**
+ * Hands control back to whatever started the interaction, if anything did. Returns true when
+ * it did so, so the caller skips its own idle transition. With `onlyIfToolLocked`, a string
+ * `onInteractionEnd` is only honored while tool lock is on; otherwise the creating tool stays
+ * active and the caller falls through to its default exit.
+ */
+export function returnToInteractionEnd(
+	editor: Editor,
+	onInteractionEnd: string | (() => void) | undefined,
+	info: object = {},
+	{ onlyIfToolLocked = false }: { onlyIfToolLocked?: boolean } = {}
+): boolean {
+	if (!onInteractionEnd) return false
+	if (typeof onInteractionEnd === 'string') {
+		if (onlyIfToolLocked && !editor.getInstanceState().isToolLocked) return false
+		editor.setCurrentTool(onInteractionEnd, info)
+	} else {
+		onInteractionEnd()
+	}
+	return true
 }

--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -22,6 +22,7 @@ export class ZoomTool extends StateNode {
 
 	override onEnter(info: TLPointerEventInfo & { onInteractionEnd: string }) {
 		this.info = info
+		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask
 		this.parent.setCurrentToolIdMask(this.getOriginatingToolId())
 		this.updateCursor()
 	}
@@ -49,6 +50,7 @@ export class ZoomTool extends StateNode {
 	}
 
 	private complete() {
+		// onInteractionEnd is a path like 'select.idle', extract just the tool ID
 		this.editor.setCurrentTool(this.getOriginatingToolId() ?? 'select')
 	}
 

--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -22,9 +22,7 @@ export class ZoomTool extends StateNode {
 
 	override onEnter(info: TLPointerEventInfo & { onInteractionEnd: string }) {
 		this.info = info
-		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask
-		const toolId = info.onInteractionEnd?.split('.')[0]
-		this.parent.setCurrentToolIdMask(toolId)
+		this.parent.setCurrentToolIdMask(this.getOriginatingToolId())
 		this.updateCursor()
 	}
 
@@ -51,9 +49,12 @@ export class ZoomTool extends StateNode {
 	}
 
 	private complete() {
-		// onInteractionEnd is a path like 'select.idle', extract just the tool ID
-		const toolId = this.info.onInteractionEnd?.split('.')[0] ?? 'select'
-		this.editor.setCurrentTool(toolId)
+		this.editor.setCurrentTool(this.getOriginatingToolId() ?? 'select')
+	}
+
+	// onInteractionEnd is a path like 'select.idle'; the tool id is the first segment
+	private getOriginatingToolId() {
+		return this.info.onInteractionEnd?.split('.')[0]
 	}
 
 	private updateCursor() {

--- a/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
@@ -87,12 +87,14 @@ export class ZoomQuick extends StateNode {
 	}
 
 	override onPointerUp() {
+		// Exit the zoom tool entirely, returning to the original tool
 		this.exitToOriginatingTool()
 	}
 
 	override onCancel() {
 		// Back to idle so onExit restores the original viewport instead of zooming to the brush
 		this.qzState = 'idle'
+		// Exit the zoom tool entirely, returning to the original tool
 		this.exitToOriginatingTool()
 	}
 
@@ -117,6 +119,7 @@ export class ZoomQuick extends StateNode {
 
 	private zoomToNewViewport() {
 		const { editor } = this
+		// return to original viewport if idle, or zoom to the new viewport if moving
 		editor.zoomToBounds(this.qzState === 'moving' ? this.nextVpb : this.initialVpb, { inset: 0 })
 	}
 
@@ -126,6 +129,7 @@ export class ZoomQuick extends StateNode {
 	}
 
 	override onTick() {
+		// If the user is idle but has moved their camera, transition to the moving state
 		if (this.qzState !== 'idle') return
 		const { editor } = this
 		const zoomLevel = editor.getZoomLevel()
@@ -155,7 +159,7 @@ export class ZoomQuick extends StateNode {
 		}
 		const { x, y } = editor.inputs.getCurrentPagePoint()
 
-		// Keep the brush anchored under the cursor at the same normalized screen offset
+		// Normalize the offset on the current screen point within the current viewport screen bounds
 		const vsb = editor.getViewportScreenBounds()
 		const vsp = editor.inputs.getCurrentScreenPoint()
 		const nx = vsp.x / vsb.w

--- a/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/childStates/ZoomQuick.ts
@@ -13,9 +13,7 @@ export class ZoomQuick extends StateNode {
 	/** The camera zoom right after the overview zoom-out in onEnter. */
 	overviewZoom = 1
 
-	cleanupZoomReactor() {
-		void null
-	}
+	private cleanupZoomReactor: (() => void) | null = null
 
 	nextVpb = new Box()
 
@@ -82,20 +80,24 @@ export class ZoomQuick extends StateNode {
 	}
 
 	override onExit() {
-		this.cleanupZoomReactor()
+		this.cleanupZoomReactor?.()
+		this.cleanupZoomReactor = null
 		this.zoomToNewViewport()
 		this.editor.updateInstanceState({ zoomBrush: null })
 	}
 
 	override onPointerUp() {
-		// Exit the zoom tool entirely, returning to the original tool
-		const toolId = this.info.onInteractionEnd?.split('.')[0] ?? 'select'
-		this.editor.setCurrentTool(toolId)
+		this.exitToOriginatingTool()
 	}
 
 	override onCancel() {
+		// Back to idle so onExit restores the original viewport instead of zooming to the brush
 		this.qzState = 'idle'
-		// Exit the zoom tool entirely, returning to the original tool
+		this.exitToOriginatingTool()
+	}
+
+	private exitToOriginatingTool() {
+		// onInteractionEnd is a path like 'select.idle'; the tool id is the first segment
 		const toolId = this.info.onInteractionEnd?.split('.')[0] ?? 'select'
 		this.editor.setCurrentTool(toolId)
 	}
@@ -115,16 +117,7 @@ export class ZoomQuick extends StateNode {
 
 	private zoomToNewViewport() {
 		const { editor } = this
-		switch (this.qzState) {
-			case 'idle':
-				// return to original viewport
-				editor.zoomToBounds(this.initialVpb, { inset: 0 })
-				break
-			case 'moving':
-				// zoom to the new viewport
-				editor.zoomToBounds(this.nextVpb, { inset: 0 })
-				break
-		}
+		editor.zoomToBounds(this.qzState === 'moving' ? this.nextVpb : this.initialVpb, { inset: 0 })
 	}
 
 	override onPointerMove() {
@@ -133,23 +126,15 @@ export class ZoomQuick extends StateNode {
 	}
 
 	override onTick() {
+		if (this.qzState !== 'idle') return
 		const { editor } = this
-
-		// If the user is idle but has moved their camera, transition to the moving state
-		switch (this.qzState) {
-			case 'idle': {
-				const zoomLevel = editor.getZoomLevel()
-				if (
-					Vec.Dist2(editor.inputs.getCurrentPagePoint(), this.initialPp) * zoomLevel >
-					editor.options.dragDistanceSquared / zoomLevel
-				) {
-					this.qzState = 'moving'
-					this.updateBrush()
-				}
-				break
-			}
-			case 'moving':
-				break
+		const zoomLevel = editor.getZoomLevel()
+		if (
+			Vec.Dist2(editor.inputs.getCurrentPagePoint(), this.initialPp) * zoomLevel >
+			editor.options.dragDistanceSquared / zoomLevel
+		) {
+			this.qzState = 'moving'
+			this.updateBrush()
 		}
 	}
 
@@ -170,10 +155,11 @@ export class ZoomQuick extends StateNode {
 		}
 		const { x, y } = editor.inputs.getCurrentPagePoint()
 
-		// Normalize the offset on the current screen point within the current viewport screen bounds
+		// Keep the brush anchored under the cursor at the same normalized screen offset
 		const vsb = editor.getViewportScreenBounds()
 		const vsp = editor.inputs.getCurrentScreenPoint()
-		const { x: nx, y: ny } = new Vec(vsp.x / vsb.w, vsp.y / vsb.h)
+		const nx = vsp.x / vsb.w
+		const ny = vsp.y / vsb.h
 
 		return new Box(x - nx * w, y - ny * h, w, h)
 	}

--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -8,12 +8,15 @@ export function getHitShapeOnCanvasPointerDown(
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
 	return (
+		// hovered shape at point
 		editor.getShapeAtPoint(currentPagePoint, {
 			hitInside: false,
 			hitLabels,
 			hitLocked: editor.options.selectLockedShapes,
 			margin: editor.getHitTestMargin(),
 			renderingOnly: true,
-		}) ?? editor.getSelectedShapeAtPoint(currentPagePoint)
+		}) ??
+		// selected shape at point
+		editor.getSelectedShapeAtPoint(currentPagePoint)
 	)
 }

--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -8,15 +8,12 @@ export function getHitShapeOnCanvasPointerDown(
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
 	return (
-		// hovered shape at point
 		editor.getShapeAtPoint(currentPagePoint, {
 			hitInside: false,
 			hitLabels,
 			hitLocked: editor.options.selectLockedShapes,
 			margin: editor.getHitTestMargin(),
 			renderingOnly: true,
-		}) ??
-		// selected shape at point
-		editor.getSelectedShapeAtPoint(currentPagePoint)
+		}) ?? editor.getSelectedShapeAtPoint(currentPagePoint)
 	)
 }

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -1,4 +1,20 @@
-import { Editor, TLClickEventInfo, TLPointerEventInfo, isShapeId } from '@tldraw/editor'
+import { Editor, TLClickEventInfo, TLPointerEventInfo, TLShape, isShapeId } from '@tldraw/editor'
+
+/**
+ * A shape inside a group is only selectable (and hoverable) directly when its group is the
+ * focused group or already selected; otherwise the interaction targets the group.
+ */
+export function getShapeToSelectForHit(editor: Editor, hitShape: TLShape): TLShape {
+	const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
+	if (
+		outermostSelectableShape === hitShape ||
+		outermostSelectableShape.id === editor.getFocusedGroupId() ||
+		editor.getSelectedShapeIds().includes(outermostSelectableShape.id)
+	) {
+		return hitShape
+	}
+	return outermostSelectableShape
+}
 
 export function selectOnCanvasPointerUp(
 	editor: Editor,
@@ -54,14 +70,7 @@ export function selectOnCanvasPointerUp(
 		return
 	}
 
-	// A shape inside a group is only selectable directly when its group is the
-	// focused group or already selected; otherwise the click selects the group.
-	const shapeToSelect =
-		outermostSelectableShape === hitShape ||
-		outermostSelectableShape.id === editor.getFocusedGroupId() ||
-		selectedShapeIds.includes(outermostSelectableShape.id)
-			? hitShape
-			: outermostSelectableShape
+	const shapeToSelect = getShapeToSelectForHit(editor, hitShape)
 
 	if (!selectedShapeIds.includes(shapeToSelect.id)) {
 		editor.markHistoryStoppingPoint('selecting shape')

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -1,4 +1,4 @@
-import { Editor, TLClickEventInfo, TLPointerEventInfo, TLShape, isShapeId } from '@tldraw/editor'
+import { Editor, TLClickEventInfo, TLPointerEventInfo, isShapeId } from '@tldraw/editor'
 
 export function selectOnCanvasPointerUp(
 	editor: Editor,
@@ -19,83 +19,52 @@ export function selectOnCanvasPointerUp(
 		filter: (shape) => selectLockedShapes || !shape.isLocked,
 	})
 
-	// Note at the start: if we select a shape that is inside of a group,
-	// the editor will automatically adjust the selection to the outermost
-	// selectable shape (the group)
+	if (!hitShape) {
+		// Holding shift with nothing under the pointer keeps the current selection
+		if (additiveSelectionKey) return
 
-	// If the shape's outermost selected id (e.g. the group that contains
-	// the shape) is not the same as the editor's only selected shape, then
-	// we want to select the outermost selected shape instead of the shape
+		if (selectedShapeIds.length > 0) {
+			editor.markHistoryStoppingPoint('selecting none')
+			editor.selectNone()
+		}
 
-	if (hitShape) {
-		const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
-		// If the user is holding shift, they're either adding to or removing from
-		// their selection.
-		if (additiveSelectionKey && !altKey) {
-			editor.cancelDoubleClick() // fuckin eh
-
-			if (selectedShapeIds.includes(outermostSelectableShape.id)) {
-				// Remove it from selected shapes
-				editor.markHistoryStoppingPoint('deselecting shape')
-				editor.deselect(outermostSelectableShape)
-			} else {
-				// Add it to selected shapes
-				editor.markHistoryStoppingPoint('shift selecting shape')
-				editor.setSelectedShapes([...selectedShapeIds, outermostSelectableShape.id])
-			}
-		} else {
-			let shapeToSelect: TLShape | undefined = undefined
-
-			if (outermostSelectableShape === hitShape) {
-				// There's no group around the shape, so we can select it.
-				shapeToSelect = hitShape
-			} else {
-				// There's a group around the hit shape.
-				// If the group is the current focus layer, OR if the group is
-				// already selected, then we can select the shape inside the group.
-				// Otherwise, if the group isn't selected and isn't our current
-				// focus layer, then we need to select the group instead.
-				if (
-					outermostSelectableShape.id === editor.getFocusedGroupId() ||
-					selectedShapeIds.includes(outermostSelectableShape.id)
-				) {
-					shapeToSelect = hitShape
-				} else {
-					shapeToSelect = outermostSelectableShape
-				}
-			}
-
-			if (shapeToSelect && !selectedShapeIds.includes(shapeToSelect.id)) {
-				editor.markHistoryStoppingPoint('selecting shape')
-				editor.select(shapeToSelect.id)
+		// Clicking outside the focused group resets focus to the page
+		const focusedGroupId = editor.getFocusedGroupId()
+		if (isShapeId(focusedGroupId)) {
+			const groupShape = editor.getShape(focusedGroupId)!
+			if (!editor.isPointInShape(groupShape, currentPagePoint, { margin: 0, hitInside: true })) {
+				editor.setFocusedGroup(null)
 			}
 		}
-	} else {
-		// We didn't hit anything...
-		if (additiveSelectionKey) {
-			// If we were holding shift, then it's a noop. We keep the
-			// current selection because we didn't add anything to it
-			return
+		return
+	}
+
+	const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
+
+	if (additiveSelectionKey && !altKey) {
+		editor.cancelDoubleClick()
+
+		if (selectedShapeIds.includes(outermostSelectableShape.id)) {
+			editor.markHistoryStoppingPoint('deselecting shape')
+			editor.deselect(outermostSelectableShape)
 		} else {
-			// Otherwise, we clear the selction because the user selected
-			// nothing instead of their current selection.
-
-			if (selectedShapeIds.length > 0) {
-				editor.markHistoryStoppingPoint('selecting none')
-				editor.selectNone()
-			}
-
-			// If the click was inside of the current focused group, then
-			// we keep that focused group; otherwise we clear the focused
-			// group (reset it to the page)
-			const focusedGroupId = editor.getFocusedGroupId()
-
-			if (isShapeId(focusedGroupId)) {
-				const groupShape = editor.getShape(focusedGroupId)!
-				if (!editor.isPointInShape(groupShape, currentPagePoint, { margin: 0, hitInside: true })) {
-					editor.setFocusedGroup(null)
-				}
-			}
+			editor.markHistoryStoppingPoint('shift selecting shape')
+			editor.setSelectedShapes([...selectedShapeIds, outermostSelectableShape.id])
 		}
+		return
+	}
+
+	// A shape inside a group is only selectable directly when its group is the
+	// focused group or already selected; otherwise the click selects the group.
+	const shapeToSelect =
+		outermostSelectableShape === hitShape ||
+		outermostSelectableShape.id === editor.getFocusedGroupId() ||
+		selectedShapeIds.includes(outermostSelectableShape.id)
+			? hitShape
+			: outermostSelectableShape
+
+	if (!selectedShapeIds.includes(shapeToSelect.id)) {
+		editor.markHistoryStoppingPoint('selecting shape')
+		editor.select(shapeToSelect.id)
 	}
 }

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -6,6 +6,12 @@ import { Editor, TLClickEventInfo, TLPointerEventInfo, TLShape, isShapeId } from
  */
 export function getShapeToSelectForHit(editor: Editor, hitShape: TLShape): TLShape {
 	const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
+	// There's no group around the shape, so we can select it.
+	// If there's a group around the hit shape:
+	// If the group is the current focus layer, OR if the group is
+	// already selected, then we can select the shape inside the group.
+	// Otherwise, if the group isn't selected and isn't our current
+	// focus layer, then we need to select the group instead.
 	if (
 		outermostSelectableShape === hitShape ||
 		outermostSelectableShape.id === editor.getFocusedGroupId() ||
@@ -35,16 +41,30 @@ export function selectOnCanvasPointerUp(
 		filter: (shape) => selectLockedShapes || !shape.isLocked,
 	})
 
+	// Note at the start: if we select a shape that is inside of a group,
+	// the editor will automatically adjust the selection to the outermost
+	// selectable shape (the group)
+
+	// If the shape's outermost selected id (e.g. the group that contains
+	// the shape) is not the same as the editor's only selected shape, then
+	// we want to select the outermost selected shape instead of the shape
+
 	if (!hitShape) {
-		// Holding shift with nothing under the pointer keeps the current selection
+		// We didn't hit anything...
+		// If we were holding shift, then it's a noop. We keep the
+		// current selection because we didn't add anything to it
 		if (additiveSelectionKey) return
 
+		// Otherwise, we clear the selction because the user selected
+		// nothing instead of their current selection.
 		if (selectedShapeIds.length > 0) {
 			editor.markHistoryStoppingPoint('selecting none')
 			editor.selectNone()
 		}
 
-		// Clicking outside the focused group resets focus to the page
+		// If the click was inside of the current focused group, then
+		// we keep that focused group; otherwise we clear the focused
+		// group (reset it to the page)
 		const focusedGroupId = editor.getFocusedGroupId()
 		if (isShapeId(focusedGroupId)) {
 			const groupShape = editor.getShape(focusedGroupId)!
@@ -57,13 +77,17 @@ export function selectOnCanvasPointerUp(
 
 	const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
 
+	// If the user is holding shift, they're either adding to or removing from
+	// their selection.
 	if (additiveSelectionKey && !altKey) {
-		editor.cancelDoubleClick()
+		editor.cancelDoubleClick() // fuckin eh
 
 		if (selectedShapeIds.includes(outermostSelectableShape.id)) {
+			// Remove it from selected shapes
 			editor.markHistoryStoppingPoint('deselecting shape')
 			editor.deselect(outermostSelectableShape)
 		} else {
+			// Add it to selected shapes
 			editor.markHistoryStoppingPoint('shift selecting shape')
 			editor.setSelectedShapes([...selectedShapeIds, outermostSelectableShape.id])
 		}

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
@@ -18,8 +18,10 @@ export function updateHoveredOverlayId(editor: Editor): boolean {
 
 	if (overlay) {
 		editor.overlays.setHoveredOverlay(overlay.id)
+		// Clear shape hover when over an overlay
 		editor.setHoveredShape(null)
 
+		// Update cursor based on the hovered overlay
 		const util = editor.overlays.getOverlayUtil(overlay)
 		const cursor = util.getCursor(overlay)
 		if (cursor) {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
@@ -18,10 +18,8 @@ export function updateHoveredOverlayId(editor: Editor): boolean {
 
 	if (overlay) {
 		editor.overlays.setHoveredOverlay(overlay.id)
-		// Clear shape hover when over an overlay
 		editor.setHoveredShape(null)
 
-		// Update cursor based on the hovered overlay
 		const util = editor.overlays.getOverlayUtil(overlay)
 		const cursor = util.getCursor(overlay)
 		if (cursor) {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -1,4 +1,5 @@
 import { Editor, TLShapeId, throttle } from '@tldraw/editor'
+import { getShapeToSelectForHit } from './selectOnCanvasPointerUp'
 
 /*
 Hit-testing is expensive in large documents, so hover updates pause while the
@@ -22,15 +23,7 @@ function getShapeToHover(editor: Editor): TLShapeId | null {
 
 	if (!hitShape) return null
 
-	const outermostShape = editor.getOutermostSelectableShape(hitShape)
-	if (
-		outermostShape === hitShape ||
-		outermostShape.id === editor.getFocusedGroupId() ||
-		editor.getSelectedShapeIds().includes(outermostShape.id)
-	) {
-		return hitShape.id
-	}
-	return outermostShape.id
+	return getShapeToSelectForHit(editor, hitShape).id
 }
 
 function _updateHoveredShapeId(editor: Editor) {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -1,25 +1,15 @@
-import { Editor, TLShape, TLShapeId, throttle } from '@tldraw/editor'
+import { Editor, TLShapeId, throttle } from '@tldraw/editor'
 
 /*
-Perf optimization: Skip hover updates while panning.
-
-Hit-testing shapes is expensive in large documents. When panning, we don't need
-continuous hover updates - we just need to resume when the camera stops.
-
-The logic:
+Hit-testing is expensive in large documents, so hover updates pause while the
+camera moves:
 1. Camera idle → update hover normally, unlock
 2. Camera moving + locked → skip entirely (no hit-testing)
 3. Camera moving + no current hover → lock immediately
-4. Camera moving + same shape → keep current hover (no change needed)
+4. Camera moving + same shape → keep current hover
 5. Camera moving + different shape → clear hover and lock
-
-This means: when you start panning over a shape, it stays hovered until
-your cursor moves off it, then hover clears and we stop hit-testing until
-the camera stops.
 */
-
-// Track per-editor state for hover updates during camera movement
-const hoverLockedEditors = new WeakMap<Editor, boolean>()
+const hoverLockedEditors = new WeakSet<Editor>()
 
 function getShapeToHover(editor: Editor): TLShapeId | null {
 	const hitShape = editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
@@ -32,56 +22,38 @@ function getShapeToHover(editor: Editor): TLShapeId | null {
 
 	if (!hitShape) return null
 
-	let shapeToHover: TLShape | undefined = undefined
-
 	const outermostShape = editor.getOutermostSelectableShape(hitShape)
-
-	if (outermostShape === hitShape) {
-		shapeToHover = hitShape
-	} else {
-		if (
-			outermostShape.id === editor.getFocusedGroupId() ||
-			editor.getSelectedShapeIds().includes(outermostShape.id)
-		) {
-			shapeToHover = hitShape
-		} else {
-			shapeToHover = outermostShape
-		}
+	if (
+		outermostShape === hitShape ||
+		outermostShape.id === editor.getFocusedGroupId() ||
+		editor.getSelectedShapeIds().includes(outermostShape.id)
+	) {
+		return hitShape.id
 	}
-
-	return shapeToHover.id
+	return outermostShape.id
 }
 
 function _updateHoveredShapeId(editor: Editor) {
 	if (editor.isDisposed) return
 
-	const cameraMoving = editor.getCameraState() === 'moving'
-
-	if (!cameraMoving) {
-		hoverLockedEditors.set(editor, false)
-		const nextHoveredId = getShapeToHover(editor)
-		return editor.setHoveredShape(nextHoveredId)
+	if (editor.getCameraState() !== 'moving') {
+		hoverLockedEditors.delete(editor)
+		editor.setHoveredShape(getShapeToHover(editor))
+		return
 	}
 
-	if (hoverLockedEditors.get(editor)) {
-		return undefined
-	}
+	if (hoverLockedEditors.has(editor)) return
 
 	const currentHoveredId = editor.getHoveredShapeId()
-
 	if (!currentHoveredId) {
-		hoverLockedEditors.set(editor, true)
-		return undefined
+		hoverLockedEditors.add(editor)
+		return
 	}
 
-	const nextHoveredId = getShapeToHover(editor)
-	if (nextHoveredId === currentHoveredId) {
-		return undefined
-	}
+	if (getShapeToHover(editor) === currentHoveredId) return
 
 	editor.setHoveredShape(null)
-	hoverLockedEditors.set(editor, true)
-	return undefined
+	hoverLockedEditors.add(editor)
 }
 
 const THROTTLE_MS = process.env.NODE_ENV === 'test' ? 0 : 32

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -2,14 +2,24 @@ import { Editor, TLShapeId, throttle } from '@tldraw/editor'
 import { getShapeToSelectForHit } from './selectOnCanvasPointerUp'
 
 /*
-Hit-testing is expensive in large documents, so hover updates pause while the
-camera moves:
+Perf optimization: Skip hover updates while panning.
+
+Hit-testing shapes is expensive in large documents. When panning, we don't need
+continuous hover updates - we just need to resume when the camera stops.
+
+The logic:
 1. Camera idle → update hover normally, unlock
 2. Camera moving + locked → skip entirely (no hit-testing)
 3. Camera moving + no current hover → lock immediately
-4. Camera moving + same shape → keep current hover
+4. Camera moving + same shape → keep current hover (no change needed)
 5. Camera moving + different shape → clear hover and lock
+
+This means: when you start panning over a shape, it stays hovered until
+your cursor moves off it, then hover clears and we stop hit-testing until
+the camera stops.
 */
+
+// Track per-editor state for hover updates during camera movement
 const hoverLockedEditors = new WeakSet<Editor>()
 
 function getShapeToHover(editor: Editor): TLShapeId | null {

--- a/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
+++ b/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
@@ -345,6 +345,8 @@ export async function putExcalidrawContent(
 	editor.setSelectedShapes(rootShapeIds)
 }
 
+/* --------------- Translating Helpers --------_------ */
+
 function getBoundLabelElement(elements: any[], element: any): any {
 	let labelElement: any
 	if (element.boundElements !== null) {

--- a/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
+++ b/packages/tldraw/src/lib/utils/excalidraw/putExcalidrawContent.ts
@@ -100,10 +100,12 @@ export async function putExcalidrawContent(
 		}
 
 		if (element.groupIds && element.groupIds.length > 0) {
-			if (groupShapeIdToChildren.has(element.groupIds[0])) {
-				groupShapeIdToChildren.get(element.groupIds[0])?.push(id)
+			const groupId = element.groupIds[0]
+			const siblings = groupShapeIdToChildren.get(groupId)
+			if (siblings) {
+				siblings.push(id)
 			} else {
-				groupShapeIdToChildren.set(element.groupIds[0], [id])
+				groupShapeIdToChildren.set(groupId, [id])
 			}
 		} else {
 			rootShapeIds.push(id)
@@ -113,20 +115,11 @@ export async function putExcalidrawContent(
 			case 'rectangle':
 			case 'ellipse':
 			case 'diamond': {
-				let text = ''
-				let align: TLDefaultHorizontalAlignStyle = 'middle'
-
-				if (element.boundElements !== null) {
-					for (const boundElement of element.boundElements) {
-						if (boundElement.type === 'text') {
-							const labelElement = elements.find((elm: any) => elm.id === boundElement.id)
-							if (labelElement) {
-								text = labelElement.text
-								align = textAlignToAlignTypes[labelElement.textAlign]
-							}
-						}
-					}
-				}
+				const labelElement = getBoundLabelElement(elements, element)
+				const text = labelElement?.text ?? ''
+				const align: TLDefaultHorizontalAlignStyle = labelElement
+					? textAlignToAlignTypes[labelElement.textAlign]
+					: 'middle'
 
 				const colorToUse =
 					element.backgroundColor === 'transparent' ? element.strokeColor : element.backgroundColor
@@ -177,8 +170,7 @@ export async function putExcalidrawContent(
 				break
 			}
 			case 'line': {
-				const points = element.points.slice()
-				if (points.length < 2) {
+				if (element.points.length < 2) {
 					break
 				}
 				const indices = getIndices(element.points.length)
@@ -206,18 +198,7 @@ export async function putExcalidrawContent(
 				break
 			}
 			case 'arrow': {
-				let text = ''
-
-				if (element.boundElements !== null) {
-					for (const boundElement of element.boundElements) {
-						if (boundElement.type === 'text') {
-							const labelElement = elements.find((elm: any) => elm.id === boundElement.id)
-							if (labelElement) {
-								text = labelElement.text
-							}
-						}
-					}
-				}
+				const text = getBoundLabelElement(elements, element)?.text ?? ''
 
 				const start = element.points[0]
 				const end = element.points[element.points.length - 1]
@@ -243,32 +224,19 @@ export async function putExcalidrawContent(
 					},
 				})
 
-				if (startTargetId) {
+				for (const [terminal, toId] of [
+					['start', startTargetId],
+					['end', endTargetId],
+				] as const) {
+					if (!toId) continue
 					tldrawContent.bindings!.push({
 						id: createBindingId(),
 						typeName: 'binding',
 						type: 'arrow',
 						fromId: id,
-						toId: startTargetId,
+						toId,
 						props: {
-							terminal: 'start',
-							snap: 'none',
-							normalizedAnchor: { x: 0.5, y: 0.5 },
-							isPrecise: false,
-							isExact: false,
-						},
-						meta: {},
-					})
-				}
-				if (endTargetId) {
-					tldrawContent.bindings!.push({
-						id: createBindingId(),
-						typeName: 'binding',
-						type: 'arrow',
-						fromId: id,
-						toId: endTargetId,
-						props: {
-							terminal: 'end',
+							terminal,
 							snap: 'none',
 							normalizedAnchor: { x: 0.5, y: 0.5 },
 							isPrecise: false,
@@ -377,7 +345,17 @@ export async function putExcalidrawContent(
 	editor.setSelectedShapes(rootShapeIds)
 }
 
-/* --------------- Translating Helpers --------_------ */
+function getBoundLabelElement(elements: any[], element: any): any {
+	let labelElement: any
+	if (element.boundElements !== null) {
+		for (const boundElement of element.boundElements) {
+			if (boundElement.type === 'text') {
+				labelElement = elements.find((elm: any) => elm.id === boundElement.id) ?? labelElement
+			}
+		}
+	}
+	return labelElement
+}
 
 const getOpacity = (opacity: number): TLOpacityType => {
 	const t = opacity / 100
@@ -449,8 +427,7 @@ function mapExcalidrawColorToTldrawColors(
 	light: TLDefaultColorStyle,
 	dark: TLDefaultColorStyle
 ) {
-	const colors = [0, 1, 2, 3, 4].map((index) => oc[excalidrawColor][index])
-	return Object.fromEntries(colors.map((c, i) => [c, i < 3 ? light : dark]))
+	return Object.fromEntries(oc[excalidrawColor].map((c, i) => [c, i < 3 ? light : dark]))
 }
 
 const colorsToColors: Record<string, TLDefaultColorStyle> = {

--- a/packages/tldraw/src/lib/utils/export/export.ts
+++ b/packages/tldraw/src/lib/utils/export/export.ts
@@ -1,38 +1,4 @@
-import {
-	Editor,
-	FileHelpers,
-	TLImageExportOptions,
-	TLShapeId,
-	exhaustiveSwitchError,
-} from '@tldraw/editor'
-
-async function getSvgString(editor: Editor, ids: TLShapeId[], opts: TLImageExportOptions) {
-	const svg = await editor.getSvgString(ids, opts)
-	if (!svg) {
-		throw new Error('Could not construct SVG.')
-	}
-	return svg
-}
-
-export async function exportToString(
-	editor: Editor,
-	ids: TLShapeId[],
-	format: 'svg' | 'json',
-	opts: TLImageExportOptions = {}
-) {
-	switch (format) {
-		case 'svg': {
-			return (await getSvgString(editor, ids, opts))?.svg
-		}
-		case 'json': {
-			const data = await editor.resolveAssetsInContent(editor.getContentFromCurrentPage(ids))
-			return JSON.stringify(data)
-		}
-		default: {
-			exhaustiveSwitchError(format)
-		}
-	}
-}
+import { Editor, FileHelpers, TLImageExportOptions, TLShapeId } from '@tldraw/editor'
 
 const clipboardMimeTypesByFormat = {
 	jpeg: 'image/jpeg',
@@ -47,13 +13,11 @@ export function exportToImagePromiseForClipboard(
 	opts: TLImageExportOptions = {}
 ): { blobPromise: Promise<Blob>; mimeType: string } {
 	const idsToUse = ids?.length ? ids : [...editor.getCurrentPageShapeIds()]
-	const format = opts.format ?? 'png'
+	const mimeType = clipboardMimeTypesByFormat[opts.format ?? 'png']
 	return {
 		blobPromise: editor
 			.toImage(idsToUse, opts)
-			.then((result) =>
-				FileHelpers.rewriteMimeType(result.blob, clipboardMimeTypesByFormat[format])
-			),
-		mimeType: clipboardMimeTypesByFormat[format],
+			.then((result) => FileHelpers.rewriteMimeType(result.blob, mimeType)),
+		mimeType,
 	}
 }

--- a/packages/tldraw/src/lib/utils/export/exportAs.ts
+++ b/packages/tldraw/src/lib/utils/export/exportAs.ts
@@ -29,18 +29,14 @@ export async function exportAs(
 	ids: TLShapeId[],
 	opts: ExportAsOptions
 ): Promise<void> {
-	// If we don't get name then use a predefined one
 	let name = opts.name
 	if (!name) {
-		name = `shapes at ${getTimestamp()}`
-		if (ids.length === 1) {
-			const first = editor.getShape(ids[0])!
-			// Uses isShapeOfType (not isFrameLike) because it accesses frame-specific props (name)
-			if (editor.isShapeOfType(first, 'frame')) {
-				name = first.props.name || 'frame'
-			} else {
-				name = `${sanitizeId(first.id)} at ${getTimestamp()}`
-			}
+		const first = ids.length === 1 ? editor.getShape(ids[0])! : undefined
+		// Uses isShapeOfType (not isFrameLike) because it accesses frame-specific props (name)
+		if (first && editor.isShapeOfType(first, 'frame')) {
+			name = first.props.name || 'frame'
+		} else {
+			name = `${first ? sanitizeId(first.id) : 'shapes'} at ${getTimestamp()}`
 		}
 	}
 	name += `.${opts.format}`

--- a/packages/tldraw/src/lib/utils/export/exportAs.ts
+++ b/packages/tldraw/src/lib/utils/export/exportAs.ts
@@ -29,6 +29,7 @@ export async function exportAs(
 	ids: TLShapeId[],
 	opts: ExportAsOptions
 ): Promise<void> {
+	// If we don't get name then use a predefined one
 	let name = opts.name
 	if (!name) {
 		const first = ids.length === 1 ? editor.getShape(ids[0])! : undefined

--- a/packages/tldraw/src/lib/utils/frames/frames.ts
+++ b/packages/tldraw/src/lib/utils/frames/frames.ts
@@ -28,15 +28,15 @@ export function removeFrame(editor: Editor, ids: TLShapeId[]) {
 
 	const allChildren: TLShapeId[] = []
 	editor.run(() => {
-		frames.map((frame) => {
+		for (const frame of frames) {
 			const children = editor.getSortedChildIdsForParent(frame.id)
 			if (children.length) {
 				kickoutOccludedShapes(editor, children, {
-					filter: (s) => !frames.find((f) => f.id === s.id),
+					filter: (s) => !frames.some((f) => f.id === s.id),
 				})
 				allChildren.push(...children)
 			}
-		})
+		}
 		editor.setSelectedShapes(allChildren)
 		editor.deleteShapes(ids)
 	})

--- a/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
+++ b/packages/tldraw/src/lib/utils/static-assets/assetUrls.ts
@@ -24,25 +24,27 @@ export interface TLEditorAssetUrls {
 	}
 }
 
+const cdn = getDefaultCdnBaseUrl()
+
 /** @public */
 export let defaultEditorAssetUrls: TLEditorAssetUrls = {
 	fonts: {
-		tldraw_mono: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexMono-Medium.woff2`,
-		tldraw_mono_italic: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexMono-MediumItalic.woff2`,
-		tldraw_mono_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexMono-Bold.woff2`,
-		tldraw_mono_italic_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexMono-BoldItalic.woff2`,
-		tldraw_serif: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSerif-Medium.woff2`,
-		tldraw_serif_italic: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSerif-MediumItalic.woff2`,
-		tldraw_serif_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSerif-Bold.woff2`,
-		tldraw_serif_italic_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSerif-BoldItalic.woff2`,
-		tldraw_sans: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSans-Medium.woff2`,
-		tldraw_sans_italic: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSans-MediumItalic.woff2`,
-		tldraw_sans_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSans-Bold.woff2`,
-		tldraw_sans_italic_bold: `${getDefaultCdnBaseUrl()}/fonts/IBMPlexSans-BoldItalic.woff2`,
-		tldraw_draw: `${getDefaultCdnBaseUrl()}/fonts/Shantell_Sans-Informal_Regular.woff2`,
-		tldraw_draw_italic: `${getDefaultCdnBaseUrl()}/fonts/Shantell_Sans-Informal_Regular_Italic.woff2`,
-		tldraw_draw_bold: `${getDefaultCdnBaseUrl()}/fonts/Shantell_Sans-Informal_Bold.woff2`,
-		tldraw_draw_italic_bold: `${getDefaultCdnBaseUrl()}/fonts/Shantell_Sans-Informal_Bold_Italic.woff2`,
+		tldraw_mono: `${cdn}/fonts/IBMPlexMono-Medium.woff2`,
+		tldraw_mono_italic: `${cdn}/fonts/IBMPlexMono-MediumItalic.woff2`,
+		tldraw_mono_bold: `${cdn}/fonts/IBMPlexMono-Bold.woff2`,
+		tldraw_mono_italic_bold: `${cdn}/fonts/IBMPlexMono-BoldItalic.woff2`,
+		tldraw_serif: `${cdn}/fonts/IBMPlexSerif-Medium.woff2`,
+		tldraw_serif_italic: `${cdn}/fonts/IBMPlexSerif-MediumItalic.woff2`,
+		tldraw_serif_bold: `${cdn}/fonts/IBMPlexSerif-Bold.woff2`,
+		tldraw_serif_italic_bold: `${cdn}/fonts/IBMPlexSerif-BoldItalic.woff2`,
+		tldraw_sans: `${cdn}/fonts/IBMPlexSans-Medium.woff2`,
+		tldraw_sans_italic: `${cdn}/fonts/IBMPlexSans-MediumItalic.woff2`,
+		tldraw_sans_bold: `${cdn}/fonts/IBMPlexSans-Bold.woff2`,
+		tldraw_sans_italic_bold: `${cdn}/fonts/IBMPlexSans-BoldItalic.woff2`,
+		tldraw_draw: `${cdn}/fonts/Shantell_Sans-Informal_Regular.woff2`,
+		tldraw_draw_italic: `${cdn}/fonts/Shantell_Sans-Informal_Regular_Italic.woff2`,
+		tldraw_draw_bold: `${cdn}/fonts/Shantell_Sans-Informal_Bold.woff2`,
+		tldraw_draw_italic_bold: `${cdn}/fonts/Shantell_Sans-Informal_Bold_Italic.woff2`,
 	},
 }
 
@@ -59,7 +61,7 @@ export function useDefaultEditorAssetsWithOverrides(
 		if (!overrides) return defaultEditorAssetUrls
 
 		return {
-			fonts: { ...defaultEditorAssetUrls.fonts, ...overrides?.fonts },
+			fonts: { ...defaultEditorAssetUrls.fonts, ...overrides.fonts },
 		}
 	}, [overrides])
 }

--- a/packages/tldraw/src/lib/utils/svg/sanitizeSvg.ts
+++ b/packages/tldraw/src/lib/utils/svg/sanitizeSvg.ts
@@ -421,10 +421,6 @@ function sanitizeCssValue(css: string): string {
 	return decoded
 }
 
-function sanitizeStyleElement(textContent: string): string {
-	return sanitizeCssValue(textContent)
-}
-
 // --- Animation safety ---
 // Animation elements (<animate>, <set>) can overwrite attributes at runtime.
 // If attributeName targets a URI attr (href) or event handler (on*), the animation
@@ -500,7 +496,7 @@ function sanitizeEmbeddedSvgDataUri(value: string, depth: number): string | null
 	return encodeAsSvgDataUri(sanitized)
 }
 
-function sanitizeUri(el: Element, attrName: string, value: string, depth: number): string | null {
+function sanitizeUri(el: Element, value: string, depth: number): string | null {
 	const stripped = value.replace(INVISIBLE_WHITESPACE, '')
 	const tagName = el.tagName.toLowerCase()
 
@@ -552,7 +548,7 @@ function sanitizeSvgAttributes(el: Element, depth: number): void {
 
 		// URI attributes need context-dependent sanitization
 		if (name === 'href' || name === 'xlink:href') {
-			const sanitized = sanitizeUri(el, name, attr.value, depth)
+			const sanitized = sanitizeUri(el, attr.value, depth)
 			if (sanitized === null) {
 				el.removeAttribute(attr.name)
 			} else if (sanitized !== attr.value) {
@@ -634,7 +630,7 @@ function sanitizeNode(node: Element, mode: SanitizeMode, depth: number): void {
 				// <style>: sanitize attrs, sanitize text content as CSS
 				sanitizeSvgAttributes(child, depth)
 				if (child.textContent) {
-					child.textContent = sanitizeStyleElement(child.textContent)
+					child.textContent = sanitizeCssValue(child.textContent)
 				}
 			} else if (ANIMATION_TAGS.has(tag) && isAnimationDangerous(child)) {
 				// Animation targeting href/on* can inject javascript: URIs at runtime

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -89,6 +89,10 @@ export const tipTapDefaultExtensions: Extensions = getTipTapDefaultExtensions()
 // todo: bust this if the editor changes, too
 const htmlCache = new WeakCache<TLRichText, string>()
 
+function getTipTapExtensions(editor: Editor) {
+	return editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
+}
+
 /**
  * Renders HTML from a rich text string using an explicit set of TipTap extensions, rather than the
  * ones configured on an editor. Use this when rendering rich text outside of a shape's editor
@@ -119,11 +123,9 @@ export function renderHtmlFromRichTextWithExtensions(
  * @public
  */
 export function renderHtmlFromRichText(editor: Editor, richText: TLRichText) {
-	return htmlCache.get(richText, () => {
-		const tipTapExtensions =
-			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-		return renderHtmlFromRichTextWithExtensions(richText, tipTapExtensions)
-	})
+	return htmlCache.get(richText, () =>
+		renderHtmlFromRichTextWithExtensions(richText, getTipTapExtensions(editor))
+	)
 }
 
 /**
@@ -138,7 +140,6 @@ export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: T
 	return `<div class="tl-rich-text">${html}</div>`
 }
 
-// A weak cache used to store plaintext that's been extracted from rich text.
 const plainTextFromRichTextCache = new WeakCache<TLRichText, string>()
 
 export function isEmptyRichText(richText: TLRichText) {
@@ -175,13 +176,9 @@ export function isEditingRichTextList(editor: Editor) {
 export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText) {
 	if (isEmptyRichText(richText)) return ''
 
-	return plainTextFromRichTextCache.get(richText, () => {
-		const tipTapExtensions =
-			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-		return generateText(richText as JSONContent, tipTapExtensions, {
-			blockSeparator: '\n',
-		})
-	})
+	return plainTextFromRichTextCache.get(richText, () =>
+		generateText(richText as JSONContent, getTipTapExtensions(editor), { blockSeparator: '\n' })
+	)
 }
 
 /**
@@ -192,9 +189,7 @@ export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText
  * @public
  */
 export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText {
-	const tipTapExtensions =
-		editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-	return generateJSON(html, tipTapExtensions) as TLRichText
+	return generateJSON(html, getTipTapExtensions(editor)) as TLRichText
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -140,6 +140,7 @@ export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: T
 	return `<div class="tl-rich-text">${html}</div>`
 }
 
+// A weak cache used to store plaintext that's been extracted from rich text.
 const plainTextFromRichTextCache = new WeakCache<TLRichText, string>()
 
 export function isEmptyRichText(richText: TLRichText) {

--- a/packages/tldraw/src/lib/utils/text/text.ts
+++ b/packages/tldraw/src/lib/utils/text/text.ts
@@ -20,9 +20,10 @@ function replaceTabsWithSpaces(text: string) {
  * @internal
  */
 function stripCommonMinimumIndentation(text: string): string {
+	// Split the text into individual lines
 	const lines = text.split('\n')
 
-	// remove any leading lines that are only whitespace
+	// remove any leading lines that are only whitespace or newlines
 	while (lines[0] && lines[0].trim().length === 0) {
 		lines.shift()
 	}

--- a/packages/tldraw/src/lib/utils/text/text.ts
+++ b/packages/tldraw/src/lib/utils/text/text.ts
@@ -20,10 +20,9 @@ function replaceTabsWithSpaces(text: string) {
  * @internal
  */
 function stripCommonMinimumIndentation(text: string): string {
-	// Split the text into individual lines
 	const lines = text.split('\n')
 
-	// remove any leading lines that are only whitespace or newlines
+	// remove any leading lines that are only whitespace
 	while (lines[0] && lines[0].trim().length === 0) {
 		lines.shift()
 	}

--- a/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
+++ b/packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts
@@ -104,494 +104,397 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 		// Create pages
 
 		const v1PageIdsToV2PageIds = new Map<string, TLPageId>()
+		const v1Pages = Object.values(document.pages ?? {}).sort((a, b) =>
+			(a.childIndex ?? 1) < (b.childIndex ?? 1) ? -1 : 1
+		)
 
-		Object.values(document.pages ?? {})
-			.sort((a, b) => ((a.childIndex ?? 1) < (b.childIndex ?? 1) ? -1 : 1))
-			.forEach((v1Page, i) => {
-				if (i === 0) {
-					v1PageIdsToV2PageIds.set(v1Page.id, editor.getCurrentPageId())
-				} else {
-					const pageId = PageRecordType.createId()
-					v1PageIdsToV2PageIds.set(v1Page.id, pageId)
-					editor.createPage({ name: v1Page.name ?? 'Page', id: pageId })
+		v1Pages.forEach((v1Page, i) => {
+			if (i === 0) {
+				v1PageIdsToV2PageIds.set(v1Page.id, editor.getCurrentPageId())
+			} else {
+				const pageId = PageRecordType.createId()
+				v1PageIdsToV2PageIds.set(v1Page.id, pageId)
+				editor.createPage({ name: v1Page.name ?? 'Page', id: pageId })
+			}
+		})
+
+		v1Pages.forEach((v1Page) => {
+			// Set the current page id to the current page
+			editor.setCurrentPage(v1PageIdsToV2PageIds.get(v1Page.id)!)
+
+			const v1ShapeIdsToV2ShapeIds = new Map<string, TLShapeId>()
+			const v1GroupShapeIdsToV1ChildIds = new Map<string, string[]>()
+
+			const v1Shapes = Object.values(v1Page.shapes ?? {})
+				.sort((a, b) => (a.childIndex < b.childIndex ? -1 : 1))
+				.slice(0, editor.options.maxShapesPerPage)
+
+			// Groups only
+			v1Shapes.forEach((v1Shape) => {
+				if (v1Shape.type !== TLV1ShapeType.Group) return
+
+				const shapeId = createShapeId()
+				v1ShapeIdsToV2ShapeIds.set(v1Shape.id, shapeId)
+				v1GroupShapeIdsToV1ChildIds.set(v1Shape.id, [])
+			})
+
+			function decideNotToCreateShape(v1Shape: TLV1Shape) {
+				v1ShapeIdsToV2ShapeIds.delete(v1Shape.id)
+				const v1GroupParent = v1GroupShapeIdsToV1ChildIds.has(v1Shape.parentId)
+				if (v1GroupParent) {
+					const ids = v1GroupShapeIdsToV1ChildIds
+						.get(v1Shape.parentId)!
+						.filter((id) => id !== v1Shape.id)
+					v1GroupShapeIdsToV1ChildIds.set(v1Shape.parentId, ids)
+				}
+			}
+
+			// Non-groups only
+			v1Shapes.forEach((v1Shape) => {
+				// Skip groups for now, we'll create groups via the app's API
+				if (v1Shape.type === TLV1ShapeType.Group) {
+					return
+				}
+
+				const shapeId = createShapeId()
+				v1ShapeIdsToV2ShapeIds.set(v1Shape.id, shapeId)
+
+				if (v1Shape.parentId !== v1Page.id) {
+					// If the parent is a group, then add the shape to the group's children
+					if (v1GroupShapeIdsToV1ChildIds.has(v1Shape.parentId)) {
+						v1GroupShapeIdsToV1ChildIds.get(v1Shape.parentId)!.push(v1Shape.id)
+					} else {
+						console.warn('parent does not exist', v1Shape)
+					}
+				}
+
+				// First, try to find the shape's parent among the existing groups
+				const parentId = v1PageIdsToV2PageIds.get(v1Page.id)!
+
+				const inCommon = {
+					id: shapeId,
+					parentId,
+					x: coerceNumber(v1Shape.point[0]),
+					y: coerceNumber(v1Shape.point[1]),
+					rotation: 0,
+					isLocked: !!v1Shape.isLocked,
+				}
+
+				switch (v1Shape.type) {
+					case TLV1ShapeType.Sticky: {
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'note',
+								props: {
+									richText: toRichText(v1Shape.text ?? ''),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									align: getV2Align(v1Shape.style.textAlign),
+								},
+							},
+						])
+						break
+					}
+					case TLV1ShapeType.Rectangle: {
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'geo',
+								props: {
+									geo: 'rectangle',
+									w: coerceDimension(v1Shape.size[0]),
+									h: coerceDimension(v1Shape.size[1]),
+									richText: toRichText(v1Shape.label ?? ''),
+									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+									labelColor: getV2Color(v1Shape.style.color),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									dash: getV2Dash(v1Shape.style.dash),
+									align: 'middle',
+								},
+							},
+						])
+
+						applyV1GeoLabel(editor, inCommon.id, v1Shape.label)
+						break
+					}
+					case TLV1ShapeType.Triangle: {
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'geo',
+								props: {
+									geo: 'triangle',
+									w: coerceDimension(v1Shape.size[0]),
+									h: coerceDimension(v1Shape.size[1]),
+									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+									labelColor: getV2Color(v1Shape.style.color),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									dash: getV2Dash(v1Shape.style.dash),
+									align: 'middle',
+								},
+							},
+						])
+
+						applyV1GeoLabel(editor, inCommon.id, v1Shape.label)
+						break
+					}
+					case TLV1ShapeType.Ellipse: {
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'geo',
+								props: {
+									geo: 'ellipse',
+									w: coerceDimension(v1Shape.radius[0]) * 2,
+									h: coerceDimension(v1Shape.radius[1]) * 2,
+									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+									labelColor: getV2Color(v1Shape.style.color),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									dash: getV2Dash(v1Shape.style.dash),
+									align: 'middle',
+								},
+							},
+						])
+
+						applyV1GeoLabel(editor, inCommon.id, v1Shape.label)
+
+						break
+					}
+					case TLV1ShapeType.Draw: {
+						if (v1Shape.points.length === 0) {
+							decideNotToCreateShape(v1Shape)
+							break
+						}
+
+						const points = v1Shape.points.map(getV2Point)
+						const base64Points = b64Vecs.encodePoints(points)
+
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'draw',
+								props: {
+									fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									dash: getV2Dash(v1Shape.style.dash),
+									isPen: false,
+									isComplete: v1Shape.isComplete,
+									segments: [{ type: 'free', path: base64Points }],
+									scale: 1,
+									scaleX: 1,
+									scaleY: 1,
+								},
+							},
+						])
+						break
+					}
+					case TLV1ShapeType.Arrow: {
+						const v1Bend = coerceNumber(v1Shape.bend)
+						const v1Start = getV2Point(v1Shape.handles.start.point)
+						const v1End = getV2Point(v1Shape.handles.end.point)
+						const dist = Vec.Dist(v1Start, v1End)
+						const v2Bend = (dist * -v1Bend) / 2
+
+						// Could also be a line... but we'll use it as an arrow anyway
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'arrow',
+								props: {
+									richText: toRichText(v1Shape.label ?? ''),
+									color: getV2Color(v1Shape.style.color),
+									labelColor: getV2Color(v1Shape.style.color),
+									size: getV2Size(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									dash: getV2Dash(v1Shape.style.dash),
+									arrowheadStart: getV2Arrowhead(v1Shape.decorations?.start),
+									arrowheadEnd: getV2Arrowhead(v1Shape.decorations?.end),
+									start: {
+										x: coerceNumber(v1Shape.handles.start.point[0]),
+										y: coerceNumber(v1Shape.handles.start.point[1]),
+									},
+									end: {
+										x: coerceNumber(v1Shape.handles.end.point[0]),
+										y: coerceNumber(v1Shape.handles.end.point[1]),
+									},
+									bend: v2Bend,
+								},
+							},
+						])
+
+						break
+					}
+					case TLV1ShapeType.Text: {
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'text',
+								props: {
+									richText: toRichText(v1Shape.text ?? ' '),
+									color: getV2Color(v1Shape.style.color),
+									size: getV2TextSize(v1Shape.style.size),
+									font: getV2Font(v1Shape.style.font),
+									textAlign: getV2TextAlign(v1Shape.style.textAlign),
+									scale: v1Shape.style.scale ?? 1,
+								},
+							},
+						])
+						break
+					}
+					case TLV1ShapeType.Image: {
+						const assetId = v1AssetIdsToV2AssetIds.get(v1Shape.assetId)
+
+						if (!assetId) {
+							console.warn('Could not find asset id', v1Shape.assetId)
+							return
+						}
+
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'image',
+								props: {
+									w: coerceDimension(v1Shape.size[0]),
+									h: coerceDimension(v1Shape.size[1]),
+									assetId,
+								},
+							},
+						])
+						break
+					}
+					case TLV1ShapeType.Video: {
+						const assetId = v1AssetIdsToV2AssetIds.get(v1Shape.assetId)
+
+						if (!assetId) {
+							console.warn('Could not find asset id', v1Shape.assetId)
+							return
+						}
+
+						editor.createShapes([
+							{
+								...inCommon,
+								type: 'video',
+								props: {
+									w: coerceDimension(v1Shape.size[0]),
+									h: coerceDimension(v1Shape.size[1]),
+									assetId,
+								},
+							},
+						])
+						break
+					}
+				}
+
+				const rotation = coerceNumber(v1Shape.rotation)
+
+				if (rotation !== 0) {
+					editor.select(shapeId)
+					editor.rotateShapesBy([shapeId], rotation)
 				}
 			})
 
-		Object.values(document.pages ?? {})
-			.sort((a, b) => ((a.childIndex ?? 1) < (b.childIndex ?? 1) ? -1 : 1))
-			.forEach((v1Page) => {
-				// Set the current page id to the current page
-				editor.setCurrentPage(v1PageIdsToV2PageIds.get(v1Page.id)!)
+			// Create groups
+			v1GroupShapeIdsToV1ChildIds.forEach((v1ChildIds, v1GroupId) => {
+				const v2ChildShapeIds = v1ChildIds.map((id) => v1ShapeIdsToV2ShapeIds.get(id)!)
+				const v2GroupId = v1ShapeIdsToV2ShapeIds.get(v1GroupId)!
+				editor.groupShapes(v2ChildShapeIds, { groupId: v2GroupId })
 
-				const v1ShapeIdsToV2ShapeIds = new Map<string, TLShapeId>()
-				const v1GroupShapeIdsToV1ChildIds = new Map<string, string[]>()
+				const v1Group = v1Page.shapes[v1GroupId]
+				const rotation = coerceNumber(v1Group.rotation)
 
-				const v1Shapes = Object.values(v1Page.shapes ?? {})
-					.sort((a, b) => (a.childIndex < b.childIndex ? -1 : 1))
-					.slice(0, editor.options.maxShapesPerPage)
+				if (rotation !== 0) {
+					editor.select(v2GroupId)
+					editor.rotateShapesBy([v2GroupId], rotation)
+				}
+			})
 
-				// Groups only
-				v1Shapes.forEach((v1Shape) => {
-					if (v1Shape.type !== TLV1ShapeType.Group) return
+			// Bind arrows to shapes
 
-					const shapeId = createShapeId()
-					v1ShapeIdsToV2ShapeIds.set(v1Shape.id, shapeId)
-					v1GroupShapeIdsToV1ChildIds.set(v1Shape.id, [])
-				})
-
-				function decideNotToCreateShape(v1Shape: TLV1Shape) {
-					v1ShapeIdsToV2ShapeIds.delete(v1Shape.id)
-					const v1GroupParent = v1GroupShapeIdsToV1ChildIds.has(v1Shape.parentId)
-					if (v1GroupParent) {
-						const ids = v1GroupShapeIdsToV1ChildIds
-							.get(v1Shape.parentId)!
-							.filter((id) => id !== v1Shape.id)
-						v1GroupShapeIdsToV1ChildIds.set(v1Shape.parentId, ids)
-					}
+			v1Shapes.forEach((v1Shape) => {
+				if (v1Shape.type !== TLV1ShapeType.Arrow) {
+					return
 				}
 
-				// Non-groups only
-				v1Shapes.forEach((v1Shape) => {
-					// Skip groups for now, we'll create groups via the app's API
-					if (v1Shape.type === TLV1ShapeType.Group) {
-						return
-					}
+				const v2ShapeId = v1ShapeIdsToV2ShapeIds.get(v1Shape.id)!
+				const util = editor.getShapeUtil<TLArrowShape>('arrow')
 
-					const shapeId = createShapeId()
-					v1ShapeIdsToV2ShapeIds.set(v1Shape.id, shapeId)
+				// dumb but necessary
+				editor.inputs.setCtrlKey(false)
 
-					if (v1Shape.parentId !== v1Page.id) {
-						// If the parent is a group, then add the shape to the group's children
-						if (v1GroupShapeIdsToV1ChildIds.has(v1Shape.parentId)) {
-							v1GroupShapeIdsToV1ChildIds.get(v1Shape.parentId)!.push(v1Shape.id)
-						} else {
-							console.warn('parent does not exist', v1Shape)
+				for (const handleId of ['start', 'end'] as const) {
+					const bindingId = v1Shape.handles[handleId].bindingId
+					if (bindingId) {
+						const binding = v1Page.bindings[bindingId]
+						if (!binding) {
+							// arrow has a reference to a binding that no longer exists
+							continue
 						}
-					}
 
-					// First, try to find the shape's parent among the existing groups
-					const parentId = v1PageIdsToV2PageIds.get(v1Page.id)!
+						const targetId = v1ShapeIdsToV2ShapeIds.get(binding.toId)!
 
-					const inCommon = {
-						id: shapeId,
-						parentId,
-						x: coerceNumber(v1Shape.point[0]),
-						y: coerceNumber(v1Shape.point[1]),
-						rotation: 0,
-						isLocked: !!v1Shape.isLocked,
-					}
+						const targetShape = editor.getShape(targetId)!
 
-					switch (v1Shape.type) {
-						case TLV1ShapeType.Sticky: {
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'note',
-									props: {
-										richText: toRichText(v1Shape.text ?? ''),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										align: getV2Align(v1Shape.style.textAlign),
-									},
+						// (unexpected) We didn't create the target shape
+						if (!targetShape) continue
+
+						if (targetId) {
+							const bounds = editor.getShapePageBounds(targetId)!
+
+							const v2ShapeFresh = editor.getShape<TLArrowShape>(v2ShapeId)!
+
+							const nx = clamp((coerceNumber(binding.point[0]) + 0.5) / 2, 0.2, 0.8)
+							const ny = clamp((coerceNumber(binding.point[1]) + 0.5) / 2, 0.2, 0.8)
+
+							const point = editor.getPointInShapeSpace(v2ShapeFresh, {
+								x: bounds.minX + bounds.width * nx,
+								y: bounds.minY + bounds.height * ny,
+							})
+
+							const handles = editor.getShapeHandles(v2ShapeFresh)!
+							const change = util.onHandleDrag!(v2ShapeFresh, {
+								handle: {
+									...handles.find((h) => h.id === handleId)!,
+									x: point.x,
+									y: point.y,
 								},
-							])
-							break
-						}
-						case TLV1ShapeType.Rectangle: {
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'geo',
-									props: {
-										geo: 'rectangle',
-										w: coerceDimension(v1Shape.size[0]),
-										h: coerceDimension(v1Shape.size[1]),
-										richText: toRichText(v1Shape.label ?? ''),
-										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-										labelColor: getV2Color(v1Shape.style.color),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										dash: getV2Dash(v1Shape.style.dash),
-										align: 'middle',
-									},
-								},
-							])
+								isPrecise: point.x !== 0.5 || point.y !== 0.5,
+								isCreatingShape: true,
+							})
 
-							const pageBoundsBeforeLabel = editor.getShapePageBounds(inCommon.id)!
-
-							editor.updateShapes([
-								{
-									id: inCommon.id,
-									type: 'geo',
-									props: {
-										richText: toRichText(v1Shape.label ?? ''),
-									},
-								},
-							])
-
-							if (pageBoundsBeforeLabel.width === pageBoundsBeforeLabel.height) {
-								const shape = editor.getShape<TLGeoShape>(inCommon.id)!
-								const { growY } = shape.props
-								const w = coerceDimension(shape.props.w)
-								const h = coerceDimension(shape.props.h)
-								const newW = w + growY / 2
-								const newH = h + growY / 2
-
-								editor.updateShapes([
-									{
-										id: inCommon.id,
-										type: 'geo',
-										x: coerceNumber(shape.x) - (newW - w) / 2,
-										y: coerceNumber(shape.y) - (newH - h) / 2,
-										props: {
-											w: newW,
-											h: newH,
-										},
-									},
-								])
-							}
-							break
-						}
-						case TLV1ShapeType.Triangle: {
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'geo',
-									props: {
-										geo: 'triangle',
-										w: coerceDimension(v1Shape.size[0]),
-										h: coerceDimension(v1Shape.size[1]),
-										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-										labelColor: getV2Color(v1Shape.style.color),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										dash: getV2Dash(v1Shape.style.dash),
-										align: 'middle',
-									},
-								},
-							])
-
-							const pageBoundsBeforeLabel = editor.getShapePageBounds(inCommon.id)!
-
-							editor.updateShapes([
-								{
-									id: inCommon.id,
-									type: 'geo',
-									props: {
-										richText: toRichText(v1Shape.label ?? ''),
-									},
-								},
-							])
-
-							if (pageBoundsBeforeLabel.width === pageBoundsBeforeLabel.height) {
-								const shape = editor.getShape<TLGeoShape>(inCommon.id)!
-								const { growY } = shape.props
-								const w = coerceDimension(shape.props.w)
-								const h = coerceDimension(shape.props.h)
-								const newW = w + growY / 2
-								const newH = h + growY / 2
-
-								editor.updateShapes([
-									{
-										id: inCommon.id,
-										type: 'geo',
-										x: coerceNumber(shape.x) - (newW - w) / 2,
-										y: coerceNumber(shape.y) - (newH - h) / 2,
-										props: {
-											w: newW,
-											h: newH,
-										},
-									},
-								])
-							}
-							break
-						}
-						case TLV1ShapeType.Ellipse: {
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'geo',
-									props: {
-										geo: 'ellipse',
-										w: coerceDimension(v1Shape.radius[0]) * 2,
-										h: coerceDimension(v1Shape.radius[1]) * 2,
-										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-										labelColor: getV2Color(v1Shape.style.color),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										dash: getV2Dash(v1Shape.style.dash),
-										align: 'middle',
-									},
-								},
-							])
-
-							const pageBoundsBeforeLabel = editor.getShapePageBounds(inCommon.id)!
-
-							editor.updateShapes([
-								{
-									id: inCommon.id,
-									type: 'geo',
-									props: {
-										richText: toRichText(v1Shape.label ?? ''),
-									},
-								},
-							])
-
-							if (pageBoundsBeforeLabel.width === pageBoundsBeforeLabel.height) {
-								const shape = editor.getShape<TLGeoShape>(inCommon.id)!
-								const { growY } = shape.props
-								const w = coerceDimension(shape.props.w)
-								const h = coerceDimension(shape.props.h)
-								const newW = w + growY / 2
-								const newH = h + growY / 2
-
-								editor.updateShapes([
-									{
-										id: inCommon.id,
-										type: 'geo',
-										x: coerceNumber(shape.x) - (newW - w) / 2,
-										y: coerceNumber(shape.y) - (newH - h) / 2,
-										props: {
-											w: newW,
-											h: newH,
-										},
-									},
-								])
+							if (change) {
+								editor.updateShape(change)
 							}
 
-							break
-						}
-						case TLV1ShapeType.Draw: {
-							if (v1Shape.points.length === 0) {
-								decideNotToCreateShape(v1Shape)
-								break
-							}
-
-							const points = v1Shape.points.map(getV2Point)
-							const base64Points = b64Vecs.encodePoints(points)
-
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'draw',
-									props: {
-										fill: getV2Fill(v1Shape.style.isFilled, v1Shape.style.color),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										dash: getV2Dash(v1Shape.style.dash),
-										isPen: false,
-										isComplete: v1Shape.isComplete,
-										segments: [{ type: 'free', path: base64Points }],
-										scale: 1,
-										scaleX: 1,
-										scaleY: 1,
-									},
-								},
-							])
-							break
-						}
-						case TLV1ShapeType.Arrow: {
-							const v1Bend = coerceNumber(v1Shape.bend)
-							const v1Start = getV2Point(v1Shape.handles.start.point)
-							const v1End = getV2Point(v1Shape.handles.end.point)
-							const dist = Vec.Dist(v1Start, v1End)
-							const v2Bend = (dist * -v1Bend) / 2
-
-							// Could also be a line... but we'll use it as an arrow anyway
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'arrow',
-									props: {
-										richText: toRichText(v1Shape.label ?? ''),
-										color: getV2Color(v1Shape.style.color),
-										labelColor: getV2Color(v1Shape.style.color),
-										size: getV2Size(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										dash: getV2Dash(v1Shape.style.dash),
-										arrowheadStart: getV2Arrowhead(v1Shape.decorations?.start),
-										arrowheadEnd: getV2Arrowhead(v1Shape.decorations?.end),
-										start: {
-											x: coerceNumber(v1Shape.handles.start.point[0]),
-											y: coerceNumber(v1Shape.handles.start.point[1]),
-										},
-										end: {
-											x: coerceNumber(v1Shape.handles.end.point[0]),
-											y: coerceNumber(v1Shape.handles.end.point[1]),
-										},
-										bend: v2Bend,
-									},
-								},
-							])
-
-							break
-						}
-						case TLV1ShapeType.Text: {
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'text',
-									props: {
-										richText: toRichText(v1Shape.text ?? ' '),
-										color: getV2Color(v1Shape.style.color),
-										size: getV2TextSize(v1Shape.style.size),
-										font: getV2Font(v1Shape.style.font),
-										textAlign: getV2TextAlign(v1Shape.style.textAlign),
-										scale: v1Shape.style.scale ?? 1,
-									},
-								},
-							])
-							break
-						}
-						case TLV1ShapeType.Image: {
-							const assetId = v1AssetIdsToV2AssetIds.get(v1Shape.assetId)
-
-							if (!assetId) {
-								console.warn('Could not find asset id', v1Shape.assetId)
-								return
-							}
-
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'image',
-									props: {
-										w: coerceDimension(v1Shape.size[0]),
-										h: coerceDimension(v1Shape.size[1]),
-										assetId,
-									},
-								},
-							])
-							break
-						}
-						case TLV1ShapeType.Video: {
-							const assetId = v1AssetIdsToV2AssetIds.get(v1Shape.assetId)
-
-							if (!assetId) {
-								console.warn('Could not find asset id', v1Shape.assetId)
-								return
-							}
-
-							editor.createShapes([
-								{
-									...inCommon,
-									type: 'video',
-									props: {
-										w: coerceDimension(v1Shape.size[0]),
-										h: coerceDimension(v1Shape.size[1]),
-										assetId,
-									},
-								},
-							])
-							break
-						}
-					}
-
-					const rotation = coerceNumber(v1Shape.rotation)
-
-					if (rotation !== 0) {
-						editor.select(shapeId)
-						editor.rotateShapesBy([shapeId], rotation)
-					}
-				})
-
-				// Create groups
-				v1GroupShapeIdsToV1ChildIds.forEach((v1ChildIds, v1GroupId) => {
-					const v2ChildShapeIds = v1ChildIds.map((id) => v1ShapeIdsToV2ShapeIds.get(id)!)
-					const v2GroupId = v1ShapeIdsToV2ShapeIds.get(v1GroupId)!
-					editor.groupShapes(v2ChildShapeIds, { groupId: v2GroupId })
-
-					const v1Group = v1Page.shapes[v1GroupId]
-					const rotation = coerceNumber(v1Group.rotation)
-
-					if (rotation !== 0) {
-						editor.select(v2GroupId)
-						editor.rotateShapesBy([v2GroupId], rotation)
-					}
-				})
-
-				// Bind arrows to shapes
-
-				v1Shapes.forEach((v1Shape) => {
-					if (v1Shape.type !== TLV1ShapeType.Arrow) {
-						return
-					}
-
-					const v2ShapeId = v1ShapeIdsToV2ShapeIds.get(v1Shape.id)!
-					const util = editor.getShapeUtil<TLArrowShape>('arrow')
-
-					// dumb but necessary
-					editor.inputs.setCtrlKey(false)
-
-					for (const handleId of ['start', 'end'] as const) {
-						const bindingId = v1Shape.handles[handleId].bindingId
-						if (bindingId) {
-							const binding = v1Page.bindings[bindingId]
-							if (!binding) {
-								// arrow has a reference to a binding that no longer exists
-								continue
-							}
-
-							const targetId = v1ShapeIdsToV2ShapeIds.get(binding.toId)!
-
-							const targetShape = editor.getShape(targetId)!
-
-							// (unexpected) We didn't create the target shape
-							if (!targetShape) continue
-
-							if (targetId) {
-								const bounds = editor.getShapePageBounds(targetId)!
-
-								const v2ShapeFresh = editor.getShape<TLArrowShape>(v2ShapeId)!
-
-								const nx = clamp((coerceNumber(binding.point[0]) + 0.5) / 2, 0.2, 0.8)
-								const ny = clamp((coerceNumber(binding.point[1]) + 0.5) / 2, 0.2, 0.8)
-
-								const point = editor.getPointInShapeSpace(v2ShapeFresh, {
-									x: bounds.minX + bounds.width * nx,
-									y: bounds.minY + bounds.height * ny,
-								})
-
-								const handles = editor.getShapeHandles(v2ShapeFresh)!
-								const change = util.onHandleDrag!(v2ShapeFresh, {
-									handle: {
-										...handles.find((h) => h.id === handleId)!,
-										x: point.x,
-										y: point.y,
-									},
-									isPrecise: point.x !== 0.5 || point.y !== 0.5,
-									isCreatingShape: true,
-								})
-
-								if (change) {
-									editor.updateShape(change)
+							const freshBinding = getArrowBindings(
+								editor,
+								editor.getShape<TLArrowShape>(v2ShapeId)!
+							)[handleId]
+							if (freshBinding) {
+								const updatedFreshBinding = structuredClone(freshBinding)
+								if (binding.distance === 0) {
+									updatedFreshBinding.props.isExact = true
+								}
+								if (updatedFreshBinding.toId !== targetId) {
+									updatedFreshBinding.toId = targetId
+									updatedFreshBinding.props.normalizedAnchor = { x: nx, y: ny }
 								}
 
-								const freshBinding = getArrowBindings(
-									editor,
-									editor.getShape<TLArrowShape>(v2ShapeId)!
-								)[handleId]
-								if (freshBinding) {
-									const updatedFreshBinding = structuredClone(freshBinding)
-									if (binding.distance === 0) {
-										updatedFreshBinding.props.isExact = true
-									}
-									if (updatedFreshBinding.toId !== targetId) {
-										updatedFreshBinding.toId = targetId
-										updatedFreshBinding.props.normalizedAnchor = { x: nx, y: ny }
-									}
-
-									editor.updateBinding(updatedFreshBinding)
-								}
+								editor.updateBinding(updatedFreshBinding)
 							}
 						}
 					}
-				})
+				}
 			})
+		})
 
 		// Set the current page to the first page again
 		editor.setCurrentPage(firstPageId)
@@ -604,6 +507,31 @@ export function buildFromV1Document(editor: Editor, _document: unknown) {
 			editor.zoomToBounds(bounds, { targetZoom: 1 })
 		}
 	})
+}
+
+function applyV1GeoLabel(editor: Editor, id: TLShapeId, label: string | undefined) {
+	const pageBoundsBeforeLabel = editor.getShapePageBounds(id)!
+
+	editor.updateShapes([{ id, type: 'geo', props: { richText: toRichText(label ?? '') } }])
+
+	if (pageBoundsBeforeLabel.width === pageBoundsBeforeLabel.height) {
+		const shape = editor.getShape<TLGeoShape>(id)!
+		const { growY } = shape.props
+		const w = coerceDimension(shape.props.w)
+		const h = coerceDimension(shape.props.h)
+		const newW = w + growY / 2
+		const newH = h + growY / 2
+
+		editor.updateShapes([
+			{
+				id,
+				type: 'geo',
+				x: coerceNumber(shape.x) - (newW - w) / 2,
+				y: coerceNumber(shape.y) - (newH - h) / 2,
+				props: { w: newW, h: newH },
+			},
+		])
+	}
 }
 
 function coerceNumber(n: unknown): number {

--- a/packages/tldraw/src/lib/utils/tldr/file.ts
+++ b/packages/tldraw/src/lib/utils/tldr/file.ts
@@ -79,10 +79,7 @@ const tldrawFileValidator: T.Validator<TldrawFile> = T.object({
 /** @public */
 export function isV1File(data: any) {
 	try {
-		if (data.document?.version) {
-			return true
-		}
-		return false
+		return !!data.document?.version
 	} catch {
 		return false
 	}
@@ -182,41 +179,28 @@ function pruneUnusedAssets(records: TLRecord[]) {
 export async function serializeTldrawJson(editor: Editor): Promise<string> {
 	const records: TLRecord[] = []
 	for (const record of editor.store.allRecords()) {
-		switch (record.typeName) {
-			case 'asset':
-				if (
-					record.type !== 'bookmark' &&
-					record.props.src &&
-					!record.props.src.startsWith('data:')
-				) {
-					let assetSrcToSave
-					try {
-						let src = record.props.src
-						if (!src.startsWith('http')) {
-							src =
-								(await editor.resolveAssetUrl(record.id, { shouldResolveToOriginal: true })) || ''
-						}
-						// try to save the asset as a base64 string
-						assetSrcToSave = await FileHelpers.blobToDataUrl(await (await fetch(src)).blob())
-					} catch {
-						// if that fails, just save the original src
-						assetSrcToSave = record.props.src
-					}
-
-					records.push({
-						...record,
-						props: {
-							...record.props,
-							src: assetSrcToSave,
-						},
-					})
-				} else {
-					records.push(record)
+		if (
+			record.typeName === 'asset' &&
+			record.type !== 'bookmark' &&
+			record.props.src &&
+			!record.props.src.startsWith('data:')
+		) {
+			let assetSrcToSave
+			try {
+				let src = record.props.src
+				if (!src.startsWith('http')) {
+					src = (await editor.resolveAssetUrl(record.id, { shouldResolveToOriginal: true })) || ''
 				}
-				break
-			default:
-				records.push(record)
-				break
+				// try to save the asset as a base64 string
+				assetSrcToSave = await FileHelpers.blobToDataUrl(await (await fetch(src)).blob())
+			} catch {
+				// if that fails, just save the original src
+				assetSrcToSave = record.props.src
+			}
+
+			records.push({ ...record, props: { ...record.props, src: assetSrcToSave } })
+		} else {
+			records.push(record)
 		}
 	}
 
@@ -358,7 +342,6 @@ async function extractAssets(
 					severity: 'error',
 				})
 				console.error(error)
-				return
 			}
 		})
 	)


### PR DESCRIPTION
In order to make the tldraw package easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over the non-UI parts of `packages/tldraw` (shapes, tools, overlays, utils, bindings, and the top-level `Tldraw` files) and applies the fixes. It is the tldraw core slice of #10068, split out so it can be reviewed on its own (the `src/lib/ui` slice is a separate PR). The public API is unchanged and behavior is intended to be preserved: it deduplicates copy-pasted helpers, replaces switch/if chains with lookup tables, deletes dead code and never-read state, hoists repeated work out of hot paths, and trims narration, banner, and restatement comments per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` and the unit suites for the touched packages pass.

- [x] Unit tests

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change    |
| --------- | ------------- |
| Core code | +2000 / -3670 |
