### PR TITLE
refactor(templates): simplify pass over the chat, branching-chat, shader, and server templates

### DIFF
--- a/templates/branching-chat/client/App.tsx
+++ b/templates/branching-chat/client/App.tsx
@@ -18,14 +18,10 @@ import { disableTransparency } from './disableTransparency.tsx'
 import { NodeShapeUtil } from './nodes/NodeShapeUtil.tsx'
 import { PointingPort } from './ports/PointingPort.tsx'
 
-// Define custom shape utilities that extend tldraw's shape system
 const shapeUtils = [NodeShapeUtil, ConnectionShapeUtil]
-// Define binding utilities that handle relationships between shapes
 const bindingUtils = [ConnectionBindingUtil]
-// Canvas overlays — adds the "+" insert handle at the midpoint of each connection
 const overlayUtils = [ConnectionCenterHandleOverlayUtil]
 
-// Customize tldraw's UI components to add workflow-specific functionality
 const components: TLComponents = {
 	Toolbar: () => (
 		<>
@@ -44,12 +40,9 @@ const components: TLComponents = {
 		const editor = useEditor()
 		const shouldShowStylePanel = useValue(
 			'shouldShowStylePanel',
-			() => {
-				return (
-					!editor.isIn('select') ||
-					editor.getSelectedShapes().some((s) => s.type !== 'node' && s.type !== 'connection')
-				)
-			},
+			() =>
+				!editor.isIn('select') ||
+				editor.getSelectedShapes().some((s) => s.type !== 'node' && s.type !== 'connection'),
 			[editor]
 		)
 		if (!shouldShowStylePanel) return
@@ -81,17 +74,11 @@ function App() {
 
 					editor.user.updateUserPreferences({ isSnapMode: true })
 
-					// Add our custom pointing port tool to the select tool's state machine
-					// This allows users to create connections by pointing at ports
+					// Lets users create connections by dragging from ports
 					editor.getStateDescendant('select')!.addChild(PointingPort)
 
 					// todo: move connections to on the canvas layer
-
-					// Ensure connections always stay at the bottom of the shape stack
-					// This prevents them from covering other shapes
 					keepConnectionsAtBottom(editor)
-
-					// Disable transparency for workflow shapes
 					disableTransparency(editor, ['node', 'connection'])
 				}}
 			/>

--- a/templates/branching-chat/client/components/WorkflowToolbar.tsx
+++ b/templates/branching-chat/client/components/WorkflowToolbar.tsx
@@ -33,31 +33,25 @@ import { NodeShape } from '../nodes/NodeShapeUtil'
 import { getNodeDefinitions, NodeType } from '../nodes/nodeTypes'
 
 function createNodeShape(editor: Editor, shapeId: TLShapeId, center: Vec, node: NodeType) {
-	// Mark a history stopping point for undo/redo
-	const markId = editor.markHistoryStoppingPoint('create node')
+	editor.markHistoryStoppingPoint('create node')
 
 	editor.run(() => {
-		// Create the shape with the node definition
 		editor.createShape({
 			id: shapeId,
 			type: 'node',
 			props: { node },
 		})
 
-		// Get the created shape and its bounds
+		// Center the shape on the drop point; its size isn't known until it exists
 		const shape = editor.getShape<NodeShape>(shapeId)!
 		const shapeBounds = editor.getShapePageBounds(shapeId)!
-
-		// Position the shape so its center aligns with the drop point
-		const x = center.x - shapeBounds.width / 2
-		const y = center.y - shapeBounds.height / 2
-		editor.updateShape({ ...shape, x, y })
-
-		// Select the newly created shape
+		editor.updateShape({
+			...shape,
+			x: center.x - shapeBounds.width / 2,
+			y: center.y - shapeBounds.height / 2,
+		})
 		editor.select(shapeId)
 	})
-
-	return markId
 }
 
 export const overrides: TLUiOverrides = {

--- a/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
@@ -45,49 +45,42 @@ export class ConnectionBindingUtil extends BindingUtil<ConnectionBinding> {
 		return {}
 	}
 
+	// A connection can't outlive either of the nodes it's bound to
 	onBeforeIsolateToShape({ binding }: BindingOnShapeIsolateOptions<ConnectionBinding>): void {
-		// When we're duplicating a node but not its connection, delete the connection
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<ConnectionBinding>): void {
-		// When we're deleting a node, delete any connections that are bound to it
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onAfterCreate({ binding }: BindingOnCreateOptions<ConnectionBinding>): void {
-		// Our ports system has an `onConnect` callback - call it when we create a connection
-		const node = this.editor.getShape(binding.toId)
-		if (!node || !this.editor.isShapeOfType(node, 'node')) return
-		onNodePortConnect(this.editor, node, binding.props.portId)
+		const node = this.getBoundNode(binding)
+		if (node) onNodePortConnect(this.editor, node, binding.props.portId)
 	}
 
 	onAfterChange({ bindingBefore, bindingAfter }: BindingOnChangeOptions<ConnectionBinding>): void {
-		// We also might need to call the connection callbacks if we change the thing this connection is binding to.
 		if (
-			bindingBefore.props.portId !== bindingAfter.props.portId ||
-			bindingBefore.toId !== bindingAfter.toId
+			bindingBefore.props.portId === bindingAfter.props.portId &&
+			bindingBefore.toId === bindingAfter.toId
 		) {
-			const nodeBefore = this.editor.getShape(bindingBefore.toId)
-			const nodeAfter = this.editor.getShape(bindingAfter.toId)
-			if (
-				!nodeBefore ||
-				!nodeAfter ||
-				!this.editor.isShapeOfType(nodeBefore, 'node') ||
-				!this.editor.isShapeOfType(nodeAfter, 'node')
-			) {
-				return
-			}
-			onNodePortDisconnect(this.editor, nodeBefore, bindingBefore.props.portId)
-			onNodePortConnect(this.editor, nodeAfter, bindingAfter.props.portId)
+			return
 		}
+		const nodeBefore = this.getBoundNode(bindingBefore)
+		const nodeAfter = this.getBoundNode(bindingAfter)
+		if (!nodeBefore || !nodeAfter) return
+		onNodePortDisconnect(this.editor, nodeBefore, bindingBefore.props.portId)
+		onNodePortConnect(this.editor, nodeAfter, bindingAfter.props.portId)
 	}
 
 	onAfterDelete({ binding }: BindingOnDeleteOptions<ConnectionBinding>): void {
-		// When we're deleting a connection, we need to call the node's port disconnect callback
+		const node = this.getBoundNode(binding)
+		if (node) onNodePortDisconnect(this.editor, node, binding.props.portId)
+	}
+
+	private getBoundNode(binding: ConnectionBinding): NodeShape | undefined {
 		const node = this.editor.getShape(binding.toId)
-		if (!node || !this.editor.isShapeOfType(node, 'node')) return
-		onNodePortDisconnect(this.editor, node, binding.props.portId)
+		return node && this.editor.isShapeOfType(node, 'node') ? node : undefined
 	}
 }
 
@@ -102,7 +95,6 @@ export function getConnectionBindings(
 	editor: Editor,
 	shape: ConnectionShape | TLShapeId
 ): ConnectionBindings {
-	// we cache the bindings so we don't have to recompute them every time - this function gets called a lot.
 	return connectionBindingsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
 
@@ -121,9 +113,7 @@ const connectionBindingsCache = createComputedCache(
 		return { start, end }
 	},
 	{
-		// we only look at the arrow IDs:
 		areRecordsEqual: (a, b) => a.id === b.id,
-		// the records should stay the same:
 		areResultsEqual: (a, b) => a.start === b.start && a.end === b.end,
 	}
 )
@@ -133,15 +123,12 @@ export function getConnectionBindingPositionInPageSpace(
 	editor: Editor,
 	binding: ConnectionBinding
 ) {
-	// Find the shape that this binding is bound to
 	const targetShape = editor.getShape(binding.toId)
 	if (!targetShape || !editor.isShapeOfType(targetShape, 'node')) return null
 
-	// Find the port in the shape that the connection is bound to
-	const port = getNodePorts(editor, targetShape)?.[binding.props.portId]
+	const port = getNodePorts(editor, targetShape)[binding.props.portId]
 	if (!port) return null
 
-	// Transform the port position from shape space to page space
 	return editor.getShapePageTransform(targetShape).applyToPoint(port)
 }
 

--- a/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
@@ -24,8 +24,7 @@ interface TLConnectionCenterHandleOverlay extends TLOverlay {
 
 /**
  * Renders a clickable "+" handle at the midpoint of each fully-bound connection
- * so users can insert a new node into the middle of a connection. Replaces the
- * old SVG indicator-based handle.
+ * so users can insert a new node into the middle of a connection.
  */
 export class ConnectionCenterHandleOverlayUtil extends OverlayUtil<TLConnectionCenterHandleOverlay> {
 	static override type = 'connection_center_handle'
@@ -66,7 +65,7 @@ export class ConnectionCenterHandleOverlayUtil extends OverlayUtil<TLConnectionC
 	}
 
 	override getCursor(): TLCursorType {
-		return 'pointer' as TLCursorType
+		return 'pointer'
 	}
 
 	override onPointerDown(overlay: TLConnectionCenterHandleOverlay, _info: TLPointerEventInfo) {

--- a/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-import classNames from 'classnames'
 import {
 	CubicBezier2d,
 	Editor,
@@ -11,6 +9,7 @@ import {
 	TLHandle,
 	TLHandleDragInfo,
 	TLShape,
+	TLShapeId,
 	Vec,
 	VecLike,
 	VecModel,
@@ -82,20 +81,15 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		return true
 	}
 	override canSnap(_shape: ConnectionShape) {
-		// disable snapping this shape to other shapes
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: ConnectionShape) {
-		return {
-			// disable snapping other shape to this shape
-			points: [],
-		}
+		return { points: [] }
 	}
 
-	// Define the geometry of our connection shape as a cubic bezier curve
 	getGeometry(connection: ConnectionShape) {
 		const { start, end } = getConnectionTerminals(this.editor, connection)
-		const [cp1, cp2] = getConnectionControlPoints(start, end, 'vertical')
+		const [cp1, cp2] = getConnectionControlPoints(start, end)
 		return new CubicBezier2d({
 			start: Vec.From(start),
 			cp1: Vec.From(cp1),
@@ -105,7 +99,6 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 
 	getHandles(connection: ConnectionShape): TLHandle[] {
-		// Handles are draggable points on a shape. In our connection shape, we have a handle at each end.
 		const { start, end } = getConnectionTerminals(this.editor, connection)
 		return [
 			{
@@ -125,38 +118,28 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		]
 	}
 
-	// Handle dragging of connection terminals to connect/disconnect from ports
 	onHandleDrag(connection: ConnectionShape, { handle }: TLHandleDragInfo<ConnectionShape>) {
-		// First, get some info about the connection and the terminal we're dragging
 		const existingBindings = getConnectionBindings(this.editor, connection)
 		const draggingTerminal = handle.id as 'start' | 'end'
 		const oppositeTerminal = draggingTerminal === 'start' ? 'end' : 'start'
 		const oppositeTerminalShapeId = existingBindings[oppositeTerminal]?.toId
 
-		// Find the new position of the handle in page space
-		const shapeTransform = this.editor.getShapePageTransform(connection)
-		const handlePagePosition = shapeTransform.applyToPoint(handle)
-
-		// Find the port at the new position
+		const handlePagePosition = this.editor.getShapePageTransform(connection).applyToPoint(handle)
 		const target = getPortAtPoint(this.editor, handlePagePosition, {
 			margin: 8,
-			terminal: handle.id as 'start' | 'end',
+			terminal: draggingTerminal,
 		})
 
 		// only 'start' ports (outputs) can have multiple connections
 		const allowsMultipleConnections = draggingTerminal === 'start'
-
-		// does this port have an existing connection (excluding this one)?
 		const hasExistingConnection =
 			target?.existingConnections.some((c) => c.connectionId !== connection.id) ?? false
 
-		// find out which nodes would create a cycle based on what the other end of the connection
-		// is bound to
+		// anything reachable from the other end of the connection would form a cycle
 		const nodesWhichWouldCreateACycle = oppositeTerminalShapeId
 			? getAllConnectedNodes(this.editor, oppositeTerminalShapeId, draggingTerminal)
 			: null
 
-		// update our port UI state to highlight which ports are eligible to connect to
 		updatePortState(this.editor, {
 			eligiblePorts: {
 				terminal: draggingTerminal,
@@ -164,16 +147,10 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			},
 		})
 
-		// if for whatever reason we can't connect to this port...
 		const wouldCreateACycle = (target && nodesWhichWouldCreateACycle?.has(target.shape.id)) ?? false
 		if (!target || (hasExistingConnection && !allowsMultipleConnections) || wouldCreateACycle) {
-			// ... update our port ui state to not highlight any ports...
 			updatePortState(this.editor, { hintingPort: null })
-
-			// ... remove any existing binding for this connection terminal...
 			removeConnectionBinding(this.editor, connection, draggingTerminal)
-
-			// ... and return the connection with the new position.
 			return {
 				...connection,
 				props: {
@@ -182,83 +159,38 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			}
 		}
 
-		// if we can connect to this port, update our port ui state to highlight the port we're
-		// connecting to
 		updatePortState(this.editor, {
 			hintingPort: { portId: target.port.id, shapeId: target.shape.id },
 		})
-
-		// create or update the connection binding for this connection terminal
 		createOrUpdateConnectionBinding(this.editor, connection, target.shape, {
 			portId: target.port.id,
 			terminal: draggingTerminal,
 		})
 
-		// return the connection unmodified because we only need to update the binding.
+		// the binding now determines the terminal position, so the shape itself is unchanged
 		return connection
 	}
 
-	// Handle the end of dragging a connection terminal
 	onHandleDragEnd(
 		connection: ConnectionShape,
 		{ handle, isCreatingShape }: TLHandleDragInfo<ConnectionShape>
 	) {
-		// clear our port UI state
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 
 		const draggingTerminal = handle.id as 'start' | 'end'
-
-		// if we successfully connected & now have a binding, we're done!
 		const bindings = getConnectionBindings(this.editor, connection)
-		if (bindings[draggingTerminal]) {
-			return
-		}
+		if (bindings[draggingTerminal]) return
 
-		// If we were creating a new connection and didn't attach it to anything, open the component
-		// picker to let the user choose a node to create.
 		if (isCreatingShape && draggingTerminal === 'end') {
-			this.editor.selectNone()
-			const newNodeId = createShapeId()
-			const terminalInPageSpace = this.editor.inputs.getCurrentPagePoint()
-			this.editor.createShape({
-				type: 'node',
-				id: newNodeId,
-				x: terminalInPageSpace.x,
-				y: terminalInPageSpace.y,
-				props: {
-					node: { type: 'message', userMessage: '', assistantMessage: '' },
-				},
-			})
-			this.editor.select(newNodeId)
-
-			// Position the node so its input port aligns with the connection end
-			const ports = getNodePorts(this.editor, newNodeId)
-			const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
-			if (firstInputPort) {
-				this.editor.updateShape({
-					id: newNodeId,
-					type: 'node',
-					x: terminalInPageSpace.x - firstInputPort.x,
-					y: terminalInPageSpace.y - firstInputPort.y,
-				})
-
-				// bind the connection to the node's first input port
-				createOrUpdateConnectionBinding(this.editor, connection, newNodeId, {
-					portId: firstInputPort.id,
-					terminal: draggingTerminal,
-				})
-			}
-		} else {
-			// if we're not creating a new connection and we just let go, there must be bindings. If
-			// not, let's interpret this as the user disconnecting the shape.
-			if (!bindings.start || !bindings.end) {
-				this.editor.deleteShapes([connection.id])
-			}
+			// A new connection dropped in empty space gets a fresh node to connect to
+			createNodeAtConnectionEnd(this.editor, connection, this.editor.inputs.getCurrentPagePoint())
+		} else if (!bindings.start || !bindings.end) {
+			// Letting go of an existing connection's terminal with nothing under it disconnects it
+			this.editor.deleteShapes([connection.id])
 		}
 	}
 
 	onHandleDragCancel() {
-		// if we cancel a drag part way through, we need to clear out our port UI state.
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 	}
 
@@ -272,18 +204,15 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 }
 
-// Main connection component that renders the SVG path
 function ConnectionShape({ connection }: { connection: ConnectionShape }) {
 	const editor = useEditor()
-
-	// Get the connection terminals
 	const { start, end } = useValue('terminals', () => getConnectionTerminals(editor, connection), [
 		editor,
 		connection,
 	])
 
 	return (
-		<SVGContainer className={classNames('ConnectionShape')}>
+		<SVGContainer className="ConnectionShape">
 			<path d={getConnectionPath(start, end)} />
 		</SVGContainer>
 	)
@@ -299,7 +228,7 @@ export function getConnectionPageCenter(editor: Editor, connection: ConnectionSh
 	const startPage = getConnectionBindingPositionInPageSpace(editor, bindings.start)
 	const endPage = getConnectionBindingPositionInPageSpace(editor, bindings.end)
 	if (!startPage || !endPage) return null
-	const [cp1, cp2] = getConnectionControlPoints(startPage, endPage, 'vertical')
+	const [cp1, cp2] = getConnectionControlPoints(startPage, endPage)
 	// Cubic bezier midpoint at t=0.5: (P0 + 3·P1 + 3·P2 + P3) / 8
 	return new Vec(
 		(startPage.x + 3 * cp1.x + 3 * cp2.x + endPage.x) / 8,
@@ -307,55 +236,69 @@ export function getConnectionPageCenter(editor: Editor, connection: ConnectionSh
 	)
 }
 
-// Calculate control points for smooth bezier curves
-function getConnectionControlPoints(start: VecLike, end: VecLike, dir = 'horizontal'): [Vec, Vec] {
-	if (dir === 'horizontal') {
-		const distance = end.x - start.x
-		const adjustedDistance = Math.max(
-			30,
-			distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
-		)
-		return [new Vec(start.x + adjustedDistance, start.y), new Vec(end.x - adjustedDistance, end.y)]
-	} else {
-		const distance = end.y - start.y
-		const adjustedDistance = Math.max(
-			30,
-			distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
-		)
-		return [new Vec(start.x, start.y + adjustedDistance), new Vec(end.x, end.y - adjustedDistance)]
-	}
+// Connections flow top-to-bottom, so control points are offset vertically from each terminal
+function getConnectionControlPoints(start: VecLike, end: VecLike): [Vec, Vec] {
+	const distance = end.y - start.y
+	const adjustedDistance = Math.max(
+		30,
+		distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
+	)
+	return [new Vec(start.x, start.y + adjustedDistance), new Vec(end.x, end.y - adjustedDistance)]
 }
 
-// Generate SVG path for the connection
-function getConnectionPath(start: VecLike, end: VecLike, dir = 'vertical') {
-	const [cp1, cp2] = getConnectionControlPoints(start, end, dir)
+function getConnectionPath(start: VecLike, end: VecLike) {
+	const [cp1, cp2] = getConnectionControlPoints(start, end)
 	return `M ${start.x} ${start.y} C ${cp1.x} ${cp1.y} ${cp2.x} ${cp2.y} ${end.x} ${end.y}`
 }
 
-// Get the actual start and end points of a connection, considering its bindings
+/**
+ * The start and end points of a connection in its own shape space. Bound terminals follow the port
+ * they're bound to; unbound terminals use the position stored on the shape.
+ */
 export function getConnectionTerminals(editor: Editor, connection: ConnectionShape) {
-	let start, end
-
-	// if possible, set the start and end points based on the bindings
 	const bindings = getConnectionBindings(editor, connection)
 	const shapeTransform = Mat.Inverse(editor.getShapePageTransform(connection))
-	if (bindings.start) {
-		const inPageSpace = getConnectionBindingPositionInPageSpace(editor, bindings.start)
-		if (inPageSpace) {
-			start = Mat.applyToPoint(shapeTransform, inPageSpace)
-		}
-	}
-	if (bindings.end) {
-		const inPageSpace = getConnectionBindingPositionInPageSpace(editor, bindings.end)
-		if (inPageSpace) {
-			end = Mat.applyToPoint(shapeTransform, inPageSpace)
-		}
+
+	const getTerminal = (terminal: 'start' | 'end'): VecLike => {
+		const binding = bindings[terminal]
+		const inPageSpace = binding && getConnectionBindingPositionInPageSpace(editor, binding)
+		return inPageSpace ? Mat.applyToPoint(shapeTransform, inPageSpace) : connection.props[terminal]
 	}
 
-	// if we couldn't set the start and end points based on the bindings, use the values stored on
-	// the shape itself
-	if (!start) start = connection.props.start
-	if (!end) end = connection.props.end
+	return { start: getTerminal('start'), end: getTerminal('end') }
+}
 
-	return { start, end }
+/**
+ * Create a new message node whose input port sits at `point` and bind the connection's end to it.
+ * Returns the new node's id.
+ */
+export function createNodeAtConnectionEnd(
+	editor: Editor,
+	connection: ConnectionShape | TLShapeId,
+	point: VecLike
+): TLShapeId {
+	const newNodeId = createShapeId()
+	editor.createShape({
+		type: 'node',
+		id: newNodeId,
+		x: point.x,
+		y: point.y,
+		props: { node: { type: 'message', userMessage: '', assistantMessage: '' } },
+	})
+	editor.select(newNodeId)
+
+	const inputPort = Object.values(getNodePorts(editor, newNodeId)).find((p) => p.terminal === 'end')
+	if (inputPort) {
+		editor.updateShape({
+			id: newNodeId,
+			type: 'node',
+			x: point.x - inputPort.x,
+			y: point.y - inputPort.y,
+		})
+		createOrUpdateConnectionBinding(editor, connection, newNodeId, {
+			portId: inputPort.id,
+			terminal: 'end',
+		})
+	}
+	return newNodeId
 }

--- a/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
+++ b/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
@@ -5,38 +5,31 @@ import { createOrUpdateConnectionBinding, getConnectionBindings } from './Connec
 import { ConnectionShape } from './ConnectionShapeUtil'
 
 /**
- * Insert a node in the middle of a connection.
- *
- * This is used when the user clicks the center handle of a connection shape.
+ * Insert a node in the middle of a connection, used when the user clicks a connection's center
+ * handle. Downstream nodes are nudged out of the way to make room.
  */
 export function insertNodeWithinConnection(
 	editor: Editor,
 	connection: ConnectionShape,
 	direction: 'horizontal' | 'vertical' = 'horizontal'
 ) {
-	// mark the history so we can undo this operation
 	const mark = editor.markHistoryStoppingPoint()
 
-	// get the original bindings of the connection
 	const originalBindings = getConnectionBindings(editor, connection)
-
-	// if the connection doesn't have bindings, we can't insert a node in the middle of it
 	if (!originalBindings.start || !originalBindings.end) return
 
-	// find the ideal position for the new node based on direction:
 	const startBounds = editor.getShapePageBounds(originalBindings.start.toId)!
 	const endBounds = editor.getShapePageBounds(originalBindings.end.toId)!
 
+	// Aim for the midpoint between the two nodes, but never overlap the upstream one
 	let newNodeX: number, newNodeY: number
 
 	if (direction === 'horizontal') {
-		// horizontal layout: nodes flow left to right
 		newNodeY = (startBounds.top + endBounds.top) / 2
 		const newNodeIdealX = (startBounds.right + endBounds.left - NODE_WIDTH_PX) / 2
 		const newNodeMin = startBounds.right + DEFAULT_NODE_SPACING_PX
 		newNodeX = Math.max(newNodeIdealX, newNodeMin)
 	} else {
-		// vertical layout: nodes flow top to bottom
 		newNodeX = (startBounds.left + endBounds.left) / 2
 		if (startBounds.top > endBounds.bottom) {
 			const newNodeIdealY = (startBounds.top + endBounds.bottom - NODE_HEIGHT_PX) / 2
@@ -49,7 +42,6 @@ export function insertNodeWithinConnection(
 		}
 	}
 
-	// create the new node
 	const newNodeId = createShapeId()
 	editor.createShape({
 		type: 'node',
@@ -59,8 +51,6 @@ export function insertNodeWithinConnection(
 		props: { node: { type: 'message', userMessage: '', assistantMessage: '' } },
 	})
 
-	// now, we need to connect up the new node.
-	// first, lets find the first input and output port on the new node.
 	const ports = getNodePorts(editor, newNodeId)
 	const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
 	const firstOutputPort = Object.values(ports).find((p) => p.terminal === 'start')
@@ -69,13 +59,12 @@ export function insertNodeWithinConnection(
 		return
 	}
 
-	// update the existing connection to connect to the input of our new node
+	// re-point the existing connection at the new node, then connect the new node to the old target
 	createOrUpdateConnectionBinding(editor, connection, newNodeId, {
 		portId: firstInputPort.id,
 		terminal: 'end',
 	})
 
-	// create a new connection between the new node and the end of the original connection
 	const newConnectionId = createShapeId()
 	editor.createShape({
 		type: 'connection',
@@ -90,20 +79,16 @@ export function insertNodeWithinConnection(
 		terminal: 'end',
 	})
 
-	// move around any connected nodes to make room for the new one
 	moveNodesIfNeeded(editor, newNodeId, originalBindings.end.toId, direction)
-
-	// select the new node
 	editor.select(newNodeId)
 
-	// update the pointer so that e.g. the editor's internal hovered shape id is correct
+	// so the editor's hovered shape reflects what's now under the pointer
 	editor.updatePointer()
 }
 
 /**
- * Move around any connected nodes to make room for the new node.
- *
- * This is used when the user inserts a node in the middle of a connection.
+ * Nudge the downstream nodes of `rootNodeId` away from the newly inserted node, then animate
+ * everything into place.
  */
 function moveNodesIfNeeded(
 	editor: Editor,
@@ -122,14 +107,11 @@ function moveNodesIfNeeded(
 		return
 	}
 
-	// first, we need to nudge all the downstream nodes to make room for the new node.
-	// toNudge tracks all the nodes we need to nudge.
 	const toNudge = new Map<
 		TLShapeId,
 		{ initialX: number; initialY: number; amountX: number; amountY: number }
 	>()
 
-	// we start with the expanded bounds of the newly added node:
 	const newNodeBounds = editor.getShapePageBounds(newNodeId)!.clone()
 	visit(rootNodeId, newNodeBounds.expandBy(DEFAULT_NODE_SPACING_PX))
 
@@ -137,8 +119,7 @@ function moveNodesIfNeeded(
 		const node = editor.getShape(nodeId)
 		if (!node || !editor.isShapeOfType(node, 'node')) return
 
-		// if this node has already been visited, we need to continue on from the nudge we
-		// calculated last time:
+		// a node reachable via several paths accumulates nudges from each visit
 		const currentNudge = toNudge.get(nodeId) ?? {
 			initialX: node.x,
 			initialY: node.y,
@@ -150,22 +131,13 @@ function moveNodesIfNeeded(
 			.clone()
 			.translate({ x: currentNudge.amountX, y: currentNudge.amountY })
 
-		// if this node isn't colliding with the expanded parent node, it's already far enough away
-		// and we don't need to do anything!
-		if (!nodeBounds.collides(parentExpandedBounds)) {
-			return
-		}
+		if (!nodeBounds.collides(parentExpandedBounds)) return
 
-		// we need to nudge this node to make room for the new node.
-		// direction determines whether we nudge horizontally or vertically
 		let newNudgeAmountX = 0
 		let newNudgeAmountY = 0
-
 		if (direction === 'horizontal') {
-			// nudge to the right for horizontal layout
 			newNudgeAmountX = parentExpandedBounds.right - nodeBounds.left
 		} else {
-			// nudge downward for vertical layout
 			newNudgeAmountY = parentExpandedBounds.bottom - nodeBounds.top
 		}
 
@@ -176,20 +148,18 @@ function moveNodesIfNeeded(
 			amountY: currentNudge.amountY + newNudgeAmountY,
 		})
 
-		// now, we traverse the downstream connections from this node and nudge them all if needed.
 		nodeBounds
 			.translate({ x: newNudgeAmountX, y: newNudgeAmountY })
 			.expandBy(DEFAULT_NODE_SPACING_PX)
-		for (const connection of Object.values(getNodePortConnections(editor, node))) {
-			if (!connection || connection.terminal !== 'start') continue
+		for (const connection of getNodePortConnections(editor, node)) {
+			if (connection.terminal !== 'start') continue
 			visit(connection.connectedShapeId, nodeBounds)
 		}
 	}
 
 	editor
-		// hide the new node for the purposes of the animation
+		// start the new node invisible so it fades in alongside the nudge animation
 		.updateShape({ id: newNodeId, type: 'node', opacity: 0 })
-		// animate the new node fading in, and all the other nodes to their new positions
 		.animateShapes(
 			[
 				{

--- a/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
+++ b/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
@@ -1,48 +1,37 @@
 import { Editor, getIndexBetween, getIndicesBetween, TLParentId } from 'tldraw'
 
 /**
- * This function registers side effects that will make sure connection shapes are always below all
- * other shapes in the same parent. We do this because we don't want to connections on top of nodes,
- * which might be distracting.
+ * Registers side effects that keep connection shapes below all other shapes in the same parent,
+ * so connections never render on top of nodes.
  */
 export function keepConnectionsAtBottom(editor: Editor) {
-	// whenever an operation happens, we'll keep track of the parent ids that we might need to
-	// re-sort the children of. An operation is any atomic change to the tldraw store.
+	// Parents whose children may need re-sorting once the current operation completes
 	let pendingChangedParentIds = new Set<TLParentId>()
 
-	// whenever a shape is created, we'll add the parent id to the set of parent ids that we might
-	// need to re-sort the children of.
 	editor.sideEffects.registerAfterCreateHandler('shape', (shape, source) => {
 		if (source === 'remote') return
 		pendingChangedParentIds.add(shape.parentId)
 	})
-	// whenever a shape's index or parent id changes, we'll add the parent id to the set of parent
-	// ids that we might need to re-sort the children of.
 	editor.sideEffects.registerAfterChangeHandler('shape', (oldShape, newShape, source) => {
 		if (source === 'remote') return
 		if (oldShape.parentId === newShape.parentId && oldShape.index === newShape.index) return
 		pendingChangedParentIds.add(newShape.parentId)
 	})
 
-	// then, when the operation is complete, we re-sort the children as needed:
 	editor.sideEffects.registerOperationCompleteHandler(() => {
 		if (pendingChangedParentIds.size === 0) return
 
-		// reset the set of pending changed parent ids
 		const changedParentIds = pendingChangedParentIds
 		pendingChangedParentIds = new Set()
 
 		const updates = []
 
 		for (const parentId of changedParentIds) {
-			// iterate through all the children of this parent. We want all the connections at the
-			// bottom (first), and everything else after that. Because this fn runs all the time,
-			// things should always be roughly in the right place to begin with. Because of that,
-			// we'll just find any non-connections that are in the wrong place and move them up.
-
+			// Because this runs after every operation, children are always roughly sorted already,
+			// so we only need to find non-connections that sit below the highest connection and
+			// move them up above it (keeping their relative order).
 			const childIds = editor.getSortedChildIdsForParent(parentId)
 
-			// we iterate in reverse because we want to find the highest connection index:
 			let i = childIds.length - 1
 			let highestConnectionIndex = null
 			let nextIndexAboveHighestConnectionIndex = null
@@ -58,39 +47,22 @@ export function keepConnectionsAtBottom(editor: Editor) {
 				}
 			}
 
-			// now that we've found the highest connection index, we switch to looking for
-			// non-connection shapes. these need to be moved up above the highest connection index.
 			const shapesToMove = []
 			for (; i >= 0; i--) {
 				const child = editor.getShape(childIds[i])
-				if (!child) continue
-
-				if (child.type !== 'connection') {
-					shapesToMove.push(child)
-				}
+				if (child && child.type !== 'connection') shapesToMove.push(child)
 			}
-
-			// the shapesToMove array will be in reverse order, so we need to reverse it:
 			shapesToMove.reverse()
 
-			// now we need the new indexes for each shape. These need to stay in the same relative
-			// order, and be inserted above the `hightestConnectionIndex`, but below the index of
-			// the next non-connection shape.
 			const newIndexes = getIndicesBetween(
 				highestConnectionIndex,
 				nextIndexAboveHighestConnectionIndex,
 				shapesToMove.length
 			)
 
-			// now we can create the update partials for those shapes:
 			for (let i = 0; i < shapesToMove.length; i++) {
 				const shape = shapesToMove[i]
-				const newIndex = newIndexes[i]
-				updates.push({
-					id: shape.id,
-					type: shape.type,
-					index: newIndex,
-				} as const)
+				updates.push({ id: shape.id, type: shape.type, index: newIndexes[i] } as const)
 			}
 		}
 
@@ -99,8 +71,7 @@ export function keepConnectionsAtBottom(editor: Editor) {
 }
 
 /**
- * Get the index of the next connection shape in the given parent. This will be above all other
- * connections, but the connections should be below all other shapes.
+ * Get an index just above the highest connection in the given parent, but below every other shape.
  */
 export function getNextConnectionIndex(
 	editor: Editor,

--- a/templates/branching-chat/client/disableTransparency.tsx
+++ b/templates/branching-chat/client/disableTransparency.tsx
@@ -1,17 +1,13 @@
-import { Editor } from 'tldraw'
+import { Editor, TLShape } from 'tldraw'
 
 export function disableTransparency(editor: Editor, shapeTypes: string[]) {
 	const shapeTypesSet = new Set(shapeTypes)
 
-	editor.sideEffects.registerBeforeCreateHandler('shape', (shape) => {
-		if (!shapeTypesSet.has(shape.type)) return shape
-		if (shape.opacity === 1) return shape
-		return { ...shape, opacity: 1 }
-	})
+	const forceOpaque = (shape: TLShape) =>
+		shapeTypesSet.has(shape.type) && shape.opacity !== 1 ? { ...shape, opacity: 1 } : shape
 
-	editor.sideEffects.registerBeforeChangeHandler('shape', (_shapeOld, shapeNew) => {
-		if (!shapeTypesSet.has(shapeNew.type)) return shapeNew
-		if (shapeNew.opacity === 1) return shapeNew
-		return { ...shapeNew, opacity: 1 }
-	})
+	editor.sideEffects.registerBeforeCreateHandler('shape', forceOpaque)
+	editor.sideEffects.registerBeforeChangeHandler('shape', (_shapeOld, shapeNew) =>
+		forceOpaque(shapeNew)
+	)
 }

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -1,13 +1,10 @@
-import classNames from 'classnames'
 import {
 	Circle2d,
 	Group2d,
 	HTMLContainer,
 	RecordProps,
 	Rectangle2d,
-	resizeBox,
 	ShapeUtil,
-	TLResizeInfo,
 	TLShape,
 	useEditor,
 	useValue,
@@ -31,10 +28,8 @@ declare module 'tldraw' {
 	}
 }
 
-// Define our custom node shape type that extends tldraw's base shape system
 export type NodeShape = TLShape<typeof NODE_TYPE>
 
-// This class extends tldraw's ShapeUtil to define how our custom node shapes behave
 export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	static override type = NODE_TYPE
 	static override props: RecordProps<NodeShape> = {
@@ -74,7 +69,6 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	// Define the geometry of our node shape including ports
 	getGeometry(shape: NodeShape) {
 		const ports = getNodePorts(this.editor, shape)
 
@@ -101,10 +95,6 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		})
 	}
 
-	override onResize(shape: any, info: TLResizeInfo<any>) {
-		return resizeBox(shape, info)
-	}
-
 	component(shape: NodeShape) {
 		return <NodeShape shape={shape} />
 	}
@@ -122,13 +112,12 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	}
 }
 
-// Main node component that renders the HTML content
 function NodeShape({ shape }: { shape: NodeShape }) {
 	const editor = useEditor()
 
 	return (
 		<HTMLContainer
-			className={classNames('NodeShape')}
+			className="NodeShape"
 			style={{
 				width: getNodeWidthPx(editor, shape),
 				height: getNodeHeightPx(editor, shape),

--- a/templates/branching-chat/client/nodes/nodePorts.tsx
+++ b/templates/branching-chat/client/nodes/nodePorts.tsx
@@ -1,16 +1,9 @@
-/**
- * This file contains functions for working with ports and connections on nodes.
- */
 import { createComputedCache, Editor, TLShapeId } from 'tldraw'
 import { getConnectionBindings } from '../connection/ConnectionBindingUtil'
 import { PortId } from '../ports/Port'
 import { NodeShape } from './NodeShapeUtil'
 import { getNodeTypePorts, NodeTypePorts } from './nodeTypes'
 
-/**
- * Get the ports for a node. This is cached, because we only want to re-evaluate it when the
- * underlying records change.
- */
 export function getNodePorts(editor: Editor, shape: NodeShape | TLShapeId): NodeTypePorts {
 	return nodePortsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
@@ -19,9 +12,6 @@ const nodePortsCache = createComputedCache(
 	(editor: Editor, node: NodeShape): NodeTypePorts => getNodeTypePorts(editor, node)
 )
 
-/**
- * A connection from one node to another.
- */
 export interface NodePortConnection {
 	connectedShapeId: TLShapeId
 	connectionId: TLShapeId
@@ -30,9 +20,6 @@ export interface NodePortConnection {
 	connectedPortId: PortId
 }
 
-/**
- * Get the connections for a node. This is cached.
- */
 export function getNodePortConnections(
 	editor: Editor,
 	shape: NodeShape | TLShapeId
@@ -79,9 +66,7 @@ export function getAllConnectedNodes(
 	const found = new Set<TLShapeId>()
 
 	while (toVisit.length > 0) {
-		const nodeId = toVisit.shift()
-		if (!nodeId) continue
-
+		const nodeId = toVisit.shift()!
 		const node = editor.getShape(nodeId)
 		if (!node || !editor.isShapeOfType(node, 'node')) continue
 

--- a/templates/branching-chat/client/nodes/nodeTypes.tsx
+++ b/templates/branching-chat/client/nodes/nodeTypes.tsx
@@ -4,7 +4,6 @@ import { NodeShape } from './NodeShapeUtil'
 import { MessageNodeDefinition } from './types/MessageNode'
 import { NodeDefinition, NodeDefinitionConstructor } from './types/shared'
 
-/** All our node types */
 export const NodeDefinitions = {
 	message: MessageNodeDefinition,
 } satisfies Record<string, NodeDefinitionConstructor<any>>
@@ -14,11 +13,13 @@ const nodeDefinitions = new WeakCache<
 	{ [K in keyof typeof NodeDefinitions]: InstanceType<(typeof NodeDefinitions)[K]> }
 >()
 export function getNodeDefinitions(editor: Editor) {
-	return nodeDefinitions.get(editor, () => {
-		return Object.fromEntries(
-			Object.values(NodeDefinitions).map((value) => [value.type, new value(editor)])
-		) as any
-	})
+	return nodeDefinitions.get(
+		editor,
+		() =>
+			Object.fromEntries(
+				Object.values(NodeDefinitions).map((value) => [value.type, new value(editor)])
+			) as any
+	)
 }
 
 export function getNodeDefinition(
@@ -30,9 +31,6 @@ export function getNodeDefinition(
 	] as NodeDefinition<NodeType>
 }
 
-/**
- * A union type of all our node types.
- */
 export type NodeType = T.TypeOf<typeof NodeType>
 export const NodeType = T.union(
 	'type',
@@ -41,20 +39,12 @@ export const NodeType = T.union(
 	}
 )
 
-export function getNodeBodyHeightPx(editor: Editor, shape: NodeShape): number {
+export function getNodeHeightPx(editor: Editor, shape: NodeShape): number {
 	return getNodeDefinition(editor, shape.props.node).getBodyHeightPx(shape, shape.props.node)
 }
 
-export function getNodeBodyWidthPx(editor: Editor, shape: NodeShape): number {
-	return getNodeDefinition(editor, shape.props.node).getBodyWidthPx(shape, shape.props.node)
-}
-
-export function getNodeHeightPx(editor: Editor, shape: NodeShape): number {
-	return getNodeBodyHeightPx(editor, shape)
-}
-
 export function getNodeWidthPx(editor: Editor, shape: NodeShape): number {
-	return getNodeBodyWidthPx(editor, shape)
+	return getNodeDefinition(editor, shape.props.node).getBodyWidthPx(shape, shape.props.node)
 }
 
 const _nodeTypePorts = T.dict(T.string, shapePort)

--- a/templates/branching-chat/client/nodes/types/MessageNode.tsx
+++ b/templates/branching-chat/client/nodes/types/MessageNode.tsx
@@ -14,9 +14,6 @@ import {
 	updateNode,
 } from './shared'
 
-/**
- * This node is a message from the user.
- */
 export type MessageNode = T.TypeOf<typeof MessageNode>
 export const MessageNode = T.object({
 	type: T.literal('message'),
@@ -40,8 +37,8 @@ export class MessageNodeDefinition extends NodeDefinition<MessageNode> {
 	getBodyWidthPx(_shape: NodeShape, _node: MessageNode): number {
 		return NODE_WIDTH_PX
 	}
-	getBodyHeightPx(_shape: NodeShape, _node: MessageNode): number {
-		const assistantMessage = _node.assistantMessage.trim()
+	getBodyHeightPx(_shape: NodeShape, node: MessageNode): number {
+		const assistantMessage = node.assistantMessage.trim()
 		if (assistantMessage === '') return NODE_HEIGHT_PX
 		const size = this.editor.textMeasure.measureText(assistantMessage, {
 			fontFamily: 'Inter',
@@ -71,43 +68,25 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 	const editor = useEditor()
 
 	const handleSend = useCallback(() => {
-		// 1. gather up parents and create message history
-		// 2. create prompt
-		// 3. send prompt to ai
-		// 4. update node with assistant message
-
+		// Walk upstream through the ancestors to build the message history, oldest first
 		const messages: ModelMessage[] = []
-
-		const connectedNodeShapes = getAllConnectedNodes(editor, shape, 'end')
-		for (const connectedShape of connectedNodeShapes) {
+		for (const connectedShape of getAllConnectedNodes(editor, shape, 'end')) {
 			const node = editor.getShape(connectedShape)
-
-			if (!node) continue
-			if (!editor.isShapeOfType(node, 'node')) continue
+			if (!node || !editor.isShapeOfType(node, 'node')) continue
 			if (node.props.node.type !== 'message') continue
 
 			if (node.props.node.assistantMessage && connectedShape !== shape.id) {
-				messages.push({
-					role: 'assistant',
-					content: node.props.node.assistantMessage ?? '',
-				})
+				messages.push({ role: 'assistant', content: node.props.node.assistantMessage })
 			}
-
-			messages.push({
-				role: 'user',
-				content: node.props.node.userMessage ?? '',
-			})
+			messages.push({ role: 'user', content: node.props.node.userMessage })
 		}
-
 		messages.reverse()
 
-		// clear any previous assistant message before starting
 		updateNode<MessageNode>(editor, shape, (node) => ({
 			...node,
 			assistantMessage: '...',
 		}))
 
-		// stream the response and append as chunks arrive
 		;(async () => {
 			try {
 				const response = await fetch('/stream', {
@@ -154,70 +133,68 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 	)
 
 	return (
-		<>
-			<div
-				style={{
-					pointerEvents: 'auto',
-					display: 'flex',
-					flexDirection: 'column',
-				}}
-			>
-				<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-					<div
-						style={{
-							height: '100%',
-							width: 32,
-							paddingLeft: 4,
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-							cursor: 'grab',
-						}}
-					>
-						<TldrawUiButtonIcon icon={<HandleIcon />} />
-					</div>
-					<div
-						style={{ padding: '4px 0px 0px 4px', flexGrow: 2 }}
-						onPointerDown={editor.markEventAsHandled}
-					>
-						<div style={{ padding: '0px 12px', borderRadius: 6, border: '1px solid #e2e8f0' }}>
-							<TldrawUiInput
-								value={node.userMessage}
-								onValueChange={handleMessageChange}
-								onComplete={handleSend}
-							/>
-						</div>
-					</div>
-					<div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0px 0px' }}>
-						<TldrawUiButton
-							type="primary"
-							onClick={handleSend}
-							onPointerDown={editor.markEventAsHandled}
-						>
-							<TldrawUiButtonIcon icon={<SendIcon />} />
-						</TldrawUiButton>
+		<div
+			style={{
+				pointerEvents: 'auto',
+				display: 'flex',
+				flexDirection: 'column',
+			}}
+		>
+			<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+				<div
+					style={{
+						height: '100%',
+						width: 32,
+						paddingLeft: 4,
+						display: 'flex',
+						justifyContent: 'center',
+						alignItems: 'center',
+						cursor: 'grab',
+					}}
+				>
+					<TldrawUiButtonIcon icon={<HandleIcon />} />
+				</div>
+				<div
+					style={{ padding: '4px 0px 0px 4px', flexGrow: 2 }}
+					onPointerDown={editor.markEventAsHandled}
+				>
+					<div style={{ padding: '0px 12px', borderRadius: 6, border: '1px solid #e2e8f0' }}>
+						<TldrawUiInput
+							value={node.userMessage}
+							onValueChange={handleMessageChange}
+							onComplete={handleSend}
+						/>
 					</div>
 				</div>
-				{node.assistantMessage && (
-					<div style={{ padding: 4 }}>
-						<div
-							style={{
-								padding: 8,
-								lineHeight: '1.3',
-								fontSize: '12px',
-								borderRadius: 6,
-								border: '1px solid #e2e8f0',
-								fontWeight: '500',
-								fontFamily: 'Inter',
-								overflowWrap: 'normal',
-								whiteSpace: 'pre-wrap',
-							}}
-						>
-							{node.assistantMessage}
-						</div>
-					</div>
-				)}
+				<div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0px 0px' }}>
+					<TldrawUiButton
+						type="primary"
+						onClick={handleSend}
+						onPointerDown={editor.markEventAsHandled}
+					>
+						<TldrawUiButtonIcon icon={<SendIcon />} />
+					</TldrawUiButton>
+				</div>
 			</div>
-		</>
+			{node.assistantMessage && (
+				<div style={{ padding: 4 }}>
+					<div
+						style={{
+							padding: 8,
+							lineHeight: '1.3',
+							fontSize: '12px',
+							borderRadius: 6,
+							border: '1px solid #e2e8f0',
+							fontWeight: '500',
+							fontFamily: 'Inter',
+							overflowWrap: 'normal',
+							whiteSpace: 'pre-wrap',
+						}}
+					>
+						{node.assistantMessage}
+					</div>
+				</div>
+			)}
+		</div>
 	)
 }

--- a/templates/branching-chat/client/nodes/types/shared.tsx
+++ b/templates/branching-chat/client/nodes/types/shared.tsx
@@ -37,9 +37,6 @@ export interface NodeDefinitionConstructor<Node extends { type: string }> {
 	readonly validator: T.Validator<Node>
 }
 
-/**
- * The standard input port for a node.
- */
 export const shapeInputPort: ShapePort = {
 	id: 'input',
 	terminal: 'end',
@@ -47,9 +44,6 @@ export const shapeInputPort: ShapePort = {
 	y: 0,
 }
 
-/**
- * The standard output port for a node.
- */
 export const shapeOutputPort: ShapePort = {
 	id: 'output',
 	terminal: 'start',
@@ -57,9 +51,6 @@ export const shapeOutputPort: ShapePort = {
 	y: NODE_HEIGHT_PX,
 }
 
-/**
- * Update the `node` prop within a node shape.
- */
 export function updateNode<T extends NodeType>(
 	editor: Editor,
 	shape: NodeShape,

--- a/templates/branching-chat/client/ports/PointingPort.tsx
+++ b/templates/branching-chat/client/ports/PointingPort.tsx
@@ -1,19 +1,19 @@
 import { createShapeId, StateNode, TLPointerEventInfo, TLShapeId } from 'tldraw'
 import { createOrUpdateConnectionBinding } from '../connection/ConnectionBindingUtil.tsx'
+import { createNodeAtConnectionEnd } from '../connection/ConnectionShapeUtil.tsx'
 import { getNextConnectionIndex } from '../connection/keepConnectionsAtBottom.tsx'
-import { DEFAULT_NODE_SPACING_PX, NODE_WIDTH_PX } from '../constants.tsx'
-import { getNodePortConnections, getNodePorts } from '../nodes/nodePorts.tsx'
+import { DEFAULT_NODE_SPACING_PX } from '../constants.tsx'
+import { getNodePortConnections } from '../nodes/nodePorts.tsx'
 import { PortId } from './Port.tsx'
 
-// Information about which port is being pointed at
 interface PointingPortInfo {
 	shapeId: TLShapeId
 	portId: PortId
 	terminal: 'start' | 'end'
 }
 
-// State node that handles pointing at ports to create connections
-// This will be added to tldraw's state machine to customize the built-in select tool
+// Child state of the select tool: entered on pointer down over a port. A drag creates (or moves) a
+// connection; a click on an output port spawns a connected node below.
 export class PointingPort extends StateNode {
 	static override id = 'pointing_port'
 
@@ -23,99 +23,84 @@ export class PointingPort extends StateNode {
 		this.info = info
 	}
 
+	private getExistingConnection() {
+		const { shapeId, portId } = this.info!
+		return getNodePortConnections(this.editor, shapeId).find((c) => c.ownPortId === portId)
+	}
+
 	override onPointerMove(info: TLPointerEventInfo): void {
-		// isDragging is true if the user has moved the pointer sufficiently. below this threshold,
-		// we treat the pointer as a click.
-		if (this.editor.inputs.getIsDragging()) {
-			const allowsMultipleConnections = this.info?.terminal === 'start'
-			const hasExistingConnection = getNodePortConnections(this.editor, this.info!.shapeId).find(
-				(c) => c.ownPortId === this.info!.portId
-			)
+		if (!this.editor.inputs.getIsDragging()) return
+		const { shapeId, portId, terminal: connectingTerminal } = this.info!
 
-			// If we can't have multiple connections and one already exists, move the existing
-			// connection by transitioning to dragging the existing connection's handle.
-			if (!allowsMultipleConnections && hasExistingConnection) {
-				this.parent.transition('dragging_handle', {
-					...info,
-					target: 'handle',
-					shape: this.editor.getShape(hasExistingConnection.connectionId)!,
-					handle: this.editor
-						.getShapeHandles(hasExistingConnection.connectionId)!
-						.find((h) => h.id === this.info!.terminal),
-				})
-				return
-			}
-
-			// Otherwise, create a new connection, and start dragging that connection's handle instead.
-			const creatingMarkId = this.editor.markHistoryStoppingPoint()
-			const connectionShapeId = createShapeId()
-			const connectingTerminal = this.info!.terminal
-			const draggingTerminal = connectingTerminal === 'start' ? 'end' : 'start'
-
-			this.editor.createShape({
-				type: 'connection',
-				id: connectionShapeId,
-				x: this.editor.inputs.getCurrentPagePoint().x,
-				y: this.editor.inputs.getCurrentPagePoint().y,
-				index: getNextConnectionIndex(this.editor),
-				props: {
-					start: { x: 0, y: 0 },
-					end: { x: 0, y: 0 },
-				},
-			})
-
-			// bind one end of the connection to the port the user pointer-down'd on.
-			createOrUpdateConnectionBinding(this.editor, connectionShapeId, this.info!.shapeId, {
-				portId: this.info!.portId,
-				terminal: connectingTerminal,
-			})
-
-			// transition to dragging the other end of the connection:
-			const handle = this.editor
-				.getShapeHandles(connectionShapeId)
-				?.find((h) => h.id === draggingTerminal)
-
+		// Only 'start' ports (outputs) can have multiple connections; dragging from an already
+		// connected input moves the existing connection instead of creating a new one.
+		const existingConnection = this.getExistingConnection()
+		if (connectingTerminal !== 'start' && existingConnection) {
 			this.parent.transition('dragging_handle', {
 				...info,
 				target: 'handle',
-				shape: this.editor.getShape(connectionShapeId)!,
-				handle: handle!,
-				creatingMarkId,
-				isCreating: true,
+				shape: this.editor.getShape(existingConnection.connectionId)!,
+				handle: this.editor
+					.getShapeHandles(existingConnection.connectionId)!
+					.find((h) => h.id === connectingTerminal),
 			})
+			return
 		}
+
+		const creatingMarkId = this.editor.markHistoryStoppingPoint()
+		const connectionShapeId = createShapeId()
+		const draggingTerminal = connectingTerminal === 'start' ? 'end' : 'start'
+		const pagePoint = this.editor.inputs.getCurrentPagePoint()
+
+		this.editor.createShape({
+			type: 'connection',
+			id: connectionShapeId,
+			x: pagePoint.x,
+			y: pagePoint.y,
+			index: getNextConnectionIndex(this.editor),
+			props: {
+				start: { x: 0, y: 0 },
+				end: { x: 0, y: 0 },
+			},
+		})
+		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
+			portId,
+			terminal: connectingTerminal,
+		})
+
+		const handle = this.editor
+			.getShapeHandles(connectionShapeId)
+			?.find((h) => h.id === draggingTerminal)
+
+		this.parent.transition('dragging_handle', {
+			...info,
+			target: 'handle',
+			shape: this.editor.getShape(connectionShapeId)!,
+			handle: handle!,
+			creatingMarkId,
+			isCreating: true,
+		})
 	}
 
 	override onPointerUp(info: TLPointerEventInfo): void {
-		// if we get a pointer up while we're still in this state, it means we haven't transitioned
-		// into a dragging state so we'll treat this as a click:
+		// still here on pointer up means we never started dragging, so treat it as a click
 		this.onClick()
-		// switch back to the idle state when we're done:
 		this.parent.transition('idle', info)
 	}
 
-	// Handle clicks on ports (without dragging)
 	private onClick() {
-		// Only handle clicks on start ports (output ports)
 		if (this.info?.terminal !== 'start') return
+		if (this.getExistingConnection()) return
+		const { shapeId, portId } = this.info
 
-		// Don't create new connections if one already exists
-		const hasExistingConnection = getNodePortConnections(this.editor, this.info!.shapeId).find(
-			(c) => c.ownPortId === this.info!.portId
-		)
-		if (hasExistingConnection) return
-
-		// Get the bounds of the source node
-		const bounds = this.editor.getShapePageBounds(this.info!.shapeId)
+		const bounds = this.editor.getShapePageBounds(shapeId)
 		if (!bounds) return
 
-		// Calculate position for new node to the right of the source node
 		const targetPositionInPageSpace = {
 			x: bounds.midX,
 			y: bounds.bottom + DEFAULT_NODE_SPACING_PX,
 		}
 
-		// Create a connection shape
 		const connectionShapeId = createShapeId()
 		this.editor.createShape({
 			type: 'connection',
@@ -124,18 +109,14 @@ export class PointingPort extends StateNode {
 			y: bounds.top,
 			index: getNextConnectionIndex(this.editor),
 		})
-
-		// Bind the connection to the source port
-		createOrUpdateConnectionBinding(this.editor, connectionShapeId, this.info!.shapeId, {
-			portId: this.info!.portId,
+		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
+			portId,
 			terminal: 'start',
 		})
 
-		// Position the connection end point where the new node will be
 		const targetPositionInConnectionSpace = this.editor
 			.getPointInShapeSpace(connectionShapeId, targetPositionInPageSpace)
 			.addXY(0, 200)
-
 		this.editor.updateShape({
 			id: connectionShapeId,
 			type: 'connection',
@@ -144,34 +125,6 @@ export class PointingPort extends StateNode {
 			},
 		})
 
-		const newNodeId = createShapeId()
-		this.editor.createShape({
-			type: 'node',
-			id: newNodeId,
-			x: targetPositionInPageSpace.x - NODE_WIDTH_PX / 2,
-			y: targetPositionInPageSpace.y + 100,
-			props: {
-				node: { type: 'message', userMessage: '', assistantMessage: '' },
-			},
-		})
-		this.editor.select(newNodeId)
-
-		// Position the node so its input port aligns with the connection end
-		const ports = getNodePorts(this.editor, newNodeId)
-		const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
-		if (firstInputPort) {
-			this.editor.updateShape({
-				id: newNodeId,
-				type: 'node',
-				x: targetPositionInPageSpace.x - firstInputPort.x,
-				y: targetPositionInPageSpace.y - firstInputPort.y,
-			})
-
-			// Connect the new node to the connection
-			createOrUpdateConnectionBinding(this.editor, connectionShapeId, newNodeId, {
-				portId: firstInputPort.id,
-				terminal: 'end',
-			})
-		}
+		createNodeAtConnectionEnd(this.editor, connectionShapeId, targetPositionInPageSpace)
 	}
 }

--- a/templates/branching-chat/client/ports/Port.tsx
+++ b/templates/branching-chat/client/ports/Port.tsx
@@ -14,23 +14,16 @@ export const shapePort = T.object({
 
 export type ShapePort = T.TypeOf<typeof shapePort>
 
-/**
- * Port ids are unique within a shape. To identify a port we need both the shape id and the port id.
- */
+/** Port ids are only unique within a shape, so identifying a port needs both. */
 export interface PortIdentifier {
 	shapeId: TLShapeId
 	portId: PortId
 }
 
-/**
- * This react component renders a port.
- */
 export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort }) {
 	const editor = useEditor()
-	if (!port) throw new Error(`Port not found on shape ${shapeId}`)
 
-	// isHinting is true if the user is currently dragging a connection to this port. it means we
-	// should highlight this port.
+	// the user is dragging a connection over this port
 	const isHinting = useValue(
 		'isHinting',
 		() => {
@@ -40,18 +33,16 @@ export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort })
 		[editor, shapeId, port.id]
 	)
 
-	// isEligible is true if the the user is currently dragging a connection, and this port is one
-	// that the connection can be connected to.
+	// the user is dragging a connection that could be dropped on this port
 	const isEligible = useValue(
 		'isEligible',
 		() => {
-			const { eligiblePorts: eligiblePorts } = portState.get(editor)
+			const { eligiblePorts } = portState.get(editor)
 			if (!eligiblePorts) return false
 			if (eligiblePorts.terminal !== port.terminal) return false
 			if (eligiblePorts.excludeNodes?.has(shapeId)) return false
 			if (port.terminal === 'end') {
-				// if the port is an end port, it can only have one connection, so it's not eligible
-				// when there is a connection
+				// input ports only accept one connection
 				const connections = getNodePortConnections(editor, shapeId)
 				return !connections.some((c) => c.ownPortId === port.id)
 			}

--- a/templates/branching-chat/client/ports/getPortAtPoint.tsx
+++ b/templates/branching-chat/client/ports/getPortAtPoint.tsx
@@ -7,23 +7,16 @@ export function getPortAtPoint(
 	point: VecLike,
 	opts?: { terminal?: 'start' | 'end'; margin?: number }
 ) {
-	// find the shape at that point:
 	const shape = editor.getShapeAtPoint(point, {
 		hitInside: true,
-		// only node shapes can have ports
 		filter: (shape) => editor.isShapeOfType(shape, 'node'),
 		...opts,
 	})
 	if (!shape || !editor.isShapeOfType(shape, 'node')) return null
 
-	// get the ports on that shape
 	const ports = getNodePorts(editor, shape)
-	if (!ports) return null
-
-	// transform the ports to page space
 	const shapeTransform = editor.getShapePageTransform(shape)
 
-	// find the port closest to the point
 	let bestPort: ShapePort | null = null
 	let bestDistance = Infinity
 
@@ -38,10 +31,8 @@ export function getPortAtPoint(
 		}
 	}
 
-	// if we didn't find a port, return null
 	if (!bestPort) return null
 
-	// otherwise, return the port and it's existing connections
 	const existingConnections = getNodePortConnections(editor, shape).filter(
 		(c) => c.ownPortId === bestPort.id
 	)

--- a/templates/branching-chat/client/ports/portState.ts
+++ b/templates/branching-chat/client/ports/portState.ts
@@ -1,13 +1,11 @@
 import { Editor, EditorAtom, TLShapeId } from 'tldraw'
 import { PortIdentifier } from './Port'
 
-/**
- * The UI state for ports. These mostly highlight ports relevant to the user's current action.
- */
+/** UI state highlighting the ports relevant to the user's current drag. */
 export interface PortState {
-	// hintingPort is the port that the user is currently dragging a connection to.
+	// the port a connection is currently being dragged over
 	hintingPort: PortIdentifier | null
-	// eligiblePorts is the set of ports that the user can connect a new connection to.
+	// which ports the dragged connection could be dropped on
 	eligiblePorts: {
 		terminal: 'start' | 'end'
 		excludeNodes: Set<TLShapeId> | null
@@ -20,8 +18,5 @@ export const portState = new EditorAtom<PortState>('port state', () => ({
 }))
 
 export function updatePortState(editor: Editor, update: Partial<PortState>) {
-	portState.update(editor, (state) => {
-		const newState = { ...state, ...update }
-		return newState
-	})
+	portState.update(editor, (state) => ({ ...state, ...update }))
 }

--- a/templates/branching-chat/worker/worker.ts
+++ b/templates/branching-chat/worker/worker.ts
@@ -5,7 +5,8 @@ import { WorkerEntrypoint } from 'cloudflare:workers'
 import { AutoRouter, error, IRequest } from 'itty-router'
 import { Environment } from './types'
 
-// Worker (handles AI requests directly)
+const MODEL_ID = 'gemini-3-flash-preview'
+
 export default class extends WorkerEntrypoint<Environment> {
 	private readonly router = AutoRouter<IRequest, [env: Environment, ctx: ExecutionContext]>({
 		catch: (e) => {
@@ -21,25 +22,21 @@ export default class extends WorkerEntrypoint<Environment> {
 	}
 
 	private getModel(env: Environment) {
-		return createGoogleGenerativeAI({
-			apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
-		})
+		return createGoogleGenerativeAI({ apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY })(MODEL_ID)
 	}
 
-	// Generate a new response from the model
 	private async generate(request: IRequest, env: Environment) {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>
 			const { text } = await generateText({
-				model: this.getModel(env)('gemini-3-flash-preview'),
+				model: this.getModel(env),
 				messages: prompt,
 			})
 
-			// Send back the response as a JSON object
 			return new Response(text, {
 				headers: { 'Content-Type': 'application/json' },
 			})
-		} catch (error: any) {
+		} catch (error) {
 			console.error('AI response error:', error)
 			return new Response('An internal server error occurred.', {
 				status: 500,
@@ -47,13 +44,12 @@ export default class extends WorkerEntrypoint<Environment> {
 		}
 	}
 
-	// Stream a new response from the model
 	private async stream(request: IRequest, env: Environment): Promise<Response> {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>
 
 			const result = streamText({
-				model: this.getModel(env)('gemini-3-flash-preview'),
+				model: this.getModel(env),
 				messages: prompt,
 				experimental_transform: smoothStream(),
 			})

--- a/templates/chat/src/app/api/chat/route.ts
+++ b/templates/chat/src/app/api/chat/route.ts
@@ -1,7 +1,6 @@
 import { google } from '@ai-sdk/google'
 import { convertToModelMessages, streamText, UIMessage } from 'ai'
 
-// Allow streaming responses up to 60 seconds
 export const maxDuration = 60
 
 export async function POST(req: Request) {

--- a/templates/chat/src/app/api/upload/route.ts
+++ b/templates/chat/src/app/api/upload/route.ts
@@ -16,14 +16,11 @@ export async function POST(req: Request) {
 		return new Response('x-file-name is not set', { status: 400 })
 	}
 
-	const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY })
+	const ai = new GoogleGenAI({ apiKey })
 
 	const file = await ai.files.upload({
 		file: await req.blob(),
-		config: {
-			mimeType: contentType,
-			displayName,
-		},
+		config: { mimeType: contentType, displayName },
 	})
 
 	return Response.json({ uploadedUrl: file.uri, expiresAt: file.expirationTime })

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -3,18 +3,17 @@
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport, FileUIPart, TextUIPart, UIMessage } from 'ai'
 import { useCallback, useEffect } from 'react'
-import { TLEditorSnapshot } from 'tldraw'
 import { useChatMessageStorage } from '@/hooks/useChatMessageStorage'
 import { uploadMessageContents } from '@/utils/uploadMessageContents'
 import { useChatInputState } from '../hooks/useChatInputState'
 import { useScrollToBottom } from '../hooks/useScrollToBottom'
 import { ChatInput } from './ChatInput'
+import { ImageClickTarget } from './ChatMessage'
 import { ClearChatIcon } from './ClearChatIcon'
 import { MessageList } from './MessageList'
 import { TldrawProviderMetadata, WhiteboardImage } from './WhiteboardModal'
 
 export function Chat() {
-	// store chat messages locally in the browser
 	const [initialMessages, saveMessages] = useChatMessageStorage()
 
 	if (!initialMessages) return null
@@ -29,11 +28,10 @@ function ChatInner({
 	initialMessages: UIMessage[]
 	saveMessages: (messages: UIMessage[]) => void
 }) {
-	// All state relating to the chat input and the tldraw modal is managed in this hook
 	const [chatInputState, chatInputDispatch] = useChatInputState()
 
-	// We use the Vercel AI SDK's useChat hook to send messages to the server and manage the chat
-	// history. You could replace this with your own chat implementation.
+	// The Vercel AI SDK's useChat hook sends messages to the server and manages the chat history.
+	// You could replace this with your own chat implementation.
 	const chat = useChat({
 		transport: new DefaultChatTransport({
 			api: '/api/chat',
@@ -56,14 +54,12 @@ function ChatInner({
 
 	const { sendMessage, status, error, clearError, setMessages } = chat
 
-	// save the chat messages to local storage when the chat finishes
 	useEffect(() => {
 		if (chat.status === 'ready') {
 			saveMessages(chat.messages)
 		}
-	}, [chat.status, chat.messages, saveMessages, setMessages])
+	}, [chat.status, chat.messages, saveMessages])
 
-	// If the chat encounters an error, we alert the user and clear the error.
 	useEffect(() => {
 		if (error) {
 			alert(error.message)
@@ -71,8 +67,6 @@ function ChatInner({
 		}
 	}, [error, clearError])
 
-	// when the user send a message, we take the text they've written and any images / sketches
-	// they've attached and send them to the model.
 	const handleSendMessage = useCallback(
 		(text: string, images: WhiteboardImage[]) => {
 			chatInputDispatch({ type: 'clear' })
@@ -95,28 +89,20 @@ function ChatInner({
 				parts.push({ type: 'text', text })
 			}
 
-			sendMessage({
-				parts,
-			})
+			sendMessage({ parts })
 		},
 		[sendMessage, chatInputDispatch]
 	)
 
-	// keep the chat scrolled to the bottom as messages are added or changed
 	const scrollToBottom = useScrollToBottom()
 	useEffect(() => {
 		scrollToBottom()
 	}, [chat.messages, scrollToBottom])
 
-	// when the user clicks on an image from chat history, we open the tldraw modal. here they can
-	// see a larger version of the image, but also annotate it and re-add it to the chat.
+	// Clicking an image in the chat history opens it in the whiteboard modal, where the user can
+	// annotate it and re-add it to the chat.
 	const handleImageClick = useCallback(
-		(opts: { snapshot: TLEditorSnapshot; imageName: string } | { uploadedFile: File }) => {
-			chatInputDispatch({
-				type: 'openWhiteboard',
-				...opts,
-			})
-		},
+		(opts: ImageClickTarget) => chatInputDispatch({ type: 'openWhiteboard', ...opts }),
 		[chatInputDispatch]
 	)
 
@@ -125,8 +111,6 @@ function ChatInner({
 		saveMessages([])
 	}, [setMessages, saveMessages])
 
-	// users can drag and drop images to the chat input area to add them to their message. when
-	// they're dragging we keep track of a special isDragging state.
 	const handleDragOver = (e: React.DragEvent) => {
 		e.preventDefault()
 		if (
@@ -155,7 +139,7 @@ function ChatInner({
 		}
 	}
 
-	// if the chat is empty, we put the input area right in the middle of the page
+	// An empty chat puts the input right in the middle of the page.
 	if (chat.messages.length === 0) {
 		return (
 			<div
@@ -180,7 +164,6 @@ function ChatInner({
 		)
 	}
 
-	// otherwise, we show the chat history and the input area at the bottom.
 	return (
 		<div
 			className="chat-container"

--- a/templates/chat/src/components/ChatInput.tsx
+++ b/templates/chat/src/components/ChatInput.tsx
@@ -29,113 +29,77 @@ export function ChatInput({
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
 
 	useEffect(() => {
-		if (!disabled && textareaRef.current) {
-			// focus the textarea when the input is enabled
-			textareaRef.current.focus()
-		}
+		if (!disabled) textareaRef.current?.focus()
 	}, [disabled])
 
-	// Auto-resize textarea and scroll to bottom when content changes.
+	// Auto-resize the textarea to fit its content.
 	useLayoutEffect(() => {
 		if (textareaRef.current) {
-			// Reset height to auto to get the correct scrollHeight
+			// reset to auto first so scrollHeight reflects the content, not the previous height
 			textareaRef.current.style.height = 'auto'
-			// Set height based on scrollHeight, with max height for ~5 lines
 			textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
 		}
 	}, [input])
 
-	// Scroll to bottom when images are added.
 	useLayoutEffect(() => {
-		if (scrollToBottom) {
-			scrollToBottom('instant')
-		}
+		scrollToBottom('instant')
 	}, [images, scrollToBottom])
 
-	// the user can only send a message if the input is not disabled and there are either images or
-	// text ready to send
 	const canSend = !disabled && (images.length > 0 || input.trim())
 
-	// when the user submits the form, we send the message.
+	const send = () => {
+		if (canSend) onSendMessage(input, images)
+	}
+
 	const handleSubmit = (e: FormEvent) => {
 		e.preventDefault()
-		if (canSend) {
-			onSendMessage(input, images)
-		}
+		send()
 	}
 
-	// when the user presses enter, we send the message.
+	// Enter sends; shift+enter keeps the default newline behavior.
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter') {
-			if (e.shiftKey) {
-				// Shift+Enter: allow default behavior (insert newline)
-				return
-			} else {
-				// Enter: submit form
-				e.preventDefault()
-				if (canSend) {
-					onSendMessage(input, images)
-				}
-			}
-		}
+		if (e.key !== 'Enter' || e.shiftKey) return
+		e.preventDefault()
+		send()
 	}
 
-	// when the user clicks the image upload button, we open a file input to allow them to select an
-	// image from their device.
 	const handleImageUpload = useCallback(() => {
 		const input = document.createElement('input')
 		input.type = 'file'
 		input.accept = 'image/*'
 		input.onchange = (e: Event) => {
-			const target = e.target as HTMLInputElement
-			const file = target.files?.[0]
+			const file = (e.target as HTMLInputElement).files?.[0]
 			if (!file || !file.type.startsWith('image/')) return
-
-			// Open whiteboard with the uploaded file
-			dispatch({
-				type: 'openWhiteboard',
-				uploadedFile: file,
-				imageName: file.name,
-			})
+			dispatch({ type: 'openWhiteboard', uploadedFile: file, imageName: file.name })
 		}
 		input.click()
 	}, [dispatch])
 
-	// when the user cancels the whiteboard modal, we close it.
 	const handleCancelWhiteboard = useCallback(() => {
 		dispatch({ type: 'closeWhiteboard' })
 	}, [dispatch])
 
-	// when the user accepts the whiteboard modal, we add the image to the chat input & close it.
 	const handleAcceptWhiteboard = useCallback(
 		(image: WhiteboardImage) => {
 			dispatch({ type: 'closeWhiteboard' })
 			dispatch({ type: 'setImage', image })
-			// Re-focus the input after adding an image
-			if (textareaRef.current) {
-				textareaRef.current.focus()
-			}
+			textareaRef.current?.focus()
 		},
 		[dispatch]
 	)
 
 	return (
 		<form onSubmit={handleSubmit} className="chat-input-form">
-			{/* if the user is dragging an image over the input area, we show a visual indicator
-			hiding the normal input content. */}
 			{isDragging && (
 				<div className="drag-drop-indicator">
 					<svg className="outline">
-						{/* we use an svg to draw a dashed outline of the input area. svg allows us
-						to control the dash length in a way that for example a normal <div> with a
-						border would not. */}
+						{/* svg lets us control the dash length of the outline in a way a css border can't */}
 						<rect />
 					</svg>
 					<UploadIcon />
 				</div>
 			)}
 
-			{/* if the user has added images to the chat input, we show them above the input. */}
 			{images.length > 0 && (
 				<div className="input-images">
 					{images.map((image) => (
@@ -156,7 +120,6 @@ export function ChatInput({
 				</div>
 			)}
 
-			{/* the main input is a text area. we resize it automatically to fit its content. */}
 			<div className="input-container">
 				<textarea
 					ref={textareaRef}
@@ -176,9 +139,7 @@ export function ChatInput({
 				)}
 			</div>
 
-			{/* below the input we have several controls: */}
 			<div className="chat-input-bottom">
-				{/* a button to upload an image */}
 				<button
 					type="button"
 					aria-label="Upload an image"
@@ -189,7 +150,6 @@ export function ChatInput({
 				>
 					<ImageIcon />
 				</button>
-				{/* a button to open the whiteboard modal */}
 				<button
 					type="button"
 					aria-label="Draw a sketch"
@@ -200,7 +160,6 @@ export function ChatInput({
 				>
 					<WhiteboardIcon />
 				</button>
-				{/* a button to send the message */}
 				<button
 					type="submit"
 					disabled={!canSend || disabled}
@@ -212,7 +171,6 @@ export function ChatInput({
 				</button>
 			</div>
 
-			{/* if the user has opened the whiteboard modal, we show it. */}
 			{openWhiteboard && (
 				<WhiteboardModal
 					imageId={openWhiteboard.id}

--- a/templates/chat/src/components/ChatMessage.tsx
+++ b/templates/chat/src/components/ChatMessage.tsx
@@ -1,18 +1,17 @@
 import { type UIMessage } from '@ai-sdk/react'
 import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { FileHelpers, TLEditorSnapshot } from 'tldraw'
+import { FileHelpers } from 'tldraw'
 import { TldrawProviderMetadata } from './WhiteboardModal'
+
+export type ImageClickTarget = TldrawProviderMetadata | { uploadedFile: File }
 
 interface ChatMessageProps {
 	message: UIMessage
-	onImageClick: (
-		opts: { snapshot: TLEditorSnapshot; imageName: string } | { uploadedFile: File }
-	) => void
+	onImageClick: (opts: ImageClickTarget) => void
 }
 
 export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: ChatMessageProps) {
-	// For AI messages with no content, show thinking state
 	if (
 		message.role === 'assistant' &&
 		!message.parts.some((part) => part.type === 'file' || part.type === 'text')
@@ -30,10 +29,9 @@ export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: 
 		>
 			{message.parts.map((part, index) => {
 				if (part.type === 'file') {
-					// we stash a snapshot of the tldraw document in the provider metadata:
+					// whiteboard images carry a tldraw snapshot in the provider metadata so they can be re-edited
 					const tldrawMetadata = part.providerMetadata?.tldraw as TldrawProviderMetadata | undefined
 					const handleImageClick = async () => {
-						// if we have a tldraw snapshot, we open the tldraw modal when it's clicked:
 						if (tldrawMetadata) {
 							onImageClick(tldrawMetadata)
 						} else {

--- a/templates/chat/src/components/MessageList.tsx
+++ b/templates/chat/src/components/MessageList.tsx
@@ -1,11 +1,10 @@
 import { type UIMessage } from '@ai-sdk/react'
 import { memo } from 'react'
-import { ChatMessage } from './ChatMessage'
-import { TldrawProviderMetadata } from './WhiteboardModal'
+import { ChatMessage, ImageClickTarget } from './ChatMessage'
 
 interface MessageListProps {
 	messages: UIMessage[]
-	onImageClick: (tldrawMetadata: TldrawProviderMetadata | { uploadedFile: File }) => void
+	onImageClick: (target: ImageClickTarget) => void
 }
 
 export const MessageList = memo(function MessageList({ messages, onImageClick }: MessageListProps) {

--- a/templates/chat/src/components/WhiteboardModal.tsx
+++ b/templates/chat/src/components/WhiteboardModal.tsx
@@ -39,11 +39,10 @@ interface WhiteboardModalProps {
 }
 
 const options: Partial<TldrawOptions> = {
-	// disable the ability to create new pages:
 	maxPages: 1,
-	// make sure the action shortcuts are always in the top-right menu area, not on the toolbar:
+	// keep the action shortcuts in the top-right menu area, not on the toolbar
 	actionShortcutsLocation: 'menu',
-	// disable font pre-loading to avoid the ui popping in after the modal appears:
+	// skip font pre-loading so the ui doesn't pop in after the modal appears
 	maxFontsToLoadBeforeRender: 0,
 }
 
@@ -60,57 +59,43 @@ export function WhiteboardModal({
 	const handleSave = useCallback(async () => {
 		if (!editor) return
 
-		// if there are no shapes, we don't want to save the image:
 		const shapes = editor.getCurrentPageShapes()
 		if (shapes.length === 0) {
 			onCancel()
 			return
 		}
 
-		// when the user clicks save, we convert the current whiteboard to an image:
-		const image = await editor.toImageDataUrl(shapes, {
-			format: 'png',
-		})
+		const image = await editor.toImageDataUrl(shapes, { format: 'png' })
 
-		// we also take a snapshot of the editor state, so we can still edit
-		// it if we open it up again later:
-		const snapshot = editor.getSnapshot()
-
-		// we pass the image data and the snapshot to the parent component, so it
-		// can add it to the chat input:
+		// the snapshot lets the image be re-opened and edited later
 		onAccept({
 			id: imageId ?? crypto.randomUUID(),
 			name: imageName ?? 'tldraw whiteboard.png',
-			snapshot,
+			snapshot: editor.getSnapshot(),
 			type: 'image/png',
 			...image,
 		})
 	}, [onCancel, onAccept, imageId, imageName, editor])
 
-	// components are used to override parts of the tldraw ui. they shouldn't change often, so it's
-	// important that we memoize them or define them outside the tldraw component.
+	// components must be memoized (or defined outside the component) or tldraw remounts them every render
 	const components = useMemo(
 		(): TLComponents => ({
-			// The "SharePanel" is in the top-right of the editor. Here we want it to show our save
-			// and cancel buttons:
-			SharePanel: () => {
-				return (
-					<TldrawUiRow className="whiteboard-actions">
-						<TldrawUiButton type="normal" onClick={onCancel}>
-							Cancel
-						</TldrawUiButton>
-						<TldrawUiButton type="primary" onClick={handleSave}>
-							{imageId ? 'Save' : 'Add'}
-						</TldrawUiButton>
-					</TldrawUiRow>
-				)
-			},
+			// the share panel is in the top-right of the editor; we use it for our save and cancel buttons
+			SharePanel: () => (
+				<TldrawUiRow className="whiteboard-actions">
+					<TldrawUiButton type="normal" onClick={onCancel}>
+						Cancel
+					</TldrawUiButton>
+					<TldrawUiButton type="primary" onClick={handleSave}>
+						{imageId ? 'Save' : 'Add'}
+					</TldrawUiButton>
+				</TldrawUiRow>
+			),
 		}),
 		[onCancel, handleSave, imageId]
 	)
 
-	// when the user clicks outside the modal, we close it. we add their image to the chat input in
-	// case they wanted it - they can easily delete it if not.
+	// clicking outside the modal saves rather than discards - the image is easy to delete if unwanted
 	const handleOverlayClick = (e: React.MouseEvent) => {
 		if (e.target === e.currentTarget) {
 			handleSave()
@@ -132,9 +117,7 @@ export function WhiteboardModal({
 					editor.zoomToSelection()
 				}}
 			>
-				{/* if the user uploaded a file, we insert it in a special component. this means we
-				can use hooks that depend on tldraw's ui to do things like show a toast if
-				something goes wrong. */}
+				{/* rendered inside Tldraw so it can use the editor and ui hooks (e.g. toasts) */}
 				<InsideOfTldrawContext uploadedFile={uploadedFile} />
 			</Tldraw>
 		</div>
@@ -149,34 +132,25 @@ function InsideOfTldrawContext({ uploadedFile }: { uploadedFile?: File }) {
 	useEffect(() => {
 		if (!uploadedFile) return
 
-		// this effect can run multiple times, but we only want the file to be uploaded once:
+		// this effect can run multiple times, but the file must only be inserted once
 		if ((uploadedFile as any).didUpload) return
 		;(uploadedFile as any).didUpload = true
 		;(async () => {
-			// we check if the file is allowed to be uploaded:
-			const isOk = notifyIfFileNotAllowed(editor, uploadedFile, {
-				toasts,
-				msg,
-			})
-			if (!isOk) return
+			if (!notifyIfFileNotAllowed(editor, uploadedFile, { toasts, msg })) return
 
-			// we get the asset for the uploaded file:
 			const asset = await editor.getAssetForExternalContent({
 				type: 'file',
 				file: uploadedFile,
 			})
 			if (!asset || asset.type !== 'image') return
 
-			// scale so the max dimension is 1000px:
+			// scale down so the max dimension is 1000px
 			const scale = Math.min(1000 / Math.max(asset.props.w, asset.props.h), 1)
 			const center = editor.getViewportPageBounds().center
 			const width = asset.props.w * scale
 			const height = asset.props.h * scale
-
-			// create an ID for the new shape so we can select it later:
 			const shapeId = createShapeId()
 
-			// create the shape, select it, make it fill the screen, and start cropping it:
 			editor
 				.createAssets([asset])
 				.createShape({

--- a/templates/chat/src/hooks/useChatInputState.ts
+++ b/templates/chat/src/hooks/useChatInputState.ts
@@ -2,77 +2,63 @@ import { useReducer } from 'react'
 import { TLEditorSnapshot } from 'tldraw'
 import { WhiteboardImage } from '../components/WhiteboardModal'
 
+interface OpenWhiteboard {
+	snapshot?: TLEditorSnapshot
+	id?: string
+	uploadedFile?: File
+	imageName?: string
+}
+
 interface ChatInputState {
 	input: string
 	images: WhiteboardImage[]
-	openWhiteboard: {
-		snapshot?: TLEditorSnapshot
-		id?: string
-		uploadedFile?: File
-		imageName?: string
-	} | null
+	openWhiteboard: OpenWhiteboard | null
 	isDragging: boolean
 }
 
 type ChatInputAction =
-	/** Updates the text input value */
 	| { type: 'setInput'; input: string }
-	/** Adds or updates an image in the chat input */
 	| { type: 'setImage'; image: WhiteboardImage }
-	/** Removes an image from the chat input by its ID */
 	| { type: 'removeImage'; imageId: string }
-	/** Clears all input data (text, images, modals) */
 	| { type: 'clear' }
-	/** Opens the whiteboard modal for drawing/editing */
-	| {
-			type: 'openWhiteboard'
-			snapshot?: TLEditorSnapshot
-			id?: string
-			uploadedFile?: File
-			imageName?: string
-	  }
-	/** Closes the whiteboard modal */
+	| ({ type: 'openWhiteboard' } & OpenWhiteboard)
 	| { type: 'closeWhiteboard' }
-	/** Indicates a file is being dragged over the input area */
 	| { type: 'dragEnter' }
-	/** Indicates drag operation has left the input area */
 	| { type: 'dragLeave' }
-	/** Handles dropping an image file to open in whiteboard */
 	| { type: 'drop'; file: File }
+
+const initialState: ChatInputState = {
+	input: '',
+	images: [],
+	openWhiteboard: null,
+	isDragging: false,
+}
 
 function chatInputReducer(state: ChatInputState, action: ChatInputAction): ChatInputState {
 	switch (action.type) {
 		case 'setInput':
 			return { ...state, input: action.input }
 		case 'setImage': {
-			const index = state.images.findIndex((img) => img.id === action.image.id)
-			if (index !== -1) {
-				const newImages = [...state.images]
-				newImages[index] = action.image
-				return { ...state, images: newImages }
+			const exists = state.images.some((img) => img.id === action.image.id)
+			return {
+				...state,
+				images: exists
+					? state.images.map((img) => (img.id === action.image.id ? action.image : img))
+					: [...state.images, action.image],
 			}
-			return { ...state, images: [...state.images, action.image] }
 		}
 		case 'removeImage':
 			return { ...state, images: state.images.filter((img) => img.id !== action.imageId) }
 		case 'clear':
-			return {
-				input: '',
-				images: [],
-				openWhiteboard: null,
-				isDragging: false,
-			}
-		case 'openWhiteboard':
+			return initialState
+		case 'openWhiteboard': {
+			const { snapshot, id, uploadedFile, imageName } = action
 			return {
 				...state,
-				openWhiteboard: {
-					snapshot: action.snapshot,
-					id: action.id,
-					uploadedFile: action.uploadedFile,
-					imageName: action.imageName,
-				},
+				openWhiteboard: { snapshot, id, uploadedFile, imageName },
 				isDragging: false,
 			}
+		}
 		case 'closeWhiteboard':
 			return { ...state, openWhiteboard: null }
 		case 'dragEnter':
@@ -90,24 +76,7 @@ function chatInputReducer(state: ChatInputState, action: ChatInputAction): ChatI
 	}
 }
 
-/**
- * Hook for managing chat input state including text, images, whiteboard modal, and drag/drop interactions.
- *
- * Handles:
- * - Text input value
- * - Whiteboard images attached to the message
- * - Whiteboard modal state for drawing/editing
- * - Drag and drop file upload interactions
- *
- * @returns A tuple containing the current state and dispatch function for actions
- */
+/** Text input, attached whiteboard images, whiteboard modal state, and drag/drop state for the chat input. */
 export function useChatInputState(): [ChatInputState, React.Dispatch<ChatInputAction>] {
-	const [state, dispatch] = useReducer(chatInputReducer, {
-		input: '',
-		images: [],
-		openWhiteboard: null,
-		isDragging: false,
-	})
-
-	return [state, dispatch]
+	return useReducer(chatInputReducer, initialState)
 }

--- a/templates/chat/src/hooks/useChatMessageStorage.tsx
+++ b/templates/chat/src/hooks/useChatMessageStorage.tsx
@@ -46,10 +46,9 @@ export function useChatMessageStorage(): [UIMessage[] | null, (messages: UIMessa
 		const root = await navigator.storage.getDirectory()
 		const file = await root.getFileHandle(STORAGE_FILE_NAME, { create: true })
 		const writable = await file.createWritable({ keepExistingData: false })
-		const text = JSON.stringify(messages)
-		await writable.write(text)
+		await writable.write(JSON.stringify(messages))
 		await writable.close()
 	}, [])
 
-	return [initialMessages, saveMessages] as const
+	return [initialMessages, saveMessages]
 }

--- a/templates/chat/src/utils/uploadMessageContents.ts
+++ b/templates/chat/src/utils/uploadMessageContents.ts
@@ -32,10 +32,7 @@ export async function uploadMessageContents(messages: UIMessage[]) {
 			if (part.type === 'file' && part.url.startsWith('data:')) {
 				const metadata = getUploadedMetadata(part)
 				if (metadata && metadata.expiresAt > now) {
-					partsToSend.push({
-						...part,
-						url: metadata.uploadedUrl,
-					})
+					partsToSend.push({ ...part, url: metadata.uploadedUrl })
 					partsToSave.push(part)
 				} else {
 					const partToSend = { ...part }
@@ -56,11 +53,13 @@ export async function uploadMessageContents(messages: UIMessage[]) {
 						partToSend.url = data.uploadedUrl
 						if (partToSend.providerMetadata) {
 							partToSend.providerMetadata = { ...partToSend.providerMetadata }
-							delete partToSend.providerMetadata.tldraw_uploaded
+							delete partToSend.providerMetadata[UPLOAD_METADATA_KEY]
 							delete partToSend.providerMetadata.tldraw
 						}
-						partToSave.providerMetadata = { ...partToSave.providerMetadata }
-						partToSave.providerMetadata.tldraw_uploaded = data as any
+						partToSave.providerMetadata = {
+							...partToSave.providerMetadata,
+							[UPLOAD_METADATA_KEY]: data as any,
+						}
 					})()
 
 					promises.push(promise)

--- a/templates/shader/src/App.tsx
+++ b/templates/shader/src/App.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { DefaultStylePanel, Tldraw, TldrawUiButton, useLocalStorageState } from 'tldraw'
 import { FluidConfigPanel } from './fluid/FluidConfigPanel'
 import { FluidRenderer } from './fluid/FluidRenderer'
@@ -9,42 +8,40 @@ import { RainbowRenderer } from './rainbow/RainbowRenderer'
 import { ShadowControlPanel } from './shadow/ShadowControlPanel'
 import { ShadowRenderer } from './shadow/ShadowRenderer'
 
+const EXAMPLES = [
+	{ label: 'Fluid', value: 'fluid', ConfigPanel: FluidConfigPanel, Renderer: FluidRenderer },
+	{
+		label: 'Rainbow',
+		value: 'rainbow',
+		ConfigPanel: RainbowConfigPanel,
+		Renderer: RainbowRenderer,
+	},
+	{ label: 'Shadows', value: 'shadows', ConfigPanel: ShadowControlPanel, Renderer: ShadowRenderer },
+	{
+		label: 'Minimal',
+		value: 'minimal',
+		ConfigPanel: MinimalConfigPanel,
+		Renderer: MinimalRenderer,
+	},
+]
+
 function App() {
-	const options = [
-		{ label: 'Fluid', value: 'fluid' },
-		{ label: 'Rainbow', value: 'rainbow' },
-		{ label: 'Shadows', value: 'shadows' },
-		{ label: 'Minimal', value: 'minimal' },
-	]
-
 	const [selected, setSelected] = useLocalStorageState<string>('shader-selected', 'fluid')
-
-	const ConfigComponent = useMemo(() => {
-		if (selected === 'fluid') return FluidConfigPanel
-		if (selected === 'rainbow') return RainbowConfigPanel
-		if (selected === 'shadows') return ShadowControlPanel
-		if (selected === 'minimal') return MinimalConfigPanel
-	}, [selected])
-
-	const BackgroundComponent = useMemo(() => {
-		if (selected === 'fluid') return FluidRenderer
-		if (selected === 'rainbow') return RainbowRenderer
-		if (selected === 'shadows') return ShadowRenderer
-		if (selected === 'minimal') return MinimalRenderer
-	}, [selected])
+	const example = EXAMPLES.find((e) => e.value === selected)
+	const ConfigComponent = example?.ConfigPanel
 
 	return (
 		<div className="shader-app">
 			<Tldraw
 				persistenceKey="shader"
 				components={{
-					Background: BackgroundComponent,
+					Background: example?.Renderer,
 					StylePanel: () => {
 						return (
 							<div style={{ display: 'flex', flexDirection: 'row' }}>
 								{ConfigComponent && <ConfigComponent />}
 								<div className="tlui-menu shader-app__example-menu">
-									{options.map((option) => (
+									{EXAMPLES.map((option) => (
 										<TldrawUiButton
 											type="menu"
 											key={option.value}

--- a/templates/shader/src/WebGLManager.ts
+++ b/templates/shader/src/WebGLManager.ts
@@ -9,7 +9,6 @@ export interface WebGLManagerConfig {
 
 /**
  * Base class for WebGL-powered canvas managers integrated with tldraw's reactive system.
- * Provides lifecycle hooks, animation loop management, and automatic viewport synchronization.
  *
  * Lifecycle:
  * 1. constructor() - Initialize reactive dependencies and quality monitoring
@@ -17,18 +16,18 @@ export interface WebGLManagerConfig {
  * 3. onInitialize() - Hook for subclass resource setup (shaders, buffers, etc.)
  * 4. Animation loop (if not paused):
  *    - onUpdate() - Logic and state updates
- *    - onFirstRender() - One-time setup after context creation
+ *    - onFirstRender() - One-time setup after context creation or resize
  *    - onRender() - Draw calls and rendering
  * 5. dispose() - Stop animation and clean up resources
  * 6. onDispose() - Hook for subclass cleanup
  */
 export abstract class WebGLManager<T extends WebGLManagerConfig> {
-	gl: WebGLRenderingContext | WebGL2RenderingContext | null = null
+	gl: WebGL2RenderingContext | null = null
 	animationFrameId: number | null = null
-	lastFrameTime: number = 0
-	isInitialized: boolean = false
-	isDisposed: boolean = false
-	private _needsFirstRender: boolean = true
+	lastFrameTime = 0
+	isInitialized = false
+	isDisposed = false
+	private _needsFirstRender = true
 
 	disposables = new Set<() => void>()
 
@@ -55,9 +54,8 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 	}
 
 	/**
-	 * Creates the WebGL2 context and initializes the manager.
-	 * Must be called before any rendering operations. Calls onInitialize() hook for subclass setup.
-	 * Automatically starts the animation loop unless startPaused is true in config.
+	 * Creates the WebGL2 context, runs onInitialize(), and starts the animation loop unless
+	 * startPaused is set.
 	 */
 	initialize = (): void => {
 		const { startPaused, contextAttributes } = this.getConfig()
@@ -72,29 +70,21 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 			return
 		}
 
-		// Create WebGL2 context with optional attributes
-		const contextType = 'webgl2'
-
-		this.gl = this.canvas.getContext(contextType, contextAttributes) as
-			| WebGLRenderingContext
-			| WebGL2RenderingContext
-			| null
+		this.gl = this.canvas.getContext('webgl2', contextAttributes)
 
 		if (!this.gl) {
 			throw Error('WebGL2 not available')
 		}
 
-		// Configure viewport to match canvas dimensions
 		if (this.canvas.width > 0 && this.canvas.height > 0) {
 			this.gl.viewport(0, 0, this.canvas.width, this.canvas.height)
 		} else {
 			console.warn('Canvas has zero dimensions, skipping viewport setup')
 		}
 
-		// Execute subclass initialization hook before marking as ready
 		this.onInitialize()
 
-		// Abort if subclass called dispose() during initialization
+		// The subclass may have called dispose() during initialization
 		if (this.isDisposed) {
 			console.error('Initialization was aborted')
 			return
@@ -104,24 +94,14 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 		this.lastFrameTime = performance.now()
 		this.resize()
 
-		// Begin animation loop unless configured to start paused
 		if (!startPaused) {
 			this.startAnimationLoop()
 		}
 	}
 
-	/**
-	 * Lifecycle hook for subclass-specific initialization.
-	 * Called after WebGL context creation but before animation loop starts.
-	 * Use this to compile shaders, create buffers, load textures, etc.
-	 */
-	protected onInitialize = (): void => {
-		// Override in subclass
-	}
+	/** Called after context creation, before the animation loop starts. Compile shaders, create buffers, etc. */
+	protected onInitialize = (): void => {}
 
-	/**
-	 * Begins the requestAnimationFrame loop, calling onUpdate() and onRender() each frame.
-	 */
 	private startAnimationLoop = (): void => {
 		const frame = (currentTime: number) => {
 			if (this.isDisposed) return
@@ -129,11 +109,9 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 			const deltaTime = (currentTime - this.lastFrameTime) / 1000
 			this.lastFrameTime = currentTime
 
-			// Execute lifecycle hooks each frame
 			this.onUpdate(deltaTime, currentTime)
 			this.onRender(deltaTime, currentTime)
 
-			// Queue next frame
 			this.animationFrameId = requestAnimationFrame(frame)
 		}
 
@@ -141,47 +119,26 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 	}
 
 	/**
-	 * Lifecycle hook for logic and state updates.
-	 * Called once per frame before onRender(). Override to update uniforms, animation state, etc.
-	 * @param deltaTime - Seconds elapsed since previous frame
-	 * @param currentTime - Absolute timestamp from performance.now() in milliseconds
+	 * Called once per frame before onRender().
+	 * @param deltaTime - Seconds since the previous frame
+	 * @param currentTime - performance.now() timestamp in milliseconds
 	 */
-	protected onUpdate = (_deltaTime: number, _currentTime: number): void => {
-		// Override in subclass
-	}
+	protected onUpdate = (_deltaTime: number, _currentTime: number): void => {}
+
+	/** Called before the first onRender() after context creation and after each resize. */
+	protected onFirstRender = (): void => {}
 
 	/**
-	 * Lifecycle hook called once after context creation or recreation.
-	 * Invoked before the first onRender() call and after resize events that recreate the canvas.
-	 * Use this for one-time setup that depends on final canvas dimensions.
+	 * Called once per frame after onUpdate().
+	 * @param deltaTime - Seconds since the previous frame
+	 * @param currentTime - performance.now() timestamp in milliseconds
 	 */
-	protected onFirstRender = (): void => {
-		// Override in subclass
-	}
+	protected onRender = (_deltaTime: number, _currentTime: number): void => {}
 
-	/**
-	 * Lifecycle hook for rendering to the canvas.
-	 * Called after onUpdate() each frame. Override to execute draw calls and render your scene.
-	 * @param deltaTime - Seconds elapsed since previous frame
-	 * @param currentTime - Absolute timestamp from performance.now() in milliseconds
-	 */
-	protected onRender = (_deltaTime: number, _currentTime: number): void => {
-		// Override in subclass
-	}
+	/** Called during dispose() before the WebGL context is dropped. Delete GPU resources here. */
+	protected onDispose = (): void => {}
 
-	/**
-	 * Lifecycle hook for cleanup of subclass-specific resources.
-	 * Called during dispose() before clearing the WebGL context.
-	 * Use this to delete shaders, buffers, textures, and other GPU resources.
-	 */
-	protected onDispose = (): void => {
-		// Override in subclass
-	}
-
-	/**
-	 * Stops the animation loop and releases all resources.
-	 * Calls onDispose() hook for subclass cleanup. Instance cannot be reused after disposal.
-	 */
+	/** Stops the animation loop and releases all resources. The instance cannot be reused. */
 	dispose = (): void => {
 		this.disposables.forEach((dispose) => dispose())
 		this.disposables.clear()
@@ -191,16 +148,10 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 			return
 		}
 
-		// Cancel any pending animation frame
-		if (this.animationFrameId !== null) {
-			cancelAnimationFrame(this.animationFrameId)
-			this.animationFrameId = null
-		}
-
-		// Execute subclass cleanup hook
+		this.pause()
 		this.onDispose()
 
-		// Clear WebGL context reference (avoid explicit context loss to prevent React conflicts)
+		// Drop the reference rather than forcing context loss, which conflicts with React unmounting
 		this.gl = null
 
 		this.isDisposed = true
@@ -208,63 +159,30 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 	}
 
 	/**
-	 * Returns true if initialize() has been called successfully.
-	 */
-	getIsInitialized = (): boolean => {
-		return this.isInitialized
-	}
-
-	/**
-	 * Returns true if dispose() has been called.
-	 */
-	getIsDisposed = (): boolean => {
-		return this.isDisposed
-	}
-
-	/**
-	 * Returns the WebGL rendering context, or null if not initialized or disposed.
-	 */
-	getGL = (): WebGLRenderingContext | WebGL2RenderingContext | null => {
-		return this.gl
-	}
-
-	/**
-	 * Returns the HTMLCanvasElement this manager is rendering to.
-	 */
-	getCanvas = (): HTMLCanvasElement => {
-		return this.canvas
-	}
-
-	/**
-	 * Updates canvas dimensions and WebGL viewport based on current bounding rect and quality setting.
-	 * Automatically called when viewport bounds or quality changes via reactive dependency.
-	 * Triggers onFirstRender() and a single frame if animation loop is paused.
+	 * Matches canvas resolution to its bounding rect scaled by quality. Runs automatically when
+	 * viewport bounds or quality change, and renders a frame immediately if the loop is paused.
 	 */
 	resize = (): void => {
-		const { width, height } = this.canvas.getBoundingClientRect()
 		if (!this.isInitialized || this.isDisposed || !this.gl) {
 			return
 		}
 
-		const { quality } = this.getConfig()
-		this.canvas.width = Math.floor(width * quality)
-		this.canvas.height = Math.floor(height * quality)
-
-		// Update WebGL viewport to match new canvas resolution
+		this.updateCanvasSize()
 		this.gl.viewport(0, 0, this.canvas.width, this.canvas.height)
-
-		// Flag that onFirstRender() should be called on next frame
 		this._needsFirstRender = true
 
-		// Render immediately if paused to reflect resize
 		if (!this.isRunning()) {
 			this.tick()
 		}
 	}
 
-	/**
-	 * Stops the animation loop by canceling the current requestAnimationFrame.
-	 */
+	private updateCanvasSize() {
+		const { width, height } = this.canvas.getBoundingClientRect()
+		const { quality } = this.getConfig()
+		this.canvas.width = Math.floor(width * quality)
+		this.canvas.height = Math.floor(height * quality)
+	}
+
 	pause = (): void => {
 		if (this.animationFrameId !== null) {
 			cancelAnimationFrame(this.animationFrameId)
@@ -272,22 +190,15 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 		}
 	}
 
-	/**
-	 * Restarts the animation loop if currently paused.
-	 * Resets lastFrameTime to prevent large deltaTime jump.
-	 */
 	resume = (): void => {
 		if (this.animationFrameId === null && this.isInitialized && !this.isDisposed) {
+			// Reset so the first frame after resuming doesn't see a huge deltaTime
 			this.lastFrameTime = performance.now()
 			this.startAnimationLoop()
 		}
 	}
 
-	/**
-	 * Executes a single frame update and render cycle manually.
-	 * Useful for on-demand rendering when paused, or for controlled frame stepping.
-	 * Calls onFirstRender() if needed, then onUpdate() and onRender().
-	 */
+	/** Runs a single update/render cycle. Useful for on-demand rendering while paused. */
 	tick = (): void => {
 		if (this.isDisposed) return
 
@@ -295,16 +206,10 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 		const deltaTime = (currentTime - this.lastFrameTime) / 1000
 		this.lastFrameTime = currentTime
 
-		// Execute update hook
 		this.onUpdate(deltaTime, currentTime)
 
 		if (this._needsFirstRender) {
-			// Ensure canvas has correct dimensions before first render
-			const { width, height } = this.canvas.getBoundingClientRect()
-			const { quality } = this.getConfig()
-			this.canvas.width = Math.floor(width * quality)
-			this.canvas.height = Math.floor(height * quality)
-
+			this.updateCanvasSize()
 			this.onFirstRender()
 			this._needsFirstRender = false
 		}
@@ -312,9 +217,6 @@ export abstract class WebGLManager<T extends WebGLManagerConfig> {
 		this.onRender(deltaTime, currentTime)
 	}
 
-	/**
-	 * Returns true if the animation loop is actively running via requestAnimationFrame.
-	 */
 	isRunning = (): boolean => {
 		return this.animationFrameId !== null
 	}

--- a/templates/shader/src/config-panel/ConfigPanel.tsx
+++ b/templates/shader/src/config-panel/ConfigPanel.tsx
@@ -23,7 +23,6 @@ export function ConfigPanel({
 				e.stopPropagation()
 			}}
 		>
-			{/* Header with collapse/expand button */}
 			<div className="shader-config-panel__header">
 				{isExpanded && (
 					<TldrawUiButton

--- a/templates/shader/src/config-panel/ConfigPanelSlider.tsx
+++ b/templates/shader/src/config-panel/ConfigPanelSlider.tsx
@@ -20,7 +20,7 @@ export function ConfigPanelSlider({
 	type: 'float' | 'int'
 	onChange: (prop: string, value: number) => void
 }) {
-	// Map actual value (min to max) to slider value (1 to 10)
+	// Map actual value (min to max) to slider value (1 to STEPS)
 	const sliderValue = value != null ? 1 + ((value - min) / (max - min)) * (STEPS - 1) : 1
 
 	return (
@@ -33,7 +33,6 @@ export function ConfigPanelSlider({
 				label={sliderValue.toFixed(0) + '%'}
 				title={label}
 				onValueChange={(sliderValue) => {
-					// Map slider value (1 to 10) back to actual value (min to max)
 					const actualValue = min + ((sliderValue - 1) / (STEPS - 1)) * (max - min)
 					onChange(prop, type === 'float' ? actualValue : Math.round(actualValue))
 				}}

--- a/templates/shader/src/fluid/FluidConfigPanel.tsx
+++ b/templates/shader/src/fluid/FluidConfigPanel.tsx
@@ -5,14 +5,6 @@ import { ConfigPanelBooleanControl } from '../config-panel/ConfigPanelBooleanCon
 import { ConfigPanelSlider } from '../config-panel/ConfigPanelSlider'
 import { fluidConfig, resetFluidConfig } from './config'
 
-/**
- * Configuration panel for the fluid simulation.
- * Provides UI controls for adjusting all fluid simulation parameters including:
- * - General settings (quality, velocity)
- * - Simulation parameters (resolution, dissipation, pressure)
- * - Splat settings (radius, force, colors)
- * - Post-processing effects (bloom, sunrays)
- */
 export function FluidConfigPanel() {
 	const config = useValue('config', () => fluidConfig.get(), [])
 

--- a/templates/shader/src/fluid/FluidManager.ts
+++ b/templates/shader/src/fluid/FluidManager.ts
@@ -131,10 +131,7 @@ export const DEFAULT_CONFIG: FluidManagerConfig = {
 	pixelate: false,
 }
 
-/**
- * Manages fluid simulation interactions with tldraw shapes.
- * Handles shape tracking, geometry extraction, and fluid simulation lifecycle.
- */
+/** Drives the fluid simulation from tldraw shape, camera, and pointer changes. */
 export class FluidManager {
 	private fluidSim: FluidSimulation | null = null
 	private config: FluidManagerConfig
@@ -194,14 +191,10 @@ export class FluidManager {
 		)
 	}
 
-	/**
-	 * Initialize the fluid simulation with the canvas.
-	 * Must be called before using other methods.
-	 */
+	/** Must be called before using other methods. */
 	initialize(darkMode: boolean = false): void {
 		this.darkMode = darkMode
 
-		// Set canvas internal resolution based on display size
 		const rect = this.canvas.getBoundingClientRect()
 		this.canvas.width = rect.width
 		this.canvas.height = rect.height
@@ -239,20 +232,6 @@ export class FluidManager {
 		this.handleViewportChange(this.editor.getViewportScreenBounds(), new Vec(0, -0.2))
 	}
 
-	/**
-	 * Create random splats in the fluid simulation.
-	 * @param count - Number of random splats to create. If not provided, uses randomSplatsRange from config.
-	 */
-	createRandomSplats = (count?: number): void => {
-		if (!this.fluidSim) return
-		const splatCount = count ?? Math.floor(Math.random() * 20) + 5
-		this.fluidSim.addRandomSplats(splatCount)
-	}
-
-	/**
-	 * Clean up resources and dispose of the fluid simulation.
-	 * Destroys the fluid simulation instance and clears all registered disposables.
-	 */
 	dispose = (): void => {
 		if (this.fluidSim) {
 			this.fluidSim.destroy()
@@ -262,39 +241,24 @@ export class FluidManager {
 		this.disposables.clear()
 	}
 
-	/**
-	 * Handle pointer down event.
-	 * Initiates drag interaction with the fluid simulation when the eraser tool is active.
-	 */
 	handlePointerDown = (): void => {
 		if (!this.isPointerEffectActive) return
 		const { x, y } = this.getNormalizedPosition()
 		this.fluidSim?.startDrag(x, y)
 	}
 
-	/**
-	 * Handle pointer move event.
-	 * Updates drag position in the fluid simulation during active dragging.
-	 */
 	handlePointerMove = (): void => {
 		if (!this.isPointerEffectActive || !this.editor.inputs.getIsDragging()) return
 		const { x, y } = this.getNormalizedPosition()
 		this.fluidSim?.updateDrag(x, y)
 	}
 
-	/**
-	 * Handle pointer up event.
-	 * Ends drag interaction with the fluid simulation.
-	 */
 	handlePointerUp = (): void => {
 		if (!this.isPointerEffectActive || !this.editor.inputs.getIsDragging()) return
 		this.fluidSim?.endDrag()
 	}
 
-	/**
-	 * Get the current pointer position normalized to fluid simulation coordinates.
-	 * @returns Normalized coordinates where x and y are in the range [0, 1], with y inverted for WebGL.
-	 */
+	/** Pointer position in [0, 1] with y inverted for WebGL. */
 	private getNormalizedPosition() {
 		const position = this.editor.inputs.getCurrentScreenPoint()
 		const vsb = this.editor.getViewportScreenBounds()
@@ -304,151 +268,55 @@ export class FluidManager {
 		}
 	}
 
-	/**
-	 * Process shape changes and update fluid simulation accordingly.
-	 * Handles both newly created shapes and updated shapes, including group shapes.
-	 * Throttled to run at most once every 32ms for performance.
-	 * @param created - Array of newly created shapes
-	 * @param updated - Array of tuples containing [previousShape, currentShape] for updated shapes
-	 */
 	updateShapes = throttle((created: TLShape[], updated: [TLShape, TLShape][]): void => {
 		if (!this.fluidSim) return
 		const vsb = this.editor.getViewportScreenBounds()
 
-		created.forEach((shape) => {
-			if (shape.type === 'group') {
-				const children = this.editor.getSortedChildIdsForParent(shape.id)
-				children.forEach((childId) => {
-					const child = this.editor.getShape(childId)
-					if (!child) return
-					this.handleNewShape(child, vsb)
-				})
-				return
-			}
-			this.handleNewShape(shape, vsb)
-		})
-
-		updated.forEach(([prevShape, shape]) => {
-			if (shape.type === 'group') {
-				const children = this.editor.getSortedChildIdsForParent(shape.id)
-				children.forEach((childId) => {
-					const child = this.editor.getShape(childId)
-					if (!child) return
-					this.handleNewShape(child, vsb)
-				})
-			} else {
-				this.handleShapeChange(shape, prevShape, vsb)
-			}
-		})
-	}, 32)
-
-	/**
-	 * Handle a newly created shape by extracting its geometry and creating fluid splats.
-	 * @param shape - The newly created shape
-	 * @param vsb - The viewport screen bounds
-	 */
-	private handleNewShape = (shape: TLShape, vsb: Box): void => {
-		const geometryData = this.extractShapeGeometry(shape, vsb)
-		const color = this.getShapeColor(shape)
-		if (geometryData.points.length > 0) {
-			this.fluidSim!.createSplatsFromGeometry(
-				geometryData.points,
-				{ x: 0, y: 0 },
-				geometryData.isClosed,
-				color
-			)
+		for (const shape of created) {
+			this.splatShapeOrGroup(shape, vsb, { x: 0, y: 0 })
 		}
-	}
 
-	/**
-	 * Handle a shape update by calculating velocity from position change and creating fluid splats.
-	 * @param shape - The current state of the shape
-	 * @param prevShape - The previous state of the shape
-	 * @param vsb - The viewport screen bounds
-	 */
-	private handleShapeChange = (shape: TLShape, prevShape: TLShape, vsb: Box): void => {
-		const geometryData = this.extractShapeGeometry(shape, vsb)
-		const color = this.getShapeColor(shape)
 		const { velocityScale } = this.config
-		if (geometryData.points.length > 0) {
-			// Calculate velocity based on position change
-			const velocity = {
+		for (const [prevShape, shape] of updated) {
+			this.splatShapeOrGroup(shape, vsb, {
 				x: (shape.x - prevShape.x) * velocityScale,
 				y: (shape.y - prevShape.y) * velocityScale - 0.05,
-			}
-			this.fluidSim!.createSplatsFromGeometry(
-				geometryData.points,
-				velocity,
-				geometryData.isClosed,
-				color
-			)
-		}
-	}
-
-	/**
-	 * Handle viewport/camera changes by creating splats for all visible shapes.
-	 * Throttled to prevent excessive updates during camera movements.
-	 * @param vsb - The viewport screen bounds
-	 * @param cameraVelocity - The velocity of the camera movement
-	 */
-	private handleViewportChange = throttle((vsb: Box, cameraVelocity: Vec): void => {
-		const renderingShape = this.editor.getRenderingShapes()
-		for (const { shape } of renderingShape) {
-			const geometryData = this.extractShapeGeometry(shape, vsb)
-			const color = this.getShapeColor(shape)
-			if (geometryData.points.length > 0) {
-				this.fluidSim!.createSplatsFromGeometry(
-					geometryData.points,
-					cameraVelocity,
-					geometryData.isClosed,
-					color
-				)
-			}
+			})
 		}
 	}, 32)
 
-	/**
-	 * Extract the color from a shape and convert it to RGB values.
-	 * Uses the appropriate color map based on dark mode setting.
-	 * @param shape - The shape to extract color from
-	 * @returns RGB color values in the range [0, 1]
-	 */
-	private getShapeColor(shape: TLShape): [number, number, number] {
-		try {
-			// Try to get color from shape props
-			let colorValue = 'black' // Default
-			if (this.hasStringColorProp(shape)) {
-				colorValue = (shape.props as any).color
-			}
-
-			// Convert tldraw color names to RGB values
-			const colorMap = this.darkMode ? this.config.darkModeColorMap : this.config.lightModeColorMap
-			const color = colorMap[colorValue] || colorMap.blue
-			return color
-		} catch (error) {
-			console.warn('Failed to extract color for shape:', shape.type, error)
-			return this.darkMode ? DEFAULT_DARK_MODE_COLOR_MAP.blue : DEFAULT_LIGHT_MODE_COLOR_MAP.blue // Default color
+	private splatShapeOrGroup(shape: TLShape, vsb: Box, velocity: { x: number; y: number }) {
+		if (shape.type !== 'group') {
+			this.splatShape(shape, vsb, velocity)
+			return
+		}
+		// Group children always splat without velocity, matching how a new group is handled
+		for (const childId of this.editor.getSortedChildIdsForParent(shape.id)) {
+			const child = this.editor.getShape(childId)
+			if (child) this.splatShape(child, vsb, { x: 0, y: 0 })
 		}
 	}
 
-	/**
-	 * Check if a shape has a valid string color property.
-	 * @param shape - The shape to check
-	 * @returns True if the shape has a string color property
-	 */
-	private hasStringColorProp(shape: TLShape): boolean {
-		return (
-			shape &&
-			shape.props &&
-			Object.prototype.hasOwnProperty.call(shape.props, 'color') &&
-			typeof (shape.props as any).color === 'string'
-		)
+	private splatShape(shape: TLShape, vsb: Box, velocity: { x: number; y: number }) {
+		const { points, isClosed } = this.extractShapeGeometry(shape, vsb)
+		if (points.length === 0) return
+		this.fluidSim!.createSplatsFromGeometry(points, velocity, isClosed, this.getShapeColor(shape))
 	}
 
-	/**
-	 * Extract geometry points from a shape using tldraw's geometry helpers.
-	 * Points are returned in normalized screen coordinates (0-1 range).
-	 */
+	private handleViewportChange = throttle((vsb: Box, cameraVelocity: Vec): void => {
+		for (const { shape } of this.editor.getRenderingShapes()) {
+			this.splatShape(shape, vsb, cameraVelocity)
+		}
+	}, 32)
+
+	/** RGB in [0, 1] from the shape's tldraw color name, using the color map for the current theme. */
+	private getShapeColor(shape: TLShape): [number, number, number] {
+		const colorMap = this.darkMode ? this.config.darkModeColorMap : this.config.lightModeColorMap
+		const color = (shape.props as { color?: unknown }).color
+		return colorMap[typeof color === 'string' ? color : 'black'] || colorMap.blue
+	}
+
+	/** Shape outline points in normalized screen coordinates (0-1, y up). */
 	private extractShapeGeometry = (
 		shape: TLShape,
 		vsb: Box
@@ -456,68 +324,41 @@ export class FluidManager {
 		points: Array<{ x: number; y: number }>
 		isClosed: boolean
 	} => {
-		// Convert page coordinates to normalized coordinates
-		const toNormalized = (pageX: number, pageY: number) => {
-			const screenPoint = this.editor.pageToScreen({ x: pageX, y: pageY })
+		const toNormalized = (pagePoint: { x: number; y: number }) => {
+			const screenPoint = this.editor.pageToScreen(pagePoint)
 			return {
 				x: (screenPoint.x - vsb.x) / vsb.w,
 				y: ((screenPoint.y - vsb.y) / vsb.h) * -1 + 1,
 			}
 		}
 
-		const transformAndNormalize = (
-			vertex: { x: number; y: number },
-			transform: { a: number; b: number; c: number; d: number; e: number; f: number }
-		) => {
-			const transformedX = transform.a * vertex.x + transform.c * vertex.y + transform.e
-			const transformedY = transform.b * vertex.x + transform.d * vertex.y + transform.f
-			return toNormalized(transformedX, transformedY)
-		}
+		const isOpenShapeType = shape.type === 'arrow' || shape.type === 'line'
 
 		try {
-			// Get the shape's geometry using tldraw's built-in helpers
 			const geometry = this.editor.getShapeGeometry(shape)
-
-			const points: Array<{ x: number; y: number }> = []
-			let isClosed = true // Default to closed
-
-			// Get the shape's transform
 			const transform = this.editor.getShapePageTransform(shape)
 			if (!transform) return { points: [], isClosed: false }
 
-			// Check if geometry has isClosed property
-			if (shape.type === 'arrow' || shape.type === 'line') {
-				isClosed = false
-			} else {
-				if ('isClosed' in geometry && typeof geometry.isClosed === 'boolean') {
-					isClosed = geometry.isClosed
-				}
-			}
+			const points: Array<{ x: number; y: number }> = []
+			let isClosed = isOpenShapeType ? false : geometry.isClosed
 
-			// Sample points along the geometry
-			// Use the vertices property directly
-			if (geometry.vertices && geometry.vertices.length > 0) {
-				geometry.vertices.forEach((vertex) => {
-					points.push(transformAndNormalize(vertex, transform))
-				})
-			} else if ('bounds' in geometry) {
-				// Sample points around the perimeter using bounds
-				const bounds = geometry.bounds
-				const sampleCount = this.config.boundsSampleCount
-				const corners = bounds.corners
-				const pointsPerEdge = Math.ceil(sampleCount / 4)
+			if (geometry.vertices.length > 0) {
+				for (const vertex of geometry.vertices) {
+					points.push(toNormalized(transform.applyToPoint(vertex)))
+				}
+			} else {
+				// Sample points around the bounds perimeter
+				const corners = geometry.bounds.corners
+				const pointsPerEdge = Math.ceil(this.config.boundsSampleCount / 4)
 				for (let j = 0; j < 4; j++) {
 					for (let i = 0; i < pointsPerEdge; i++) {
 						points.push(
-							transformAndNormalize(
-								Vec.Lrp(corners[j], corners[(j + 1) % 4], i / pointsPerEdge),
-								transform
+							toNormalized(
+								transform.applyToPoint(Vec.Lrp(corners[j], corners[(j + 1) % 4], i / pointsPerEdge))
 							)
 						)
 					}
 				}
-
-				// Bounds-based shapes are typically closed
 				isClosed = true
 			}
 
@@ -525,22 +366,18 @@ export class FluidManager {
 		} catch (error) {
 			console.warn('Failed to extract geometry for shape:', shape.type, error)
 
-			// Fallback to bounds-based approach
 			const bounds = this.editor.getShapePageBounds(shape)
 			if (!bounds) return { points: [], isClosed: false }
 
 			const { x, y, w, h } = bounds
-			const fallbackIsClosed =
-				!this.editor.isShapeOfType(shape, 'arrow') && !this.editor.isShapeOfType(shape, 'line')
-
 			return {
 				points: [
-					toNormalized(x, y),
-					toNormalized(x + w, y),
-					toNormalized(x + w, y + h),
-					toNormalized(x, y + h),
+					toNormalized({ x, y }),
+					toNormalized({ x: x + w, y }),
+					toNormalized({ x: x + w, y: y + h }),
+					toNormalized({ x, y: y + h }),
 				],
-				isClosed: fallbackIsClosed,
+				isClosed: !isOpenShapeType,
 			}
 		}
 	}

--- a/templates/shader/src/fluid/FluidRenderer.tsx
+++ b/templates/shader/src/fluid/FluidRenderer.tsx
@@ -3,28 +3,15 @@ import { useColorMode, useEditor, useValue } from 'tldraw'
 import { fluidConfig } from './config'
 import { FluidManager } from './FluidManager'
 
-/**
- * React component that renders the fluid simulation canvas.
- * Initializes and manages the FluidManager lifecycle, including:
- * - WebGL context setup
- * - Pointer event handling
- * - Cleanup on unmount
- */
 export const FluidRenderer = memo(() => {
 	const editor = useEditor()
 	const rCanvas = useRef<HTMLCanvasElement>(null)
-	const rFluidManager = useRef<FluidManager | null>(null)
 	const darkMode = useColorMode() === 'dark'
 
 	const config = useValue('config', () => fluidConfig.get(), [])
 
-	// Initialize FluidManager
 	useLayoutEffect(() => {
-		const canvas = rCanvas.current!
-		const manager = new FluidManager(canvas, editor, config)
-		rFluidManager.current = manager
-
-		// Initialize the WebGL context and start the animation loop
+		const manager = new FluidManager(rCanvas.current!, editor, config)
 		manager.initialize(darkMode)
 
 		function handlePointerDown(e: PointerEvent) {
@@ -54,12 +41,10 @@ export const FluidRenderer = memo(() => {
 
 			manager.handlePointerUp()
 			manager.dispose()
-			rFluidManager.current = null
 		}
 	}, [darkMode, editor, config])
 
-	const pixelate = config.pixelate ?? false
-	const canvasClassName = `shader-app__canvas${pixelate ? ' shader-app__canvas--pixelated' : ''}`
+	const canvasClassName = `shader-app__canvas${config.pixelate ? ' shader-app__canvas--pixelated' : ''}`
 
 	return <canvas ref={rCanvas} className={canvasClassName} />
 })

--- a/templates/shader/src/fluid/config.ts
+++ b/templates/shader/src/fluid/config.ts
@@ -1,7 +1,6 @@
 import { atom, react } from 'tldraw'
 import { DEFAULT_CONFIG, FluidManagerConfig } from './FluidManager'
 
-/** Storage key for persisting fluid configuration in localStorage */
 const STORAGE_KEY = 'shader-fluid-config-1'
 
 let initialValue = DEFAULT_CONFIG
@@ -13,20 +12,12 @@ try {
 	// noop
 }
 
-/**
- * Reactive atom containing the fluid simulation configuration.
- * Changes to this atom are automatically persisted to localStorage.
- */
 export const fluidConfig = atom<FluidManagerConfig>('fluid-config', initialValue)
 
-/**
- * Resets the fluid configuration to default values.
- */
 export function resetFluidConfig() {
 	fluidConfig.set(DEFAULT_CONFIG)
 }
 
-// When the config changes, save it to localStorage
 react('save to local storage', () => {
 	localStorage.setItem(STORAGE_KEY, JSON.stringify(fluidConfig.get()))
 })

--- a/templates/shader/src/fluid/fluid.ts
+++ b/templates/shader/src/fluid/fluid.ts
@@ -122,6 +122,54 @@ function createPointer(): Pointer {
 	}
 }
 
+type GL = WebGL2RenderingContext | WebGLRenderingContext
+
+function compileShader(gl: GL, type: number, source: string, keywords?: string[]) {
+	source = addKeywords(source, keywords)
+
+	const shader = gl.createShader(type)!
+	gl.shaderSource(shader, source)
+	gl.compileShader(shader)
+
+	if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+		console.trace(gl.getShaderInfoLog(shader))
+	}
+
+	return shader
+}
+
+function addKeywords(source: string, keywords?: string[]) {
+	if (keywords == null) return source
+	let keywordsString = ''
+	keywords.forEach((keyword) => {
+		keywordsString += '#define ' + keyword + '\n'
+	})
+	return keywordsString + source
+}
+
+function createProgram(gl: GL, vertexShader: WebGLShader, fragmentShader: WebGLShader) {
+	let program = gl.createProgram()!
+	gl.attachShader(program, vertexShader)
+	gl.attachShader(program, fragmentShader)
+	gl.linkProgram(program)
+
+	if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+		console.trace(gl.getProgramInfoLog(program))
+	}
+
+	return program
+}
+
+function getUniforms(gl: GL, program: WebGLProgram) {
+	let uniforms: { [key: string]: WebGLUniformLocation } = {}
+	let uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)
+	for (let i = 0; i < uniformCount; i++) {
+		let uniformName = gl.getActiveUniform(program, i)!.name
+		uniforms[uniformName] = gl.getUniformLocation(program, uniformName)!
+	}
+	return uniforms
+}
+
 /**
  * Main fluid simulation class implementing a GPU-accelerated Navier-Stokes solver.
  * Based on the WebGL fluid simulation by Pavel Dobryakov (MIT License).
@@ -135,7 +183,7 @@ function createPointer(): Pointer {
  * - User interaction via pointer/drag events
  */
 export class FluidSimulation {
-	private gl: WebGL2RenderingContext | WebGLRenderingContext
+	private gl: GL
 	private ext: any
 	private pointers: Pointer[] = []
 	private splatStack: number[] = []
@@ -252,12 +300,7 @@ export class FluidSimulation {
 		}
 	}
 
-	private getSupportedFormat(
-		gl: WebGL2RenderingContext | WebGLRenderingContext,
-		internalFormat: number,
-		format: number,
-		type: number
-	): any {
+	private getSupportedFormat(gl: GL, internalFormat: number, format: number, type: number): any {
 		if (!this.supportRenderTextureFormat(gl, internalFormat, format, type)) {
 			switch (internalFormat) {
 				case (gl as WebGL2RenderingContext).R16F:
@@ -280,12 +323,7 @@ export class FluidSimulation {
 		}
 	}
 
-	private supportRenderTextureFormat(
-		gl: WebGL2RenderingContext | WebGLRenderingContext,
-		internalFormat: number,
-		format: number,
-		type: number
-	) {
+	private supportRenderTextureFormat(gl: GL, internalFormat: number, format: number, type: number) {
 		let texture = gl.createTexture()
 		gl.bindTexture(gl.TEXTURE_2D, texture)
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
@@ -306,55 +344,10 @@ export class FluidSimulation {
 		return /Mobi|Android/i.test(navigator.userAgent)
 	}
 
-	private compileShader(type: number, source: string, keywords?: string[]) {
-		source = this.addKeywords(source, keywords)
-
-		const shader = this.gl.createShader(type)!
-		this.gl.shaderSource(shader, source)
-		this.gl.compileShader(shader)
-
-		if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
-			console.trace(this.gl.getShaderInfoLog(shader))
-		}
-
-		return shader
-	}
-
-	private addKeywords(source: string, keywords?: string[]) {
-		if (keywords == null) return source
-		let keywordsString = ''
-		keywords.forEach((keyword) => {
-			keywordsString += '#define ' + keyword + '\n'
-		})
-		return keywordsString + source
-	}
-
-	private createProgram(vertexShader: WebGLShader, fragmentShader: WebGLShader) {
-		let program = this.gl.createProgram()!
-		this.gl.attachShader(program, vertexShader)
-		this.gl.attachShader(program, fragmentShader)
-		this.gl.linkProgram(program)
-
-		if (!this.gl.getProgramParameter(program, this.gl.LINK_STATUS)) {
-			console.trace(this.gl.getProgramInfoLog(program))
-		}
-
-		return program
-	}
-
-	private getUniforms(program: WebGLProgram) {
-		let uniforms: { [key: string]: WebGLUniformLocation } = {}
-		let uniformCount = this.gl.getProgramParameter(program, this.gl.ACTIVE_UNIFORMS)
-		for (let i = 0; i < uniformCount; i++) {
-			let uniformName = this.gl.getActiveUniform(program, i)!.name
-			uniforms[uniformName] = this.gl.getUniformLocation(program, uniformName)!
-		}
-		return uniforms
-	}
-
 	private initializeShaders() {
 		// Base vertex shader
-		const baseVertexShader = this.compileShader(
+		const baseVertexShader = compileShader(
+			this.gl,
 			this.gl.VERTEX_SHADER,
 			`
 			precision highp float;
@@ -378,7 +371,8 @@ export class FluidSimulation {
 		)
 
 		// Blur vertex shader for bloom
-		const blurVertexShader = this.compileShader(
+		const blurVertexShader = compileShader(
+			this.gl,
 			this.gl.VERTEX_SHADER,
 			`
 			precision highp float;
@@ -399,7 +393,8 @@ export class FluidSimulation {
 		)
 
 		// Simple copy shader
-		const copyShader = this.compileShader(
+		const copyShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -414,7 +409,8 @@ export class FluidSimulation {
 		)
 
 		// Color shader
-		const colorShader = this.compileShader(
+		const colorShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -427,7 +423,8 @@ export class FluidSimulation {
 		)
 
 		// Splat shader
-		const splatShader = this.compileShader(
+		const splatShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision highp float;
@@ -450,7 +447,8 @@ export class FluidSimulation {
 		)
 
 		// Blur shader for bloom
-		const blurShader = this.compileShader(
+		const blurShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -470,7 +468,8 @@ export class FluidSimulation {
 		)
 
 		// Bloom prefilter shader
-		const bloomPrefilterShader = this.compileShader(
+		const bloomPrefilterShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -492,7 +491,8 @@ export class FluidSimulation {
 		)
 
 		// Bloom blur shader
-		const bloomBlurShader = this.compileShader(
+		const bloomBlurShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -516,7 +516,8 @@ export class FluidSimulation {
 		)
 
 		// Bloom final shader
-		const bloomFinalShader = this.compileShader(
+		const bloomFinalShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -541,7 +542,8 @@ export class FluidSimulation {
 		)
 
 		// Sunrays mask shader
-		const sunraysMaskShader = this.compileShader(
+		const sunraysMaskShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision highp float;
@@ -559,7 +561,8 @@ export class FluidSimulation {
 		)
 
 		// Sunrays shader
-		const sunraysShader = this.compileShader(
+		const sunraysShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision highp float;
@@ -597,7 +600,8 @@ export class FluidSimulation {
 		)
 
 		// Additional shaders for complete simulation
-		const clearShader = this.compileShader(
+		const clearShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -612,7 +616,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const advectionShader = this.compileShader(
+		const advectionShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision highp float;
@@ -645,7 +650,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const divergenceShader = this.compileShader(
+		const divergenceShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -675,7 +681,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const curlShader = this.compileShader(
+		const curlShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -698,7 +705,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const vorticityShader = this.compileShader(
+		const vorticityShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision highp float;
@@ -733,7 +741,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const pressureShader = this.compileShader(
+		const pressureShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -759,7 +768,8 @@ export class FluidSimulation {
 		`
 		)
 
-		const gradientSubtractShader = this.compileShader(
+		const gradientSubtractShader = compileShader(
+			this.gl,
 			this.gl.FRAGMENT_SHADER,
 			`
 			precision mediump float;
@@ -892,10 +902,10 @@ export class FluidSimulation {
 	}
 
 	private createProgramWithUniforms(vertexShader: WebGLShader, fragmentShader: WebGLShader) {
-		const program = this.createProgram(vertexShader, fragmentShader)
+		const program = createProgram(this.gl, vertexShader, fragmentShader)
 		return {
 			program,
-			uniforms: this.getUniforms(program),
+			uniforms: getUniforms(this.gl, program),
 			bind: () => this.gl.useProgram(program),
 		}
 	}
@@ -1686,8 +1696,6 @@ export class FluidSimulation {
 	updateDrag(x: number, y: number) {
 		if (!this.isDragging || !this.dragPointer) return
 
-		// console.log('dragPointer', this.dragPointer)
-
 		this.dragPointer.prevTexcoordX = this.dragPointer.texcoordX
 		this.dragPointer.prevTexcoordY = this.dragPointer.texcoordY
 		this.dragPointer.texcoordX = x
@@ -1821,35 +1829,7 @@ export class FluidSimulation {
 	 */
 	adaptiveDecimatePoints(points: Array<{ x: number; y: number }>): Array<{ x: number; y: number }> {
 		if (points.length <= 3) return points
-
-		// Calculate bounding box to estimate shape size
-		let minX = points[0].x,
-			maxX = points[0].x
-		let minY = points[0].y,
-			maxY = points[0].y
-
-		for (const point of points) {
-			minX = Math.min(minX, point.x)
-			maxX = Math.max(maxX, point.x)
-			minY = Math.min(minY, point.y)
-			maxY = Math.max(maxY, point.y)
-		}
-
-		// const shapeWidth = maxX - minX
-		// const shapeHeight = maxY - minY
-		// const shapeSize = Math.sqrt(shapeWidth * shapeWidth + shapeHeight * shapeHeight)
-
-		// Adaptive threshold: larger shapes can have more aggressive decimation
-		const threshold = 0.002 // Base threshold for small shapes
-		// if (shapeSize > 0.1) threshold = 0.004 // Medium shapes
-		// if (shapeSize > 0.3) threshold = 0.008 // Large shapes
-		// if (shapeSize > 0.5) threshold = 0.012 // Very large shapes
-
-		// Also consider point density
-		// const pointDensity = points.length / shapeSize
-		// if (pointDensity > 100) threshold *= 1.5 // More aggressive for very dense geometry
-
-		return this.decimatePoints(points, threshold)
+		return this.decimatePoints(points, 0.002)
 	}
 
 	/**
@@ -1981,28 +1961,15 @@ export class FluidSimulation {
  * Supports dynamic shader compilation with preprocessor definitions.
  */
 class Material {
-	private vertexShader: WebGLShader
-	private fragmentShaderSource: string
 	private programs: { [key: number]: WebGLProgram } = {}
 	private activeProgram: WebGLProgram | null = null
 	public uniforms: { [key: string]: WebGLUniformLocation } = {}
-	private gl: WebGL2RenderingContext | WebGLRenderingContext
 
-	/**
-	 * Creates a new Material instance.
-	 * @param gl - WebGL rendering context
-	 * @param vertexShader - Compiled vertex shader
-	 * @param fragmentShaderSource - Fragment shader source code
-	 */
 	constructor(
-		gl: WebGL2RenderingContext | WebGLRenderingContext,
-		vertexShader: WebGLShader,
-		fragmentShaderSource: string
-	) {
-		this.gl = gl
-		this.vertexShader = vertexShader
-		this.fragmentShaderSource = fragmentShaderSource
-	}
+		private gl: GL,
+		private vertexShader: WebGLShader,
+		private fragmentShaderSource: string
+	) {}
 
 	/**
 	 * Sets shader keywords (preprocessor definitions) and compiles a variant if needed.
@@ -2014,72 +1981,24 @@ class Material {
 
 		let program = this.programs[hash]
 		if (program == null) {
-			let fragmentShader = this.compileShader(
+			let fragmentShader = compileShader(
+				this.gl,
 				this.gl.FRAGMENT_SHADER,
 				this.fragmentShaderSource,
 				keywords
 			)
-			program = this.createProgram(this.vertexShader, fragmentShader)
+			program = createProgram(this.gl, this.vertexShader, fragmentShader)
 			this.programs[hash] = program
 		}
 
 		if (program == this.activeProgram) return
 
-		this.uniforms = this.getUniforms(program)
+		this.uniforms = getUniforms(this.gl, program)
 		this.activeProgram = program
 	}
 
-	/**
-	 * Binds this material's active program for rendering.
-	 */
 	bind() {
 		this.gl.useProgram(this.activeProgram)
-	}
-
-	private compileShader(type: number, source: string, keywords?: string[]) {
-		source = this.addKeywords(source, keywords)
-
-		const shader = this.gl.createShader(type)!
-		this.gl.shaderSource(shader, source)
-		this.gl.compileShader(shader)
-
-		if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
-			console.trace(this.gl.getShaderInfoLog(shader))
-		}
-
-		return shader
-	}
-
-	private addKeywords(source: string, keywords?: string[]) {
-		if (keywords == null) return source
-		let keywordsString = ''
-		keywords.forEach((keyword) => {
-			keywordsString += '#define ' + keyword + '\n'
-		})
-		return keywordsString + source
-	}
-
-	private createProgram(vertexShader: WebGLShader, fragmentShader: WebGLShader) {
-		let program = this.gl.createProgram()!
-		this.gl.attachShader(program, vertexShader)
-		this.gl.attachShader(program, fragmentShader)
-		this.gl.linkProgram(program)
-
-		if (!this.gl.getProgramParameter(program, this.gl.LINK_STATUS)) {
-			console.trace(this.gl.getProgramInfoLog(program))
-		}
-
-		return program
-	}
-
-	private getUniforms(program: WebGLProgram) {
-		let uniforms: { [key: string]: WebGLUniformLocation } = {}
-		let uniformCount = this.gl.getProgramParameter(program, this.gl.ACTIVE_UNIFORMS)
-		for (let i = 0; i < uniformCount; i++) {
-			let uniformName = this.gl.getActiveUniform(program, i)!.name
-			uniforms[uniformName] = this.gl.getUniformLocation(program, uniformName)!
-		}
-		return uniforms
 	}
 
 	private hashCode(s: string) {

--- a/templates/shader/src/minimal/MinimalConfigPanel.tsx
+++ b/templates/shader/src/minimal/MinimalConfigPanel.tsx
@@ -18,12 +18,12 @@ export function MinimalConfigPanel() {
 
 	return (
 		<ConfigPanel onReset={resetShaderConfig}>
-			{Object.entries(config).map(([prop, value], i) => {
+			{Object.entries(config).map(([prop, value]) => {
 				if (typeof value === 'number') {
 					const sliderConfig = SLIDER_CONFIGS[prop] || { min: 0, max: 1 }
 					return (
 						<ConfigPanelSlider
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							min={sliderConfig.min}
@@ -33,10 +33,11 @@ export function MinimalConfigPanel() {
 							onChange={handleChange}
 						/>
 					)
-				} else if (typeof value === 'boolean') {
+				}
+				if (typeof value === 'boolean') {
 					return (
 						<ConfigPanelBooleanControl
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							value={value}

--- a/templates/shader/src/minimal/MinimalRenderer.tsx
+++ b/templates/shader/src/minimal/MinimalRenderer.tsx
@@ -7,12 +7,9 @@ import { MinimalShaderManager } from './MinimalShaderManager'
 export const MinimalRenderer = memo(() => {
 	const editor = useEditor()
 	const rCanvas = useRef<HTMLCanvasElement>(null)
-	const rShaderManager = useRef<MinimalShaderManager | null>(null)
 
 	useLayoutEffect(() => {
-		const canvas = rCanvas.current!
-		const manager = new MinimalShaderManager(editor, canvas, shaderConfig)
-		rShaderManager.current = manager
+		const manager = new MinimalShaderManager(editor, rCanvas.current!, shaderConfig)
 
 		const handlePointerMove = (e: PointerEvent) => manager.pointerMove(e.clientX, e.clientY)
 
@@ -21,7 +18,6 @@ export const MinimalRenderer = memo(() => {
 		return () => {
 			window.removeEventListener('pointermove', handlePointerMove)
 			manager.dispose()
-			rShaderManager.current = null
 		}
 	}, [editor])
 

--- a/templates/shader/src/minimal/MinimalShaderManager.ts
+++ b/templates/shader/src/minimal/MinimalShaderManager.ts
@@ -33,8 +33,6 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
-		const isWebGL2 = this.gl instanceof WebGL2RenderingContext
-
 		const maxTextureSize = this.gl.getParameter(this.gl.MAX_TEXTURE_SIZE)
 
 		if (!maxTextureSize) {
@@ -42,29 +40,23 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
+		const gl = this.gl
 		const compileShader = (type: number, source: string): WebGLShader | null => {
-			if (!this.gl) {
-				console.error('No GL context')
-				return null
-			}
-
-			const shader = this.gl.createShader(type)
+			const shader = gl.createShader(type)
 			if (!shader) {
 				console.error('Failed to create shader - createShader returned null')
 				return null
 			}
 
-			this.gl.shaderSource(shader, source)
-			this.gl.compileShader(shader)
+			gl.shaderSource(shader, source)
+			gl.compileShader(shader)
 
-			const compileStatus = this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)
-			const shaderType = type === this.gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
-
-			if (compileStatus !== true) {
-				const log = this.gl.getShaderInfoLog(shader)
+			if (gl.getShaderParameter(shader, gl.COMPILE_STATUS) !== true) {
+				const shaderType = type === gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
+				const log = gl.getShaderInfoLog(shader)
 				console.error(`${shaderType} shader compile error:`, log || 'No error log available')
 				console.error('Shader source:', source)
-				this.gl.deleteShader(shader)
+				gl.deleteShader(shader)
 				return null
 			}
 
@@ -104,11 +96,8 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 
 		this.positionBuffer = this.gl.createBuffer()
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			this.vao = gl2.createVertexArray()
-			gl2.bindVertexArray(this.vao)
-		}
+		this.vao = this.gl.createVertexArray()
+		this.gl.bindVertexArray(this.vao)
 
 		this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.positionBuffer)
 		const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1])
@@ -118,10 +107,7 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.gl.enableVertexAttribArray(a_position)
 		this.gl.vertexAttribPointer(a_position, 2, this.gl.FLOAT, false, 0, 0)
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			gl2.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 
 		this.disposables.add(react('dependencies', this.tick))
 
@@ -153,20 +139,14 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.gl.clearColor(0, 0, 0, 0)
 		this.gl.clear(this.gl.COLOR_BUFFER_BIT)
 
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(this.vao)
-		}
-
+		this.gl.bindVertexArray(this.vao)
 		this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4)
-
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 	}
 
 	onDispose = (): void => {
 		if (this.gl) {
-			if (this.vao && this.gl instanceof WebGL2RenderingContext) {
+			if (this.vao) {
 				this.gl.deleteVertexArray(this.vao)
 				this.vao = null
 			}
@@ -188,23 +168,13 @@ export class MinimalShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.tick()
 	}
 
-	refresh = (): void => {
-		try {
-			this.tick()
-		} catch (e) {
-			console.log('Error refreshing geometries', e)
-		}
-	}
-
 	pageToCanvas = (
 		point: Vec,
 		camera: { x: number; y: number; z: number },
 		viewportScreenBounds: Box
 	): Vec => {
-		const screenX = (point.x + camera.x) * camera.z + viewportScreenBounds.x
-		const screenY = (point.y + camera.y) * camera.z + viewportScreenBounds.y
-		const canvasX = (screenX - viewportScreenBounds.x) / viewportScreenBounds.width
-		const canvasY = 1.0 - (screenY - viewportScreenBounds.y) / viewportScreenBounds.height
+		const canvasX = ((point.x + camera.x) * camera.z) / viewportScreenBounds.width
+		const canvasY = 1.0 - ((point.y + camera.y) * camera.z) / viewportScreenBounds.height
 		return new Vec(canvasX, canvasY)
 	}
 }

--- a/templates/shader/src/rainbow/RainbowConfigPanel.tsx
+++ b/templates/shader/src/rainbow/RainbowConfigPanel.tsx
@@ -20,12 +20,12 @@ export function RainbowConfigPanel() {
 
 	return (
 		<ConfigPanel onReset={resetShaderConfig}>
-			{Object.entries(config).map(([prop, value], i) => {
+			{Object.entries(config).map(([prop, value]) => {
 				if (typeof value === 'number') {
 					const sliderConfig = SLIDER_CONFIGS[prop] || { min: 0, max: 1 }
 					return (
 						<ConfigPanelSlider
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							min={sliderConfig.min}
@@ -35,10 +35,11 @@ export function RainbowConfigPanel() {
 							onChange={handleChange}
 						/>
 					)
-				} else if (typeof value === 'boolean') {
+				}
+				if (typeof value === 'boolean') {
 					return (
 						<ConfigPanelBooleanControl
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							value={value}

--- a/templates/shader/src/rainbow/RainbowRenderer.tsx
+++ b/templates/shader/src/rainbow/RainbowRenderer.tsx
@@ -7,14 +7,9 @@ import { RainbowShaderManager } from './RainbowShaderManager'
 export const RainbowRenderer = memo(() => {
 	const editor = useEditor()
 	const rCanvas = useRef<HTMLCanvasElement>(null)
-	const rShaderManager = useRef<RainbowShaderManager | null>(null)
 
 	useLayoutEffect(() => {
-		const canvas = rCanvas.current!
-		const manager = new RainbowShaderManager(editor, canvas, shaderConfig)
-		rShaderManager.current = manager
-
-		manager.refresh()
+		const manager = new RainbowShaderManager(editor, rCanvas.current!, shaderConfig)
 
 		const handlePointerMove = (e: PointerEvent) => manager.pointerMove(e.clientX, e.clientY)
 
@@ -23,7 +18,6 @@ export const RainbowRenderer = memo(() => {
 		return () => {
 			window.removeEventListener('pointermove', handlePointerMove)
 			manager.dispose()
-			rShaderManager.current = null
 		}
 	}, [editor])
 

--- a/templates/shader/src/rainbow/RainbowShaderManager.ts
+++ b/templates/shader/src/rainbow/RainbowShaderManager.ts
@@ -1,11 +1,8 @@
 import { Atom, Box, Editor, Group2d, react, TLShape, Vec } from 'tldraw'
 import { WebGLManager } from '../WebGLManager'
 import { ShaderManagerConfig } from './config'
-import fragmentShader from './fragment.glsl?raw'
-import vertexShader from './vertex.glsl?raw'
-
-const VERTEX_SHADER = vertexShader
-const FRAGMENT_SHADER = fragmentShader
+import FRAGMENT_SHADER from './fragment.glsl?raw'
+import VERTEX_SHADER from './vertex.glsl?raw'
 
 export type Geometry = Array<{ start: Vec; end: Vec }>
 
@@ -52,8 +49,6 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
-		const isWebGL2 = this.gl instanceof WebGL2RenderingContext
-
 		const maxTextureSize = this.gl.getParameter(this.gl.MAX_TEXTURE_SIZE)
 
 		if (!maxTextureSize) {
@@ -61,29 +56,23 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
+		const gl = this.gl
 		const compileShader = (type: number, source: string): WebGLShader | null => {
-			if (!this.gl) {
-				console.error('No GL context')
-				return null
-			}
-
-			const shader = this.gl.createShader(type)
+			const shader = gl.createShader(type)
 			if (!shader) {
 				console.error('Failed to create shader - createShader returned null')
 				return null
 			}
 
-			this.gl.shaderSource(shader, source)
-			this.gl.compileShader(shader)
+			gl.shaderSource(shader, source)
+			gl.compileShader(shader)
 
-			const compileStatus = this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)
-			const shaderType = type === this.gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
-
-			if (compileStatus !== true) {
-				const log = this.gl.getShaderInfoLog(shader)
+			if (gl.getShaderParameter(shader, gl.COMPILE_STATUS) !== true) {
+				const shaderType = type === gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
+				const log = gl.getShaderInfoLog(shader)
 				console.error(`${shaderType} shader compile error:`, log || 'No error log available')
 				console.error('Shader source:', source)
-				this.gl.deleteShader(shader)
+				gl.deleteShader(shader)
 				return null
 			}
 
@@ -132,11 +121,8 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 
 		this.positionBuffer = this.gl.createBuffer()
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			this.vao = gl2.createVertexArray()
-			gl2.bindVertexArray(this.vao)
-		}
+		this.vao = this.gl.createVertexArray()
+		this.gl.bindVertexArray(this.vao)
 
 		this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.positionBuffer)
 		const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1])
@@ -146,10 +132,7 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.gl.enableVertexAttribArray(a_position)
 		this.gl.vertexAttribPointer(a_position, 2, this.gl.FLOAT, false, 0, 0)
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			gl2.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 
 		this.disposables.add(react('dependencies', this.tick))
 
@@ -160,10 +143,9 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		const { editor } = this
 		const vsb = editor.getViewportScreenBounds()
 		const camera = editor.getCamera()
-		const shapes = this.editor.getCurrentPageShapes()
 		this.geometries = []
 
-		for (const shape of shapes) {
+		for (const shape of editor.getCurrentPageShapes()) {
 			try {
 				const geometry = this.extractGeometry(shape, camera, vsb)
 				if (geometry) {
@@ -240,20 +222,14 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			this.gl.uniform1f(this.u_segmentCount, Math.min(allSegments.length / 4, this.maxSegments))
 		}
 
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(this.vao)
-		}
-
+		this.gl.bindVertexArray(this.vao)
 		this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4)
-
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 	}
 
 	onDispose = (): void => {
 		if (this.gl) {
-			if (this.vao && this.gl instanceof WebGL2RenderingContext) {
+			if (this.vao) {
 				this.gl.deleteVertexArray(this.vao)
 				this.vao = null
 			}
@@ -265,14 +241,6 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 				this.gl.deleteProgram(this.program)
 				this.program = null
 			}
-		}
-	}
-
-	refresh = (): void => {
-		try {
-			this.tick()
-		} catch (e) {
-			console.log('Error refreshing geometries', e)
 		}
 	}
 
@@ -288,10 +256,8 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		camera: { x: number; y: number; z: number },
 		viewportScreenBounds: Box
 	): Vec => {
-		const screenX = (point.x + camera.x) * camera.z + viewportScreenBounds.x
-		const screenY = (point.y + camera.y) * camera.z + viewportScreenBounds.y
-		const canvasX = (screenX - viewportScreenBounds.x) / viewportScreenBounds.width
-		const canvasY = 1.0 - (screenY - viewportScreenBounds.y) / viewportScreenBounds.height
+		const canvasX = ((point.x + camera.x) * camera.z) / viewportScreenBounds.width
+		const canvasY = 1.0 - ((point.y + camera.y) * camera.z) / viewportScreenBounds.height
 		return new Vec(canvasX, canvasY)
 	}
 
@@ -299,22 +265,19 @@ export class RainbowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		shape: TLShape,
 		camera: { x: number; y: number; z: number },
 		viewportScreenBounds: Box
-	): Array<{ start: Vec; end: Vec }> | null => {
-		const { editor } = this
+	): Geometry | null => {
 		const geometry = this.editor.getShapeGeometry(shape)
-		const transform = editor.getShapePageTransform(shape)
+		const transform = this.editor.getShapePageTransform(shape)
 		if (!transform) return null
 
 		const canvasPoints = geometry.vertices.map((c) =>
 			this.pageToCanvas(transform.applyToPoint(c), camera, viewportScreenBounds)
 		)
 
-		const segments: Array<{ start: Vec; end: Vec }> = []
+		const segments: Geometry = []
 
 		for (let i = 0; i < canvasPoints.length - 1; i++) {
-			const start = canvasPoints[i]
-			const end = canvasPoints[i + 1]
-			segments.push({ start, end })
+			segments.push({ start: canvasPoints[i], end: canvasPoints[i + 1] })
 		}
 
 		const isClosed =

--- a/templates/shader/src/shadow/ShadowControlPanel.tsx
+++ b/templates/shader/src/shadow/ShadowControlPanel.tsx
@@ -19,12 +19,12 @@ export function ShadowControlPanel() {
 
 	return (
 		<ConfigPanel onReset={resetShaderConfig}>
-			{Object.entries(config).map(([prop, value], i) => {
+			{Object.entries(config).map(([prop, value]) => {
 				if (typeof value === 'number') {
 					const sliderConfig = SLIDER_CONFIGS[prop] || { min: 0, max: 1 }
 					return (
 						<ConfigPanelSlider
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							min={sliderConfig.min}
@@ -34,10 +34,11 @@ export function ShadowControlPanel() {
 							onChange={handleChange}
 						/>
 					)
-				} else if (typeof value === 'boolean') {
+				}
+				if (typeof value === 'boolean') {
 					return (
 						<ConfigPanelBooleanControl
-							key={i}
+							key={prop}
 							prop={prop}
 							label={prop}
 							value={value}

--- a/templates/shader/src/shadow/ShadowRenderer.tsx
+++ b/templates/shader/src/shadow/ShadowRenderer.tsx
@@ -7,12 +7,9 @@ import { ShadowShaderManager } from './ShadowShaderManager'
 export const ShadowRenderer = memo(() => {
 	const editor = useEditor()
 	const rCanvas = useRef<HTMLCanvasElement>(null)
-	const rShaderManager = useRef<ShadowShaderManager | null>(null)
 
 	useLayoutEffect(() => {
-		const canvas = rCanvas.current!
-		const manager = new ShadowShaderManager(editor, canvas, shaderConfig)
-		rShaderManager.current = manager
+		const manager = new ShadowShaderManager(editor, rCanvas.current!, shaderConfig)
 
 		const handlePointerMove = (e: PointerEvent) => manager.pointerMove(e.clientX, e.clientY)
 
@@ -21,7 +18,6 @@ export const ShadowRenderer = memo(() => {
 		return () => {
 			window.removeEventListener('pointermove', handlePointerMove)
 			manager.dispose()
-			rShaderManager.current = null
 		}
 	}, [editor])
 

--- a/templates/shader/src/shadow/ShadowShaderManager.ts
+++ b/templates/shader/src/shadow/ShadowShaderManager.ts
@@ -1,11 +1,8 @@
 import { Atom, Box, Editor, Group2d, react, TLShape, Vec } from 'tldraw'
 import { WebGLManager } from '../WebGLManager'
 import { ShaderManagerConfig } from './config'
-import fragmentShader from './fragment.glsl?raw'
-import vertexShader from './vertex.glsl?raw'
-
-const VERTEX_SHADER = vertexShader
-const FRAGMENT_SHADER = fragmentShader
+import FRAGMENT_SHADER from './fragment.glsl?raw'
+import VERTEX_SHADER from './vertex.glsl?raw'
 
 export type Geometry = Array<{ start: Vec; end: Vec }>
 
@@ -50,8 +47,6 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
-		const isWebGL2 = this.gl instanceof WebGL2RenderingContext
-
 		const maxTextureSize = this.gl.getParameter(this.gl.MAX_TEXTURE_SIZE)
 
 		if (!maxTextureSize) {
@@ -59,29 +54,23 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			return
 		}
 
+		const gl = this.gl
 		const compileShader = (type: number, source: string): WebGLShader | null => {
-			if (!this.gl) {
-				console.error('No GL context')
-				return null
-			}
-
-			const shader = this.gl.createShader(type)
+			const shader = gl.createShader(type)
 			if (!shader) {
 				console.error('Failed to create shader - createShader returned null')
 				return null
 			}
 
-			this.gl.shaderSource(shader, source)
-			this.gl.compileShader(shader)
+			gl.shaderSource(shader, source)
+			gl.compileShader(shader)
 
-			const compileStatus = this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)
-			const shaderType = type === this.gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
-
-			if (compileStatus !== true) {
-				const log = this.gl.getShaderInfoLog(shader)
+			if (gl.getShaderParameter(shader, gl.COMPILE_STATUS) !== true) {
+				const shaderType = type === gl.VERTEX_SHADER ? 'VERTEX' : 'FRAGMENT'
+				const log = gl.getShaderInfoLog(shader)
 				console.error(`${shaderType} shader compile error:`, log || 'No error log available')
 				console.error('Shader source:', source)
-				this.gl.deleteShader(shader)
+				gl.deleteShader(shader)
 				return null
 			}
 
@@ -128,11 +117,8 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 
 		this.positionBuffer = this.gl.createBuffer()
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			this.vao = gl2.createVertexArray()
-			gl2.bindVertexArray(this.vao)
-		}
+		this.vao = this.gl.createVertexArray()
+		this.gl.bindVertexArray(this.vao)
 
 		this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.positionBuffer)
 		const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1])
@@ -142,10 +128,7 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.gl.enableVertexAttribArray(a_position)
 		this.gl.vertexAttribPointer(a_position, 2, this.gl.FLOAT, false, 0, 0)
 
-		if (isWebGL2) {
-			const gl2 = this.gl as WebGL2RenderingContext
-			gl2.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 
 		this.disposables.add(react('dependencies', this.tick))
 
@@ -156,10 +139,9 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		const { editor } = this
 		const vsb = editor.getViewportScreenBounds()
 		const camera = editor.getCamera()
-		const shapes = this.editor.getCurrentPageShapes()
 		this.geometries = []
 
-		for (const shape of shapes) {
+		for (const shape of editor.getCurrentPageShapes()) {
 			try {
 				const geometry = this.extractGeometry(shape, camera, vsb)
 				if (geometry) {
@@ -231,20 +213,14 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 			this.gl.uniform1f(this.u_segmentCount, Math.min(allSegments.length / 4, this.maxSegments))
 		}
 
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(this.vao)
-		}
-
+		this.gl.bindVertexArray(this.vao)
 		this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4)
-
-		if (this.vao && this.gl instanceof WebGL2RenderingContext) {
-			this.gl.bindVertexArray(null)
-		}
+		this.gl.bindVertexArray(null)
 	}
 
 	onDispose = (): void => {
 		if (this.gl) {
-			if (this.vao && this.gl instanceof WebGL2RenderingContext) {
+			if (this.vao) {
 				this.gl.deleteVertexArray(this.vao)
 				this.vao = null
 			}
@@ -266,23 +242,13 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		this.tick()
 	}
 
-	refresh = (): void => {
-		try {
-			this.tick()
-		} catch (e) {
-			console.log('Error refreshing geometries', e)
-		}
-	}
-
 	private pageToCanvas = (
 		point: Vec,
 		camera: { x: number; y: number; z: number },
 		viewportScreenBounds: Box
 	): Vec => {
-		const screenX = (point.x + camera.x) * camera.z + viewportScreenBounds.x
-		const screenY = (point.y + camera.y) * camera.z + viewportScreenBounds.y
-		const canvasX = (screenX - viewportScreenBounds.x) / viewportScreenBounds.width
-		const canvasY = 1.0 - (screenY - viewportScreenBounds.y) / viewportScreenBounds.height
+		const canvasX = ((point.x + camera.x) * camera.z) / viewportScreenBounds.width
+		const canvasY = 1.0 - ((point.y + camera.y) * camera.z) / viewportScreenBounds.height
 		return new Vec(canvasX, canvasY)
 	}
 
@@ -290,22 +256,19 @@ export class ShadowShaderManager extends WebGLManager<ShaderManagerConfig> {
 		shape: TLShape,
 		camera: { x: number; y: number; z: number },
 		viewportScreenBounds: Box
-	): Array<{ start: Vec; end: Vec }> | null => {
-		const { editor } = this
+	): Geometry | null => {
 		const geometry = this.editor.getShapeGeometry(shape)
-		const transform = editor.getShapePageTransform(shape)
+		const transform = this.editor.getShapePageTransform(shape)
 		if (!transform) return null
 
 		const canvasPoints = geometry.vertices.map((c) =>
 			this.pageToCanvas(transform.applyToPoint(c), camera, viewportScreenBounds)
 		)
 
-		const segments: Array<{ start: Vec; end: Vec }> = []
+		const segments: Geometry = []
 
 		for (let i = 0; i < canvasPoints.length - 1; i++) {
-			const start = canvasPoints[i]
-			const end = canvasPoints[i + 1]
-			segments.push({ start, end })
+			segments.push({ start: canvasPoints[i], end: canvasPoints[i + 1] })
 		}
 
 		const isClosed =

--- a/templates/simple-server-example/src/client/App.tsx
+++ b/templates/simple-server-example/src/client/App.tsx
@@ -14,24 +14,19 @@ const WORKER_URL = `http://localhost:5858`
 const roomId = 'test-room'
 
 function App() {
-	// Create a store connected to multiplayer.
 	const store = useSync({
-		// We need to know the websocket's URI...
 		uri: `${WORKER_URL}/connect/${roomId}`,
-		// ...and how to handle static assets like images & videos
 		assets: multiplayerAssets,
 	})
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
-				// we can pass the connected store into the Tldraw component which will handle
-				// loading states & enable multiplayer UX like cursors & a presence menu
+				// the synced store handles loading states & enables multiplayer UX like cursors & presence
 				store={store}
 				onMount={(editor) => {
 					// @ts-expect-error
 					window.editor = editor
-					// when the editor is ready, we need to register out bookmark unfurling service
 					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
 				}}
 			/>
@@ -39,13 +34,10 @@ function App() {
 	)
 }
 
-// How does our server handle assets like images and videos?
+// Assets like images and videos are PUT to the server under a unique name.
 const multiplayerAssets: TLAssetStore = {
-	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
 	async upload(_asset, file) {
-		const id = uniqueId()
-
-		const objectName = `${id}-${file.name}`
+		const objectName = `${uniqueId()}-${file.name}`
 		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
 
 		const response = await fetch(url, {
@@ -59,14 +51,14 @@ const multiplayerAssets: TLAssetStore = {
 
 		return { src: url }
 	},
-	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
-	// auth, or to serve optimized versions / sizes of the asset.
+	// the same URL serves the asset. you could customize this to add extra auth, or to serve
+	// optimized versions / sizes of the asset.
 	resolve(asset) {
 		return asset.props.src
 	},
 }
 
-// How does our server handle bookmark unfurling?
+// Bookmark unfurling: ask the server for the URL's metadata and fill in an asset record.
 async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
 	const asset: TLBookmarkAsset = {
 		id: AssetRecordType.createId(getHashForString(url)),

--- a/templates/simple-server-example/src/server/rooms.ts
+++ b/templates/simple-server-example/src/server/rooms.ts
@@ -12,7 +12,6 @@ function sanitizeRoomId(roomId: string): string {
 	return roomId.replace(/[^a-zA-Z0-9_-]/g, '_')
 }
 
-// We'll keep an in-memory map of active rooms
 const rooms = new Map<string, TLSocketRoom<any, void>>()
 
 export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
@@ -24,7 +23,6 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	}
 
 	console.log('loading room', roomId)
-	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
 	const storage = new SQLiteSyncStorage({ sql })

--- a/templates/simple-server-example/src/server/server.ts
+++ b/templates/simple-server-example/src/server/server.ts
@@ -49,8 +49,8 @@ app.register(async (app) => {
 		}
 	})
 
-	// To enable blob storage for assets, we add a simple endpoint supporting PUT and GET requests
-	// But first we need to allow all content types with no parsing, so we can handle raw data
+	// Asset blob storage: PUT and GET endpoints. Allow all content types with no parsing so
+	// we get the raw request body.
 	app.addContentTypeParser('*', (_, __, done) => done(null))
 	app.put('/uploads/:id', {}, async (req, res) => {
 		const id = (req.params as any).id as string

--- a/templates/socketio-server-example/src/client/App.tsx
+++ b/templates/socketio-server-example/src/client/App.tsx
@@ -17,29 +17,24 @@ const WORKER_URL = `http://localhost:5858`
 const roomId = 'test-room'
 
 function App() {
-	// Create a store connected to multiplayer.
 	const store = useSync({
-		// We need a connection to the server:
 		connect: useCallback((query) => {
 			const socket = io(WORKER_URL, {
 				query: { ...query, roomId },
 			})
 			return socketIoToTldrawSocket(socket)
 		}, []),
-		// ...and how to handle static assets like images & videos
 		assets: multiplayerAssets,
 	})
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
-				// we can pass the connected store into the Tldraw component which will handle
-				// loading states & enable multiplayer UX like cursors & a presence menu
+				// the synced store handles loading states & enables multiplayer UX like cursors & presence
 				store={store}
 				onMount={(editor) => {
 					// @ts-expect-error
 					window.editor = editor
-					// when the editor is ready, we need to register out bookmark unfurling service
 					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
 				}}
 			/>
@@ -47,7 +42,7 @@ function App() {
 	)
 }
 
-// Helper function to convert Socket.IO to TLPersistentClientSocket
+// Adapt a Socket.IO socket to the TLPersistentClientSocket interface that useSync expects
 function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRecord> {
 	const statusChangeListeners = new Set<(event: TLSocketStatusChangeEvent) => void>()
 	const tldrawSocket: TLPersistentClientSocket<TLRecord> = {
@@ -59,15 +54,11 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 
 		onReceiveMessage: (callback) => {
-			// Listen for tldraw sync protocol messages
 			const handler = (message: any) => {
 				console.log('📥 Received:', message)
 				callback(message)
 			}
-
 			ioSocket.on('tldraw-message', handler)
-
-			// Return cleanup function
 			return () => {
 				ioSocket.off('tldraw-message', handler)
 			}
@@ -95,26 +86,15 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 	}
 
-	// Map Socket.IO events to TLPersistentClientSocket status
-	const connectHandler = () => {
-		tldrawSocket.connectionStatus = 'online'
-		statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
+	const setStatus = (event: TLSocketStatusChangeEvent) => {
+		tldrawSocket.connectionStatus = event.status
+		statusChangeListeners.forEach((cb) => cb(event))
 	}
 
-	const disconnectHandler = () => {
-		tldrawSocket.connectionStatus = 'offline'
-		statusChangeListeners.forEach((cb) => cb({ status: 'offline' }))
-	}
-
-	const errorHandler = (error: any) => {
-		tldrawSocket.connectionStatus = 'error'
-		statusChangeListeners.forEach((cb) =>
-			cb({
-				status: 'error',
-				reason: error.message || 'Connection error',
-			})
-		)
-	}
+	const connectHandler = () => setStatus({ status: 'online' })
+	const disconnectHandler = () => setStatus({ status: 'offline' })
+	const errorHandler = (error: any) =>
+		setStatus({ status: 'error', reason: error.message || 'Connection error' })
 
 	ioSocket.on('connect', connectHandler)
 	ioSocket.on('disconnect', disconnectHandler)
@@ -122,22 +102,16 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 
 	// Set initial status
 	const initialStatusTimeout = setTimeout(() => {
-		if (ioSocket.connected) {
-			tldrawSocket.connectionStatus = 'online'
-			statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
-		}
+		if (ioSocket.connected) connectHandler()
 	}, 0)
 
 	return tldrawSocket
 }
 
-// How does our server handle assets like images and videos?
+// Assets like images and videos are PUT to the server under a unique name.
 const multiplayerAssets: TLAssetStore = {
-	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
 	async upload(_asset, file) {
-		const id = uniqueId()
-
-		const objectName = `${id}-${file.name}`
+		const objectName = `${uniqueId()}-${file.name}`
 		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
 
 		const response = await fetch(url, {
@@ -151,14 +125,14 @@ const multiplayerAssets: TLAssetStore = {
 
 		return { src: url }
 	},
-	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
-	// auth, or to serve optimized versions / sizes of the asset.
+	// the same URL serves the asset. you could customize this to add extra auth, or to serve
+	// optimized versions / sizes of the asset.
 	resolve(asset) {
 		return asset.props.src
 	},
 }
 
-// How does our server handle bookmark unfurling?
+// Bookmark unfurling: ask the server for the URL's metadata and fill in an asset record.
 async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
 	const asset: TLBookmarkAsset = {
 		id: AssetRecordType.createId(getHashForString(url)),

--- a/templates/socketio-server-example/src/server/rooms.ts
+++ b/templates/socketio-server-example/src/server/rooms.ts
@@ -12,7 +12,6 @@ function sanitizeRoomId(roomId: string): string {
 	return roomId.replace(/[^a-zA-Z0-9_-]/g, '_')
 }
 
-// We'll keep an in-memory map of active rooms
 const rooms = new Map<string, TLSocketRoom<any, void>>()
 
 export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
@@ -24,8 +23,6 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	}
 
 	console.log('loading room', roomId)
-
-	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
 	const storage = new SQLiteSyncStorage({ sql })

--- a/templates/socketio-server-example/src/server/server.ts
+++ b/templates/socketio-server-example/src/server/server.ts
@@ -10,11 +10,9 @@ const PORT = 5858
 
 // For this example we use Socket.IO with Express
 // To keep things simple we're skipping normal production concerns like rate limiting and input validation.
-// Create Express app and HTTP server for Socket.IO
 const app = express()
 const server = createServer(app)
 
-// Enable CORS and parse JSON
 app.use(express.json())
 app.use((req, res, next) => {
 	res.header('Access-Control-Allow-Origin', '*')
@@ -31,7 +29,6 @@ export interface ClientToServerMessage {
 	'tldraw-message': (message: string) => void
 }
 
-// Create Socket.IO server
 const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 	cors: {
 		origin: '*',
@@ -43,8 +40,8 @@ const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 io.on('connection', async (socket) => {
 	console.log('Socket.IO client connected:', socket.id)
 
-	// The roomId and sessionId are passed from the client as query params,
-	// you need to extract them and pass them to the room.
+	// The client passes its roomId and sessionId as query params; the room needs them to
+	// identify the socket.
 	const sessionId = socket.handshake.query.sessionId as string
 	const roomId = socket.handshake.query.roomId as string
 
@@ -57,10 +54,9 @@ io.on('connection', async (socket) => {
 	console.log('Connecting to room:', roomId, 'with session:', sessionId)
 
 	try {
-		// Here we make or get an existing instance of TLSocketRoom for the given roomId
 		const room = makeOrLoadRoom(roomId)
 
-		// Create a socket adapter for TLSocketRoom
+		// Adapt the Socket.IO socket to the minimal WebSocket interface TLSocketRoom expects
 		const socketAdapter: WebSocketMinimal = {
 			send: (message) => {
 				socket.emit('tldraw-message', JSON.parse(message))
@@ -73,19 +69,12 @@ io.on('connection', async (socket) => {
 			},
 		}
 
-		// and finally connect the socket to the room
-		room.handleSocketConnect({
-			sessionId: sessionId,
-			socket: socketAdapter,
-		})
+		room.handleSocketConnect({ sessionId, socket: socketAdapter })
 
-		// Handle tldraw sync messages
 		socket.on('tldraw-message', (message) => {
-			// Ensure message is a string - Socket.IO might send it as an object or buffer
 			room.handleSocketMessage(sessionId, message)
 		})
 
-		// Handle disconnect
 		socket.on('disconnect', () => {
 			console.log('Socket.IO client disconnected:', socket.id)
 		})
@@ -95,7 +84,7 @@ io.on('connection', async (socket) => {
 	}
 })
 
-// To enable blob storage for assets, we add simple endpoints supporting PUT and GET requests
+// Asset blob storage: PUT and GET endpoints
 app.put('/uploads/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
 	try {
 		const id = req.params.id
@@ -136,7 +125,6 @@ app.get('/unfurl', async (req, res) => {
 	}
 })
 
-// Start server
 server.listen(PORT, () => {
 	console.log(`Server started on port ${PORT}`)
 })

--- a/templates/sync-cloudflare/client/getBookmarkPreview.tsx
+++ b/templates/sync-cloudflare/client/getBookmarkPreview.tsx
@@ -1,8 +1,7 @@
 import { AssetRecordType, TLAsset, TLBookmarkAsset, getHashForString } from 'tldraw'
 
-// How does our server handle bookmark unfurling?
+// Bookmark unfurling: ask the worker for the URL's metadata and fill in an asset record.
 export async function getBookmarkPreview({ url }: { url: string }): Promise<TLAsset> {
-	// we start with an empty asset record
 	const asset: TLBookmarkAsset = {
 		id: AssetRecordType.createId(getHashForString(url)),
 		typeName: 'asset',
@@ -18,11 +17,9 @@ export async function getBookmarkPreview({ url }: { url: string }): Promise<TLAs
 	}
 
 	try {
-		// try to fetch the preview data from the server
 		const response = await fetch(`/api/unfurl?url=${encodeURIComponent(url)}`)
 		const data: any = await response.json()
 
-		// fill in our asset with whatever info we found
 		asset.props.description = data?.description ?? ''
 		asset.props.image = data?.image ?? ''
 		asset.props.favicon = data?.favicon ?? ''

--- a/templates/sync-cloudflare/client/localStorage.ts
+++ b/templates/sync-cloudflare/client/localStorage.ts
@@ -1,8 +1,4 @@
-/**
- * Safe localStorage helpers that handle cases where localStorage is not available
- * or access is restricted by the browser.
- */
-
+// localStorage throws when storage is unavailable or access is restricted by the browser
 export function getLocalStorageItem(key: string): string | null {
 	try {
 		return localStorage.getItem(key)
@@ -17,13 +13,5 @@ export function setLocalStorageItem(key: string, value: string): void {
 		localStorage.setItem(key, value)
 	} catch (error) {
 		console.warn('Failed to set localStorage item:', error)
-	}
-}
-
-export function removeLocalStorageItem(key: string): void {
-	try {
-		localStorage.removeItem(key)
-	} catch (error) {
-		console.warn('Failed to remove localStorage item:', error)
 	}
 }

--- a/templates/sync-cloudflare/client/multiplayerAssetStore.tsx
+++ b/templates/sync-cloudflare/client/multiplayerAssetStore.tsx
@@ -1,15 +1,11 @@
 import { TLAssetStore, uniqueId } from 'tldraw'
 
-// How does our server handle assets like images and videos?
+// Assets like images and videos are POSTed to the worker, which stores them in the bucket.
 export const multiplayerAssetStore: TLAssetStore = {
-	// to upload an asset, we...
 	async upload(_asset, file) {
-		// ...create a unique name & URL...
-		const id = uniqueId()
-		const objectName = `${id}-${file.name}`.replace(/[^a-zA-Z0-9.]/g, '-')
+		const objectName = `${uniqueId()}-${file.name}`.replace(/[^a-zA-Z0-9.]/g, '-')
 		const url = `/api/uploads/${objectName}`
 
-		// ...POST it to out worker to upload it...
 		const response = await fetch(url, {
 			method: 'POST',
 			body: file,
@@ -19,12 +15,11 @@ export const multiplayerAssetStore: TLAssetStore = {
 			throw new Error(`Failed to upload asset: ${response.statusText}`)
 		}
 
-		// ...and return the URL to be stored with the asset record.
 		return { src: url }
 	},
 
-	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
-	// auth, or to serve optimized versions / sizes of the asset.
+	// the same URL serves the asset. you could customize this to add extra auth, or to serve
+	// optimized versions / sizes of the asset.
 	resolve(asset) {
 		return asset.props.src
 	},

--- a/templates/sync-cloudflare/client/pages/Room.tsx
+++ b/templates/sync-cloudflare/client/pages/Room.tsx
@@ -8,23 +8,18 @@ import { multiplayerAssetStore } from '../multiplayerAssetStore'
 export function Room() {
 	const { roomId } = useParams<{ roomId: string }>()
 
-	// Create a store connected to multiplayer.
 	const store = useSync({
-		// We need to know the websockets URI...
 		uri: `${window.location.origin}/api/connect/${roomId}`,
-		// ...and how to handle static assets like images & videos
 		assets: multiplayerAssetStore,
 	})
 
 	return (
 		<RoomWrapper roomId={roomId}>
 			<Tldraw
-				// we can pass the connected store into the Tldraw component which will handle
-				// loading states & enable multiplayer UX like cursors & a presence menu
+				// the synced store handles loading states & enables multiplayer UX like cursors & presence
 				store={store}
 				options={{ deepLinks: true }}
 				onMount={(editor) => {
-					// when the editor is ready, we need to register our bookmark unfurling service
 					editor.registerExternalAssetHandler('url', getBookmarkPreview)
 				}}
 			/>

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -24,6 +24,11 @@ interface SocketAttachment {
 	snapshot: SessionStateSnapshot | null
 }
 
+function getAttachment(ws: WebSocket): SocketAttachment | null {
+	const attachment = ws.deserializeAttachment() as SocketAttachment | null
+	return attachment?.sessionId ? attachment : null
+}
+
 // Each whiteboard room is hosted in a Durable Object with WebSocket Hibernation.
 // https://developers.cloudflare.com/durable-objects/
 //
@@ -66,16 +71,13 @@ export class TldrawDurableObject extends DurableObject {
 
 			// Resume any sessions that survived hibernation
 			for (const ws of this.ctx.getWebSockets()) {
-				const attachment = ws.deserializeAttachment() as SocketAttachment | null
-				if (!attachment?.sessionId) continue
-
-				if (attachment.snapshot) {
-					this.room.handleSocketResume({
-						sessionId: attachment.sessionId,
-						socket: ws,
-						snapshot: attachment.snapshot,
-					})
-				}
+				const attachment = getAttachment(ws)
+				if (!attachment?.snapshot) continue
+				this.room.handleSocketResume({
+					sessionId: attachment.sessionId,
+					socket: ws,
+					snapshot: attachment.snapshot,
+				})
 			}
 		}
 		return this.room
@@ -86,17 +88,14 @@ export class TldrawDurableObject extends DurableObject {
 		(request) => this.handleConnect(request)
 	)
 
-	// Entry point for all requests to the Durable Object
 	fetch(request: Request): Response | Promise<Response> {
 		return this.router.fetch(request)
 	}
 
-	// Handle new WebSocket connection requests
 	async handleConnect(request: IRequest) {
 		const sessionId = request.query.sessionId as string
 		if (!sessionId) return error(400, 'Missing sessionId')
 
-		// Create the websocket pair for the client
 		const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair()
 		// Use hibernation API instead of serverWebSocket.accept()
 		this.ctx.acceptWebSocket(serverWebSocket)
@@ -113,19 +112,12 @@ export class TldrawDurableObject extends DurableObject {
 		return new Response(null, { status: 101, webSocket: clientWebSocket })
 	}
 
-	// --- WebSocket Hibernation API handlers ---
-
-	private getSessionId(ws: WebSocket): string | null {
-		const attachment = ws.deserializeAttachment() as SocketAttachment | null
-		return attachment?.sessionId ?? null
-	}
-
 	override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
-		const sessionId = this.getSessionId(ws)
-		if (!sessionId) return
+		const attachment = getAttachment(ws)
+		if (!attachment) return
 
-		this.sessionIdToWs.set(sessionId, ws)
-		this.getOrCreateRoom().handleSocketMessage(sessionId, message)
+		this.sessionIdToWs.set(attachment.sessionId, ws)
+		this.getOrCreateRoom().handleSocketMessage(attachment.sessionId, message)
 	}
 
 	override async webSocketClose(ws: WebSocket) {
@@ -137,8 +129,8 @@ export class TldrawDurableObject extends DurableObject {
 	}
 
 	private handleWebSocketEnd(ws: WebSocket, method: 'handleSocketClose' | 'handleSocketError') {
-		const attachment = ws.deserializeAttachment() as SocketAttachment | null
-		if (!attachment?.sessionId) return
+		const attachment = getAttachment(ws)
+		if (!attachment) return
 
 		this.sessionIdToWs.delete(attachment.sessionId)
 


### PR DESCRIPTION
In order to make the remaining starter templates easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `templates/chat`, `templates/branching-chat`, `templates/shader`, `templates/sync-cloudflare`, `templates/simple-server-example`, and `templates/socketio-server-example` and applies the fixes. It is a templates slice of #10068, split out so it can be reviewed on its own. Behavior is intended to be preserved: it deduplicates helpers, deletes dead code, and trims comment density to what template code needs per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` passes.
2. `yarn dev-template <name>` and smoke each template.

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change   |
| --------- | ------------ |
| Templates | +722 / -1720 |
