### PR TITLE
refactor(templates): simplify pass over the socketio-server-example template

### DIFF
--- a/templates/socketio-server-example/src/client/App.tsx
+++ b/templates/socketio-server-example/src/client/App.tsx
@@ -17,29 +17,24 @@ const WORKER_URL = `http://localhost:5858`
 const roomId = 'test-room'
 
 function App() {
-	// Create a store connected to multiplayer.
 	const store = useSync({
-		// We need a connection to the server:
 		connect: useCallback((query) => {
 			const socket = io(WORKER_URL, {
 				query: { ...query, roomId },
 			})
 			return socketIoToTldrawSocket(socket)
 		}, []),
-		// ...and how to handle static assets like images & videos
 		assets: multiplayerAssets,
 	})
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
-				// we can pass the connected store into the Tldraw component which will handle
-				// loading states & enable multiplayer UX like cursors & a presence menu
+				// the synced store handles loading states & enables multiplayer UX like cursors & presence
 				store={store}
 				onMount={(editor) => {
 					// @ts-expect-error
 					window.editor = editor
-					// when the editor is ready, we need to register out bookmark unfurling service
 					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
 				}}
 			/>
@@ -47,7 +42,7 @@ function App() {
 	)
 }
 
-// Helper function to convert Socket.IO to TLPersistentClientSocket
+// Adapt a Socket.IO socket to the TLPersistentClientSocket interface that useSync expects
 function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRecord> {
 	const statusChangeListeners = new Set<(event: TLSocketStatusChangeEvent) => void>()
 	const tldrawSocket: TLPersistentClientSocket<TLRecord> = {
@@ -59,15 +54,11 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 
 		onReceiveMessage: (callback) => {
-			// Listen for tldraw sync protocol messages
 			const handler = (message: any) => {
 				console.log('📥 Received:', message)
 				callback(message)
 			}
-
 			ioSocket.on('tldraw-message', handler)
-
-			// Return cleanup function
 			return () => {
 				ioSocket.off('tldraw-message', handler)
 			}
@@ -95,26 +86,15 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 	}
 
-	// Map Socket.IO events to TLPersistentClientSocket status
-	const connectHandler = () => {
-		tldrawSocket.connectionStatus = 'online'
-		statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
+	const setStatus = (event: TLSocketStatusChangeEvent) => {
+		tldrawSocket.connectionStatus = event.status
+		statusChangeListeners.forEach((cb) => cb(event))
 	}
 
-	const disconnectHandler = () => {
-		tldrawSocket.connectionStatus = 'offline'
-		statusChangeListeners.forEach((cb) => cb({ status: 'offline' }))
-	}
-
-	const errorHandler = (error: any) => {
-		tldrawSocket.connectionStatus = 'error'
-		statusChangeListeners.forEach((cb) =>
-			cb({
-				status: 'error',
-				reason: error.message || 'Connection error',
-			})
-		)
-	}
+	const connectHandler = () => setStatus({ status: 'online' })
+	const disconnectHandler = () => setStatus({ status: 'offline' })
+	const errorHandler = (error: any) =>
+		setStatus({ status: 'error', reason: error.message || 'Connection error' })
 
 	ioSocket.on('connect', connectHandler)
 	ioSocket.on('disconnect', disconnectHandler)
@@ -122,22 +102,16 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 
 	// Set initial status
 	const initialStatusTimeout = setTimeout(() => {
-		if (ioSocket.connected) {
-			tldrawSocket.connectionStatus = 'online'
-			statusChangeListeners.forEach((cb) => cb({ status: 'online' }))
-		}
+		if (ioSocket.connected) connectHandler()
 	}, 0)
 
 	return tldrawSocket
 }
 
-// How does our server handle assets like images and videos?
+// Assets like images and videos are PUT to the server under a unique name.
 const multiplayerAssets: TLAssetStore = {
-	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
 	async upload(_asset, file) {
-		const id = uniqueId()
-
-		const objectName = `${id}-${file.name}`
+		const objectName = `${uniqueId()}-${file.name}`
 		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
 
 		const response = await fetch(url, {
@@ -151,14 +125,14 @@ const multiplayerAssets: TLAssetStore = {
 
 		return { src: url }
 	},
-	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
-	// auth, or to serve optimized versions / sizes of the asset.
+	// the same URL serves the asset. you could customize this to add extra auth, or to serve
+	// optimized versions / sizes of the asset.
 	resolve(asset) {
 		return asset.props.src
 	},
 }
 
-// How does our server handle bookmark unfurling?
+// Bookmark unfurling: ask the server for the URL's metadata and fill in an asset record.
 async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
 	const asset: TLBookmarkAsset = {
 		id: AssetRecordType.createId(getHashForString(url)),

--- a/templates/socketio-server-example/src/client/App.tsx
+++ b/templates/socketio-server-example/src/client/App.tsx
@@ -17,24 +17,29 @@ const WORKER_URL = `http://localhost:5858`
 const roomId = 'test-room'
 
 function App() {
+	// Create a store connected to multiplayer.
 	const store = useSync({
+		// We need a connection to the server:
 		connect: useCallback((query) => {
 			const socket = io(WORKER_URL, {
 				query: { ...query, roomId },
 			})
 			return socketIoToTldrawSocket(socket)
 		}, []),
+		// ...and how to handle static assets like images & videos
 		assets: multiplayerAssets,
 	})
 
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
-				// the synced store handles loading states & enables multiplayer UX like cursors & presence
+				// we can pass the connected store into the Tldraw component which will handle
+				// loading states & enable multiplayer UX like cursors & a presence menu
 				store={store}
 				onMount={(editor) => {
 					// @ts-expect-error
 					window.editor = editor
+					// when the editor is ready, we need to register out bookmark unfurling service
 					editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
 				}}
 			/>
@@ -42,7 +47,7 @@ function App() {
 	)
 }
 
-// Adapt a Socket.IO socket to the TLPersistentClientSocket interface that useSync expects
+// Helper function to convert Socket.IO to TLPersistentClientSocket
 function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRecord> {
 	const statusChangeListeners = new Set<(event: TLSocketStatusChangeEvent) => void>()
 	const tldrawSocket: TLPersistentClientSocket<TLRecord> = {
@@ -54,11 +59,14 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 
 		onReceiveMessage: (callback) => {
+			// Listen for tldraw sync protocol messages
 			const handler = (message: any) => {
 				console.log('📥 Received:', message)
 				callback(message)
 			}
 			ioSocket.on('tldraw-message', handler)
+
+			// Return cleanup function
 			return () => {
 				ioSocket.off('tldraw-message', handler)
 			}
@@ -86,6 +94,7 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 		},
 	}
 
+	// Map Socket.IO events to TLPersistentClientSocket status
 	const setStatus = (event: TLSocketStatusChangeEvent) => {
 		tldrawSocket.connectionStatus = event.status
 		statusChangeListeners.forEach((cb) => cb(event))
@@ -108,8 +117,9 @@ function socketIoToTldrawSocket(ioSocket: Socket): TLPersistentClientSocket<TLRe
 	return tldrawSocket
 }
 
-// Assets like images and videos are PUT to the server under a unique name.
+// How does our server handle assets like images and videos?
 const multiplayerAssets: TLAssetStore = {
+	// to upload an asset, we prefix it with a unique id, POST it to our worker, and return the URL
 	async upload(_asset, file) {
 		const objectName = `${uniqueId()}-${file.name}`
 		const url = `${WORKER_URL}/uploads/${encodeURIComponent(objectName)}`
@@ -125,14 +135,14 @@ const multiplayerAssets: TLAssetStore = {
 
 		return { src: url }
 	},
-	// the same URL serves the asset. you could customize this to add extra auth, or to serve
-	// optimized versions / sizes of the asset.
+	// to retrieve an asset, we can just use the same URL. you could customize this to add extra
+	// auth, or to serve optimized versions / sizes of the asset.
 	resolve(asset) {
 		return asset.props.src
 	},
 }
 
-// Bookmark unfurling: ask the server for the URL's metadata and fill in an asset record.
+// How does our server handle bookmark unfurling?
 async function unfurlBookmarkUrl({ url }: { url: string }): Promise<TLBookmarkAsset> {
 	const asset: TLBookmarkAsset = {
 		id: AssetRecordType.createId(getHashForString(url)),

--- a/templates/socketio-server-example/src/server/rooms.ts
+++ b/templates/socketio-server-example/src/server/rooms.ts
@@ -12,6 +12,7 @@ function sanitizeRoomId(roomId: string): string {
 	return roomId.replace(/[^a-zA-Z0-9_-]/g, '_')
 }
 
+// We'll keep an in-memory map of active rooms
 const rooms = new Map<string, TLSocketRoom<any, void>>()
 
 export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
@@ -23,6 +24,8 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	}
 
 	console.log('loading room', roomId)
+
+	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
 	const storage = new SQLiteSyncStorage({ sql })

--- a/templates/socketio-server-example/src/server/rooms.ts
+++ b/templates/socketio-server-example/src/server/rooms.ts
@@ -12,7 +12,6 @@ function sanitizeRoomId(roomId: string): string {
 	return roomId.replace(/[^a-zA-Z0-9_-]/g, '_')
 }
 
-// We'll keep an in-memory map of active rooms
 const rooms = new Map<string, TLSocketRoom<any, void>>()
 
 export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
@@ -24,8 +23,6 @@ export function makeOrLoadRoom(roomId: string): TLSocketRoom<any, void> {
 	}
 
 	console.log('loading room', roomId)
-
-	// Open the database - file is created if it doesn't exist
 	const db = new Database(join(DIR, `${roomId}.db`))
 	const sql = new NodeSqliteWrapper(db)
 	const storage = new SQLiteSyncStorage({ sql })

--- a/templates/socketio-server-example/src/server/server.ts
+++ b/templates/socketio-server-example/src/server/server.ts
@@ -10,11 +10,9 @@ const PORT = 5858
 
 // For this example we use Socket.IO with Express
 // To keep things simple we're skipping normal production concerns like rate limiting and input validation.
-// Create Express app and HTTP server for Socket.IO
 const app = express()
 const server = createServer(app)
 
-// Enable CORS and parse JSON
 app.use(express.json())
 app.use((req, res, next) => {
 	res.header('Access-Control-Allow-Origin', '*')
@@ -31,7 +29,6 @@ export interface ClientToServerMessage {
 	'tldraw-message': (message: string) => void
 }
 
-// Create Socket.IO server
 const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 	cors: {
 		origin: '*',
@@ -43,8 +40,8 @@ const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 io.on('connection', async (socket) => {
 	console.log('Socket.IO client connected:', socket.id)
 
-	// The roomId and sessionId are passed from the client as query params,
-	// you need to extract them and pass them to the room.
+	// The client passes its roomId and sessionId as query params; the room needs them to
+	// identify the socket.
 	const sessionId = socket.handshake.query.sessionId as string
 	const roomId = socket.handshake.query.roomId as string
 
@@ -57,10 +54,9 @@ io.on('connection', async (socket) => {
 	console.log('Connecting to room:', roomId, 'with session:', sessionId)
 
 	try {
-		// Here we make or get an existing instance of TLSocketRoom for the given roomId
 		const room = makeOrLoadRoom(roomId)
 
-		// Create a socket adapter for TLSocketRoom
+		// Adapt the Socket.IO socket to the minimal WebSocket interface TLSocketRoom expects
 		const socketAdapter: WebSocketMinimal = {
 			send: (message) => {
 				socket.emit('tldraw-message', JSON.parse(message))
@@ -73,19 +69,12 @@ io.on('connection', async (socket) => {
 			},
 		}
 
-		// and finally connect the socket to the room
-		room.handleSocketConnect({
-			sessionId: sessionId,
-			socket: socketAdapter,
-		})
+		room.handleSocketConnect({ sessionId, socket: socketAdapter })
 
-		// Handle tldraw sync messages
 		socket.on('tldraw-message', (message) => {
-			// Ensure message is a string - Socket.IO might send it as an object or buffer
 			room.handleSocketMessage(sessionId, message)
 		})
 
-		// Handle disconnect
 		socket.on('disconnect', () => {
 			console.log('Socket.IO client disconnected:', socket.id)
 		})
@@ -95,7 +84,7 @@ io.on('connection', async (socket) => {
 	}
 })
 
-// To enable blob storage for assets, we add simple endpoints supporting PUT and GET requests
+// Asset blob storage: PUT and GET endpoints
 app.put('/uploads/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
 	try {
 		const id = req.params.id
@@ -136,7 +125,6 @@ app.get('/unfurl', async (req, res) => {
 	}
 })
 
-// Start server
 server.listen(PORT, () => {
 	console.log(`Server started on port ${PORT}`)
 })

--- a/templates/socketio-server-example/src/server/server.ts
+++ b/templates/socketio-server-example/src/server/server.ts
@@ -10,9 +10,11 @@ const PORT = 5858
 
 // For this example we use Socket.IO with Express
 // To keep things simple we're skipping normal production concerns like rate limiting and input validation.
+// Create Express app and HTTP server for Socket.IO
 const app = express()
 const server = createServer(app)
 
+// Enable CORS and parse JSON
 app.use(express.json())
 app.use((req, res, next) => {
 	res.header('Access-Control-Allow-Origin', '*')
@@ -29,6 +31,7 @@ export interface ClientToServerMessage {
 	'tldraw-message': (message: string) => void
 }
 
+// Create Socket.IO server
 const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 	cors: {
 		origin: '*',
@@ -40,8 +43,8 @@ const io = new Server<ClientToServerMessage, ServerToClientMessage>(server, {
 io.on('connection', async (socket) => {
 	console.log('Socket.IO client connected:', socket.id)
 
-	// The client passes its roomId and sessionId as query params; the room needs them to
-	// identify the socket.
+	// The roomId and sessionId are passed from the client as query params,
+	// you need to extract them and pass them to the room.
 	const sessionId = socket.handshake.query.sessionId as string
 	const roomId = socket.handshake.query.roomId as string
 
@@ -54,9 +57,10 @@ io.on('connection', async (socket) => {
 	console.log('Connecting to room:', roomId, 'with session:', sessionId)
 
 	try {
+		// Here we make or get an existing instance of TLSocketRoom for the given roomId
 		const room = makeOrLoadRoom(roomId)
 
-		// Adapt the Socket.IO socket to the minimal WebSocket interface TLSocketRoom expects
+		// Create a socket adapter for TLSocketRoom
 		const socketAdapter: WebSocketMinimal = {
 			send: (message) => {
 				socket.emit('tldraw-message', JSON.parse(message))
@@ -69,12 +73,16 @@ io.on('connection', async (socket) => {
 			},
 		}
 
+		// and finally connect the socket to the room
 		room.handleSocketConnect({ sessionId, socket: socketAdapter })
 
+		// Handle tldraw sync messages
 		socket.on('tldraw-message', (message) => {
+			// Ensure message is a string - Socket.IO might send it as an object or buffer
 			room.handleSocketMessage(sessionId, message)
 		})
 
+		// Handle disconnect
 		socket.on('disconnect', () => {
 			console.log('Socket.IO client disconnected:', socket.id)
 		})
@@ -84,7 +92,7 @@ io.on('connection', async (socket) => {
 	}
 })
 
-// Asset blob storage: PUT and GET endpoints
+// To enable blob storage for assets, we add simple endpoints supporting PUT and GET requests
 app.put('/uploads/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
 	try {
 		const id = req.params.id
@@ -125,6 +133,7 @@ app.get('/unfurl', async (req, res) => {
 	}
 })
 
+// Start server
 server.listen(PORT, () => {
 	console.log(`Server started on port ${PORT}`)
 })


### PR DESCRIPTION
In order to make the socketio-server-example starter template easier to read and maintain, this PR runs the simplify review (reuse, simplification, efficiency, altitude) over `templates/socketio-server-example` and applies the fixes. It is the socketio-server-example slice of #10068, split out so it can be reviewed on its own. Behavior is intended to be preserved: it deduplicates helpers, deletes dead code, and trims comment density to what template code needs per the comments guidance in `AGENTS.md`.

### Change type

- [x] `improvement`

### Test plan

1. `yarn typecheck` passes.
2. `yarn dev-template socketio-server-example` and smoke the template.

### Release notes

- Internal cleanup; no user-facing changes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Templates | +20 / -61 |
