### PR TITLE
refactor(templates): simplify pass over the chat template

### DIFF
--- a/templates/chat/src/app/api/chat/route.ts
+++ b/templates/chat/src/app/api/chat/route.ts
@@ -1,7 +1,6 @@
 import { google } from '@ai-sdk/google'
 import { convertToModelMessages, streamText, UIMessage } from 'ai'
 
-// Allow streaming responses up to 60 seconds
 export const maxDuration = 60
 
 export async function POST(req: Request) {

--- a/templates/chat/src/app/api/chat/route.ts
+++ b/templates/chat/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { google } from '@ai-sdk/google'
 import { convertToModelMessages, streamText, UIMessage } from 'ai'
 
+// Allow streaming responses up to 60 seconds
 export const maxDuration = 60
 
 export async function POST(req: Request) {

--- a/templates/chat/src/app/api/upload/route.ts
+++ b/templates/chat/src/app/api/upload/route.ts
@@ -16,14 +16,11 @@ export async function POST(req: Request) {
 		return new Response('x-file-name is not set', { status: 400 })
 	}
 
-	const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY })
+	const ai = new GoogleGenAI({ apiKey })
 
 	const file = await ai.files.upload({
 		file: await req.blob(),
-		config: {
-			mimeType: contentType,
-			displayName,
-		},
+		config: { mimeType: contentType, displayName },
 	})
 
 	return Response.json({ uploadedUrl: file.uri, expiresAt: file.expirationTime })

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -3,18 +3,17 @@
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport, FileUIPart, TextUIPart, UIMessage } from 'ai'
 import { useCallback, useEffect } from 'react'
-import { TLEditorSnapshot } from 'tldraw'
 import { useChatMessageStorage } from '@/hooks/useChatMessageStorage'
 import { uploadMessageContents } from '@/utils/uploadMessageContents'
 import { useChatInputState } from '../hooks/useChatInputState'
 import { useScrollToBottom } from '../hooks/useScrollToBottom'
 import { ChatInput } from './ChatInput'
+import { ImageClickTarget } from './ChatMessage'
 import { ClearChatIcon } from './ClearChatIcon'
 import { MessageList } from './MessageList'
 import { TldrawProviderMetadata, WhiteboardImage } from './WhiteboardModal'
 
 export function Chat() {
-	// store chat messages locally in the browser
 	const [initialMessages, saveMessages] = useChatMessageStorage()
 
 	if (!initialMessages) return null
@@ -29,11 +28,10 @@ function ChatInner({
 	initialMessages: UIMessage[]
 	saveMessages: (messages: UIMessage[]) => void
 }) {
-	// All state relating to the chat input and the tldraw modal is managed in this hook
 	const [chatInputState, chatInputDispatch] = useChatInputState()
 
-	// We use the Vercel AI SDK's useChat hook to send messages to the server and manage the chat
-	// history. You could replace this with your own chat implementation.
+	// The Vercel AI SDK's useChat hook sends messages to the server and manages the chat history.
+	// You could replace this with your own chat implementation.
 	const chat = useChat({
 		transport: new DefaultChatTransport({
 			api: '/api/chat',
@@ -56,14 +54,12 @@ function ChatInner({
 
 	const { sendMessage, status, error, clearError, setMessages } = chat
 
-	// save the chat messages to local storage when the chat finishes
 	useEffect(() => {
 		if (chat.status === 'ready') {
 			saveMessages(chat.messages)
 		}
-	}, [chat.status, chat.messages, saveMessages, setMessages])
+	}, [chat.status, chat.messages, saveMessages])
 
-	// If the chat encounters an error, we alert the user and clear the error.
 	useEffect(() => {
 		if (error) {
 			alert(error.message)
@@ -71,8 +67,6 @@ function ChatInner({
 		}
 	}, [error, clearError])
 
-	// when the user send a message, we take the text they've written and any images / sketches
-	// they've attached and send them to the model.
 	const handleSendMessage = useCallback(
 		(text: string, images: WhiteboardImage[]) => {
 			chatInputDispatch({ type: 'clear' })
@@ -95,28 +89,20 @@ function ChatInner({
 				parts.push({ type: 'text', text })
 			}
 
-			sendMessage({
-				parts,
-			})
+			sendMessage({ parts })
 		},
 		[sendMessage, chatInputDispatch]
 	)
 
-	// keep the chat scrolled to the bottom as messages are added or changed
 	const scrollToBottom = useScrollToBottom()
 	useEffect(() => {
 		scrollToBottom()
 	}, [chat.messages, scrollToBottom])
 
-	// when the user clicks on an image from chat history, we open the tldraw modal. here they can
-	// see a larger version of the image, but also annotate it and re-add it to the chat.
+	// Clicking an image in the chat history opens it in the whiteboard modal, where the user can
+	// annotate it and re-add it to the chat.
 	const handleImageClick = useCallback(
-		(opts: { snapshot: TLEditorSnapshot; imageName: string } | { uploadedFile: File }) => {
-			chatInputDispatch({
-				type: 'openWhiteboard',
-				...opts,
-			})
-		},
+		(opts: ImageClickTarget) => chatInputDispatch({ type: 'openWhiteboard', ...opts }),
 		[chatInputDispatch]
 	)
 
@@ -125,8 +111,6 @@ function ChatInner({
 		saveMessages([])
 	}, [setMessages, saveMessages])
 
-	// users can drag and drop images to the chat input area to add them to their message. when
-	// they're dragging we keep track of a special isDragging state.
 	const handleDragOver = (e: React.DragEvent) => {
 		e.preventDefault()
 		if (
@@ -155,7 +139,7 @@ function ChatInner({
 		}
 	}
 
-	// if the chat is empty, we put the input area right in the middle of the page
+	// An empty chat puts the input right in the middle of the page.
 	if (chat.messages.length === 0) {
 		return (
 			<div
@@ -180,7 +164,6 @@ function ChatInner({
 		)
 	}
 
-	// otherwise, we show the chat history and the input area at the bottom.
 	return (
 		<div
 			className="chat-container"

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -14,6 +14,7 @@ import { MessageList } from './MessageList'
 import { TldrawProviderMetadata, WhiteboardImage } from './WhiteboardModal'
 
 export function Chat() {
+	// store chat messages locally in the browser
 	const [initialMessages, saveMessages] = useChatMessageStorage()
 
 	if (!initialMessages) return null
@@ -28,10 +29,11 @@ function ChatInner({
 	initialMessages: UIMessage[]
 	saveMessages: (messages: UIMessage[]) => void
 }) {
+	// All state relating to the chat input and the tldraw modal is managed in this hook
 	const [chatInputState, chatInputDispatch] = useChatInputState()
 
-	// The Vercel AI SDK's useChat hook sends messages to the server and manages the chat history.
-	// You could replace this with your own chat implementation.
+	// We use the Vercel AI SDK's useChat hook to send messages to the server and manage the chat
+	// history. You could replace this with your own chat implementation.
 	const chat = useChat({
 		transport: new DefaultChatTransport({
 			api: '/api/chat',
@@ -54,12 +56,14 @@ function ChatInner({
 
 	const { sendMessage, status, error, clearError, setMessages } = chat
 
+	// save the chat messages to local storage when the chat finishes
 	useEffect(() => {
 		if (chat.status === 'ready') {
 			saveMessages(chat.messages)
 		}
 	}, [chat.status, chat.messages, saveMessages])
 
+	// If the chat encounters an error, we alert the user and clear the error.
 	useEffect(() => {
 		if (error) {
 			alert(error.message)
@@ -67,6 +71,8 @@ function ChatInner({
 		}
 	}, [error, clearError])
 
+	// when the user send a message, we take the text they've written and any images / sketches
+	// they've attached and send them to the model.
 	const handleSendMessage = useCallback(
 		(text: string, images: WhiteboardImage[]) => {
 			chatInputDispatch({ type: 'clear' })
@@ -94,13 +100,14 @@ function ChatInner({
 		[sendMessage, chatInputDispatch]
 	)
 
+	// keep the chat scrolled to the bottom as messages are added or changed
 	const scrollToBottom = useScrollToBottom()
 	useEffect(() => {
 		scrollToBottom()
 	}, [chat.messages, scrollToBottom])
 
-	// Clicking an image in the chat history opens it in the whiteboard modal, where the user can
-	// annotate it and re-add it to the chat.
+	// when the user clicks on an image from chat history, we open the tldraw modal. here they can
+	// see a larger version of the image, but also annotate it and re-add it to the chat.
 	const handleImageClick = useCallback(
 		(opts: ImageClickTarget) => chatInputDispatch({ type: 'openWhiteboard', ...opts }),
 		[chatInputDispatch]
@@ -111,6 +118,8 @@ function ChatInner({
 		saveMessages([])
 	}, [setMessages, saveMessages])
 
+	// users can drag and drop images to the chat input area to add them to their message. when
+	// they're dragging we keep track of a special isDragging state.
 	const handleDragOver = (e: React.DragEvent) => {
 		e.preventDefault()
 		if (
@@ -139,7 +148,7 @@ function ChatInner({
 		}
 	}
 
-	// An empty chat puts the input right in the middle of the page.
+	// if the chat is empty, we put the input area right in the middle of the page
 	if (chat.messages.length === 0) {
 		return (
 			<div
@@ -164,6 +173,7 @@ function ChatInner({
 		)
 	}
 
+	// otherwise, we show the chat history and the input area at the bottom.
 	return (
 		<div
 			className="chat-container"

--- a/templates/chat/src/components/ChatInput.tsx
+++ b/templates/chat/src/components/ChatInput.tsx
@@ -29,113 +29,77 @@ export function ChatInput({
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
 
 	useEffect(() => {
-		if (!disabled && textareaRef.current) {
-			// focus the textarea when the input is enabled
-			textareaRef.current.focus()
-		}
+		if (!disabled) textareaRef.current?.focus()
 	}, [disabled])
 
-	// Auto-resize textarea and scroll to bottom when content changes.
+	// Auto-resize the textarea to fit its content.
 	useLayoutEffect(() => {
 		if (textareaRef.current) {
-			// Reset height to auto to get the correct scrollHeight
+			// reset to auto first so scrollHeight reflects the content, not the previous height
 			textareaRef.current.style.height = 'auto'
-			// Set height based on scrollHeight, with max height for ~5 lines
 			textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
 		}
 	}, [input])
 
-	// Scroll to bottom when images are added.
 	useLayoutEffect(() => {
-		if (scrollToBottom) {
-			scrollToBottom('instant')
-		}
+		scrollToBottom('instant')
 	}, [images, scrollToBottom])
 
-	// the user can only send a message if the input is not disabled and there are either images or
-	// text ready to send
 	const canSend = !disabled && (images.length > 0 || input.trim())
 
-	// when the user submits the form, we send the message.
+	const send = () => {
+		if (canSend) onSendMessage(input, images)
+	}
+
 	const handleSubmit = (e: FormEvent) => {
 		e.preventDefault()
-		if (canSend) {
-			onSendMessage(input, images)
-		}
+		send()
 	}
 
-	// when the user presses enter, we send the message.
+	// Enter sends; shift+enter keeps the default newline behavior.
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter') {
-			if (e.shiftKey) {
-				// Shift+Enter: allow default behavior (insert newline)
-				return
-			} else {
-				// Enter: submit form
-				e.preventDefault()
-				if (canSend) {
-					onSendMessage(input, images)
-				}
-			}
-		}
+		if (e.key !== 'Enter' || e.shiftKey) return
+		e.preventDefault()
+		send()
 	}
 
-	// when the user clicks the image upload button, we open a file input to allow them to select an
-	// image from their device.
 	const handleImageUpload = useCallback(() => {
 		const input = document.createElement('input')
 		input.type = 'file'
 		input.accept = 'image/*'
 		input.onchange = (e: Event) => {
-			const target = e.target as HTMLInputElement
-			const file = target.files?.[0]
+			const file = (e.target as HTMLInputElement).files?.[0]
 			if (!file || !file.type.startsWith('image/')) return
-
-			// Open whiteboard with the uploaded file
-			dispatch({
-				type: 'openWhiteboard',
-				uploadedFile: file,
-				imageName: file.name,
-			})
+			dispatch({ type: 'openWhiteboard', uploadedFile: file, imageName: file.name })
 		}
 		input.click()
 	}, [dispatch])
 
-	// when the user cancels the whiteboard modal, we close it.
 	const handleCancelWhiteboard = useCallback(() => {
 		dispatch({ type: 'closeWhiteboard' })
 	}, [dispatch])
 
-	// when the user accepts the whiteboard modal, we add the image to the chat input & close it.
 	const handleAcceptWhiteboard = useCallback(
 		(image: WhiteboardImage) => {
 			dispatch({ type: 'closeWhiteboard' })
 			dispatch({ type: 'setImage', image })
-			// Re-focus the input after adding an image
-			if (textareaRef.current) {
-				textareaRef.current.focus()
-			}
+			textareaRef.current?.focus()
 		},
 		[dispatch]
 	)
 
 	return (
 		<form onSubmit={handleSubmit} className="chat-input-form">
-			{/* if the user is dragging an image over the input area, we show a visual indicator
-			hiding the normal input content. */}
 			{isDragging && (
 				<div className="drag-drop-indicator">
 					<svg className="outline">
-						{/* we use an svg to draw a dashed outline of the input area. svg allows us
-						to control the dash length in a way that for example a normal <div> with a
-						border would not. */}
+						{/* svg lets us control the dash length of the outline in a way a css border can't */}
 						<rect />
 					</svg>
 					<UploadIcon />
 				</div>
 			)}
 
-			{/* if the user has added images to the chat input, we show them above the input. */}
 			{images.length > 0 && (
 				<div className="input-images">
 					{images.map((image) => (
@@ -156,7 +120,6 @@ export function ChatInput({
 				</div>
 			)}
 
-			{/* the main input is a text area. we resize it automatically to fit its content. */}
 			<div className="input-container">
 				<textarea
 					ref={textareaRef}
@@ -176,9 +139,7 @@ export function ChatInput({
 				)}
 			</div>
 
-			{/* below the input we have several controls: */}
 			<div className="chat-input-bottom">
-				{/* a button to upload an image */}
 				<button
 					type="button"
 					aria-label="Upload an image"
@@ -189,7 +150,6 @@ export function ChatInput({
 				>
 					<ImageIcon />
 				</button>
-				{/* a button to open the whiteboard modal */}
 				<button
 					type="button"
 					aria-label="Draw a sketch"
@@ -200,7 +160,6 @@ export function ChatInput({
 				>
 					<WhiteboardIcon />
 				</button>
-				{/* a button to send the message */}
 				<button
 					type="submit"
 					disabled={!canSend || disabled}
@@ -212,7 +171,6 @@ export function ChatInput({
 				</button>
 			</div>
 
-			{/* if the user has opened the whiteboard modal, we show it. */}
 			{openWhiteboard && (
 				<WhiteboardModal
 					imageId={openWhiteboard.id}

--- a/templates/chat/src/components/ChatInput.tsx
+++ b/templates/chat/src/components/ChatInput.tsx
@@ -29,40 +29,50 @@ export function ChatInput({
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
 
 	useEffect(() => {
+		// focus the textarea when the input is enabled
 		if (!disabled) textareaRef.current?.focus()
 	}, [disabled])
 
-	// Auto-resize the textarea to fit its content.
+	// Auto-resize textarea and scroll to bottom when content changes.
 	useLayoutEffect(() => {
 		if (textareaRef.current) {
-			// reset to auto first so scrollHeight reflects the content, not the previous height
+			// Reset height to auto to get the correct scrollHeight
 			textareaRef.current.style.height = 'auto'
+			// Set height based on scrollHeight, with max height for ~5 lines
 			textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
 		}
 	}, [input])
 
+	// Scroll to bottom when images are added.
 	useLayoutEffect(() => {
 		scrollToBottom('instant')
 	}, [images, scrollToBottom])
 
+	// the user can only send a message if the input is not disabled and there are either images or
+	// text ready to send
 	const canSend = !disabled && (images.length > 0 || input.trim())
 
 	const send = () => {
 		if (canSend) onSendMessage(input, images)
 	}
 
+	// when the user submits the form, we send the message.
 	const handleSubmit = (e: FormEvent) => {
 		e.preventDefault()
 		send()
 	}
 
-	// Enter sends; shift+enter keeps the default newline behavior.
+	// when the user presses enter, we send the message.
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		// Shift+Enter: allow default behavior (insert newline)
 		if (e.key !== 'Enter' || e.shiftKey) return
+		// Enter: submit form
 		e.preventDefault()
 		send()
 	}
 
+	// when the user clicks the image upload button, we open a file input to allow them to select an
+	// image from their device.
 	const handleImageUpload = useCallback(() => {
 		const input = document.createElement('input')
 		input.type = 'file'
@@ -70,19 +80,24 @@ export function ChatInput({
 		input.onchange = (e: Event) => {
 			const file = (e.target as HTMLInputElement).files?.[0]
 			if (!file || !file.type.startsWith('image/')) return
+
+			// Open whiteboard with the uploaded file
 			dispatch({ type: 'openWhiteboard', uploadedFile: file, imageName: file.name })
 		}
 		input.click()
 	}, [dispatch])
 
+	// when the user cancels the whiteboard modal, we close it.
 	const handleCancelWhiteboard = useCallback(() => {
 		dispatch({ type: 'closeWhiteboard' })
 	}, [dispatch])
 
+	// when the user accepts the whiteboard modal, we add the image to the chat input & close it.
 	const handleAcceptWhiteboard = useCallback(
 		(image: WhiteboardImage) => {
 			dispatch({ type: 'closeWhiteboard' })
 			dispatch({ type: 'setImage', image })
+			// Re-focus the input after adding an image
 			textareaRef.current?.focus()
 		},
 		[dispatch]
@@ -90,16 +105,21 @@ export function ChatInput({
 
 	return (
 		<form onSubmit={handleSubmit} className="chat-input-form">
+			{/* if the user is dragging an image over the input area, we show a visual indicator
+			hiding the normal input content. */}
 			{isDragging && (
 				<div className="drag-drop-indicator">
 					<svg className="outline">
-						{/* svg lets us control the dash length of the outline in a way a css border can't */}
+						{/* we use an svg to draw a dashed outline of the input area. svg allows us
+						to control the dash length in a way that for example a normal <div> with a
+						border would not. */}
 						<rect />
 					</svg>
 					<UploadIcon />
 				</div>
 			)}
 
+			{/* if the user has added images to the chat input, we show them above the input. */}
 			{images.length > 0 && (
 				<div className="input-images">
 					{images.map((image) => (
@@ -120,6 +140,7 @@ export function ChatInput({
 				</div>
 			)}
 
+			{/* the main input is a text area. we resize it automatically to fit its content. */}
 			<div className="input-container">
 				<textarea
 					ref={textareaRef}
@@ -139,7 +160,9 @@ export function ChatInput({
 				)}
 			</div>
 
+			{/* below the input we have several controls: */}
 			<div className="chat-input-bottom">
+				{/* a button to upload an image */}
 				<button
 					type="button"
 					aria-label="Upload an image"
@@ -150,6 +173,7 @@ export function ChatInput({
 				>
 					<ImageIcon />
 				</button>
+				{/* a button to open the whiteboard modal */}
 				<button
 					type="button"
 					aria-label="Draw a sketch"
@@ -160,6 +184,7 @@ export function ChatInput({
 				>
 					<WhiteboardIcon />
 				</button>
+				{/* a button to send the message */}
 				<button
 					type="submit"
 					disabled={!canSend || disabled}
@@ -171,6 +196,7 @@ export function ChatInput({
 				</button>
 			</div>
 
+			{/* if the user has opened the whiteboard modal, we show it. */}
 			{openWhiteboard && (
 				<WhiteboardModal
 					imageId={openWhiteboard.id}

--- a/templates/chat/src/components/ChatMessage.tsx
+++ b/templates/chat/src/components/ChatMessage.tsx
@@ -1,18 +1,17 @@
 import { type UIMessage } from '@ai-sdk/react'
 import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { FileHelpers, TLEditorSnapshot } from 'tldraw'
+import { FileHelpers } from 'tldraw'
 import { TldrawProviderMetadata } from './WhiteboardModal'
+
+export type ImageClickTarget = TldrawProviderMetadata | { uploadedFile: File }
 
 interface ChatMessageProps {
 	message: UIMessage
-	onImageClick: (
-		opts: { snapshot: TLEditorSnapshot; imageName: string } | { uploadedFile: File }
-	) => void
+	onImageClick: (opts: ImageClickTarget) => void
 }
 
 export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: ChatMessageProps) {
-	// For AI messages with no content, show thinking state
 	if (
 		message.role === 'assistant' &&
 		!message.parts.some((part) => part.type === 'file' || part.type === 'text')
@@ -30,10 +29,9 @@ export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: 
 		>
 			{message.parts.map((part, index) => {
 				if (part.type === 'file') {
-					// we stash a snapshot of the tldraw document in the provider metadata:
+					// whiteboard images carry a tldraw snapshot in the provider metadata so they can be re-edited
 					const tldrawMetadata = part.providerMetadata?.tldraw as TldrawProviderMetadata | undefined
 					const handleImageClick = async () => {
-						// if we have a tldraw snapshot, we open the tldraw modal when it's clicked:
 						if (tldrawMetadata) {
 							onImageClick(tldrawMetadata)
 						} else {

--- a/templates/chat/src/components/ChatMessage.tsx
+++ b/templates/chat/src/components/ChatMessage.tsx
@@ -12,6 +12,7 @@ interface ChatMessageProps {
 }
 
 export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: ChatMessageProps) {
+	// For AI messages with no content, show thinking state
 	if (
 		message.role === 'assistant' &&
 		!message.parts.some((part) => part.type === 'file' || part.type === 'text')
@@ -29,9 +30,10 @@ export const ChatMessage = memo(function ChatMessage({ message, onImageClick }: 
 		>
 			{message.parts.map((part, index) => {
 				if (part.type === 'file') {
-					// whiteboard images carry a tldraw snapshot in the provider metadata so they can be re-edited
+					// we stash a snapshot of the tldraw document in the provider metadata:
 					const tldrawMetadata = part.providerMetadata?.tldraw as TldrawProviderMetadata | undefined
 					const handleImageClick = async () => {
+						// if we have a tldraw snapshot, we open the tldraw modal when it's clicked:
 						if (tldrawMetadata) {
 							onImageClick(tldrawMetadata)
 						} else {

--- a/templates/chat/src/components/MessageList.tsx
+++ b/templates/chat/src/components/MessageList.tsx
@@ -1,11 +1,10 @@
 import { type UIMessage } from '@ai-sdk/react'
 import { memo } from 'react'
-import { ChatMessage } from './ChatMessage'
-import { TldrawProviderMetadata } from './WhiteboardModal'
+import { ChatMessage, ImageClickTarget } from './ChatMessage'
 
 interface MessageListProps {
 	messages: UIMessage[]
-	onImageClick: (tldrawMetadata: TldrawProviderMetadata | { uploadedFile: File }) => void
+	onImageClick: (target: ImageClickTarget) => void
 }
 
 export const MessageList = memo(function MessageList({ messages, onImageClick }: MessageListProps) {

--- a/templates/chat/src/components/WhiteboardModal.tsx
+++ b/templates/chat/src/components/WhiteboardModal.tsx
@@ -39,11 +39,10 @@ interface WhiteboardModalProps {
 }
 
 const options: Partial<TldrawOptions> = {
-	// disable the ability to create new pages:
 	maxPages: 1,
-	// make sure the action shortcuts are always in the top-right menu area, not on the toolbar:
+	// keep the action shortcuts in the top-right menu area, not on the toolbar
 	actionShortcutsLocation: 'menu',
-	// disable font pre-loading to avoid the ui popping in after the modal appears:
+	// skip font pre-loading so the ui doesn't pop in after the modal appears
 	maxFontsToLoadBeforeRender: 0,
 }
 
@@ -60,57 +59,43 @@ export function WhiteboardModal({
 	const handleSave = useCallback(async () => {
 		if (!editor) return
 
-		// if there are no shapes, we don't want to save the image:
 		const shapes = editor.getCurrentPageShapes()
 		if (shapes.length === 0) {
 			onCancel()
 			return
 		}
 
-		// when the user clicks save, we convert the current whiteboard to an image:
-		const image = await editor.toImageDataUrl(shapes, {
-			format: 'png',
-		})
+		const image = await editor.toImageDataUrl(shapes, { format: 'png' })
 
-		// we also take a snapshot of the editor state, so we can still edit
-		// it if we open it up again later:
-		const snapshot = editor.getSnapshot()
-
-		// we pass the image data and the snapshot to the parent component, so it
-		// can add it to the chat input:
+		// the snapshot lets the image be re-opened and edited later
 		onAccept({
 			id: imageId ?? crypto.randomUUID(),
 			name: imageName ?? 'tldraw whiteboard.png',
-			snapshot,
+			snapshot: editor.getSnapshot(),
 			type: 'image/png',
 			...image,
 		})
 	}, [onCancel, onAccept, imageId, imageName, editor])
 
-	// components are used to override parts of the tldraw ui. they shouldn't change often, so it's
-	// important that we memoize them or define them outside the tldraw component.
+	// components must be memoized (or defined outside the component) or tldraw remounts them every render
 	const components = useMemo(
 		(): TLComponents => ({
-			// The "SharePanel" is in the top-right of the editor. Here we want it to show our save
-			// and cancel buttons:
-			SharePanel: () => {
-				return (
-					<TldrawUiRow className="whiteboard-actions">
-						<TldrawUiButton type="normal" onClick={onCancel}>
-							Cancel
-						</TldrawUiButton>
-						<TldrawUiButton type="primary" onClick={handleSave}>
-							{imageId ? 'Save' : 'Add'}
-						</TldrawUiButton>
-					</TldrawUiRow>
-				)
-			},
+			// the share panel is in the top-right of the editor; we use it for our save and cancel buttons
+			SharePanel: () => (
+				<TldrawUiRow className="whiteboard-actions">
+					<TldrawUiButton type="normal" onClick={onCancel}>
+						Cancel
+					</TldrawUiButton>
+					<TldrawUiButton type="primary" onClick={handleSave}>
+						{imageId ? 'Save' : 'Add'}
+					</TldrawUiButton>
+				</TldrawUiRow>
+			),
 		}),
 		[onCancel, handleSave, imageId]
 	)
 
-	// when the user clicks outside the modal, we close it. we add their image to the chat input in
-	// case they wanted it - they can easily delete it if not.
+	// clicking outside the modal saves rather than discards - the image is easy to delete if unwanted
 	const handleOverlayClick = (e: React.MouseEvent) => {
 		if (e.target === e.currentTarget) {
 			handleSave()
@@ -132,9 +117,7 @@ export function WhiteboardModal({
 					editor.zoomToSelection()
 				}}
 			>
-				{/* if the user uploaded a file, we insert it in a special component. this means we
-				can use hooks that depend on tldraw's ui to do things like show a toast if
-				something goes wrong. */}
+				{/* rendered inside Tldraw so it can use the editor and ui hooks (e.g. toasts) */}
 				<InsideOfTldrawContext uploadedFile={uploadedFile} />
 			</Tldraw>
 		</div>
@@ -149,34 +132,25 @@ function InsideOfTldrawContext({ uploadedFile }: { uploadedFile?: File }) {
 	useEffect(() => {
 		if (!uploadedFile) return
 
-		// this effect can run multiple times, but we only want the file to be uploaded once:
+		// this effect can run multiple times, but the file must only be inserted once
 		if ((uploadedFile as any).didUpload) return
 		;(uploadedFile as any).didUpload = true
 		;(async () => {
-			// we check if the file is allowed to be uploaded:
-			const isOk = notifyIfFileNotAllowed(editor, uploadedFile, {
-				toasts,
-				msg,
-			})
-			if (!isOk) return
+			if (!notifyIfFileNotAllowed(editor, uploadedFile, { toasts, msg })) return
 
-			// we get the asset for the uploaded file:
 			const asset = await editor.getAssetForExternalContent({
 				type: 'file',
 				file: uploadedFile,
 			})
 			if (!asset || asset.type !== 'image') return
 
-			// scale so the max dimension is 1000px:
+			// scale down so the max dimension is 1000px
 			const scale = Math.min(1000 / Math.max(asset.props.w, asset.props.h), 1)
 			const center = editor.getViewportPageBounds().center
 			const width = asset.props.w * scale
 			const height = asset.props.h * scale
-
-			// create an ID for the new shape so we can select it later:
 			const shapeId = createShapeId()
 
-			// create the shape, select it, make it fill the screen, and start cropping it:
 			editor
 				.createAssets([asset])
 				.createShape({

--- a/templates/chat/src/components/WhiteboardModal.tsx
+++ b/templates/chat/src/components/WhiteboardModal.tsx
@@ -39,10 +39,11 @@ interface WhiteboardModalProps {
 }
 
 const options: Partial<TldrawOptions> = {
+	// disable the ability to create new pages:
 	maxPages: 1,
-	// keep the action shortcuts in the top-right menu area, not on the toolbar
+	// make sure the action shortcuts are always in the top-right menu area, not on the toolbar:
 	actionShortcutsLocation: 'menu',
-	// skip font pre-loading so the ui doesn't pop in after the modal appears
+	// disable font pre-loading to avoid the ui popping in after the modal appears:
 	maxFontsToLoadBeforeRender: 0,
 }
 
@@ -59,15 +60,19 @@ export function WhiteboardModal({
 	const handleSave = useCallback(async () => {
 		if (!editor) return
 
+		// if there are no shapes, we don't want to save the image:
 		const shapes = editor.getCurrentPageShapes()
 		if (shapes.length === 0) {
 			onCancel()
 			return
 		}
 
+		// when the user clicks save, we convert the current whiteboard to an image:
 		const image = await editor.toImageDataUrl(shapes, { format: 'png' })
 
-		// the snapshot lets the image be re-opened and edited later
+		// we also take a snapshot of the editor state, so we can still edit
+		// it if we open it up again later, and we pass the image data and the
+		// snapshot to the parent component, so it can add it to the chat input:
 		onAccept({
 			id: imageId ?? crypto.randomUUID(),
 			name: imageName ?? 'tldraw whiteboard.png',
@@ -77,10 +82,12 @@ export function WhiteboardModal({
 		})
 	}, [onCancel, onAccept, imageId, imageName, editor])
 
-	// components must be memoized (or defined outside the component) or tldraw remounts them every render
+	// components are used to override parts of the tldraw ui. they shouldn't change often, so it's
+	// important that we memoize them or define them outside the tldraw component.
 	const components = useMemo(
 		(): TLComponents => ({
-			// the share panel is in the top-right of the editor; we use it for our save and cancel buttons
+			// The "SharePanel" is in the top-right of the editor. Here we want it to show our save
+			// and cancel buttons:
 			SharePanel: () => (
 				<TldrawUiRow className="whiteboard-actions">
 					<TldrawUiButton type="normal" onClick={onCancel}>
@@ -95,7 +102,8 @@ export function WhiteboardModal({
 		[onCancel, handleSave, imageId]
 	)
 
-	// clicking outside the modal saves rather than discards - the image is easy to delete if unwanted
+	// when the user clicks outside the modal, we close it. we add their image to the chat input in
+	// case they wanted it - they can easily delete it if not.
 	const handleOverlayClick = (e: React.MouseEvent) => {
 		if (e.target === e.currentTarget) {
 			handleSave()
@@ -117,7 +125,9 @@ export function WhiteboardModal({
 					editor.zoomToSelection()
 				}}
 			>
-				{/* rendered inside Tldraw so it can use the editor and ui hooks (e.g. toasts) */}
+				{/* if the user uploaded a file, we insert it in a special component. this means we
+				can use hooks that depend on tldraw's ui to do things like show a toast if
+				something goes wrong. */}
 				<InsideOfTldrawContext uploadedFile={uploadedFile} />
 			</Tldraw>
 		</div>
@@ -132,25 +142,30 @@ function InsideOfTldrawContext({ uploadedFile }: { uploadedFile?: File }) {
 	useEffect(() => {
 		if (!uploadedFile) return
 
-		// this effect can run multiple times, but the file must only be inserted once
+		// this effect can run multiple times, but we only want the file to be uploaded once:
 		if ((uploadedFile as any).didUpload) return
 		;(uploadedFile as any).didUpload = true
 		;(async () => {
+			// we check if the file is allowed to be uploaded:
 			if (!notifyIfFileNotAllowed(editor, uploadedFile, { toasts, msg })) return
 
+			// we get the asset for the uploaded file:
 			const asset = await editor.getAssetForExternalContent({
 				type: 'file',
 				file: uploadedFile,
 			})
 			if (!asset || asset.type !== 'image') return
 
-			// scale down so the max dimension is 1000px
+			// scale so the max dimension is 1000px:
 			const scale = Math.min(1000 / Math.max(asset.props.w, asset.props.h), 1)
 			const center = editor.getViewportPageBounds().center
 			const width = asset.props.w * scale
 			const height = asset.props.h * scale
+
+			// create an ID for the new shape so we can select it later:
 			const shapeId = createShapeId()
 
+			// create the shape, select it, make it fill the screen, and start cropping it:
 			editor
 				.createAssets([asset])
 				.createShape({

--- a/templates/chat/src/hooks/useChatInputState.ts
+++ b/templates/chat/src/hooks/useChatInputState.ts
@@ -17,14 +17,23 @@ interface ChatInputState {
 }
 
 type ChatInputAction =
+	/** Updates the text input value */
 	| { type: 'setInput'; input: string }
+	/** Adds or updates an image in the chat input */
 	| { type: 'setImage'; image: WhiteboardImage }
+	/** Removes an image from the chat input by its ID */
 	| { type: 'removeImage'; imageId: string }
+	/** Clears all input data (text, images, modals) */
 	| { type: 'clear' }
+	/** Opens the whiteboard modal for drawing/editing */
 	| ({ type: 'openWhiteboard' } & OpenWhiteboard)
+	/** Closes the whiteboard modal */
 	| { type: 'closeWhiteboard' }
+	/** Indicates a file is being dragged over the input area */
 	| { type: 'dragEnter' }
+	/** Indicates drag operation has left the input area */
 	| { type: 'dragLeave' }
+	/** Handles dropping an image file to open in whiteboard */
 	| { type: 'drop'; file: File }
 
 const initialState: ChatInputState = {
@@ -76,7 +85,17 @@ function chatInputReducer(state: ChatInputState, action: ChatInputAction): ChatI
 	}
 }
 
-/** Text input, attached whiteboard images, whiteboard modal state, and drag/drop state for the chat input. */
+/**
+ * Hook for managing chat input state including text, images, whiteboard modal, and drag/drop interactions.
+ *
+ * Handles:
+ * - Text input value
+ * - Whiteboard images attached to the message
+ * - Whiteboard modal state for drawing/editing
+ * - Drag and drop file upload interactions
+ *
+ * @returns A tuple containing the current state and dispatch function for actions
+ */
 export function useChatInputState(): [ChatInputState, React.Dispatch<ChatInputAction>] {
 	return useReducer(chatInputReducer, initialState)
 }

--- a/templates/chat/src/hooks/useChatInputState.ts
+++ b/templates/chat/src/hooks/useChatInputState.ts
@@ -2,77 +2,63 @@ import { useReducer } from 'react'
 import { TLEditorSnapshot } from 'tldraw'
 import { WhiteboardImage } from '../components/WhiteboardModal'
 
+interface OpenWhiteboard {
+	snapshot?: TLEditorSnapshot
+	id?: string
+	uploadedFile?: File
+	imageName?: string
+}
+
 interface ChatInputState {
 	input: string
 	images: WhiteboardImage[]
-	openWhiteboard: {
-		snapshot?: TLEditorSnapshot
-		id?: string
-		uploadedFile?: File
-		imageName?: string
-	} | null
+	openWhiteboard: OpenWhiteboard | null
 	isDragging: boolean
 }
 
 type ChatInputAction =
-	/** Updates the text input value */
 	| { type: 'setInput'; input: string }
-	/** Adds or updates an image in the chat input */
 	| { type: 'setImage'; image: WhiteboardImage }
-	/** Removes an image from the chat input by its ID */
 	| { type: 'removeImage'; imageId: string }
-	/** Clears all input data (text, images, modals) */
 	| { type: 'clear' }
-	/** Opens the whiteboard modal for drawing/editing */
-	| {
-			type: 'openWhiteboard'
-			snapshot?: TLEditorSnapshot
-			id?: string
-			uploadedFile?: File
-			imageName?: string
-	  }
-	/** Closes the whiteboard modal */
+	| ({ type: 'openWhiteboard' } & OpenWhiteboard)
 	| { type: 'closeWhiteboard' }
-	/** Indicates a file is being dragged over the input area */
 	| { type: 'dragEnter' }
-	/** Indicates drag operation has left the input area */
 	| { type: 'dragLeave' }
-	/** Handles dropping an image file to open in whiteboard */
 	| { type: 'drop'; file: File }
+
+const initialState: ChatInputState = {
+	input: '',
+	images: [],
+	openWhiteboard: null,
+	isDragging: false,
+}
 
 function chatInputReducer(state: ChatInputState, action: ChatInputAction): ChatInputState {
 	switch (action.type) {
 		case 'setInput':
 			return { ...state, input: action.input }
 		case 'setImage': {
-			const index = state.images.findIndex((img) => img.id === action.image.id)
-			if (index !== -1) {
-				const newImages = [...state.images]
-				newImages[index] = action.image
-				return { ...state, images: newImages }
+			const exists = state.images.some((img) => img.id === action.image.id)
+			return {
+				...state,
+				images: exists
+					? state.images.map((img) => (img.id === action.image.id ? action.image : img))
+					: [...state.images, action.image],
 			}
-			return { ...state, images: [...state.images, action.image] }
 		}
 		case 'removeImage':
 			return { ...state, images: state.images.filter((img) => img.id !== action.imageId) }
 		case 'clear':
-			return {
-				input: '',
-				images: [],
-				openWhiteboard: null,
-				isDragging: false,
-			}
-		case 'openWhiteboard':
+			return initialState
+		case 'openWhiteboard': {
+			const { snapshot, id, uploadedFile, imageName } = action
 			return {
 				...state,
-				openWhiteboard: {
-					snapshot: action.snapshot,
-					id: action.id,
-					uploadedFile: action.uploadedFile,
-					imageName: action.imageName,
-				},
+				openWhiteboard: { snapshot, id, uploadedFile, imageName },
 				isDragging: false,
 			}
+		}
 		case 'closeWhiteboard':
 			return { ...state, openWhiteboard: null }
 		case 'dragEnter':
@@ -90,24 +76,7 @@ function chatInputReducer(state: ChatInputState, action: ChatInputAction): ChatI
 	}
 }
 
-/**
- * Hook for managing chat input state including text, images, whiteboard modal, and drag/drop interactions.
- *
- * Handles:
- * - Text input value
- * - Whiteboard images attached to the message
- * - Whiteboard modal state for drawing/editing
- * - Drag and drop file upload interactions
- *
- * @returns A tuple containing the current state and dispatch function for actions
- */
+/** Text input, attached whiteboard images, whiteboard modal state, and drag/drop state for the chat input. */
 export function useChatInputState(): [ChatInputState, React.Dispatch<ChatInputAction>] {
-	const [state, dispatch] = useReducer(chatInputReducer, {
-		input: '',
-		images: [],
-		openWhiteboard: null,
-		isDragging: false,
-	})
-
-	return [state, dispatch]
+	return useReducer(chatInputReducer, initialState)
 }

--- a/templates/chat/src/hooks/useChatMessageStorage.tsx
+++ b/templates/chat/src/hooks/useChatMessageStorage.tsx
@@ -46,10 +46,9 @@ export function useChatMessageStorage(): [UIMessage[] | null, (messages: UIMessa
 		const root = await navigator.storage.getDirectory()
 		const file = await root.getFileHandle(STORAGE_FILE_NAME, { create: true })
 		const writable = await file.createWritable({ keepExistingData: false })
-		const text = JSON.stringify(messages)
-		await writable.write(text)
+		await writable.write(JSON.stringify(messages))
 		await writable.close()
 	}, [])
 
-	return [initialMessages, saveMessages] as const
+	return [initialMessages, saveMessages]
 }

--- a/templates/chat/src/utils/uploadMessageContents.ts
+++ b/templates/chat/src/utils/uploadMessageContents.ts
@@ -32,10 +32,7 @@ export async function uploadMessageContents(messages: UIMessage[]) {
 			if (part.type === 'file' && part.url.startsWith('data:')) {
 				const metadata = getUploadedMetadata(part)
 				if (metadata && metadata.expiresAt > now) {
-					partsToSend.push({
-						...part,
-						url: metadata.uploadedUrl,
-					})
+					partsToSend.push({ ...part, url: metadata.uploadedUrl })
 					partsToSave.push(part)
 				} else {
 					const partToSend = { ...part }
@@ -56,11 +53,13 @@ export async function uploadMessageContents(messages: UIMessage[]) {
 						partToSend.url = data.uploadedUrl
 						if (partToSend.providerMetadata) {
 							partToSend.providerMetadata = { ...partToSend.providerMetadata }
-							delete partToSend.providerMetadata.tldraw_uploaded
+							delete partToSend.providerMetadata[UPLOAD_METADATA_KEY]
 							delete partToSend.providerMetadata.tldraw
 						}
-						partToSave.providerMetadata = { ...partToSave.providerMetadata }
-						partToSave.providerMetadata.tldraw_uploaded = data as any
+						partToSave.providerMetadata = {
+							...partToSave.providerMetadata,
+							[UPLOAD_METADATA_KEY]: data as any,
+						}
 					})()
 
 					promises.push(promise)


### PR DESCRIPTION
In order to make the chat starter template easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `templates/chat` and applies the fixes. It is the chat slice of #10068, split out so it can be reviewed on its own. Behavior is intended to be preserved: it deduplicates helpers, deletes dead code, and trims comment density to what template code needs per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` passes.
2. `yarn dev-template chat` and smoke the template.

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Templates | +94 / -219 |
