### PR TITLE
refactor(templates): simplify pass over the branching-chat template

### DIFF
--- a/templates/branching-chat/client/App.tsx
+++ b/templates/branching-chat/client/App.tsx
@@ -18,14 +18,10 @@ import { disableTransparency } from './disableTransparency.tsx'
 import { NodeShapeUtil } from './nodes/NodeShapeUtil.tsx'
 import { PointingPort } from './ports/PointingPort.tsx'
 
-// Define custom shape utilities that extend tldraw's shape system
 const shapeUtils = [NodeShapeUtil, ConnectionShapeUtil]
-// Define binding utilities that handle relationships between shapes
 const bindingUtils = [ConnectionBindingUtil]
-// Canvas overlays — adds the "+" insert handle at the midpoint of each connection
 const overlayUtils = [ConnectionCenterHandleOverlayUtil]
 
-// Customize tldraw's UI components to add workflow-specific functionality
 const components: TLComponents = {
 	Toolbar: () => (
 		<>
@@ -44,12 +40,9 @@ const components: TLComponents = {
 		const editor = useEditor()
 		const shouldShowStylePanel = useValue(
 			'shouldShowStylePanel',
-			() => {
-				return (
-					!editor.isIn('select') ||
-					editor.getSelectedShapes().some((s) => s.type !== 'node' && s.type !== 'connection')
-				)
-			},
+			() =>
+				!editor.isIn('select') ||
+				editor.getSelectedShapes().some((s) => s.type !== 'node' && s.type !== 'connection'),
 			[editor]
 		)
 		if (!shouldShowStylePanel) return
@@ -81,17 +74,11 @@ function App() {
 
 					editor.user.updateUserPreferences({ isSnapMode: true })
 
-					// Add our custom pointing port tool to the select tool's state machine
-					// This allows users to create connections by pointing at ports
+					// Lets users create connections by dragging from ports
 					editor.getStateDescendant('select')!.addChild(PointingPort)
 
 					// todo: move connections to on the canvas layer
-
-					// Ensure connections always stay at the bottom of the shape stack
-					// This prevents them from covering other shapes
 					keepConnectionsAtBottom(editor)
-
-					// Disable transparency for workflow shapes
 					disableTransparency(editor, ['node', 'connection'])
 				}}
 			/>

--- a/templates/branching-chat/client/App.tsx
+++ b/templates/branching-chat/client/App.tsx
@@ -18,10 +18,14 @@ import { disableTransparency } from './disableTransparency.tsx'
 import { NodeShapeUtil } from './nodes/NodeShapeUtil.tsx'
 import { PointingPort } from './ports/PointingPort.tsx'
 
+// Define custom shape utilities that extend tldraw's shape system
 const shapeUtils = [NodeShapeUtil, ConnectionShapeUtil]
+// Define binding utilities that handle relationships between shapes
 const bindingUtils = [ConnectionBindingUtil]
+// Canvas overlays — adds the "+" insert handle at the midpoint of each connection
 const overlayUtils = [ConnectionCenterHandleOverlayUtil]
 
+// Customize tldraw's UI components to add workflow-specific functionality
 const components: TLComponents = {
 	Toolbar: () => (
 		<>
@@ -74,11 +78,17 @@ function App() {
 
 					editor.user.updateUserPreferences({ isSnapMode: true })
 
-					// Lets users create connections by dragging from ports
+					// Add our custom pointing port tool to the select tool's state machine
+					// This allows users to create connections by pointing at ports
 					editor.getStateDescendant('select')!.addChild(PointingPort)
 
 					// todo: move connections to on the canvas layer
+
+					// Ensure connections always stay at the bottom of the shape stack
+					// This prevents them from covering other shapes
 					keepConnectionsAtBottom(editor)
+
+					// Disable transparency for workflow shapes
 					disableTransparency(editor, ['node', 'connection'])
 				}}
 			/>

--- a/templates/branching-chat/client/components/WorkflowToolbar.tsx
+++ b/templates/branching-chat/client/components/WorkflowToolbar.tsx
@@ -33,23 +33,29 @@ import { NodeShape } from '../nodes/NodeShapeUtil'
 import { getNodeDefinitions, NodeType } from '../nodes/nodeTypes'
 
 function createNodeShape(editor: Editor, shapeId: TLShapeId, center: Vec, node: NodeType) {
+	// Mark a history stopping point for undo/redo
 	editor.markHistoryStoppingPoint('create node')
 
 	editor.run(() => {
+		// Create the shape with the node definition
 		editor.createShape({
 			id: shapeId,
 			type: 'node',
 			props: { node },
 		})
 
-		// Center the shape on the drop point; its size isn't known until it exists
+		// Get the created shape and its bounds
 		const shape = editor.getShape<NodeShape>(shapeId)!
 		const shapeBounds = editor.getShapePageBounds(shapeId)!
+
+		// Position the shape so its center aligns with the drop point
 		editor.updateShape({
 			...shape,
 			x: center.x - shapeBounds.width / 2,
 			y: center.y - shapeBounds.height / 2,
 		})
+
+		// Select the newly created shape
 		editor.select(shapeId)
 	})
 }

--- a/templates/branching-chat/client/components/WorkflowToolbar.tsx
+++ b/templates/branching-chat/client/components/WorkflowToolbar.tsx
@@ -33,31 +33,25 @@ import { NodeShape } from '../nodes/NodeShapeUtil'
 import { getNodeDefinitions, NodeType } from '../nodes/nodeTypes'
 
 function createNodeShape(editor: Editor, shapeId: TLShapeId, center: Vec, node: NodeType) {
-	// Mark a history stopping point for undo/redo
-	const markId = editor.markHistoryStoppingPoint('create node')
+	editor.markHistoryStoppingPoint('create node')
 
 	editor.run(() => {
-		// Create the shape with the node definition
 		editor.createShape({
 			id: shapeId,
 			type: 'node',
 			props: { node },
 		})
 
-		// Get the created shape and its bounds
+		// Center the shape on the drop point; its size isn't known until it exists
 		const shape = editor.getShape<NodeShape>(shapeId)!
 		const shapeBounds = editor.getShapePageBounds(shapeId)!
-
-		// Position the shape so its center aligns with the drop point
-		const x = center.x - shapeBounds.width / 2
-		const y = center.y - shapeBounds.height / 2
-		editor.updateShape({ ...shape, x, y })
-
-		// Select the newly created shape
+		editor.updateShape({
+			...shape,
+			x: center.x - shapeBounds.width / 2,
+			y: center.y - shapeBounds.height / 2,
+		})
 		editor.select(shapeId)
 	})
-
-	return markId
 }
 
 export const overrides: TLUiOverrides = {

--- a/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
@@ -45,49 +45,42 @@ export class ConnectionBindingUtil extends BindingUtil<ConnectionBinding> {
 		return {}
 	}
 
+	// A connection can't outlive either of the nodes it's bound to
 	onBeforeIsolateToShape({ binding }: BindingOnShapeIsolateOptions<ConnectionBinding>): void {
-		// When we're duplicating a node but not its connection, delete the connection
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<ConnectionBinding>): void {
-		// When we're deleting a node, delete any connections that are bound to it
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onAfterCreate({ binding }: BindingOnCreateOptions<ConnectionBinding>): void {
-		// Our ports system has an `onConnect` callback - call it when we create a connection
-		const node = this.editor.getShape(binding.toId)
-		if (!node || !this.editor.isShapeOfType(node, 'node')) return
-		onNodePortConnect(this.editor, node, binding.props.portId)
+		const node = this.getBoundNode(binding)
+		if (node) onNodePortConnect(this.editor, node, binding.props.portId)
 	}
 
 	onAfterChange({ bindingBefore, bindingAfter }: BindingOnChangeOptions<ConnectionBinding>): void {
-		// We also might need to call the connection callbacks if we change the thing this connection is binding to.
 		if (
-			bindingBefore.props.portId !== bindingAfter.props.portId ||
-			bindingBefore.toId !== bindingAfter.toId
+			bindingBefore.props.portId === bindingAfter.props.portId &&
+			bindingBefore.toId === bindingAfter.toId
 		) {
-			const nodeBefore = this.editor.getShape(bindingBefore.toId)
-			const nodeAfter = this.editor.getShape(bindingAfter.toId)
-			if (
-				!nodeBefore ||
-				!nodeAfter ||
-				!this.editor.isShapeOfType(nodeBefore, 'node') ||
-				!this.editor.isShapeOfType(nodeAfter, 'node')
-			) {
-				return
-			}
-			onNodePortDisconnect(this.editor, nodeBefore, bindingBefore.props.portId)
-			onNodePortConnect(this.editor, nodeAfter, bindingAfter.props.portId)
+			return
 		}
+		const nodeBefore = this.getBoundNode(bindingBefore)
+		const nodeAfter = this.getBoundNode(bindingAfter)
+		if (!nodeBefore || !nodeAfter) return
+		onNodePortDisconnect(this.editor, nodeBefore, bindingBefore.props.portId)
+		onNodePortConnect(this.editor, nodeAfter, bindingAfter.props.portId)
 	}
 
 	onAfterDelete({ binding }: BindingOnDeleteOptions<ConnectionBinding>): void {
-		// When we're deleting a connection, we need to call the node's port disconnect callback
+		const node = this.getBoundNode(binding)
+		if (node) onNodePortDisconnect(this.editor, node, binding.props.portId)
+	}
+
+	private getBoundNode(binding: ConnectionBinding): NodeShape | undefined {
 		const node = this.editor.getShape(binding.toId)
-		if (!node || !this.editor.isShapeOfType(node, 'node')) return
-		onNodePortDisconnect(this.editor, node, binding.props.portId)
+		return node && this.editor.isShapeOfType(node, 'node') ? node : undefined
 	}
 }
 
@@ -102,7 +95,6 @@ export function getConnectionBindings(
 	editor: Editor,
 	shape: ConnectionShape | TLShapeId
 ): ConnectionBindings {
-	// we cache the bindings so we don't have to recompute them every time - this function gets called a lot.
 	return connectionBindingsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
 
@@ -121,9 +113,7 @@ const connectionBindingsCache = createComputedCache(
 		return { start, end }
 	},
 	{
-		// we only look at the arrow IDs:
 		areRecordsEqual: (a, b) => a.id === b.id,
-		// the records should stay the same:
 		areResultsEqual: (a, b) => a.start === b.start && a.end === b.end,
 	}
 )
@@ -133,15 +123,12 @@ export function getConnectionBindingPositionInPageSpace(
 	editor: Editor,
 	binding: ConnectionBinding
 ) {
-	// Find the shape that this binding is bound to
 	const targetShape = editor.getShape(binding.toId)
 	if (!targetShape || !editor.isShapeOfType(targetShape, 'node')) return null
 
-	// Find the port in the shape that the connection is bound to
-	const port = getNodePorts(editor, targetShape)?.[binding.props.portId]
+	const port = getNodePorts(editor, targetShape)[binding.props.portId]
 	if (!port) return null
 
-	// Transform the port position from shape space to page space
 	return editor.getShapePageTransform(targetShape).applyToPoint(port)
 }
 

--- a/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionBindingUtil.tsx
@@ -47,19 +47,23 @@ export class ConnectionBindingUtil extends BindingUtil<ConnectionBinding> {
 
 	// A connection can't outlive either of the nodes it's bound to
 	onBeforeIsolateToShape({ binding }: BindingOnShapeIsolateOptions<ConnectionBinding>): void {
+		// When we're duplicating a node but not its connection, delete the connection
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onBeforeDeleteToShape({ binding }: BindingOnShapeDeleteOptions<ConnectionBinding>): void {
+		// When we're deleting a node, delete any connections that are bound to it
 		this.editor.deleteShapes([binding.fromId])
 	}
 
 	onAfterCreate({ binding }: BindingOnCreateOptions<ConnectionBinding>): void {
+		// Our ports system has an `onConnect` callback - call it when we create a connection
 		const node = this.getBoundNode(binding)
 		if (node) onNodePortConnect(this.editor, node, binding.props.portId)
 	}
 
 	onAfterChange({ bindingBefore, bindingAfter }: BindingOnChangeOptions<ConnectionBinding>): void {
+		// We also might need to call the connection callbacks if we change the thing this connection is binding to.
 		if (
 			bindingBefore.props.portId === bindingAfter.props.portId &&
 			bindingBefore.toId === bindingAfter.toId
@@ -74,6 +78,7 @@ export class ConnectionBindingUtil extends BindingUtil<ConnectionBinding> {
 	}
 
 	onAfterDelete({ binding }: BindingOnDeleteOptions<ConnectionBinding>): void {
+		// When we're deleting a connection, we need to call the node's port disconnect callback
 		const node = this.getBoundNode(binding)
 		if (node) onNodePortDisconnect(this.editor, node, binding.props.portId)
 	}
@@ -95,6 +100,7 @@ export function getConnectionBindings(
 	editor: Editor,
 	shape: ConnectionShape | TLShapeId
 ): ConnectionBindings {
+	// we cache the bindings so we don't have to recompute them every time - this function gets called a lot.
 	return connectionBindingsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
 
@@ -113,7 +119,9 @@ const connectionBindingsCache = createComputedCache(
 		return { start, end }
 	},
 	{
+		// we only look at the arrow IDs:
 		areRecordsEqual: (a, b) => a.id === b.id,
+		// the records should stay the same:
 		areResultsEqual: (a, b) => a.start === b.start && a.end === b.end,
 	}
 )
@@ -123,12 +131,15 @@ export function getConnectionBindingPositionInPageSpace(
 	editor: Editor,
 	binding: ConnectionBinding
 ) {
+	// Find the shape that this binding is bound to
 	const targetShape = editor.getShape(binding.toId)
 	if (!targetShape || !editor.isShapeOfType(targetShape, 'node')) return null
 
+	// Find the port in the shape that the connection is bound to
 	const port = getNodePorts(editor, targetShape)[binding.props.portId]
 	if (!port) return null
 
+	// Transform the port position from shape space to page space
 	return editor.getShapePageTransform(targetShape).applyToPoint(port)
 }
 

--- a/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
@@ -24,8 +24,7 @@ interface TLConnectionCenterHandleOverlay extends TLOverlay {
 
 /**
  * Renders a clickable "+" handle at the midpoint of each fully-bound connection
- * so users can insert a new node into the middle of a connection. Replaces the
- * old SVG indicator-based handle.
+ * so users can insert a new node into the middle of a connection.
  */
 export class ConnectionCenterHandleOverlayUtil extends OverlayUtil<TLConnectionCenterHandleOverlay> {
 	static override type = 'connection_center_handle'
@@ -66,7 +65,7 @@ export class ConnectionCenterHandleOverlayUtil extends OverlayUtil<TLConnectionC
 	}
 
 	override getCursor(): TLCursorType {
-		return 'pointer' as TLCursorType
+		return 'pointer'
 	}
 
 	override onPointerDown(overlay: TLConnectionCenterHandleOverlay, _info: TLPointerEventInfo) {

--- a/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionCenterHandleOverlayUtil.tsx
@@ -24,7 +24,8 @@ interface TLConnectionCenterHandleOverlay extends TLOverlay {
 
 /**
  * Renders a clickable "+" handle at the midpoint of each fully-bound connection
- * so users can insert a new node into the middle of a connection.
+ * so users can insert a new node into the middle of a connection. Replaces the
+ * old SVG indicator-based handle.
  */
 export class ConnectionCenterHandleOverlayUtil extends OverlayUtil<TLConnectionCenterHandleOverlay> {
 	static override type = 'connection_center_handle'

--- a/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
@@ -81,12 +81,15 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		return true
 	}
 	override canSnap(_shape: ConnectionShape) {
+		// disable snapping this shape to other shapes
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: ConnectionShape) {
+		// disable snapping other shape to this shape
 		return { points: [] }
 	}
 
+	// Define the geometry of our connection shape as a cubic bezier curve
 	getGeometry(connection: ConnectionShape) {
 		const { start, end } = getConnectionTerminals(this.editor, connection)
 		const [cp1, cp2] = getConnectionControlPoints(start, end)
@@ -99,6 +102,7 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 
 	getHandles(connection: ConnectionShape): TLHandle[] {
+		// Handles are draggable points on a shape. In our connection shape, we have a handle at each end.
 		const { start, end } = getConnectionTerminals(this.editor, connection)
 		return [
 			{
@@ -118,13 +122,18 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		]
 	}
 
+	// Handle dragging of connection terminals to connect/disconnect from ports
 	onHandleDrag(connection: ConnectionShape, { handle }: TLHandleDragInfo<ConnectionShape>) {
+		// First, get some info about the connection and the terminal we're dragging
 		const existingBindings = getConnectionBindings(this.editor, connection)
 		const draggingTerminal = handle.id as 'start' | 'end'
 		const oppositeTerminal = draggingTerminal === 'start' ? 'end' : 'start'
 		const oppositeTerminalShapeId = existingBindings[oppositeTerminal]?.toId
 
+		// Find the new position of the handle in page space
 		const handlePagePosition = this.editor.getShapePageTransform(connection).applyToPoint(handle)
+
+		// Find the port at the new position
 		const target = getPortAtPoint(this.editor, handlePagePosition, {
 			margin: 8,
 			terminal: draggingTerminal,
@@ -132,14 +141,18 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 
 		// only 'start' ports (outputs) can have multiple connections
 		const allowsMultipleConnections = draggingTerminal === 'start'
+
+		// does this port have an existing connection (excluding this one)?
 		const hasExistingConnection =
 			target?.existingConnections.some((c) => c.connectionId !== connection.id) ?? false
 
-		// anything reachable from the other end of the connection would form a cycle
+		// find out which nodes would create a cycle based on what the other end of the connection
+		// is bound to
 		const nodesWhichWouldCreateACycle = oppositeTerminalShapeId
 			? getAllConnectedNodes(this.editor, oppositeTerminalShapeId, draggingTerminal)
 			: null
 
+		// update our port UI state to highlight which ports are eligible to connect to
 		updatePortState(this.editor, {
 			eligiblePorts: {
 				terminal: draggingTerminal,
@@ -147,10 +160,16 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			},
 		})
 
+		// if for whatever reason we can't connect to this port...
 		const wouldCreateACycle = (target && nodesWhichWouldCreateACycle?.has(target.shape.id)) ?? false
 		if (!target || (hasExistingConnection && !allowsMultipleConnections) || wouldCreateACycle) {
+			// ... update our port ui state to not highlight any ports...
 			updatePortState(this.editor, { hintingPort: null })
+
+			// ... remove any existing binding for this connection terminal...
 			removeConnectionBinding(this.editor, connection, draggingTerminal)
+
+			// ... and return the connection with the new position.
 			return {
 				...connection,
 				props: {
@@ -159,25 +178,33 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			}
 		}
 
+		// if we can connect to this port, update our port ui state to highlight the port we're
+		// connecting to
 		updatePortState(this.editor, {
 			hintingPort: { portId: target.port.id, shapeId: target.shape.id },
 		})
+
+		// create or update the connection binding for this connection terminal
 		createOrUpdateConnectionBinding(this.editor, connection, target.shape, {
 			portId: target.port.id,
 			terminal: draggingTerminal,
 		})
 
-		// the binding now determines the terminal position, so the shape itself is unchanged
+		// return the connection unmodified because we only need to update the binding.
 		return connection
 	}
 
+	// Handle the end of dragging a connection terminal
 	onHandleDragEnd(
 		connection: ConnectionShape,
 		{ handle, isCreatingShape }: TLHandleDragInfo<ConnectionShape>
 	) {
+		// clear our port UI state
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 
 		const draggingTerminal = handle.id as 'start' | 'end'
+
+		// if we successfully connected & now have a binding, we're done!
 		const bindings = getConnectionBindings(this.editor, connection)
 		if (bindings[draggingTerminal]) return
 
@@ -191,6 +218,7 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 
 	onHandleDragCancel() {
+		// if we cancel a drag part way through, we need to clear out our port UI state.
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 	}
 
@@ -204,8 +232,11 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 }
 
+// Main connection component that renders the SVG path
 function ConnectionShape({ connection }: { connection: ConnectionShape }) {
 	const editor = useEditor()
+
+	// Get the connection terminals
 	const { start, end } = useValue('terminals', () => getConnectionTerminals(editor, connection), [
 		editor,
 		connection,
@@ -246,22 +277,23 @@ function getConnectionControlPoints(start: VecLike, end: VecLike): [Vec, Vec] {
 	return [new Vec(start.x, start.y + adjustedDistance), new Vec(end.x, end.y - adjustedDistance)]
 }
 
+// Generate SVG path for the connection
 function getConnectionPath(start: VecLike, end: VecLike) {
 	const [cp1, cp2] = getConnectionControlPoints(start, end)
 	return `M ${start.x} ${start.y} C ${cp1.x} ${cp1.y} ${cp2.x} ${cp2.y} ${end.x} ${end.y}`
 }
 
-/**
- * The start and end points of a connection in its own shape space. Bound terminals follow the port
- * they're bound to; unbound terminals use the position stored on the shape.
- */
+// Get the actual start and end points of a connection, considering its bindings
 export function getConnectionTerminals(editor: Editor, connection: ConnectionShape) {
+	// if possible, set the start and end points based on the bindings
 	const bindings = getConnectionBindings(editor, connection)
 	const shapeTransform = Mat.Inverse(editor.getShapePageTransform(connection))
 
 	const getTerminal = (terminal: 'start' | 'end'): VecLike => {
 		const binding = bindings[terminal]
 		const inPageSpace = binding && getConnectionBindingPositionInPageSpace(editor, binding)
+		// if we couldn't set the start and end points based on the bindings, use the values stored on
+		// the shape itself
 		return inPageSpace ? Mat.applyToPoint(shapeTransform, inPageSpace) : connection.props[terminal]
 	}
 
@@ -287,6 +319,7 @@ export function createNodeAtConnectionEnd(
 	})
 	editor.select(newNodeId)
 
+	// Position the node so its input port aligns with the connection end
 	const inputPort = Object.values(getNodePorts(editor, newNodeId)).find((p) => p.terminal === 'end')
 	if (inputPort) {
 		editor.updateShape({
@@ -295,6 +328,8 @@ export function createNodeAtConnectionEnd(
 			x: point.x - inputPort.x,
 			y: point.y - inputPort.y,
 		})
+
+		// bind the connection to the node's first input port
 		createOrUpdateConnectionBinding(editor, connection, newNodeId, {
 			portId: inputPort.id,
 			terminal: 'end',

--- a/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
+++ b/templates/branching-chat/client/connection/ConnectionShapeUtil.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-import classNames from 'classnames'
 import {
 	CubicBezier2d,
 	Editor,
@@ -11,6 +9,7 @@ import {
 	TLHandle,
 	TLHandleDragInfo,
 	TLShape,
+	TLShapeId,
 	Vec,
 	VecLike,
 	VecModel,
@@ -82,20 +81,15 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		return true
 	}
 	override canSnap(_shape: ConnectionShape) {
-		// disable snapping this shape to other shapes
 		return false
 	}
 	override getBoundsSnapGeometry(_shape: ConnectionShape) {
-		return {
-			// disable snapping other shape to this shape
-			points: [],
-		}
+		return { points: [] }
 	}
 
-	// Define the geometry of our connection shape as a cubic bezier curve
 	getGeometry(connection: ConnectionShape) {
 		const { start, end } = getConnectionTerminals(this.editor, connection)
-		const [cp1, cp2] = getConnectionControlPoints(start, end, 'vertical')
+		const [cp1, cp2] = getConnectionControlPoints(start, end)
 		return new CubicBezier2d({
 			start: Vec.From(start),
 			cp1: Vec.From(cp1),
@@ -105,7 +99,6 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 
 	getHandles(connection: ConnectionShape): TLHandle[] {
-		// Handles are draggable points on a shape. In our connection shape, we have a handle at each end.
 		const { start, end } = getConnectionTerminals(this.editor, connection)
 		return [
 			{
@@ -125,38 +118,28 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 		]
 	}
 
-	// Handle dragging of connection terminals to connect/disconnect from ports
 	onHandleDrag(connection: ConnectionShape, { handle }: TLHandleDragInfo<ConnectionShape>) {
-		// First, get some info about the connection and the terminal we're dragging
 		const existingBindings = getConnectionBindings(this.editor, connection)
 		const draggingTerminal = handle.id as 'start' | 'end'
 		const oppositeTerminal = draggingTerminal === 'start' ? 'end' : 'start'
 		const oppositeTerminalShapeId = existingBindings[oppositeTerminal]?.toId
 
-		// Find the new position of the handle in page space
-		const shapeTransform = this.editor.getShapePageTransform(connection)
-		const handlePagePosition = shapeTransform.applyToPoint(handle)
-
-		// Find the port at the new position
+		const handlePagePosition = this.editor.getShapePageTransform(connection).applyToPoint(handle)
 		const target = getPortAtPoint(this.editor, handlePagePosition, {
 			margin: 8,
-			terminal: handle.id as 'start' | 'end',
+			terminal: draggingTerminal,
 		})
 
 		// only 'start' ports (outputs) can have multiple connections
 		const allowsMultipleConnections = draggingTerminal === 'start'
-
-		// does this port have an existing connection (excluding this one)?
 		const hasExistingConnection =
 			target?.existingConnections.some((c) => c.connectionId !== connection.id) ?? false
 
-		// find out which nodes would create a cycle based on what the other end of the connection
-		// is bound to
+		// anything reachable from the other end of the connection would form a cycle
 		const nodesWhichWouldCreateACycle = oppositeTerminalShapeId
 			? getAllConnectedNodes(this.editor, oppositeTerminalShapeId, draggingTerminal)
 			: null
 
-		// update our port UI state to highlight which ports are eligible to connect to
 		updatePortState(this.editor, {
 			eligiblePorts: {
 				terminal: draggingTerminal,
@@ -164,16 +147,10 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			},
 		})
 
-		// if for whatever reason we can't connect to this port...
 		const wouldCreateACycle = (target && nodesWhichWouldCreateACycle?.has(target.shape.id)) ?? false
 		if (!target || (hasExistingConnection && !allowsMultipleConnections) || wouldCreateACycle) {
-			// ... update our port ui state to not highlight any ports...
 			updatePortState(this.editor, { hintingPort: null })
-
-			// ... remove any existing binding for this connection terminal...
 			removeConnectionBinding(this.editor, connection, draggingTerminal)
-
-			// ... and return the connection with the new position.
 			return {
 				...connection,
 				props: {
@@ -182,83 +159,38 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 			}
 		}
 
-		// if we can connect to this port, update our port ui state to highlight the port we're
-		// connecting to
 		updatePortState(this.editor, {
 			hintingPort: { portId: target.port.id, shapeId: target.shape.id },
 		})
-
-		// create or update the connection binding for this connection terminal
 		createOrUpdateConnectionBinding(this.editor, connection, target.shape, {
 			portId: target.port.id,
 			terminal: draggingTerminal,
 		})
 
-		// return the connection unmodified because we only need to update the binding.
+		// the binding now determines the terminal position, so the shape itself is unchanged
 		return connection
 	}
 
-	// Handle the end of dragging a connection terminal
 	onHandleDragEnd(
 		connection: ConnectionShape,
 		{ handle, isCreatingShape }: TLHandleDragInfo<ConnectionShape>
 	) {
-		// clear our port UI state
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 
 		const draggingTerminal = handle.id as 'start' | 'end'
-
-		// if we successfully connected & now have a binding, we're done!
 		const bindings = getConnectionBindings(this.editor, connection)
-		if (bindings[draggingTerminal]) {
-			return
-		}
+		if (bindings[draggingTerminal]) return
 
-		// If we were creating a new connection and didn't attach it to anything, open the component
-		// picker to let the user choose a node to create.
 		if (isCreatingShape && draggingTerminal === 'end') {
-			this.editor.selectNone()
-			const newNodeId = createShapeId()
-			const terminalInPageSpace = this.editor.inputs.getCurrentPagePoint()
-			this.editor.createShape({
-				type: 'node',
-				id: newNodeId,
-				x: terminalInPageSpace.x,
-				y: terminalInPageSpace.y,
-				props: {
-					node: { type: 'message', userMessage: '', assistantMessage: '' },
-				},
-			})
-			this.editor.select(newNodeId)
-
-			// Position the node so its input port aligns with the connection end
-			const ports = getNodePorts(this.editor, newNodeId)
-			const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
-			if (firstInputPort) {
-				this.editor.updateShape({
-					id: newNodeId,
-					type: 'node',
-					x: terminalInPageSpace.x - firstInputPort.x,
-					y: terminalInPageSpace.y - firstInputPort.y,
-				})
-
-				// bind the connection to the node's first input port
-				createOrUpdateConnectionBinding(this.editor, connection, newNodeId, {
-					portId: firstInputPort.id,
-					terminal: draggingTerminal,
-				})
-			}
-		} else {
-			// if we're not creating a new connection and we just let go, there must be bindings. If
-			// not, let's interpret this as the user disconnecting the shape.
-			if (!bindings.start || !bindings.end) {
-				this.editor.deleteShapes([connection.id])
-			}
+			// A new connection dropped in empty space gets a fresh node to connect to
+			createNodeAtConnectionEnd(this.editor, connection, this.editor.inputs.getCurrentPagePoint())
+		} else if (!bindings.start || !bindings.end) {
+			// Letting go of an existing connection's terminal with nothing under it disconnects it
+			this.editor.deleteShapes([connection.id])
 		}
 	}
 
 	onHandleDragCancel() {
-		// if we cancel a drag part way through, we need to clear out our port UI state.
 		updatePortState(this.editor, { hintingPort: null, eligiblePorts: null })
 	}
 
@@ -272,18 +204,15 @@ export class ConnectionShapeUtil extends ShapeUtil<ConnectionShape> {
 	}
 }
 
-// Main connection component that renders the SVG path
 function ConnectionShape({ connection }: { connection: ConnectionShape }) {
 	const editor = useEditor()
-
-	// Get the connection terminals
 	const { start, end } = useValue('terminals', () => getConnectionTerminals(editor, connection), [
 		editor,
 		connection,
 	])
 
 	return (
-		<SVGContainer className={classNames('ConnectionShape')}>
+		<SVGContainer className="ConnectionShape">
 			<path d={getConnectionPath(start, end)} />
 		</SVGContainer>
 	)
@@ -299,7 +228,7 @@ export function getConnectionPageCenter(editor: Editor, connection: ConnectionSh
 	const startPage = getConnectionBindingPositionInPageSpace(editor, bindings.start)
 	const endPage = getConnectionBindingPositionInPageSpace(editor, bindings.end)
 	if (!startPage || !endPage) return null
-	const [cp1, cp2] = getConnectionControlPoints(startPage, endPage, 'vertical')
+	const [cp1, cp2] = getConnectionControlPoints(startPage, endPage)
 	// Cubic bezier midpoint at t=0.5: (P0 + 3·P1 + 3·P2 + P3) / 8
 	return new Vec(
 		(startPage.x + 3 * cp1.x + 3 * cp2.x + endPage.x) / 8,
@@ -307,55 +236,69 @@ export function getConnectionPageCenter(editor: Editor, connection: ConnectionSh
 	)
 }
 
-// Calculate control points for smooth bezier curves
-function getConnectionControlPoints(start: VecLike, end: VecLike, dir = 'horizontal'): [Vec, Vec] {
-	if (dir === 'horizontal') {
-		const distance = end.x - start.x
-		const adjustedDistance = Math.max(
-			30,
-			distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
-		)
-		return [new Vec(start.x + adjustedDistance, start.y), new Vec(end.x - adjustedDistance, end.y)]
-	} else {
-		const distance = end.y - start.y
-		const adjustedDistance = Math.max(
-			30,
-			distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
-		)
-		return [new Vec(start.x, start.y + adjustedDistance), new Vec(end.x, end.y - adjustedDistance)]
-	}
+// Connections flow top-to-bottom, so control points are offset vertically from each terminal
+function getConnectionControlPoints(start: VecLike, end: VecLike): [Vec, Vec] {
+	const distance = end.y - start.y
+	const adjustedDistance = Math.max(
+		30,
+		distance > 0 ? distance / 3 : clamp(Math.abs(distance) + 30, 0, 100)
+	)
+	return [new Vec(start.x, start.y + adjustedDistance), new Vec(end.x, end.y - adjustedDistance)]
 }
 
-// Generate SVG path for the connection
-function getConnectionPath(start: VecLike, end: VecLike, dir = 'vertical') {
-	const [cp1, cp2] = getConnectionControlPoints(start, end, dir)
+function getConnectionPath(start: VecLike, end: VecLike) {
+	const [cp1, cp2] = getConnectionControlPoints(start, end)
 	return `M ${start.x} ${start.y} C ${cp1.x} ${cp1.y} ${cp2.x} ${cp2.y} ${end.x} ${end.y}`
 }
 
-// Get the actual start and end points of a connection, considering its bindings
+/**
+ * The start and end points of a connection in its own shape space. Bound terminals follow the port
+ * they're bound to; unbound terminals use the position stored on the shape.
+ */
 export function getConnectionTerminals(editor: Editor, connection: ConnectionShape) {
-	let start, end
-
-	// if possible, set the start and end points based on the bindings
 	const bindings = getConnectionBindings(editor, connection)
 	const shapeTransform = Mat.Inverse(editor.getShapePageTransform(connection))
-	if (bindings.start) {
-		const inPageSpace = getConnectionBindingPositionInPageSpace(editor, bindings.start)
-		if (inPageSpace) {
-			start = Mat.applyToPoint(shapeTransform, inPageSpace)
-		}
-	}
-	if (bindings.end) {
-		const inPageSpace = getConnectionBindingPositionInPageSpace(editor, bindings.end)
-		if (inPageSpace) {
-			end = Mat.applyToPoint(shapeTransform, inPageSpace)
-		}
+
+	const getTerminal = (terminal: 'start' | 'end'): VecLike => {
+		const binding = bindings[terminal]
+		const inPageSpace = binding && getConnectionBindingPositionInPageSpace(editor, binding)
+		return inPageSpace ? Mat.applyToPoint(shapeTransform, inPageSpace) : connection.props[terminal]
 	}
 
-	// if we couldn't set the start and end points based on the bindings, use the values stored on
-	// the shape itself
-	if (!start) start = connection.props.start
-	if (!end) end = connection.props.end
+	return { start: getTerminal('start'), end: getTerminal('end') }
+}
 
-	return { start, end }
+/**
+ * Create a new message node whose input port sits at `point` and bind the connection's end to it.
+ * Returns the new node's id.
+ */
+export function createNodeAtConnectionEnd(
+	editor: Editor,
+	connection: ConnectionShape | TLShapeId,
+	point: VecLike
+): TLShapeId {
+	const newNodeId = createShapeId()
+	editor.createShape({
+		type: 'node',
+		id: newNodeId,
+		x: point.x,
+		y: point.y,
+		props: { node: { type: 'message', userMessage: '', assistantMessage: '' } },
+	})
+	editor.select(newNodeId)
+
+	const inputPort = Object.values(getNodePorts(editor, newNodeId)).find((p) => p.terminal === 'end')
+	if (inputPort) {
+		editor.updateShape({
+			id: newNodeId,
+			type: 'node',
+			x: point.x - inputPort.x,
+			y: point.y - inputPort.y,
+		})
+		createOrUpdateConnectionBinding(editor, connection, newNodeId, {
+			portId: inputPort.id,
+			terminal: 'end',
+		})
+	}
+	return newNodeId
 }

--- a/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
+++ b/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
@@ -5,38 +5,31 @@ import { createOrUpdateConnectionBinding, getConnectionBindings } from './Connec
 import { ConnectionShape } from './ConnectionShapeUtil'
 
 /**
- * Insert a node in the middle of a connection.
- *
- * This is used when the user clicks the center handle of a connection shape.
+ * Insert a node in the middle of a connection, used when the user clicks a connection's center
+ * handle. Downstream nodes are nudged out of the way to make room.
  */
 export function insertNodeWithinConnection(
 	editor: Editor,
 	connection: ConnectionShape,
 	direction: 'horizontal' | 'vertical' = 'horizontal'
 ) {
-	// mark the history so we can undo this operation
 	const mark = editor.markHistoryStoppingPoint()
 
-	// get the original bindings of the connection
 	const originalBindings = getConnectionBindings(editor, connection)
-
-	// if the connection doesn't have bindings, we can't insert a node in the middle of it
 	if (!originalBindings.start || !originalBindings.end) return
 
-	// find the ideal position for the new node based on direction:
 	const startBounds = editor.getShapePageBounds(originalBindings.start.toId)!
 	const endBounds = editor.getShapePageBounds(originalBindings.end.toId)!
 
+	// Aim for the midpoint between the two nodes, but never overlap the upstream one
 	let newNodeX: number, newNodeY: number
 
 	if (direction === 'horizontal') {
-		// horizontal layout: nodes flow left to right
 		newNodeY = (startBounds.top + endBounds.top) / 2
 		const newNodeIdealX = (startBounds.right + endBounds.left - NODE_WIDTH_PX) / 2
 		const newNodeMin = startBounds.right + DEFAULT_NODE_SPACING_PX
 		newNodeX = Math.max(newNodeIdealX, newNodeMin)
 	} else {
-		// vertical layout: nodes flow top to bottom
 		newNodeX = (startBounds.left + endBounds.left) / 2
 		if (startBounds.top > endBounds.bottom) {
 			const newNodeIdealY = (startBounds.top + endBounds.bottom - NODE_HEIGHT_PX) / 2
@@ -49,7 +42,6 @@ export function insertNodeWithinConnection(
 		}
 	}
 
-	// create the new node
 	const newNodeId = createShapeId()
 	editor.createShape({
 		type: 'node',
@@ -59,8 +51,6 @@ export function insertNodeWithinConnection(
 		props: { node: { type: 'message', userMessage: '', assistantMessage: '' } },
 	})
 
-	// now, we need to connect up the new node.
-	// first, lets find the first input and output port on the new node.
 	const ports = getNodePorts(editor, newNodeId)
 	const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
 	const firstOutputPort = Object.values(ports).find((p) => p.terminal === 'start')
@@ -69,13 +59,12 @@ export function insertNodeWithinConnection(
 		return
 	}
 
-	// update the existing connection to connect to the input of our new node
+	// re-point the existing connection at the new node, then connect the new node to the old target
 	createOrUpdateConnectionBinding(editor, connection, newNodeId, {
 		portId: firstInputPort.id,
 		terminal: 'end',
 	})
 
-	// create a new connection between the new node and the end of the original connection
 	const newConnectionId = createShapeId()
 	editor.createShape({
 		type: 'connection',
@@ -90,20 +79,16 @@ export function insertNodeWithinConnection(
 		terminal: 'end',
 	})
 
-	// move around any connected nodes to make room for the new one
 	moveNodesIfNeeded(editor, newNodeId, originalBindings.end.toId, direction)
-
-	// select the new node
 	editor.select(newNodeId)
 
-	// update the pointer so that e.g. the editor's internal hovered shape id is correct
+	// so the editor's hovered shape reflects what's now under the pointer
 	editor.updatePointer()
 }
 
 /**
- * Move around any connected nodes to make room for the new node.
- *
- * This is used when the user inserts a node in the middle of a connection.
+ * Nudge the downstream nodes of `rootNodeId` away from the newly inserted node, then animate
+ * everything into place.
  */
 function moveNodesIfNeeded(
 	editor: Editor,
@@ -122,14 +107,11 @@ function moveNodesIfNeeded(
 		return
 	}
 
-	// first, we need to nudge all the downstream nodes to make room for the new node.
-	// toNudge tracks all the nodes we need to nudge.
 	const toNudge = new Map<
 		TLShapeId,
 		{ initialX: number; initialY: number; amountX: number; amountY: number }
 	>()
 
-	// we start with the expanded bounds of the newly added node:
 	const newNodeBounds = editor.getShapePageBounds(newNodeId)!.clone()
 	visit(rootNodeId, newNodeBounds.expandBy(DEFAULT_NODE_SPACING_PX))
 
@@ -137,8 +119,7 @@ function moveNodesIfNeeded(
 		const node = editor.getShape(nodeId)
 		if (!node || !editor.isShapeOfType(node, 'node')) return
 
-		// if this node has already been visited, we need to continue on from the nudge we
-		// calculated last time:
+		// a node reachable via several paths accumulates nudges from each visit
 		const currentNudge = toNudge.get(nodeId) ?? {
 			initialX: node.x,
 			initialY: node.y,
@@ -150,22 +131,13 @@ function moveNodesIfNeeded(
 			.clone()
 			.translate({ x: currentNudge.amountX, y: currentNudge.amountY })
 
-		// if this node isn't colliding with the expanded parent node, it's already far enough away
-		// and we don't need to do anything!
-		if (!nodeBounds.collides(parentExpandedBounds)) {
-			return
-		}
+		if (!nodeBounds.collides(parentExpandedBounds)) return
 
-		// we need to nudge this node to make room for the new node.
-		// direction determines whether we nudge horizontally or vertically
 		let newNudgeAmountX = 0
 		let newNudgeAmountY = 0
-
 		if (direction === 'horizontal') {
-			// nudge to the right for horizontal layout
 			newNudgeAmountX = parentExpandedBounds.right - nodeBounds.left
 		} else {
-			// nudge downward for vertical layout
 			newNudgeAmountY = parentExpandedBounds.bottom - nodeBounds.top
 		}
 
@@ -176,20 +148,18 @@ function moveNodesIfNeeded(
 			amountY: currentNudge.amountY + newNudgeAmountY,
 		})
 
-		// now, we traverse the downstream connections from this node and nudge them all if needed.
 		nodeBounds
 			.translate({ x: newNudgeAmountX, y: newNudgeAmountY })
 			.expandBy(DEFAULT_NODE_SPACING_PX)
-		for (const connection of Object.values(getNodePortConnections(editor, node))) {
-			if (!connection || connection.terminal !== 'start') continue
+		for (const connection of getNodePortConnections(editor, node)) {
+			if (connection.terminal !== 'start') continue
 			visit(connection.connectedShapeId, nodeBounds)
 		}
 	}
 
 	editor
-		// hide the new node for the purposes of the animation
+		// start the new node invisible so it fades in alongside the nudge animation
 		.updateShape({ id: newNodeId, type: 'node', opacity: 0 })
-		// animate the new node fading in, and all the other nodes to their new positions
 		.animateShapes(
 			[
 				{

--- a/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
+++ b/templates/branching-chat/client/connection/insertNodeWithinConnection.tsx
@@ -5,19 +5,25 @@ import { createOrUpdateConnectionBinding, getConnectionBindings } from './Connec
 import { ConnectionShape } from './ConnectionShapeUtil'
 
 /**
- * Insert a node in the middle of a connection, used when the user clicks a connection's center
- * handle. Downstream nodes are nudged out of the way to make room.
+ * Insert a node in the middle of a connection.
+ *
+ * This is used when the user clicks the center handle of a connection shape.
  */
 export function insertNodeWithinConnection(
 	editor: Editor,
 	connection: ConnectionShape,
 	direction: 'horizontal' | 'vertical' = 'horizontal'
 ) {
+	// mark the history so we can undo this operation
 	const mark = editor.markHistoryStoppingPoint()
 
+	// get the original bindings of the connection
 	const originalBindings = getConnectionBindings(editor, connection)
+
+	// if the connection doesn't have bindings, we can't insert a node in the middle of it
 	if (!originalBindings.start || !originalBindings.end) return
 
+	// find the ideal position for the new node based on direction:
 	const startBounds = editor.getShapePageBounds(originalBindings.start.toId)!
 	const endBounds = editor.getShapePageBounds(originalBindings.end.toId)!
 
@@ -25,11 +31,13 @@ export function insertNodeWithinConnection(
 	let newNodeX: number, newNodeY: number
 
 	if (direction === 'horizontal') {
+		// horizontal layout: nodes flow left to right
 		newNodeY = (startBounds.top + endBounds.top) / 2
 		const newNodeIdealX = (startBounds.right + endBounds.left - NODE_WIDTH_PX) / 2
 		const newNodeMin = startBounds.right + DEFAULT_NODE_SPACING_PX
 		newNodeX = Math.max(newNodeIdealX, newNodeMin)
 	} else {
+		// vertical layout: nodes flow top to bottom
 		newNodeX = (startBounds.left + endBounds.left) / 2
 		if (startBounds.top > endBounds.bottom) {
 			const newNodeIdealY = (startBounds.top + endBounds.bottom - NODE_HEIGHT_PX) / 2
@@ -42,6 +50,7 @@ export function insertNodeWithinConnection(
 		}
 	}
 
+	// create the new node
 	const newNodeId = createShapeId()
 	editor.createShape({
 		type: 'node',
@@ -51,6 +60,8 @@ export function insertNodeWithinConnection(
 		props: { node: { type: 'message', userMessage: '', assistantMessage: '' } },
 	})
 
+	// now, we need to connect up the new node.
+	// first, lets find the first input and output port on the new node.
 	const ports = getNodePorts(editor, newNodeId)
 	const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
 	const firstOutputPort = Object.values(ports).find((p) => p.terminal === 'start')
@@ -59,12 +70,13 @@ export function insertNodeWithinConnection(
 		return
 	}
 
-	// re-point the existing connection at the new node, then connect the new node to the old target
+	// update the existing connection to connect to the input of our new node
 	createOrUpdateConnectionBinding(editor, connection, newNodeId, {
 		portId: firstInputPort.id,
 		terminal: 'end',
 	})
 
+	// create a new connection between the new node and the end of the original connection
 	const newConnectionId = createShapeId()
 	editor.createShape({
 		type: 'connection',
@@ -79,16 +91,20 @@ export function insertNodeWithinConnection(
 		terminal: 'end',
 	})
 
+	// move around any connected nodes to make room for the new one
 	moveNodesIfNeeded(editor, newNodeId, originalBindings.end.toId, direction)
+
+	// select the new node
 	editor.select(newNodeId)
 
-	// so the editor's hovered shape reflects what's now under the pointer
+	// update the pointer so that e.g. the editor's internal hovered shape id is correct
 	editor.updatePointer()
 }
 
 /**
- * Nudge the downstream nodes of `rootNodeId` away from the newly inserted node, then animate
- * everything into place.
+ * Move around any connected nodes to make room for the new node.
+ *
+ * This is used when the user inserts a node in the middle of a connection.
  */
 function moveNodesIfNeeded(
 	editor: Editor,
@@ -107,11 +123,14 @@ function moveNodesIfNeeded(
 		return
 	}
 
+	// first, we need to nudge all the downstream nodes to make room for the new node.
+	// toNudge tracks all the nodes we need to nudge.
 	const toNudge = new Map<
 		TLShapeId,
 		{ initialX: number; initialY: number; amountX: number; amountY: number }
 	>()
 
+	// we start with the expanded bounds of the newly added node:
 	const newNodeBounds = editor.getShapePageBounds(newNodeId)!.clone()
 	visit(rootNodeId, newNodeBounds.expandBy(DEFAULT_NODE_SPACING_PX))
 
@@ -119,7 +138,8 @@ function moveNodesIfNeeded(
 		const node = editor.getShape(nodeId)
 		if (!node || !editor.isShapeOfType(node, 'node')) return
 
-		// a node reachable via several paths accumulates nudges from each visit
+		// if this node has already been visited, we need to continue on from the nudge we
+		// calculated last time:
 		const currentNudge = toNudge.get(nodeId) ?? {
 			initialX: node.x,
 			initialY: node.y,
@@ -131,13 +151,19 @@ function moveNodesIfNeeded(
 			.clone()
 			.translate({ x: currentNudge.amountX, y: currentNudge.amountY })
 
+		// if this node isn't colliding with the expanded parent node, it's already far enough away
+		// and we don't need to do anything!
 		if (!nodeBounds.collides(parentExpandedBounds)) return
 
+		// we need to nudge this node to make room for the new node.
+		// direction determines whether we nudge horizontally or vertically
 		let newNudgeAmountX = 0
 		let newNudgeAmountY = 0
 		if (direction === 'horizontal') {
+			// nudge to the right for horizontal layout
 			newNudgeAmountX = parentExpandedBounds.right - nodeBounds.left
 		} else {
+			// nudge downward for vertical layout
 			newNudgeAmountY = parentExpandedBounds.bottom - nodeBounds.top
 		}
 
@@ -148,6 +174,7 @@ function moveNodesIfNeeded(
 			amountY: currentNudge.amountY + newNudgeAmountY,
 		})
 
+		// now, we traverse the downstream connections from this node and nudge them all if needed.
 		nodeBounds
 			.translate({ x: newNudgeAmountX, y: newNudgeAmountY })
 			.expandBy(DEFAULT_NODE_SPACING_PX)
@@ -158,8 +185,9 @@ function moveNodesIfNeeded(
 	}
 
 	editor
-		// start the new node invisible so it fades in alongside the nudge animation
+		// hide the new node for the purposes of the animation
 		.updateShape({ id: newNodeId, type: 'node', opacity: 0 })
+		// animate the new node fading in, and all the other nodes to their new positions
 		.animateShapes(
 			[
 				{

--- a/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
+++ b/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
@@ -1,48 +1,37 @@
 import { Editor, getIndexBetween, getIndicesBetween, TLParentId } from 'tldraw'
 
 /**
- * This function registers side effects that will make sure connection shapes are always below all
- * other shapes in the same parent. We do this because we don't want to connections on top of nodes,
- * which might be distracting.
+ * Registers side effects that keep connection shapes below all other shapes in the same parent,
+ * so connections never render on top of nodes.
  */
 export function keepConnectionsAtBottom(editor: Editor) {
-	// whenever an operation happens, we'll keep track of the parent ids that we might need to
-	// re-sort the children of. An operation is any atomic change to the tldraw store.
+	// Parents whose children may need re-sorting once the current operation completes
 	let pendingChangedParentIds = new Set<TLParentId>()
 
-	// whenever a shape is created, we'll add the parent id to the set of parent ids that we might
-	// need to re-sort the children of.
 	editor.sideEffects.registerAfterCreateHandler('shape', (shape, source) => {
 		if (source === 'remote') return
 		pendingChangedParentIds.add(shape.parentId)
 	})
-	// whenever a shape's index or parent id changes, we'll add the parent id to the set of parent
-	// ids that we might need to re-sort the children of.
 	editor.sideEffects.registerAfterChangeHandler('shape', (oldShape, newShape, source) => {
 		if (source === 'remote') return
 		if (oldShape.parentId === newShape.parentId && oldShape.index === newShape.index) return
 		pendingChangedParentIds.add(newShape.parentId)
 	})
 
-	// then, when the operation is complete, we re-sort the children as needed:
 	editor.sideEffects.registerOperationCompleteHandler(() => {
 		if (pendingChangedParentIds.size === 0) return
 
-		// reset the set of pending changed parent ids
 		const changedParentIds = pendingChangedParentIds
 		pendingChangedParentIds = new Set()
 
 		const updates = []
 
 		for (const parentId of changedParentIds) {
-			// iterate through all the children of this parent. We want all the connections at the
-			// bottom (first), and everything else after that. Because this fn runs all the time,
-			// things should always be roughly in the right place to begin with. Because of that,
-			// we'll just find any non-connections that are in the wrong place and move them up.
-
+			// Because this runs after every operation, children are always roughly sorted already,
+			// so we only need to find non-connections that sit below the highest connection and
+			// move them up above it (keeping their relative order).
 			const childIds = editor.getSortedChildIdsForParent(parentId)
 
-			// we iterate in reverse because we want to find the highest connection index:
 			let i = childIds.length - 1
 			let highestConnectionIndex = null
 			let nextIndexAboveHighestConnectionIndex = null
@@ -58,39 +47,22 @@ export function keepConnectionsAtBottom(editor: Editor) {
 				}
 			}
 
-			// now that we've found the highest connection index, we switch to looking for
-			// non-connection shapes. these need to be moved up above the highest connection index.
 			const shapesToMove = []
 			for (; i >= 0; i--) {
 				const child = editor.getShape(childIds[i])
-				if (!child) continue
-
-				if (child.type !== 'connection') {
-					shapesToMove.push(child)
-				}
+				if (child && child.type !== 'connection') shapesToMove.push(child)
 			}
-
-			// the shapesToMove array will be in reverse order, so we need to reverse it:
 			shapesToMove.reverse()
 
-			// now we need the new indexes for each shape. These need to stay in the same relative
-			// order, and be inserted above the `hightestConnectionIndex`, but below the index of
-			// the next non-connection shape.
 			const newIndexes = getIndicesBetween(
 				highestConnectionIndex,
 				nextIndexAboveHighestConnectionIndex,
 				shapesToMove.length
 			)
 
-			// now we can create the update partials for those shapes:
 			for (let i = 0; i < shapesToMove.length; i++) {
 				const shape = shapesToMove[i]
-				const newIndex = newIndexes[i]
-				updates.push({
-					id: shape.id,
-					type: shape.type,
-					index: newIndex,
-				} as const)
+				updates.push({ id: shape.id, type: shape.type, index: newIndexes[i] } as const)
 			}
 		}
 
@@ -99,8 +71,7 @@ export function keepConnectionsAtBottom(editor: Editor) {
 }
 
 /**
- * Get the index of the next connection shape in the given parent. This will be above all other
- * connections, but the connections should be below all other shapes.
+ * Get an index just above the highest connection in the given parent, but below every other shape.
  */
 export function getNextConnectionIndex(
 	editor: Editor,

--- a/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
+++ b/templates/branching-chat/client/connection/keepConnectionsAtBottom.tsx
@@ -1,37 +1,48 @@
 import { Editor, getIndexBetween, getIndicesBetween, TLParentId } from 'tldraw'
 
 /**
- * Registers side effects that keep connection shapes below all other shapes in the same parent,
- * so connections never render on top of nodes.
+ * This function registers side effects that will make sure connection shapes are always below all
+ * other shapes in the same parent. We do this because we don't want to connections on top of nodes,
+ * which might be distracting.
  */
 export function keepConnectionsAtBottom(editor: Editor) {
-	// Parents whose children may need re-sorting once the current operation completes
+	// whenever an operation happens, we'll keep track of the parent ids that we might need to
+	// re-sort the children of. An operation is any atomic change to the tldraw store.
 	let pendingChangedParentIds = new Set<TLParentId>()
 
+	// whenever a shape is created, we'll add the parent id to the set of parent ids that we might
+	// need to re-sort the children of.
 	editor.sideEffects.registerAfterCreateHandler('shape', (shape, source) => {
 		if (source === 'remote') return
 		pendingChangedParentIds.add(shape.parentId)
 	})
+	// whenever a shape's index or parent id changes, we'll add the parent id to the set of parent
+	// ids that we might need to re-sort the children of.
 	editor.sideEffects.registerAfterChangeHandler('shape', (oldShape, newShape, source) => {
 		if (source === 'remote') return
 		if (oldShape.parentId === newShape.parentId && oldShape.index === newShape.index) return
 		pendingChangedParentIds.add(newShape.parentId)
 	})
 
+	// then, when the operation is complete, we re-sort the children as needed:
 	editor.sideEffects.registerOperationCompleteHandler(() => {
 		if (pendingChangedParentIds.size === 0) return
 
+		// reset the set of pending changed parent ids
 		const changedParentIds = pendingChangedParentIds
 		pendingChangedParentIds = new Set()
 
 		const updates = []
 
 		for (const parentId of changedParentIds) {
-			// Because this runs after every operation, children are always roughly sorted already,
-			// so we only need to find non-connections that sit below the highest connection and
-			// move them up above it (keeping their relative order).
+			// iterate through all the children of this parent. We want all the connections at the
+			// bottom (first), and everything else after that. Because this fn runs all the time,
+			// things should always be roughly in the right place to begin with. Because of that,
+			// we'll just find any non-connections that are in the wrong place and move them up.
+
 			const childIds = editor.getSortedChildIdsForParent(parentId)
 
+			// we iterate in reverse because we want to find the highest connection index:
 			let i = childIds.length - 1
 			let highestConnectionIndex = null
 			let nextIndexAboveHighestConnectionIndex = null
@@ -47,19 +58,27 @@ export function keepConnectionsAtBottom(editor: Editor) {
 				}
 			}
 
+			// now that we've found the highest connection index, we switch to looking for
+			// non-connection shapes. these need to be moved up above the highest connection index.
 			const shapesToMove = []
 			for (; i >= 0; i--) {
 				const child = editor.getShape(childIds[i])
 				if (child && child.type !== 'connection') shapesToMove.push(child)
 			}
+
+			// the shapesToMove array will be in reverse order, so we need to reverse it:
 			shapesToMove.reverse()
 
+			// now we need the new indexes for each shape. These need to stay in the same relative
+			// order, and be inserted above the `hightestConnectionIndex`, but below the index of
+			// the next non-connection shape.
 			const newIndexes = getIndicesBetween(
 				highestConnectionIndex,
 				nextIndexAboveHighestConnectionIndex,
 				shapesToMove.length
 			)
 
+			// now we can create the update partials for those shapes:
 			for (let i = 0; i < shapesToMove.length; i++) {
 				const shape = shapesToMove[i]
 				updates.push({ id: shape.id, type: shape.type, index: newIndexes[i] } as const)
@@ -71,7 +90,8 @@ export function keepConnectionsAtBottom(editor: Editor) {
 }
 
 /**
- * Get an index just above the highest connection in the given parent, but below every other shape.
+ * Get the index of the next connection shape in the given parent. This will be above all other
+ * connections, but the connections should be below all other shapes.
  */
 export function getNextConnectionIndex(
 	editor: Editor,

--- a/templates/branching-chat/client/disableTransparency.tsx
+++ b/templates/branching-chat/client/disableTransparency.tsx
@@ -1,17 +1,13 @@
-import { Editor } from 'tldraw'
+import { Editor, TLShape } from 'tldraw'
 
 export function disableTransparency(editor: Editor, shapeTypes: string[]) {
 	const shapeTypesSet = new Set(shapeTypes)
 
-	editor.sideEffects.registerBeforeCreateHandler('shape', (shape) => {
-		if (!shapeTypesSet.has(shape.type)) return shape
-		if (shape.opacity === 1) return shape
-		return { ...shape, opacity: 1 }
-	})
+	const forceOpaque = (shape: TLShape) =>
+		shapeTypesSet.has(shape.type) && shape.opacity !== 1 ? { ...shape, opacity: 1 } : shape
 
-	editor.sideEffects.registerBeforeChangeHandler('shape', (_shapeOld, shapeNew) => {
-		if (!shapeTypesSet.has(shapeNew.type)) return shapeNew
-		if (shapeNew.opacity === 1) return shapeNew
-		return { ...shapeNew, opacity: 1 }
-	})
+	editor.sideEffects.registerBeforeCreateHandler('shape', forceOpaque)
+	editor.sideEffects.registerBeforeChangeHandler('shape', (_shapeOld, shapeNew) =>
+		forceOpaque(shapeNew)
+	)
 }

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -28,8 +28,10 @@ declare module 'tldraw' {
 	}
 }
 
+// Define our custom node shape type that extends tldraw's base shape system
 export type NodeShape = TLShape<typeof NODE_TYPE>
 
+// This class extends tldraw's ShapeUtil to define how our custom node shapes behave
 export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	static override type = NODE_TYPE
 	static override props: RecordProps<NodeShape> = {
@@ -69,6 +71,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
+	// Define the geometry of our node shape including ports
 	getGeometry(shape: NodeShape) {
 		const ports = getNodePorts(this.editor, shape)
 
@@ -112,6 +115,7 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	}
 }
 
+// Main node component that renders the HTML content
 function NodeShape({ shape }: { shape: NodeShape }) {
 	const editor = useEditor()
 

--- a/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
+++ b/templates/branching-chat/client/nodes/NodeShapeUtil.tsx
@@ -1,13 +1,10 @@
-import classNames from 'classnames'
 import {
 	Circle2d,
 	Group2d,
 	HTMLContainer,
 	RecordProps,
 	Rectangle2d,
-	resizeBox,
 	ShapeUtil,
-	TLResizeInfo,
 	TLShape,
 	useEditor,
 	useValue,
@@ -31,10 +28,8 @@ declare module 'tldraw' {
 	}
 }
 
-// Define our custom node shape type that extends tldraw's base shape system
 export type NodeShape = TLShape<typeof NODE_TYPE>
 
-// This class extends tldraw's ShapeUtil to define how our custom node shapes behave
 export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	static override type = NODE_TYPE
 	static override props: RecordProps<NodeShape> = {
@@ -74,7 +69,6 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		}
 	}
 
-	// Define the geometry of our node shape including ports
 	getGeometry(shape: NodeShape) {
 		const ports = getNodePorts(this.editor, shape)
 
@@ -101,10 +95,6 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 		})
 	}
 
-	override onResize(shape: any, info: TLResizeInfo<any>) {
-		return resizeBox(shape, info)
-	}
-
 	component(shape: NodeShape) {
 		return <NodeShape shape={shape} />
 	}
@@ -122,13 +112,12 @@ export class NodeShapeUtil extends ShapeUtil<NodeShape> {
 	}
 }
 
-// Main node component that renders the HTML content
 function NodeShape({ shape }: { shape: NodeShape }) {
 	const editor = useEditor()
 
 	return (
 		<HTMLContainer
-			className={classNames('NodeShape')}
+			className="NodeShape"
 			style={{
 				width: getNodeWidthPx(editor, shape),
 				height: getNodeHeightPx(editor, shape),

--- a/templates/branching-chat/client/nodes/nodePorts.tsx
+++ b/templates/branching-chat/client/nodes/nodePorts.tsx
@@ -1,16 +1,9 @@
-/**
- * This file contains functions for working with ports and connections on nodes.
- */
 import { createComputedCache, Editor, TLShapeId } from 'tldraw'
 import { getConnectionBindings } from '../connection/ConnectionBindingUtil'
 import { PortId } from '../ports/Port'
 import { NodeShape } from './NodeShapeUtil'
 import { getNodeTypePorts, NodeTypePorts } from './nodeTypes'
 
-/**
- * Get the ports for a node. This is cached, because we only want to re-evaluate it when the
- * underlying records change.
- */
 export function getNodePorts(editor: Editor, shape: NodeShape | TLShapeId): NodeTypePorts {
 	return nodePortsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
@@ -19,9 +12,6 @@ const nodePortsCache = createComputedCache(
 	(editor: Editor, node: NodeShape): NodeTypePorts => getNodeTypePorts(editor, node)
 )
 
-/**
- * A connection from one node to another.
- */
 export interface NodePortConnection {
 	connectedShapeId: TLShapeId
 	connectionId: TLShapeId
@@ -30,9 +20,6 @@ export interface NodePortConnection {
 	connectedPortId: PortId
 }
 
-/**
- * Get the connections for a node. This is cached.
- */
 export function getNodePortConnections(
 	editor: Editor,
 	shape: NodeShape | TLShapeId
@@ -79,9 +66,7 @@ export function getAllConnectedNodes(
 	const found = new Set<TLShapeId>()
 
 	while (toVisit.length > 0) {
-		const nodeId = toVisit.shift()
-		if (!nodeId) continue
-
+		const nodeId = toVisit.shift()!
 		const node = editor.getShape(nodeId)
 		if (!node || !editor.isShapeOfType(node, 'node')) continue
 

--- a/templates/branching-chat/client/nodes/nodePorts.tsx
+++ b/templates/branching-chat/client/nodes/nodePorts.tsx
@@ -1,9 +1,16 @@
+/**
+ * This file contains functions for working with ports and connections on nodes.
+ */
 import { createComputedCache, Editor, TLShapeId } from 'tldraw'
 import { getConnectionBindings } from '../connection/ConnectionBindingUtil'
 import { PortId } from '../ports/Port'
 import { NodeShape } from './NodeShapeUtil'
 import { getNodeTypePorts, NodeTypePorts } from './nodeTypes'
 
+/**
+ * Get the ports for a node. This is cached, because we only want to re-evaluate it when the
+ * underlying records change.
+ */
 export function getNodePorts(editor: Editor, shape: NodeShape | TLShapeId): NodeTypePorts {
 	return nodePortsCache.get(editor, typeof shape === 'string' ? shape : shape.id) ?? {}
 }
@@ -12,6 +19,9 @@ const nodePortsCache = createComputedCache(
 	(editor: Editor, node: NodeShape): NodeTypePorts => getNodeTypePorts(editor, node)
 )
 
+/**
+ * A connection from one node to another.
+ */
 export interface NodePortConnection {
 	connectedShapeId: TLShapeId
 	connectionId: TLShapeId
@@ -20,6 +30,9 @@ export interface NodePortConnection {
 	connectedPortId: PortId
 }
 
+/**
+ * Get the connections for a node. This is cached.
+ */
 export function getNodePortConnections(
 	editor: Editor,
 	shape: NodeShape | TLShapeId

--- a/templates/branching-chat/client/nodes/nodeTypes.tsx
+++ b/templates/branching-chat/client/nodes/nodeTypes.tsx
@@ -4,6 +4,7 @@ import { NodeShape } from './NodeShapeUtil'
 import { MessageNodeDefinition } from './types/MessageNode'
 import { NodeDefinition, NodeDefinitionConstructor } from './types/shared'
 
+/** All our node types */
 export const NodeDefinitions = {
 	message: MessageNodeDefinition,
 } satisfies Record<string, NodeDefinitionConstructor<any>>
@@ -31,6 +32,9 @@ export function getNodeDefinition(
 	] as NodeDefinition<NodeType>
 }
 
+/**
+ * A union type of all our node types.
+ */
 export type NodeType = T.TypeOf<typeof NodeType>
 export const NodeType = T.union(
 	'type',

--- a/templates/branching-chat/client/nodes/nodeTypes.tsx
+++ b/templates/branching-chat/client/nodes/nodeTypes.tsx
@@ -4,7 +4,6 @@ import { NodeShape } from './NodeShapeUtil'
 import { MessageNodeDefinition } from './types/MessageNode'
 import { NodeDefinition, NodeDefinitionConstructor } from './types/shared'
 
-/** All our node types */
 export const NodeDefinitions = {
 	message: MessageNodeDefinition,
 } satisfies Record<string, NodeDefinitionConstructor<any>>
@@ -14,11 +13,13 @@ const nodeDefinitions = new WeakCache<
 	{ [K in keyof typeof NodeDefinitions]: InstanceType<(typeof NodeDefinitions)[K]> }
 >()
 export function getNodeDefinitions(editor: Editor) {
-	return nodeDefinitions.get(editor, () => {
-		return Object.fromEntries(
-			Object.values(NodeDefinitions).map((value) => [value.type, new value(editor)])
-		) as any
-	})
+	return nodeDefinitions.get(
+		editor,
+		() =>
+			Object.fromEntries(
+				Object.values(NodeDefinitions).map((value) => [value.type, new value(editor)])
+			) as any
+	)
 }
 
 export function getNodeDefinition(
@@ -30,9 +31,6 @@ export function getNodeDefinition(
 	] as NodeDefinition<NodeType>
 }
 
-/**
- * A union type of all our node types.
- */
 export type NodeType = T.TypeOf<typeof NodeType>
 export const NodeType = T.union(
 	'type',
@@ -41,20 +39,12 @@ export const NodeType = T.union(
 	}
 )
 
-export function getNodeBodyHeightPx(editor: Editor, shape: NodeShape): number {
+export function getNodeHeightPx(editor: Editor, shape: NodeShape): number {
 	return getNodeDefinition(editor, shape.props.node).getBodyHeightPx(shape, shape.props.node)
 }
 
-export function getNodeBodyWidthPx(editor: Editor, shape: NodeShape): number {
-	return getNodeDefinition(editor, shape.props.node).getBodyWidthPx(shape, shape.props.node)
-}
-
-export function getNodeHeightPx(editor: Editor, shape: NodeShape): number {
-	return getNodeBodyHeightPx(editor, shape)
-}
-
 export function getNodeWidthPx(editor: Editor, shape: NodeShape): number {
-	return getNodeBodyWidthPx(editor, shape)
+	return getNodeDefinition(editor, shape.props.node).getBodyWidthPx(shape, shape.props.node)
 }
 
 const _nodeTypePorts = T.dict(T.string, shapePort)

--- a/templates/branching-chat/client/nodes/types/MessageNode.tsx
+++ b/templates/branching-chat/client/nodes/types/MessageNode.tsx
@@ -14,6 +14,9 @@ import {
 	updateNode,
 } from './shared'
 
+/**
+ * This node is a message from the user.
+ */
 export type MessageNode = T.TypeOf<typeof MessageNode>
 export const MessageNode = T.object({
 	type: T.literal('message'),
@@ -68,7 +71,11 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 	const editor = useEditor()
 
 	const handleSend = useCallback(() => {
-		// Walk upstream through the ancestors to build the message history, oldest first
+		// 1. gather up parents and create message history
+		// 2. create prompt
+		// 3. send prompt to ai
+		// 4. update node with assistant message
+
 		const messages: ModelMessage[] = []
 		for (const connectedShape of getAllConnectedNodes(editor, shape, 'end')) {
 			const node = editor.getShape(connectedShape)
@@ -82,11 +89,13 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 		}
 		messages.reverse()
 
+		// clear any previous assistant message before starting
 		updateNode<MessageNode>(editor, shape, (node) => ({
 			...node,
 			assistantMessage: '...',
 		}))
 
+		// stream the response and append as chunks arrive
 		;(async () => {
 			try {
 				const response = await fetch('/stream', {

--- a/templates/branching-chat/client/nodes/types/MessageNode.tsx
+++ b/templates/branching-chat/client/nodes/types/MessageNode.tsx
@@ -14,9 +14,6 @@ import {
 	updateNode,
 } from './shared'
 
-/**
- * This node is a message from the user.
- */
 export type MessageNode = T.TypeOf<typeof MessageNode>
 export const MessageNode = T.object({
 	type: T.literal('message'),
@@ -40,8 +37,8 @@ export class MessageNodeDefinition extends NodeDefinition<MessageNode> {
 	getBodyWidthPx(_shape: NodeShape, _node: MessageNode): number {
 		return NODE_WIDTH_PX
 	}
-	getBodyHeightPx(_shape: NodeShape, _node: MessageNode): number {
-		const assistantMessage = _node.assistantMessage.trim()
+	getBodyHeightPx(_shape: NodeShape, node: MessageNode): number {
+		const assistantMessage = node.assistantMessage.trim()
 		if (assistantMessage === '') return NODE_HEIGHT_PX
 		const size = this.editor.textMeasure.measureText(assistantMessage, {
 			fontFamily: 'Inter',
@@ -71,43 +68,25 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 	const editor = useEditor()
 
 	const handleSend = useCallback(() => {
-		// 1. gather up parents and create message history
-		// 2. create prompt
-		// 3. send prompt to ai
-		// 4. update node with assistant message
-
+		// Walk upstream through the ancestors to build the message history, oldest first
 		const messages: ModelMessage[] = []
-
-		const connectedNodeShapes = getAllConnectedNodes(editor, shape, 'end')
-		for (const connectedShape of connectedNodeShapes) {
+		for (const connectedShape of getAllConnectedNodes(editor, shape, 'end')) {
 			const node = editor.getShape(connectedShape)
-
-			if (!node) continue
-			if (!editor.isShapeOfType(node, 'node')) continue
+			if (!node || !editor.isShapeOfType(node, 'node')) continue
 			if (node.props.node.type !== 'message') continue
 
 			if (node.props.node.assistantMessage && connectedShape !== shape.id) {
-				messages.push({
-					role: 'assistant',
-					content: node.props.node.assistantMessage ?? '',
-				})
+				messages.push({ role: 'assistant', content: node.props.node.assistantMessage })
 			}
-
-			messages.push({
-				role: 'user',
-				content: node.props.node.userMessage ?? '',
-			})
+			messages.push({ role: 'user', content: node.props.node.userMessage })
 		}
-
 		messages.reverse()
 
-		// clear any previous assistant message before starting
 		updateNode<MessageNode>(editor, shape, (node) => ({
 			...node,
 			assistantMessage: '...',
 		}))
 
-		// stream the response and append as chunks arrive
 		;(async () => {
 			try {
 				const response = await fetch('/stream', {
@@ -154,70 +133,68 @@ function MessageNodeComponent({ node, shape }: NodeComponentProps<MessageNode>) 
 	)
 
 	return (
-		<>
-			<div
-				style={{
-					pointerEvents: 'auto',
-					display: 'flex',
-					flexDirection: 'column',
-				}}
-			>
-				<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-					<div
-						style={{
-							height: '100%',
-							width: 32,
-							paddingLeft: 4,
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-							cursor: 'grab',
-						}}
-					>
-						<TldrawUiButtonIcon icon={<HandleIcon />} />
-					</div>
-					<div
-						style={{ padding: '4px 0px 0px 4px', flexGrow: 2 }}
-						onPointerDown={editor.markEventAsHandled}
-					>
-						<div style={{ padding: '0px 12px', borderRadius: 6, border: '1px solid #e2e8f0' }}>
-							<TldrawUiInput
-								value={node.userMessage}
-								onValueChange={handleMessageChange}
-								onComplete={handleSend}
-							/>
-						</div>
-					</div>
-					<div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0px 0px' }}>
-						<TldrawUiButton
-							type="primary"
-							onClick={handleSend}
-							onPointerDown={editor.markEventAsHandled}
-						>
-							<TldrawUiButtonIcon icon={<SendIcon />} />
-						</TldrawUiButton>
+		<div
+			style={{
+				pointerEvents: 'auto',
+				display: 'flex',
+				flexDirection: 'column',
+			}}
+		>
+			<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+				<div
+					style={{
+						height: '100%',
+						width: 32,
+						paddingLeft: 4,
+						display: 'flex',
+						justifyContent: 'center',
+						alignItems: 'center',
+						cursor: 'grab',
+					}}
+				>
+					<TldrawUiButtonIcon icon={<HandleIcon />} />
+				</div>
+				<div
+					style={{ padding: '4px 0px 0px 4px', flexGrow: 2 }}
+					onPointerDown={editor.markEventAsHandled}
+				>
+					<div style={{ padding: '0px 12px', borderRadius: 6, border: '1px solid #e2e8f0' }}>
+						<TldrawUiInput
+							value={node.userMessage}
+							onValueChange={handleMessageChange}
+							onComplete={handleSend}
+						/>
 					</div>
 				</div>
-				{node.assistantMessage && (
-					<div style={{ padding: 4 }}>
-						<div
-							style={{
-								padding: 8,
-								lineHeight: '1.3',
-								fontSize: '12px',
-								borderRadius: 6,
-								border: '1px solid #e2e8f0',
-								fontWeight: '500',
-								fontFamily: 'Inter',
-								overflowWrap: 'normal',
-								whiteSpace: 'pre-wrap',
-							}}
-						>
-							{node.assistantMessage}
-						</div>
-					</div>
-				)}
+				<div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0px 0px' }}>
+					<TldrawUiButton
+						type="primary"
+						onClick={handleSend}
+						onPointerDown={editor.markEventAsHandled}
+					>
+						<TldrawUiButtonIcon icon={<SendIcon />} />
+					</TldrawUiButton>
+				</div>
 			</div>
-		</>
+			{node.assistantMessage && (
+				<div style={{ padding: 4 }}>
+					<div
+						style={{
+							padding: 8,
+							lineHeight: '1.3',
+							fontSize: '12px',
+							borderRadius: 6,
+							border: '1px solid #e2e8f0',
+							fontWeight: '500',
+							fontFamily: 'Inter',
+							overflowWrap: 'normal',
+							whiteSpace: 'pre-wrap',
+						}}
+					>
+						{node.assistantMessage}
+					</div>
+				</div>
+			)}
+		</div>
 	)
 }

--- a/templates/branching-chat/client/nodes/types/shared.tsx
+++ b/templates/branching-chat/client/nodes/types/shared.tsx
@@ -37,9 +37,6 @@ export interface NodeDefinitionConstructor<Node extends { type: string }> {
 	readonly validator: T.Validator<Node>
 }
 
-/**
- * The standard input port for a node.
- */
 export const shapeInputPort: ShapePort = {
 	id: 'input',
 	terminal: 'end',
@@ -47,9 +44,6 @@ export const shapeInputPort: ShapePort = {
 	y: 0,
 }
 
-/**
- * The standard output port for a node.
- */
 export const shapeOutputPort: ShapePort = {
 	id: 'output',
 	terminal: 'start',
@@ -57,9 +51,6 @@ export const shapeOutputPort: ShapePort = {
 	y: NODE_HEIGHT_PX,
 }
 
-/**
- * Update the `node` prop within a node shape.
- */
 export function updateNode<T extends NodeType>(
 	editor: Editor,
 	shape: NodeShape,

--- a/templates/branching-chat/client/nodes/types/shared.tsx
+++ b/templates/branching-chat/client/nodes/types/shared.tsx
@@ -37,6 +37,9 @@ export interface NodeDefinitionConstructor<Node extends { type: string }> {
 	readonly validator: T.Validator<Node>
 }
 
+/**
+ * The standard input port for a node.
+ */
 export const shapeInputPort: ShapePort = {
 	id: 'input',
 	terminal: 'end',
@@ -44,6 +47,9 @@ export const shapeInputPort: ShapePort = {
 	y: 0,
 }
 
+/**
+ * The standard output port for a node.
+ */
 export const shapeOutputPort: ShapePort = {
 	id: 'output',
 	terminal: 'start',
@@ -51,6 +57,9 @@ export const shapeOutputPort: ShapePort = {
 	y: NODE_HEIGHT_PX,
 }
 
+/**
+ * Update the `node` prop within a node shape.
+ */
 export function updateNode<T extends NodeType>(
 	editor: Editor,
 	shape: NodeShape,

--- a/templates/branching-chat/client/ports/PointingPort.tsx
+++ b/templates/branching-chat/client/ports/PointingPort.tsx
@@ -6,14 +6,15 @@ import { DEFAULT_NODE_SPACING_PX } from '../constants.tsx'
 import { getNodePortConnections } from '../nodes/nodePorts.tsx'
 import { PortId } from './Port.tsx'
 
+// Information about which port is being pointed at
 interface PointingPortInfo {
 	shapeId: TLShapeId
 	portId: PortId
 	terminal: 'start' | 'end'
 }
 
-// Child state of the select tool: entered on pointer down over a port. A drag creates (or moves) a
-// connection; a click on an output port spawns a connected node below.
+// State node that handles pointing at ports to create connections
+// This will be added to tldraw's state machine to customize the built-in select tool
 export class PointingPort extends StateNode {
 	static override id = 'pointing_port'
 
@@ -29,12 +30,15 @@ export class PointingPort extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo): void {
+		// isDragging is true if the user has moved the pointer sufficiently. below this threshold,
+		// we treat the pointer as a click.
 		if (!this.editor.inputs.getIsDragging()) return
 		const { shapeId, portId, terminal: connectingTerminal } = this.info!
 
-		// Only 'start' ports (outputs) can have multiple connections; dragging from an already
-		// connected input moves the existing connection instead of creating a new one.
 		const existingConnection = this.getExistingConnection()
+
+		// If we can't have multiple connections and one already exists, move the existing
+		// connection by transitioning to dragging the existing connection's handle.
 		if (connectingTerminal !== 'start' && existingConnection) {
 			this.parent.transition('dragging_handle', {
 				...info,
@@ -47,6 +51,7 @@ export class PointingPort extends StateNode {
 			return
 		}
 
+		// Otherwise, create a new connection, and start dragging that connection's handle instead.
 		const creatingMarkId = this.editor.markHistoryStoppingPoint()
 		const connectionShapeId = createShapeId()
 		const draggingTerminal = connectingTerminal === 'start' ? 'end' : 'start'
@@ -63,11 +68,14 @@ export class PointingPort extends StateNode {
 				end: { x: 0, y: 0 },
 			},
 		})
+
+		// bind one end of the connection to the port the user pointer-down'd on.
 		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
 			portId,
 			terminal: connectingTerminal,
 		})
 
+		// transition to dragging the other end of the connection:
 		const handle = this.editor
 			.getShapeHandles(connectionShapeId)
 			?.find((h) => h.id === draggingTerminal)
@@ -83,24 +91,33 @@ export class PointingPort extends StateNode {
 	}
 
 	override onPointerUp(info: TLPointerEventInfo): void {
-		// still here on pointer up means we never started dragging, so treat it as a click
+		// if we get a pointer up while we're still in this state, it means we haven't transitioned
+		// into a dragging state so we'll treat this as a click:
 		this.onClick()
+		// switch back to the idle state when we're done:
 		this.parent.transition('idle', info)
 	}
 
+	// Handle clicks on ports (without dragging)
 	private onClick() {
+		// Only handle clicks on start ports (output ports)
 		if (this.info?.terminal !== 'start') return
+
+		// Don't create new connections if one already exists
 		if (this.getExistingConnection()) return
 		const { shapeId, portId } = this.info
 
+		// Get the bounds of the source node
 		const bounds = this.editor.getShapePageBounds(shapeId)
 		if (!bounds) return
 
+		// Calculate position for new node to the right of the source node
 		const targetPositionInPageSpace = {
 			x: bounds.midX,
 			y: bounds.bottom + DEFAULT_NODE_SPACING_PX,
 		}
 
+		// Create a connection shape
 		const connectionShapeId = createShapeId()
 		this.editor.createShape({
 			type: 'connection',
@@ -109,11 +126,14 @@ export class PointingPort extends StateNode {
 			y: bounds.top,
 			index: getNextConnectionIndex(this.editor),
 		})
+
+		// Bind the connection to the source port
 		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
 			portId,
 			terminal: 'start',
 		})
 
+		// Position the connection end point where the new node will be
 		const targetPositionInConnectionSpace = this.editor
 			.getPointInShapeSpace(connectionShapeId, targetPositionInPageSpace)
 			.addXY(0, 200)

--- a/templates/branching-chat/client/ports/PointingPort.tsx
+++ b/templates/branching-chat/client/ports/PointingPort.tsx
@@ -1,19 +1,19 @@
 import { createShapeId, StateNode, TLPointerEventInfo, TLShapeId } from 'tldraw'
 import { createOrUpdateConnectionBinding } from '../connection/ConnectionBindingUtil.tsx'
+import { createNodeAtConnectionEnd } from '../connection/ConnectionShapeUtil.tsx'
 import { getNextConnectionIndex } from '../connection/keepConnectionsAtBottom.tsx'
-import { DEFAULT_NODE_SPACING_PX, NODE_WIDTH_PX } from '../constants.tsx'
-import { getNodePortConnections, getNodePorts } from '../nodes/nodePorts.tsx'
+import { DEFAULT_NODE_SPACING_PX } from '../constants.tsx'
+import { getNodePortConnections } from '../nodes/nodePorts.tsx'
 import { PortId } from './Port.tsx'
 
-// Information about which port is being pointed at
 interface PointingPortInfo {
 	shapeId: TLShapeId
 	portId: PortId
 	terminal: 'start' | 'end'
 }
 
-// State node that handles pointing at ports to create connections
-// This will be added to tldraw's state machine to customize the built-in select tool
+// Child state of the select tool: entered on pointer down over a port. A drag creates (or moves) a
+// connection; a click on an output port spawns a connected node below.
 export class PointingPort extends StateNode {
 	static override id = 'pointing_port'
 
@@ -23,99 +23,84 @@ export class PointingPort extends StateNode {
 		this.info = info
 	}
 
+	private getExistingConnection() {
+		const { shapeId, portId } = this.info!
+		return getNodePortConnections(this.editor, shapeId).find((c) => c.ownPortId === portId)
+	}
+
 	override onPointerMove(info: TLPointerEventInfo): void {
-		// isDragging is true if the user has moved the pointer sufficiently. below this threshold,
-		// we treat the pointer as a click.
-		if (this.editor.inputs.getIsDragging()) {
-			const allowsMultipleConnections = this.info?.terminal === 'start'
-			const hasExistingConnection = getNodePortConnections(this.editor, this.info!.shapeId).find(
-				(c) => c.ownPortId === this.info!.portId
-			)
+		if (!this.editor.inputs.getIsDragging()) return
+		const { shapeId, portId, terminal: connectingTerminal } = this.info!
 
-			// If we can't have multiple connections and one already exists, move the existing
-			// connection by transitioning to dragging the existing connection's handle.
-			if (!allowsMultipleConnections && hasExistingConnection) {
-				this.parent.transition('dragging_handle', {
-					...info,
-					target: 'handle',
-					shape: this.editor.getShape(hasExistingConnection.connectionId)!,
-					handle: this.editor
-						.getShapeHandles(hasExistingConnection.connectionId)!
-						.find((h) => h.id === this.info!.terminal),
-				})
-				return
-			}
-
-			// Otherwise, create a new connection, and start dragging that connection's handle instead.
-			const creatingMarkId = this.editor.markHistoryStoppingPoint()
-			const connectionShapeId = createShapeId()
-			const connectingTerminal = this.info!.terminal
-			const draggingTerminal = connectingTerminal === 'start' ? 'end' : 'start'
-
-			this.editor.createShape({
-				type: 'connection',
-				id: connectionShapeId,
-				x: this.editor.inputs.getCurrentPagePoint().x,
-				y: this.editor.inputs.getCurrentPagePoint().y,
-				index: getNextConnectionIndex(this.editor),
-				props: {
-					start: { x: 0, y: 0 },
-					end: { x: 0, y: 0 },
-				},
-			})
-
-			// bind one end of the connection to the port the user pointer-down'd on.
-			createOrUpdateConnectionBinding(this.editor, connectionShapeId, this.info!.shapeId, {
-				portId: this.info!.portId,
-				terminal: connectingTerminal,
-			})
-
-			// transition to dragging the other end of the connection:
-			const handle = this.editor
-				.getShapeHandles(connectionShapeId)
-				?.find((h) => h.id === draggingTerminal)
-
+		// Only 'start' ports (outputs) can have multiple connections; dragging from an already
+		// connected input moves the existing connection instead of creating a new one.
+		const existingConnection = this.getExistingConnection()
+		if (connectingTerminal !== 'start' && existingConnection) {
 			this.parent.transition('dragging_handle', {
 				...info,
 				target: 'handle',
-				shape: this.editor.getShape(connectionShapeId)!,
-				handle: handle!,
-				creatingMarkId,
-				isCreating: true,
+				shape: this.editor.getShape(existingConnection.connectionId)!,
+				handle: this.editor
+					.getShapeHandles(existingConnection.connectionId)!
+					.find((h) => h.id === connectingTerminal),
 			})
+			return
 		}
+
+		const creatingMarkId = this.editor.markHistoryStoppingPoint()
+		const connectionShapeId = createShapeId()
+		const draggingTerminal = connectingTerminal === 'start' ? 'end' : 'start'
+		const pagePoint = this.editor.inputs.getCurrentPagePoint()
+
+		this.editor.createShape({
+			type: 'connection',
+			id: connectionShapeId,
+			x: pagePoint.x,
+			y: pagePoint.y,
+			index: getNextConnectionIndex(this.editor),
+			props: {
+				start: { x: 0, y: 0 },
+				end: { x: 0, y: 0 },
+			},
+		})
+		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
+			portId,
+			terminal: connectingTerminal,
+		})
+
+		const handle = this.editor
+			.getShapeHandles(connectionShapeId)
+			?.find((h) => h.id === draggingTerminal)
+
+		this.parent.transition('dragging_handle', {
+			...info,
+			target: 'handle',
+			shape: this.editor.getShape(connectionShapeId)!,
+			handle: handle!,
+			creatingMarkId,
+			isCreating: true,
+		})
 	}
 
 	override onPointerUp(info: TLPointerEventInfo): void {
-		// if we get a pointer up while we're still in this state, it means we haven't transitioned
-		// into a dragging state so we'll treat this as a click:
+		// still here on pointer up means we never started dragging, so treat it as a click
 		this.onClick()
-		// switch back to the idle state when we're done:
 		this.parent.transition('idle', info)
 	}
 
-	// Handle clicks on ports (without dragging)
 	private onClick() {
-		// Only handle clicks on start ports (output ports)
 		if (this.info?.terminal !== 'start') return
+		if (this.getExistingConnection()) return
+		const { shapeId, portId } = this.info
 
-		// Don't create new connections if one already exists
-		const hasExistingConnection = getNodePortConnections(this.editor, this.info!.shapeId).find(
-			(c) => c.ownPortId === this.info!.portId
-		)
-		if (hasExistingConnection) return
-
-		// Get the bounds of the source node
-		const bounds = this.editor.getShapePageBounds(this.info!.shapeId)
+		const bounds = this.editor.getShapePageBounds(shapeId)
 		if (!bounds) return
 
-		// Calculate position for new node to the right of the source node
 		const targetPositionInPageSpace = {
 			x: bounds.midX,
 			y: bounds.bottom + DEFAULT_NODE_SPACING_PX,
 		}
 
-		// Create a connection shape
 		const connectionShapeId = createShapeId()
 		this.editor.createShape({
 			type: 'connection',
@@ -124,18 +109,14 @@ export class PointingPort extends StateNode {
 			y: bounds.top,
 			index: getNextConnectionIndex(this.editor),
 		})
-
-		// Bind the connection to the source port
-		createOrUpdateConnectionBinding(this.editor, connectionShapeId, this.info!.shapeId, {
-			portId: this.info!.portId,
+		createOrUpdateConnectionBinding(this.editor, connectionShapeId, shapeId, {
+			portId,
 			terminal: 'start',
 		})
 
-		// Position the connection end point where the new node will be
 		const targetPositionInConnectionSpace = this.editor
 			.getPointInShapeSpace(connectionShapeId, targetPositionInPageSpace)
 			.addXY(0, 200)
-
 		this.editor.updateShape({
 			id: connectionShapeId,
 			type: 'connection',
@@ -144,34 +125,6 @@ export class PointingPort extends StateNode {
 			},
 		})
 
-		const newNodeId = createShapeId()
-		this.editor.createShape({
-			type: 'node',
-			id: newNodeId,
-			x: targetPositionInPageSpace.x - NODE_WIDTH_PX / 2,
-			y: targetPositionInPageSpace.y + 100,
-			props: {
-				node: { type: 'message', userMessage: '', assistantMessage: '' },
-			},
-		})
-		this.editor.select(newNodeId)
-
-		// Position the node so its input port aligns with the connection end
-		const ports = getNodePorts(this.editor, newNodeId)
-		const firstInputPort = Object.values(ports).find((p) => p.terminal === 'end')
-		if (firstInputPort) {
-			this.editor.updateShape({
-				id: newNodeId,
-				type: 'node',
-				x: targetPositionInPageSpace.x - firstInputPort.x,
-				y: targetPositionInPageSpace.y - firstInputPort.y,
-			})
-
-			// Connect the new node to the connection
-			createOrUpdateConnectionBinding(this.editor, connectionShapeId, newNodeId, {
-				portId: firstInputPort.id,
-				terminal: 'end',
-			})
-		}
+		createNodeAtConnectionEnd(this.editor, connectionShapeId, targetPositionInPageSpace)
 	}
 }

--- a/templates/branching-chat/client/ports/Port.tsx
+++ b/templates/branching-chat/client/ports/Port.tsx
@@ -14,16 +14,22 @@ export const shapePort = T.object({
 
 export type ShapePort = T.TypeOf<typeof shapePort>
 
-/** Port ids are only unique within a shape, so identifying a port needs both. */
+/**
+ * Port ids are unique within a shape. To identify a port we need both the shape id and the port id.
+ */
 export interface PortIdentifier {
 	shapeId: TLShapeId
 	portId: PortId
 }
 
+/**
+ * This react component renders a port.
+ */
 export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort }) {
 	const editor = useEditor()
 
-	// the user is dragging a connection over this port
+	// isHinting is true if the user is currently dragging a connection to this port. it means we
+	// should highlight this port.
 	const isHinting = useValue(
 		'isHinting',
 		() => {
@@ -33,7 +39,8 @@ export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort })
 		[editor, shapeId, port.id]
 	)
 
-	// the user is dragging a connection that could be dropped on this port
+	// isEligible is true if the the user is currently dragging a connection, and this port is one
+	// that the connection can be connected to.
 	const isEligible = useValue(
 		'isEligible',
 		() => {
@@ -42,7 +49,8 @@ export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort })
 			if (eligiblePorts.terminal !== port.terminal) return false
 			if (eligiblePorts.excludeNodes?.has(shapeId)) return false
 			if (port.terminal === 'end') {
-				// input ports only accept one connection
+				// if the port is an end port, it can only have one connection, so it's not eligible
+				// when there is a connection
 				const connections = getNodePortConnections(editor, shapeId)
 				return !connections.some((c) => c.ownPortId === port.id)
 			}

--- a/templates/branching-chat/client/ports/Port.tsx
+++ b/templates/branching-chat/client/ports/Port.tsx
@@ -14,23 +14,16 @@ export const shapePort = T.object({
 
 export type ShapePort = T.TypeOf<typeof shapePort>
 
-/**
- * Port ids are unique within a shape. To identify a port we need both the shape id and the port id.
- */
+/** Port ids are only unique within a shape, so identifying a port needs both. */
 export interface PortIdentifier {
 	shapeId: TLShapeId
 	portId: PortId
 }
 
-/**
- * This react component renders a port.
- */
 export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort }) {
 	const editor = useEditor()
-	if (!port) throw new Error(`Port not found on shape ${shapeId}`)
 
-	// isHinting is true if the user is currently dragging a connection to this port. it means we
-	// should highlight this port.
+	// the user is dragging a connection over this port
 	const isHinting = useValue(
 		'isHinting',
 		() => {
@@ -40,18 +33,16 @@ export function Port({ shapeId, port }: { shapeId: TLShapeId; port: ShapePort })
 		[editor, shapeId, port.id]
 	)
 
-	// isEligible is true if the the user is currently dragging a connection, and this port is one
-	// that the connection can be connected to.
+	// the user is dragging a connection that could be dropped on this port
 	const isEligible = useValue(
 		'isEligible',
 		() => {
-			const { eligiblePorts: eligiblePorts } = portState.get(editor)
+			const { eligiblePorts } = portState.get(editor)
 			if (!eligiblePorts) return false
 			if (eligiblePorts.terminal !== port.terminal) return false
 			if (eligiblePorts.excludeNodes?.has(shapeId)) return false
 			if (port.terminal === 'end') {
-				// if the port is an end port, it can only have one connection, so it's not eligible
-				// when there is a connection
+				// input ports only accept one connection
 				const connections = getNodePortConnections(editor, shapeId)
 				return !connections.some((c) => c.ownPortId === port.id)
 			}

--- a/templates/branching-chat/client/ports/getPortAtPoint.tsx
+++ b/templates/branching-chat/client/ports/getPortAtPoint.tsx
@@ -7,16 +7,22 @@ export function getPortAtPoint(
 	point: VecLike,
 	opts?: { terminal?: 'start' | 'end'; margin?: number }
 ) {
+	// find the shape at that point:
 	const shape = editor.getShapeAtPoint(point, {
 		hitInside: true,
+		// only node shapes can have ports
 		filter: (shape) => editor.isShapeOfType(shape, 'node'),
 		...opts,
 	})
 	if (!shape || !editor.isShapeOfType(shape, 'node')) return null
 
+	// get the ports on that shape
 	const ports = getNodePorts(editor, shape)
+
+	// transform the ports to page space
 	const shapeTransform = editor.getShapePageTransform(shape)
 
+	// find the port closest to the point
 	let bestPort: ShapePort | null = null
 	let bestDistance = Infinity
 
@@ -31,8 +37,10 @@ export function getPortAtPoint(
 		}
 	}
 
+	// if we didn't find a port, return null
 	if (!bestPort) return null
 
+	// otherwise, return the port and it's existing connections
 	const existingConnections = getNodePortConnections(editor, shape).filter(
 		(c) => c.ownPortId === bestPort.id
 	)

--- a/templates/branching-chat/client/ports/getPortAtPoint.tsx
+++ b/templates/branching-chat/client/ports/getPortAtPoint.tsx
@@ -7,23 +7,16 @@ export function getPortAtPoint(
 	point: VecLike,
 	opts?: { terminal?: 'start' | 'end'; margin?: number }
 ) {
-	// find the shape at that point:
 	const shape = editor.getShapeAtPoint(point, {
 		hitInside: true,
-		// only node shapes can have ports
 		filter: (shape) => editor.isShapeOfType(shape, 'node'),
 		...opts,
 	})
 	if (!shape || !editor.isShapeOfType(shape, 'node')) return null
 
-	// get the ports on that shape
 	const ports = getNodePorts(editor, shape)
-	if (!ports) return null
-
-	// transform the ports to page space
 	const shapeTransform = editor.getShapePageTransform(shape)
 
-	// find the port closest to the point
 	let bestPort: ShapePort | null = null
 	let bestDistance = Infinity
 
@@ -38,10 +31,8 @@ export function getPortAtPoint(
 		}
 	}
 
-	// if we didn't find a port, return null
 	if (!bestPort) return null
 
-	// otherwise, return the port and it's existing connections
 	const existingConnections = getNodePortConnections(editor, shape).filter(
 		(c) => c.ownPortId === bestPort.id
 	)

--- a/templates/branching-chat/client/ports/portState.ts
+++ b/templates/branching-chat/client/ports/portState.ts
@@ -1,11 +1,13 @@
 import { Editor, EditorAtom, TLShapeId } from 'tldraw'
 import { PortIdentifier } from './Port'
 
-/** UI state highlighting the ports relevant to the user's current drag. */
+/**
+ * The UI state for ports. These mostly highlight ports relevant to the user's current action.
+ */
 export interface PortState {
-	// the port a connection is currently being dragged over
+	// hintingPort is the port that the user is currently dragging a connection to.
 	hintingPort: PortIdentifier | null
-	// which ports the dragged connection could be dropped on
+	// eligiblePorts is the set of ports that the user can connect a new connection to.
 	eligiblePorts: {
 		terminal: 'start' | 'end'
 		excludeNodes: Set<TLShapeId> | null

--- a/templates/branching-chat/client/ports/portState.ts
+++ b/templates/branching-chat/client/ports/portState.ts
@@ -1,13 +1,11 @@
 import { Editor, EditorAtom, TLShapeId } from 'tldraw'
 import { PortIdentifier } from './Port'
 
-/**
- * The UI state for ports. These mostly highlight ports relevant to the user's current action.
- */
+/** UI state highlighting the ports relevant to the user's current drag. */
 export interface PortState {
-	// hintingPort is the port that the user is currently dragging a connection to.
+	// the port a connection is currently being dragged over
 	hintingPort: PortIdentifier | null
-	// eligiblePorts is the set of ports that the user can connect a new connection to.
+	// which ports the dragged connection could be dropped on
 	eligiblePorts: {
 		terminal: 'start' | 'end'
 		excludeNodes: Set<TLShapeId> | null
@@ -20,8 +18,5 @@ export const portState = new EditorAtom<PortState>('port state', () => ({
 }))
 
 export function updatePortState(editor: Editor, update: Partial<PortState>) {
-	portState.update(editor, (state) => {
-		const newState = { ...state, ...update }
-		return newState
-	})
+	portState.update(editor, (state) => ({ ...state, ...update }))
 }

--- a/templates/branching-chat/worker/worker.ts
+++ b/templates/branching-chat/worker/worker.ts
@@ -5,7 +5,8 @@ import { WorkerEntrypoint } from 'cloudflare:workers'
 import { AutoRouter, error, IRequest } from 'itty-router'
 import { Environment } from './types'
 
-// Worker (handles AI requests directly)
+const MODEL_ID = 'gemini-3-flash-preview'
+
 export default class extends WorkerEntrypoint<Environment> {
 	private readonly router = AutoRouter<IRequest, [env: Environment, ctx: ExecutionContext]>({
 		catch: (e) => {
@@ -21,25 +22,21 @@ export default class extends WorkerEntrypoint<Environment> {
 	}
 
 	private getModel(env: Environment) {
-		return createGoogleGenerativeAI({
-			apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
-		})
+		return createGoogleGenerativeAI({ apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY })(MODEL_ID)
 	}
 
-	// Generate a new response from the model
 	private async generate(request: IRequest, env: Environment) {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>
 			const { text } = await generateText({
-				model: this.getModel(env)('gemini-3-flash-preview'),
+				model: this.getModel(env),
 				messages: prompt,
 			})
 
-			// Send back the response as a JSON object
 			return new Response(text, {
 				headers: { 'Content-Type': 'application/json' },
 			})
-		} catch (error: any) {
+		} catch (error) {
 			console.error('AI response error:', error)
 			return new Response('An internal server error occurred.', {
 				status: 500,
@@ -47,13 +44,12 @@ export default class extends WorkerEntrypoint<Environment> {
 		}
 	}
 
-	// Stream a new response from the model
 	private async stream(request: IRequest, env: Environment): Promise<Response> {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>
 
 			const result = streamText({
-				model: this.getModel(env)('gemini-3-flash-preview'),
+				model: this.getModel(env),
 				messages: prompt,
 				experimental_transform: smoothStream(),
 			})

--- a/templates/branching-chat/worker/worker.ts
+++ b/templates/branching-chat/worker/worker.ts
@@ -7,6 +7,7 @@ import { Environment } from './types'
 
 const MODEL_ID = 'gemini-3-flash-preview'
 
+// Worker (handles AI requests directly)
 export default class extends WorkerEntrypoint<Environment> {
 	private readonly router = AutoRouter<IRequest, [env: Environment, ctx: ExecutionContext]>({
 		catch: (e) => {
@@ -25,6 +26,7 @@ export default class extends WorkerEntrypoint<Environment> {
 		return createGoogleGenerativeAI({ apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY })(MODEL_ID)
 	}
 
+	// Generate a new response from the model
 	private async generate(request: IRequest, env: Environment) {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>
@@ -33,6 +35,7 @@ export default class extends WorkerEntrypoint<Environment> {
 				messages: prompt,
 			})
 
+			// Send back the response as a JSON object
 			return new Response(text, {
 				headers: { 'Content-Type': 'application/json' },
 			})
@@ -44,6 +47,7 @@ export default class extends WorkerEntrypoint<Environment> {
 		}
 	}
 
+	// Stream a new response from the model
 	private async stream(request: IRequest, env: Environment): Promise<Response> {
 		try {
 			const prompt = (await request.json()) as Array<ModelMessage>


### PR DESCRIPTION
In order to make the branching-chat starter template easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `templates/branching-chat` and applies the fixes. It is the branching-chat slice of #10068, split out so it can be reviewed on its own. Behavior is intended to be preserved: it deduplicates helpers, deletes dead code, and trims comment density to what template code needs per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` passes.
2. `yarn dev-template branching-chat` and smoke the template.

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Templates | +280 / -575 |
