### PR TITLE
refactor(create-tldraw): simplify pass over create-tldraw

### DIFF
--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -102,16 +102,19 @@ const TELEMETRY_URLS = [
 	'https://teamldraw.com/api/starter-kit-choice',
 ]
 
-// Fire and forget: never block or fail setup on telemetry.
 function trackStarterKitChoice(templateId: string, noTelemetry?: boolean) {
+	// Skip tracking if --no-telemetry flag is set
 	if (noTelemetry) return
 
 	for (const url of TELEMETRY_URLS) {
+		// Fire and forget - don't block on this request
 		fetch(url, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ id: templateId }),
-		}).catch(() => {})
+		}).catch(() => {
+			// Silently ignore errors
+		})
 	}
 }
 

--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -70,60 +70,49 @@ main().catch((err) => {
 })
 
 async function templatePicker(argOption?: string, noTelemetry?: boolean) {
+	let template: Template
 	if (argOption) {
-		const template = TEMPLATES.find((t) => formatTemplateId(t) === argOption.toLowerCase().trim())
-
-		if (!template) {
+		const found = TEMPLATES.find((t) => formatTemplateId(t) === argOption.toLowerCase().trim())
+		if (!found) {
 			outro(`Template ${argOption} not found`)
 			process.exit(1)
 		}
-
-		trackStarterKitChoice(template.name, noTelemetry)
-		return template
+		template = found
+	} else {
+		template = await handleCancel(
+			groupSelect({
+				message: 'Select a tldraw starter kit:',
+				options: TEMPLATES.map(
+					(template): GroupSelectOption<Template> => ({
+						label: template.name,
+						hint: template.description,
+						value: template,
+					})
+				),
+			})
+		)
 	}
-
-	const template = await handleCancel(
-		groupSelect({
-			message: 'Select a tldraw starter kit:',
-			options: TEMPLATES.map(
-				(template): GroupSelectOption<Template> => ({
-					label: template.name,
-					hint: template.description,
-					value: template,
-				})
-			),
-		})
-	)
 
 	trackStarterKitChoice(template.name, noTelemetry)
 	return template
 }
 
+const TELEMETRY_URLS = [
+	'https://dashboard.tldraw.pro/api/starter-kit-choice',
+	'https://teamldraw.com/api/starter-kit-choice',
+]
+
+// Fire and forget: never block or fail setup on telemetry.
 function trackStarterKitChoice(templateId: string, noTelemetry?: boolean) {
-	// Skip tracking if --no-telemetry flag is set
 	if (noTelemetry) return
 
-	// Fire and forget - don't block on this request
-	fetch('https://dashboard.tldraw.pro/api/starter-kit-choice', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({ id: templateId }),
-	}).catch(() => {
-		// Silently ignore errors
-	})
-
-	// Fire and forget - don't block on this request
-	fetch('https://teamldraw.com/api/starter-kit-choice', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({ id: templateId }),
-	}).catch(() => {
-		// Silently ignore errors
-	})
+	for (const url of TELEMETRY_URLS) {
+		fetch(url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ id: templateId }),
+		}).catch(() => {})
+	}
 }
 
 async function namePicker(argOption?: string) {
@@ -219,76 +208,53 @@ function getHelp() {
 		{ flags: '-t, --template NAME', description: 'Use a specific template.' },
 		{ flags: '--no-telemetry', description: 'Disable anonymous usage tracking.' },
 	]
+	const templates = TEMPLATES.map((t) => ({
+		name: formatTemplateId(t),
+		description: t.shortDescription ?? t.description,
+	}))
 
 	const GAP_SIZE = 2
 	const optionPrefix = '   '
 	const templatePrefix = ' • '
 
 	const idealIndentSize =
-		Math.max(
-			...options.map((o) => o.flags.length),
-			...TEMPLATES.map((t) => formatTemplateId(t).length)
-		) +
+		Math.max(...options.map((o) => o.flags.length), ...templates.map((t) => t.name.length)) +
 		GAP_SIZE +
 		templatePrefix.length
 
-	const isNarrow = process.stdout.columns < idealIndentSize + 50
+	const columns = process.stdout.columns
+	const isNarrow = columns < idealIndentSize + 50
 
-	const lines = [
+	// Wide terminals get a two-column table; narrow ones put each description on its own wrapped line.
+	function formatRows(prefix: string, rows: { name: string; description: string }[]) {
+		if (isNarrow) {
+			const indent = ' '.repeat(prefix.length + GAP_SIZE)
+			return rows.flatMap((row) => [
+				`${prefix}${row.name}`,
+				wrapAnsi(`${indent}${row.description}`, columns, { indent }),
+			])
+		}
+		const indent = ' '.repeat(idealIndentSize)
+		return rows.map((row) => {
+			const start = `${prefix}${row.name}`.padEnd(idealIndentSize, ' ')
+			return wrapAnsi(`${start}${row.description}`, columns, { indent })
+		})
+	}
+
+	return [
 		picocolors.bold('Usage: create-tldraw [OPTION]... [DIRECTORY]'),
 		'',
 		'Create a new tldraw project from a starter kit.',
 		"With no arguments, you'll be guided through an interactive setup.",
 		'',
 		picocolors.bold('Options:'),
-	]
-
-	if (isNarrow) {
-		const indent = ' '.repeat(optionPrefix.length + GAP_SIZE)
-		for (const option of options) {
-			lines.push(`${optionPrefix}${option.flags}`)
-			lines.push(wrapAnsi(`${indent}${option.description}`, process.stdout.columns, { indent }))
-		}
-	} else {
-		const indent = ' '.repeat(idealIndentSize)
-		for (const option of options) {
-			const start = `${optionPrefix}${option.flags}`.padEnd(idealIndentSize, ' ')
-			lines.push(wrapAnsi(`${start}${option.description}`, process.stdout.columns, { indent }))
-		}
-	}
-
-	lines.push('')
-	lines.push(picocolors.bold('Available starter kits:'))
-
-	if (isNarrow) {
-		const indent = ' '.repeat(templatePrefix.length + GAP_SIZE)
-		for (const template of TEMPLATES) {
-			lines.push(`${templatePrefix}${formatTemplateId(template)}`)
-			lines.push(
-				wrapAnsi(
-					`${indent}${template.shortDescription ?? template.description}`,
-					process.stdout.columns,
-					{ indent }
-				)
-			)
-		}
-	} else {
-		const indent = ' '.repeat(idealIndentSize)
-		for (const template of TEMPLATES) {
-			const start = `${templatePrefix}${formatTemplateId(template)}`.padEnd(idealIndentSize, ' ')
-			lines.push(
-				wrapAnsi(
-					`${start}${template.shortDescription ?? template.description}`,
-					process.stdout.columns,
-					{
-						indent,
-					}
-				)
-			)
-		}
-	}
-
-	lines.push('')
-
-	return lines.join('\n')
+		...formatRows(
+			optionPrefix,
+			options.map((o) => ({ name: o.flags, description: o.description }))
+		),
+		'',
+		picocolors.bold('Available starter kits:'),
+		...formatRows(templatePrefix, templates),
+		'',
+	].join('\n')
 }

--- a/packages/create-tldraw/src/utils.ts
+++ b/packages/create-tldraw/src/utils.ts
@@ -32,7 +32,7 @@ export function isValidPackageName(projectName: string) {
 	return /^(?:@[a-z\d\-*~][a-z\d\-*._~]*\/)?[a-z\d\-~][a-z\d\-._~]*$/.test(projectName)
 }
 
-export function toValidPackageName(projectName: string) {
+function toValidPackageName(projectName: string) {
 	return projectName
 		.trim()
 		.toLowerCase()
@@ -41,7 +41,7 @@ export function toValidPackageName(projectName: string) {
 		.replace(/[^a-z\d\-~]+/g, '-')
 }
 
-export function cancel(): never {
+function cancel(): never {
 	outro('Setup cancelled.\n   Try again or visit https://tldraw.dev/docs to learn more.')
 	process.exit(1)
 }
@@ -60,9 +60,7 @@ export function getPackageManager(): PackageManager {
 	const userAgent = process.env.npm_config_user_agent
 	if (!userAgent) return 'npm'
 
-	const pkgSpec = userAgent.split(' ')[0]
-	const pkgSpecArr = pkgSpec.split('/')
-	const manager = pkgSpecArr[0]
+	const manager = userAgent.split(' ')[0].split('/')[0]
 	if (manager === 'pnpm') return 'pnpm'
 	if (manager === 'yarn') return 'yarn'
 


### PR DESCRIPTION
In order to make the create-tldraw package easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `packages/create-tldraw` and applies the fixes. It is the create-tldraw slice of #10068, split out so it can be reviewed on its own. The public API is unchanged and behavior is intended to be preserved: it deduplicates helpers, replaces switch/if chains with lookup tables, deletes dead code, and trims narration and restatement comments per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` and the package's unit suite pass.

- [x] Unit tests

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +66 / -102 |
