### PR TITLE
fix(sync): harden sync engine against reconnect races, rollback leaks, and data loss

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -594,7 +594,11 @@ export class TLFileDurableObject extends DurableObject {
 		const attachment = this.getSocketAttachment(ws)
 		if (!attachment?.sessionId) return
 
-		this.sessionIdToWs.delete(attachment.sessionId)
+		// only forget the mapping if it still points at this socket: a reconnect under the same
+		// session id may already have replaced it
+		if (this.sessionIdToWs.get(attachment.sessionId) === ws) {
+			this.sessionIdToWs.delete(attachment.sessionId)
+		}
 		if (!this._documentInfo) return
 
 		try {
@@ -611,7 +615,8 @@ export class TLFileDurableObject extends DurableObject {
 				})
 			}
 
-			room[method](attachment.sessionId)
+			// pass the socket so a close from a superseded socket can't cancel a reconnected session
+			room[method](attachment.sessionId, ws)
 		} catch (e) {
 			if (e instanceof RoomNotFoundError) {
 				// The socket is already closing/closed; nothing left to clean up on the room side.

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -239,4 +239,40 @@ describe('LocalIndexedDb', () => {
 			(await window.indexedDB.databases()).find((db) => db.name === 'TLDRAW_ASSET_STORE_v1test-0')
 		).toBeUndefined()
 	})
+
+	describe('#close', () => {
+		it('lets a write that is in flight finish instead of rolling it back', async () => {
+			const db = new LocalIndexedDb('test-0')
+			// start the write and close before it settles (as unmounting right after an edit does)
+			const write = db.storeChanges({
+				schema,
+				changes: {
+					added: { 'shape:1': { id: 'shape:1', type: 'rectangle' } },
+					updated: {},
+					removed: {},
+				},
+			})
+			const closed = db.close()
+			await write
+			await closed
+
+			const reopened = new LocalIndexedDb('test-0')
+			expect((await reopened.load()).records).toEqual([{ id: 'shape:1', type: 'rectangle' }])
+			await reopened.close()
+		})
+
+		it('resolves and releases the instance even when the database never opened', async () => {
+			const openSpy = vi.spyOn(window.indexedDB, 'open').mockImplementation(() => {
+				throw new Error('backing store unavailable')
+			})
+			try {
+				const db = new LocalIndexedDb('test-broken')
+				await expect(db.load()).rejects.toThrow('backing store unavailable')
+				await expect(db.close()).resolves.toBeUndefined()
+				expect(LocalIndexedDb.connectedInstances.has(db)).toBe(false)
+			} finally {
+				openSpy.mockRestore()
+			}
+		})
+	})
 })

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -128,7 +128,12 @@ export class LocalIndexedDb {
 		if (this.isClosed) return
 		this.isClosed = true
 		await this.pending()
-		;(await this.getDb()).close()
+		try {
+			;(await this.getDb()).close()
+		} catch {
+			// the database never opened, so there is nothing to close — but the instance must
+			// still be released, or hardReset() would abort on it before deleting anything
+		}
 		LocalIndexedDb.connectedInstances.delete(this)
 	}
 
@@ -152,15 +157,18 @@ export class LocalIndexedDb {
 			try {
 				return await cb(tx)
 			} finally {
-				if (!this.isClosed) {
-					await done
-				} else {
-					tx.abort()
-				}
+				// Always let the transaction finish, even when close() has been called meanwhile:
+				// close() waits for pending transactions before closing the database, and aborting
+				// here would roll back a write (e.g. the last persist before unmount) whose promise
+				// then resolved as if it had succeeded.
+				await done
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise))
+		// `.finally` would return a promise that rejects alongside txPromise and that nobody
+		// handles, surfacing every failed write as an unhandled rejection on top of the real one
+		const untrack = () => this.pendingTransactionSet.delete(txPromise)
+		txPromise.then(untrack, untrack)
 		return txPromise
 	}
 
@@ -208,31 +216,21 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
+			// issue every request up front and settle them together: awaiting each one would
+			// serialize the writes on the request's success event (see the idb readme)
+			const requests: Promise<unknown>[] = []
 			for (const [id, record] of Object.entries(changes.added)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
-
 			for (const [_prev, updated] of Object.values(changes.updated)) {
-				await recordsStore.put(updated, updated.id)
+				requests.push(recordsStore.put(updated, updated.id))
 			}
-
 			for (const id of Object.keys(changes.removed)) {
-				await recordsStore.delete(id)
+				requests.push(recordsStore.delete(id))
 			}
-
-			schemaStore.put(schema.serialize(), Table.Schema)
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			requests.push(schemaStore.put(schema.serialize(), Table.Schema))
+			requests.push(...putSessionState(sessionStateStore, sessionId, sessionStateSnapshot))
+			await Promise.all(requests)
 		})
 	}
 
@@ -252,26 +250,13 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
-			await recordsStore.clear()
-
+			const requests: Promise<unknown>[] = [recordsStore.clear()]
 			for (const [id, record] of Object.entries(snapshot)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
-
-			schemaStore.put(schema.serialize(), Table.Schema)
-
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			requests.push(schemaStore.put(schema.serialize(), Table.Schema))
+			requests.push(...putSessionState(sessionStateStore, sessionId, sessionStateSnapshot))
+			await Promise.all(requests)
 		})
 	}
 
@@ -307,11 +292,34 @@ export class LocalIndexedDb {
 	async removeAssets(assetId: string[]) {
 		await this.tx('readwrite', [Table.Assets], async (tx) => {
 			const assetsStore = tx.objectStore(Table.Assets)
-			for (const id of assetId) {
-				await assetsStore.delete(id)
-			}
+			await Promise.all(assetId.map((id) => assetsStore.delete(id)))
 		})
 	}
+}
+
+function putSessionState(
+	sessionStateStore: {
+		put(value: SessionStateSnapshotRow, key: string): Promise<unknown>
+	},
+	sessionId: string | null | undefined,
+	sessionStateSnapshot: TLSessionStateSnapshot | null | undefined
+): Promise<unknown>[] {
+	if (sessionStateSnapshot && sessionId) {
+		return [
+			sessionStateStore.put(
+				{
+					snapshot: sessionStateSnapshot,
+					updatedAt: Date.now(),
+					id: sessionId,
+				} satisfies SessionStateSnapshotRow,
+				sessionId
+			),
+		]
+	}
+	if (sessionStateSnapshot || sessionId) {
+		console.error('sessionStateSnapshot and sessionId must be provided together')
+	}
+	return []
 }
 
 /** @internal */

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -172,3 +172,104 @@ test('writes that come in during a persist operation will get persisted afterwar
 	await tick()
 	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
 })
+
+test('a diff broadcast by another tab while the initial load is in flight is applied once loading finishes', async () => {
+	const { client, store, channel, tick } = testClient()
+	// nothing has loaded yet, but the channel is already listened to
+	expect(channel.onmessage).toBeDefined()
+	const page = PageRecordType.create({ name: 'from other tab', index: 'a5' as IndexKey })
+	channel.onmessage!({
+		data: {
+			type: 'diff',
+			storeId: 'other',
+			schema: client.serializedSchema,
+			changes: { added: { [page.id]: page }, updated: {}, removed: {} },
+		},
+	} as any)
+	expect(store.get(page.id)).toBeUndefined()
+
+	await tick()
+	// once loaded, the held-back diff is applied — the first (full snapshot) write must not
+	// erase what the other tab persisted meanwhile
+	expect(store.get(page.id)).toEqual(page)
+})
+
+test('a tab that reports a schema mismatch on load stops writing to the database', async () => {
+	const { client, channel, onLoadError, tick } = testClient()
+	await tick()
+	channel.onmessage?.({
+		data: {
+			type: 'announce',
+			schema: {
+				...client.serializedSchema,
+				schemaVersion: client.serializedSchema.schemaVersion + 1,
+			},
+		},
+	} as any)
+	expect(onLoadError).toHaveBeenCalled()
+
+	client.store.put([PageRecordType.create({ name: 'stale', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
+test('close() writes out changes that are still queued behind the persist throttle', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'last edit', index: 'a0' as IndexKey })])
+	// no throttle tick has elapsed yet
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+
+	client.close()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+})
+
+test('close() while a write is in flight still writes the edits queued behind it before closing the db', async () => {
+	const inFlightWrite = promiseWithResolve<void>()
+	const { client, tick } = testClient()
+	client.db.storeSnapshot.mockImplementationOnce(() => inFlightWrite)
+	await tick()
+
+	client.store.put([PageRecordType.create({ name: 'first', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1) // in flight
+	client.store.put([PageRecordType.create({ name: 'during write', index: 'a1' as IndexKey })])
+
+	const dbCloseSpy = vi.spyOn(client.db, 'close')
+	client.close()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+	expect(dbCloseSpy).not.toHaveBeenCalled()
+
+	inFlightWrite.resolve()
+	await tick()
+	// the queued edit was written once the in-flight write finished, then the db was closed
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	for (let i = 0; i < 10; i++) await Promise.resolve()
+	expect(dbCloseSpy).toHaveBeenCalledTimes(1)
+})
+
+test('a schema mismatch reported by a message held back during load is not overridden by onLoad', async () => {
+	const { client, channel, onLoad, onLoadError, tick } = testClient()
+	channel.onmessage!({
+		data: {
+			type: 'announce',
+			schema: {
+				...client.serializedSchema,
+				schemaVersion: client.serializedSchema.schemaVersion + 1,
+			},
+		},
+	} as any)
+	await tick()
+	expect(onLoadError).toHaveBeenCalledTimes(1)
+	expect(onLoad).not.toHaveBeenCalled()
+})
+
+test('close() before the initial load has finished never writes', async () => {
+	const { client } = testClient()
+	client.store.put([PageRecordType.create({ name: 'too early', index: 'a0' as IndexKey })])
+	client.close()
+	// a full-snapshot write of a not-yet-loaded store would wipe the saved document
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -68,6 +68,7 @@ export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
 	private diffQueue: Array<RecordsDiff<UnknownRecord> | typeof UPDATE_INSTANCE_STATE> = []
 	private didDispose = false
+	private didLoad = false
 	private shouldDoFullDBWrite = true
 	private isReloading = false
 	readonly persistenceKey: string
@@ -107,7 +108,6 @@ export class TLLocalSyncClient {
 		this.persistenceKey = persistenceKey
 		this.sessionId = sessionId
 		this.db = new LocalIndexedDb(persistenceKey)
-		this.disposables.add(() => this.db.close())
 
 		this.serializedSchema = this.store.schema.serialize()
 		this.$sessionStateSnapshot = createSessionStateSnapshotSignal(this.store)
@@ -156,6 +156,18 @@ export class TLLocalSyncClient {
 		this.debug('connecting')
 		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
 
+		// Listen from the start and hold messages until we have loaded. A diff another tab
+		// broadcasts while our load is in flight may not be in what we read (that tab persists on
+		// a throttle), and our first persist is a full snapshot write — so if we missed it here it
+		// would be erased from IndexedDB for good. Re-applying one we did read is a no-op.
+		const messagesReceivedWhileLoading: MessageEvent[] = []
+		this.channel.onmessage = (event) => {
+			messagesReceivedWhileLoading.push(event)
+		}
+		this.disposables.add(() => {
+			this.channel.close()
+		})
+
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
 		} catch (error: any) {
@@ -201,8 +213,11 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			this.didLoad = true
+			// anything queued while loading was held back by persistIfNeeded; write it now
+			if (this.diffQueue.length > 0) this.schedulePersist()
 
-			this.channel.onmessage = ({ data }) => {
+			const handleMessage = ({ data }: MessageEvent) => {
 				this.debug('got message', data)
 				const msg = data as Message
 				// if their schema is earlier than ours, we need to tell them so they can refresh
@@ -219,6 +234,10 @@ export class TLLocalSyncClient {
 						// the schema version (which we should never do)
 						// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
 						// check out an older commit. Dev server should be fine.
+						//
+						// Either way this tab must stop writing: persisting its older schema over the
+						// newer tab's records would corrupt the next load.
+						this.isReloading = true
 						onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
 						return
 					}
@@ -245,10 +264,14 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			this.channel.onmessage = handleMessage
+			for (const event of messagesReceivedWhileLoading) {
+				handleMessage(event)
+			}
+			// a held-back message may have found us out of date (onLoadError already reported it, or
+			// the page is reloading); don't report a successful load on top of that
+			if (this.isReloading) return
 			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-			this.disposables.add(() => {
-				this.channel.close()
-			})
 			onLoad(this)
 		} catch (e: any) {
 			this.debug('error loading data from store', e)
@@ -260,14 +283,39 @@ export class TLLocalSyncClient {
 
 	close() {
 		this.debug('closing')
+		if (this.scheduledPersistTimeout) {
+			clearTimeout(this.scheduledPersistTimeout)
+			this.scheduledPersistTimeout = null
+		}
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
+		void this.flushAndCloseDb()
+	}
+
+	/**
+	 * Write out whatever is still queued instead of throwing it away — the persist throttle means
+	 * the last few hundred milliseconds of edits before an unmount are usually still pending — and
+	 * only then close the database.
+	 */
+	private async flushAndCloseDb() {
+		// let a write that is already in flight finish first; edits made during it are queued
+		if (this.currentPersist) await this.currentPersist
+		if (
+			this.didLoad &&
+			!this.isReloading &&
+			!this.store.isPossiblyCorrupted() &&
+			(this.shouldDoFullDBWrite || this.diffQueue.length > 0)
+		) {
+			await this.doPersist()
+		}
+		await this.db.close()
 	}
 
 	private isPersisting = false
+	private currentPersist: Promise<void> | null = null
 	private didLastWriteError = false
 	// eslint-disable-next-line no-restricted-globals
 	private scheduledPersistTimeout: ReturnType<typeof setTimeout> | null = null
@@ -280,7 +328,7 @@ export class TLLocalSyncClient {
 	 */
 	private schedulePersist() {
 		this.debug('schedulePersist', this.scheduledPersistTimeout)
-		if (this.scheduledPersistTimeout) return
+		if (this.didDispose || this.scheduledPersistTimeout) return
 		// eslint-disable-next-line no-restricted-globals
 		this.scheduledPersistTimeout = setTimeout(
 			() => {
@@ -315,6 +363,10 @@ export class TLLocalSyncClient {
 			this.scheduledPersistTimeout = null
 		}
 
+		// until the initial load has merged what IndexedDB holds, the store is not the source of
+		// truth: writing it out now (the first write is a full snapshot) would wipe the saved document
+		if (!this.didLoad) return
+
 		// if a persist is already in progress, we don't need to do anything -
 		// if there are still outstanding changes once it's finished, it'll
 		// schedule another persist
@@ -329,7 +381,7 @@ export class TLLocalSyncClient {
 
 		// if we're scheduled for a full write or if we have changes outstanding, let's persist them!
 		if (this.shouldDoFullDBWrite || this.diffQueue.length > 0) {
-			this.doPersist()
+			void this.doPersist()
 		}
 	}
 
@@ -337,11 +389,20 @@ export class TLLocalSyncClient {
 	 * Actually persist to IndexedDB. If the write fails, then we'll retry with a full db write after
 	 * a short delay.
 	 */
-	private async doPersist() {
+	private doPersist(): Promise<void> {
 		assert(!this.isPersisting, 'persist already in progress')
-		if (this.didDispose) return
 		this.isPersisting = true
+		this.currentPersist = this.doPersistInner().finally(() => {
+			this.isPersisting = false
+			this.currentPersist = null
+			// changes might have come in between when we started the persist and
+			// now. we request another persist so any new changes can get written
+			this.schedulePersist()
+		})
+		return this.currentPersist
+	}
 
+	private async doPersistInner() {
 		this.debug('doPersist start')
 
 		// instantly empty the diff queue, but keep our own copy of it. this way
@@ -384,11 +445,6 @@ export class TLLocalSyncClient {
 			}
 		}
 
-		this.isPersisting = false
 		this.debug('doPersist end')
-
-		// changes might have come in between when we started the persist and
-		// now. we request another persist so any new changes can get written
-		this.schedulePersist()
 	}
 }

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -438,6 +438,9 @@ export class TLLocalSyncClient {
 			this.didLastWriteError = true
 			console.error('failed to store changes in indexed db', e)
 
+			// the final flush after close() must not alert or reload: the component is unmounting,
+			// and its user is no longer looking at this document
+			if (this.didDispose) return
 			showCantWriteToIndexDbAlert()
 			if (typeof window !== 'undefined') {
 				// adios

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -75,7 +75,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 ## 8. History and listeners (H)
 
-- **H1** `store.history` is an atom that increments by exactly one for each committed change-set, carrying the `RecordsDiff` as its history diff (`historyLength` 1000).
+- **H1** `store.history` is an atom that increments by exactly one for each committed change-set, carrying the `RecordsDiff` as its history diff (`historyLength` 1000). Change-sets made inside a transaction that rolls back are never delivered to listeners: the rollback resets the counter, and accumulated entries recorded past it are discarded (interceptors, H8, still saw them synchronously).
 - **H2** `listen(fn, filters?)` registers a listener and returns a remover. Listener notification is asynchronous: accumulated entries are flushed on the next frame, not synchronously with the change.
 - **H3** A flush squashes adjacent same-source entries: a listener called after changes `[user, user, remote, user]` receives three entries (`user`, `remote`, `user`), each with the squashed (D3) diff and its source.
 - **H4** `filters.source` (`'user' | 'remote' | 'all'`) drops entries from other sources. `filters.scope` (`'document' | 'session' | 'presence' | 'all'`) filters each entry's diff down to records of that scope; if nothing remains, the listener is not called for that entry.

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -518,7 +518,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	public _flushHistory() {
 		// If we have accumulated history, flush it and update listeners
 		if (this.historyAccumulator.hasChanges()) {
-			const entries = this.historyAccumulator.flush()
+			const entries = this.historyAccumulator.flush(this.history.get())
 			for (const { changes, source } of entries) {
 				// Filtered diffs are computed at most once per scope per entry, and shared by every
 				// listener watching that scope.
@@ -570,14 +570,18 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * @param changes - The changes to add to the history.
 	 */
 	private updateHistory(changes: RecordsDiff<R>): void {
-		this.historyAccumulator.add({
-			changes,
-			source: this.isMergingRemoteChanges ? 'remote' : 'user',
-		})
+		const historyCounter = this.history.get() + 1
+		this.historyAccumulator.add(
+			{
+				changes,
+				source: this.isMergingRemoteChanges ? 'remote' : 'user',
+			},
+			historyCounter
+		)
 		if (this.listeners.size === 0) {
 			this.historyAccumulator.clear()
 		}
-		this.history.set(this.history.get() + 1, changes)
+		this.history.set(historyCounter, changes)
 	}
 
 	validate(phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests') {
@@ -1318,15 +1322,30 @@ function squashHistoryEntries<T extends UnknownRecord>(
 }
 
 /**
- * Internal class that accumulates history entries before they are flushed to listeners.
- * Handles batching and squashing of adjacent entries from the same source.
+ * Buffers change-sets between listener flushes, squashing adjacent entries from the same source.
+ * Each entry is tagged with the store's `history` counter at the time it was recorded: a
+ * transaction that rolls back resets that counter, so entries tagged at or beyond a value the
+ * counter later reaches again (or that a flush finds ahead of it) belong to changes the store no
+ * longer holds and must not reach listeners — otherwise a sync client would push, and local
+ * persistence would save, records the store never kept.
  *
  * @internal
  */
 class HistoryAccumulator<T extends UnknownRecord> {
 	private _history: HistoryEntry<T>[] = []
+	private _historyCounters: number[] = []
 
 	private _interceptors: Set<(entry: HistoryEntry<T>) => void> = new Set()
+
+	/** Drop every entry recorded at or after `historyCounter` (they were rolled back). */
+	private dropFrom(historyCounter: number) {
+		let end = this._historyCounters.length
+		while (end > 0 && this._historyCounters[end - 1] >= historyCounter) end--
+		if (end < this._historyCounters.length) {
+			this._history.length = end
+			this._historyCounters.length = end
+		}
+	}
 
 	/**
 	 * Add an interceptor that will be called for each history entry.
@@ -1343,8 +1362,10 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 * Add a history entry to the accumulator.
 	 * Calls all registered interceptors with the entry.
 	 */
-	add(entry: HistoryEntry<T>) {
+	add(entry: HistoryEntry<T>, historyCounter: number) {
+		this.dropFrom(historyCounter)
 		this._history.push(entry)
+		this._historyCounters.push(historyCounter)
 		for (const interceptor of this._interceptors) {
 			interceptor(entry)
 		}
@@ -1353,10 +1374,15 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	/**
 	 * Flush all accumulated history entries, squashing adjacent entries from the same source.
 	 * Clears the internal history buffer.
+	 *
+	 * @param historyCounter - The store's current history counter; entries recorded beyond it
+	 * were rolled back and are discarded.
 	 */
-	flush() {
+	flush(historyCounter: number) {
+		this.dropFrom(historyCounter + 1)
 		const history = squashHistoryEntries(this._history)
 		this._history = []
+		this._historyCounters = []
 		return history
 	}
 
@@ -1365,6 +1391,7 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 */
 	clear() {
 		this._history = []
+		this._historyCounters = []
 	}
 
 	/**

--- a/packages/store/src/lib/StoreListeners.test.ts
+++ b/packages/store/src/lib/StoreListeners.test.ts
@@ -99,6 +99,31 @@ describe('the history atom (H)', () => {
 })
 
 describe('listeners (H)', () => {
+	it('[H1] change-sets from a rolled-back transaction never reach listeners', async () => {
+		const listener = vi.fn()
+		store.listen(listener, { source: 'user', scope: 'document' })
+		const phantom = Book.create({ title: 'never committed', author: Author.createId('a') })
+
+		expect(() =>
+			transact(() => {
+				store.put([phantom])
+				throw new Error('boom')
+			})
+		).toThrow('boom')
+		expect(store.has(phantom.id)).toBe(false)
+
+		// flushing right after the rollback delivers nothing
+		store._flushHistory()
+		expect(listener).not.toHaveBeenCalled()
+
+		// and a later legitimate change does not drag the phantom along with it
+		const real = Book.create({ title: 'committed', author: Author.createId('a') })
+		store.put([real])
+		store._flushHistory()
+		expect(listener).toHaveBeenCalledTimes(1)
+		expect(Object.keys(listener.mock.calls[0][0].changes.added)).toEqual([real.id])
+	})
+
 	it('[H2] listen returns a remover and notification is deferred to the next frame', async () => {
 		try {
 			// @ts-expect-error - test-only escape hatch

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -626,10 +626,15 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 		// Clean up by filtering out any non-document records.
 		// This is mainly legacy support for extremely early days tldraw.
+		// Collect first: as above, deleting during a live iterator can throw on SQLite backends.
+		const idsToDelete: string[] = []
 		for (const [id, state] of storage.entries()) {
 			if (this.getType(state.typeName).scope !== 'document') {
-				storage.delete(id)
+				idsToDelete.push(id)
 			}
+		}
+		for (const id of idsToDelete) {
+			storage.delete(id)
 		}
 	}
 

--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -25,11 +25,11 @@ Sections marked **internal** describe supporting machinery that has its own cont
 ## 3. Computing diffs: `diffRecord` (D)
 
 - **D1** `diffRecord(prev, next)` returns an `ObjectDiff` describing how to turn `prev` into `next`, or `null` when there is nothing to change (including when `prev === next`).
-- **D2** A key present in `prev` but missing from `next` produces `['delete']`. A key present in `next` but missing from `prev` produces `['put', value]`.
+- **D2** A key present in `prev` but missing from `next` produces `['delete']`. A key present in `next` but missing from `prev` produces `['put', value]`. Only own keys count (inherited `Object.prototype` members are never consulted), and a key whose value is `undefined` is treated as absent on both sides — `undefined` does not survive JSON, so it is never put.
 - **D3** `props` and `meta` are the only nested keys at the top level: changes inside them are expressed as `['patch', ...]` ops. Any other top-level key whose values are not both arrays or both strings is compared with deep equality and produces a whole-value `['put', next]` on change — even when both values are plain objects.
 - **D4** Inside a nested diff (within `props`/`meta` or deeper), object values are recursively patched; `null` and primitive values are put.
 - **D5** When both values are strings (at any level, including top-level keys) and `next` starts with `prev`, the diff is `['append', addedSuffix, prev.length]`. Other string changes are puts. With `legacyAppendMode` enabled, string appends become puts instead; array appends (D7) are unaffected by `legacyAppendMode`.
-- **D6** Same-length arrays: if no items changed, no op. If at most `max(length/5, 1)` items changed, the op is `['patch', { [index]: op }]` where each changed index gets a recursive diff when both old and new items are truthy objects, and a put otherwise. If more items changed, the whole array is put.
+- **D6** Same-length arrays: if no items changed, no op. If at most `max(length/5, 1)` items changed, the op is `['patch', { [index]: op }]` where each changed index gets a recursive diff when both old and new items are truthy objects of the same kind (both arrays or both plain objects), and a put otherwise. If more items changed, the whole array is put.
 - **D7** Different-length arrays: when the shared prefix is unchanged and the array grew, the op is `['append', addedItems, prev.length]`. Any change in the shared prefix (including truncation) puts the whole array.
 
 ## 4. Applying diffs: `applyObjectDiff` (AD)
@@ -38,9 +38,10 @@ Sections marked **internal** describe supporting machinery that has its own cont
 - **AD2** A `put` is applied only when the new value is not deep-equal to the current value.
 - **AD3** An `append` is applied only when the current value is an array/string of the matching type whose length equals the op's offset. On any mismatch the op is silently ignored.
 - **AD4** A `patch` is applied only when the current value is a truthy object; it recurses with AD1 semantics. Patching a missing or primitive value is silently ignored.
-- **AD5** A `delete` removes the key when present.
+- **AD5** A `delete` removes the key when it is an own key of the object.
 - **AD6** Patching a non-object (`null`, primitives) returns the input unchanged.
 - **AD7** Arrays are cloned as arrays; ops keyed by numeric strings index into them.
+- **AD8** Ops keyed `__proto__` are ignored: diffs arrive from untrusted peers and assigning that key would change the target's prototype.
 
 ## 5. Converting diffs (ND)
 
@@ -58,7 +59,8 @@ Sections marked **internal** describe supporting machinery that has its own cont
 
 - **CH1** `chunk(msg, maxSize)` returns `[msg]` when `msg.length < maxSize` (strictly less — a message exactly at `maxSize` is chunked).
 - **CH2** Chunks are prefixed `<n>_` where `n` counts down the chunks remaining after this one; the first chunk carries the highest number and the start of the message, and concatenating the chunk bodies in order reconstructs the message.
-- **CH3** Each chunk's total length is at most `maxSize`, except that every chunk carries at least one character of content even when the prefix alone exceeds `maxSize`.
+- **CH3** Each chunk's total length is at most `maxSize`, except that every chunk carries at least one character of content even when the prefix alone exceeds `maxSize`, and except for CH9.
+- **CH9** A UTF-16 surrogate pair is never split across two chunks (`WebSocket.send` would turn each lone half into U+FFFD): the boundary moves by one character, shrinking the chunk when it has more than one character of content and otherwise growing it by one.
 - **CH4** `JsonChunkAssembler.handleMessage`: input starting with `{` while idle is parsed immediately and returned as `{ data, stringified }`. Invalid JSON in this case throws synchronously (callers treat a throw as a fatal session error).
 - **CH5** Input starting with `{` mid-sequence returns `{ error: 'Unexpected non-chunk message' }`; the partial sequence and the JSON message are both discarded and the assembler resets to idle.
 - **CH6** Chunk inputs accumulate, returning `null` until the final (`0_`) chunk arrives, then the joined body is JSON-parsed and returned; a parse failure is returned as `{ error }`. Either way the assembler resets to idle.
@@ -172,7 +174,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **CL5** On a `connect` response with `hydrationType: 'wipe_presence'`, the client reverts its speculative changes, removes all presence records, applies the server's diff, then re-applies the speculative changes on top and pushes them as a new push request.
 - **CL6** With `hydrationType: 'wipe_all'`, all document records are additionally wiped before the server's diff is applied; speculative changes still re-apply on top afterwards.
 - **CL7** After connecting, `onAfterConnect` is called with `{ isReadonly }` from the connect message, and the current presence state (if any) is pushed.
-- **CL8** When the socket goes `'offline'`, the client resets: presence records are removed from the store, pending and unsent pushes are dropped, and the client waits to reconnect. When the socket reports `'error'`, `onSyncError(reason)` fires and the client closes permanently.
+- **CL8** When the socket goes `'offline'`, the client resets: presence records are removed from the store, pending and unsent pushes are dropped, and the client waits to reconnect. When the socket reports `'error'`, `onSyncError(reason)` fires and the client closes permanently. A connect response that throws while being applied is rolled back, keeps the local speculative changes tracked, holds back `onLoad`, and restarts the socket; after three consecutive such failures the client fires `onSyncError('UNKNOWN_ERROR')` and closes instead of re-hydrating forever.
 - **CL9** While connected, a ping is sent every 5 seconds; the client warns and restarts the socket only when nothing has been heard from the server for 10 seconds AND a ping has been outstanding and unanswered for at least 10 seconds (`PONG_TIMEOUT`). Staleness without an unanswered ping (e.g. a throttled hidden tab whose own ping loop stopped) never resets. In a throttled hidden tab a genuinely dead socket is therefore detected within about two 1-minute wakes rather than one.
 - **CL10** A `pong` (or any server message) refreshes the server-interaction timestamp.
 - **CL11** When `didCancel` is provided and returns true, the next event causes the client to close instead of processing.
@@ -208,7 +210,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **RC4** Storage `onChange` notifications carrying a foreign transaction id make the room broadcast the new changes to all connected clients. The room's own transactions (id `'TLSyncRoom.txn'`) do not re-broadcast this way.
 - **RC5** If an external change leaves the storage unable to produce an incremental diff (`wipeAll`), the room closes every session so clients reconnect and re-hydrate.
 - **RC6** The idle timeout defaults to `SESSION_IDLE_TIMEOUT` (20s) and is configurable via `clientTimeout`. A finite positive timeout starts a periodic prune interval of `min(2000, timeout/4)` ms; `Infinity` or 0 disables the interval (pruning then only happens on message activity or via the follow-up prune scheduled when a socket close/error cancels a session, per SES2).
-- **RC7** `close()` closes every session's socket and stops background work; `isClosed()` reports it.
+- **RC7** `close()` marks the room closed, stops background work and pending per-session flush timers, closes every session's socket (a socket that throws on close does not stop the others) and forgets the sessions without emitting `session_removed`; no prune timers are scheduled afterwards, so late socket events cannot emit lifecycle events on a closed room. `isClosed()` reports it.
 
 ## 23. `TLSyncRoom` — connect handshake (HS)
 
@@ -217,7 +219,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **HS3** A connect message without a schema, with a schema the server cannot migrate from, or whose migrations include any non-record-scope or down-less migration, is rejected `CLIENT_TOO_OLD`.
 - **HS4** The connect response echoes `connectRequestId` and `isReadonly`, carries the server's schema and current clock, and `hydrationType: 'wipe_all'` when storage cannot produce an incremental diff since the client's `lastServerClock` (including when that clock is in the future), else `'wipe_presence'`.
 - **HS5** The connect response diff contains every _other_ session's presence record — the connecting session's own presence is excluded — plus the document changes since the client's `lastServerClock` (the full document set in the `wipe_all` case), all down-migrated when the client's schema is older.
-- **HS6** A successful handshake moves the session to `Connected`.
+- **HS6** A successful handshake moves the session to `Connected` — unless the session was removed while the handshake's transaction ran (RC5 force-reconnect), in which case it stays removed rather than being resurrected.
 
 ## 24. `TLSyncRoom` — push handling (RP)
 
@@ -239,7 +241,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 
 - **RB1** Data messages (`patch`, `push_result`) to a session are debounced: the first is sent immediately wrapped as `{ type: 'data', data: [msg] }`; messages within the following `DATA_MESSAGE_DEBOUNCE_INTERVAL` (1000/60 ms) are buffered and flushed together as one `data` message. The array handed to the socket is not mutated afterwards, so sockets may serialize lazily.
 - **RB2** Non-data messages flush any buffered data messages first, preserving order — except `pong`, which skips the flush.
-- **RB3** Sending to a session whose socket is closed cancels that session.
+- **RB3** Sending to a session whose socket is closed cancels that session — on the debounced flush path as well as the immediate one.
 - **RB4** Broadcasts are migrated per session (MG1); a migration failure rejects only the affected session, and the broadcast proceeds for the others.
 - **RB5** `sendCustomMessage` delivers `{ type: 'custom', data }` to a connected session; sending to an unknown or not-yet-connected session logs a warning and does nothing.
 
@@ -249,8 +251,8 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **SES2** Cancelling (also via `handleClose`) moves the session to `AwaitingRemoval` — keeping its presence id and meta for a quick reconnect — closes the socket, and schedules a follow-up prune.
 - **SES3** Removal deletes the session, closes the socket (with code 4099 and the reason when fatal), deletes the session's presence record and broadcasts that deletion to everyone, emits `session_removed`, and emits `room_became_empty` when it was the last session.
 - **SES4** `rejectSession` with a reason: legacy sessions (protocol ≤ 6) receive a deprecated `incompatibility_error` message (reason mapped: `CLIENT_TOO_OLD` → `clientTooOld`, `SERVER_TOO_OLD` → `serverTooOld`, `INVALID_RECORD` → `invalidRecord`, anything else → `invalidOperation`) and are then removed without a close code; modern sessions are closed with code 4099 and the reason string. Without a reason it is a plain removal.
-- **SES5** `getCanEmitStringAppend()` is false when any connected session has `supportsStringAppend: false`; pushes handled in that state use legacy append mode (D5) so broadcast diffs avoid string-append ops.
-- **SES6** `handleResumedSession` registers a session directly in `Connected` state (no handshake): `requiresDownMigrations` is recomputed from the supplied schema, and a supplied presence record is restored into the presence store.
+- **SES5** `getCanEmitStringAppend()` is false when any connected session has `supportsStringAppend: false`; pushes handled in that state use legacy append mode (D5) on every diff the room emits — the pusher's push result, the broadcast to other sessions (including the down-migrated variant, MG1), and puts over existing records — so no session receives a string-append op.
+- **SES6** `handleResumedSession` registers a session directly in `Connected` state (no handshake): `requiresDownMigrations` is recomputed from the supplied schema, and a supplied presence record is restored into the presence store. The handshake's schema checks (HS3) are re-applied — a schema the server can no longer reconcile rejects the resumed session instead of being served unmigrated diffs.
 - **SES7** A message from an unknown session id logs a warning and is ignored.
 
 ## 27. Migrations over the wire (MG)
@@ -263,10 +265,10 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 
 - **SR1** Providing both `storage` and `initialSnapshot` throws. With neither, an `InMemorySyncStorage` seeded from `DEFAULT_INITIAL_SNAPSHOT` is created; `initialSnapshot` (deprecated) accepts both room and store snapshots.
 - **SR2** The deprecated `onDataChange` callback is wired to `storage.onChange` (fires on a microtask after document changes, including programmatic ones).
-- **SR3** `log` defaults to `{ error: console.error }` only when the `log` key is absent from the options object; an explicitly passed `log: undefined` leaves the room without a logger.
-- **SR4** `handleSocketConnect` registers the session (readonly defaults to false), attaches `message`/`close`/`error` listeners when the socket supports `addEventListener`, and creates a chunk assembler for the session.
+- **SR3** `log` defaults to `{ error: console.error }` only when the `log` key is absent from the options object; an explicitly passed `log: undefined` leaves the room without a logger. The same logger is handed to the inner `TLSyncRoom`, so authorizer failures and vetoes are logged under the default too.
+- **SR4** `handleSocketConnect` registers the session (readonly defaults to false), attaches `message`/`close`/`error` listeners when the socket supports `addEventListener`, and creates a chunk assembler for the session. Connecting again under an existing session id (a reconnect) detaches the previous socket's listeners first.
 - **SR5** `handleSocketMessage` assembles chunks (CH rules), then for each complete message: invokes `onAfterReceiveMessage`, forwards to the room, and runs a prune pass (after handling, so a session is never evicted by its own message). Assembly errors close the socket via the error path; a thrown exception rejects the session with `UNKNOWN_ERROR`.
-- **SR6** `handleSocketError` and `handleSocketClose` cancel the session (grace period applies per SES2) and clear any pending session-snapshot timer.
+- **SR6** `handleSocketError` and `handleSocketClose` cancel the session (grace period applies per SES2) and clear any pending session-snapshot timer. Both accept the socket the event came from; when it is given and is not the session's current socket, the event belongs to a superseded socket for the same session id and is ignored. The listeners SR4 attaches pass their own socket.
 - **SR7** `getNumActiveSessions()` counts all sessions including those awaiting connect/removal; `getSessions()` reports `{ sessionId, isConnected, isReadonly, meta }`.
 - **SR8** `getRecord(id)` returns a deep clone of the stored record (safe to mutate), or `undefined`.
 - **SR9** `getCurrentDocumentClock()` returns the storage clock; `getCurrentSnapshot()` delegates to `storage.getSnapshot` and throws when the storage doesn't support it.
@@ -274,7 +276,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **SR11** `close()` closes the room, clears session-snapshot timers, and disposes subscriptions; `closeSession(sessionId, fatalReason?)` behaves as SES4.
 - **SR12** With `onSessionSnapshot` configured, a session snapshot is delivered 5 seconds after that session's last message; further messages reset the timer; socket close/error cancels it.
 - **SR13** `getSessionSnapshot` returns null unless the session is `Connected`; the snapshot carries the serialized schema, readonly flag, legacy/append flags, presence id, and the presence record with large fields stripped (`scribbles: []`, `chatMessage: ''`, `selectedShapeIds: []`, `brush: null`).
-- **SR14** `handleSocketResume` restores a session from a snapshot directly into `Connected` state without attaching socket listeners (hibernation environments deliver events via methods); the resumed session handles pings and pushes normally.
+- **SR14** `handleSocketResume` restores a session from a snapshot directly into `Connected` state without attaching socket listeners (hibernation environments deliver events via methods); the resumed session handles pings and pushes normally. Resuming a socket that is no longer open while a different, open socket owns the session id is ignored (the resumed socket is stale); otherwise the last resume wins.
 - **SR15** `getPresenceRecords()` returns a map of presence id to presence record for every presence currently in the room.
 
 ## 29. `updateStore` (US) — deprecated

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -22,7 +22,6 @@ import { TLDocument } from 'tldraw';
 import { TLPage } from 'tldraw';
 import { TLRecord } from '@tldraw/tlschema';
 import { TLStoreSnapshot } from '@tldraw/tlschema';
-import { TLStoreSnapshot as TLStoreSnapshot_2 } from 'tldraw';
 import { UnknownRecord } from '@tldraw/store';
 
 // @internal
@@ -161,7 +160,7 @@ export class JsonChunkAssembler {
 }
 
 // @public
-export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot_2): void;
+export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot): void;
 
 // @internal (undocumented)
 export interface MinimalDocStore<R extends UnknownRecord> {
@@ -515,7 +514,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
         sessionId: string;
     }>;
     getSessionSnapshot(sessionId: string): null | SessionStateSnapshot;
-    handleSocketClose(sessionId: string): void;
+    handleSocketClose(sessionId: string, socket?: WebSocketMinimal): void;
     handleSocketConnect(opts: {
         isReadonly?: boolean;
         objectAccess?: TLObjectStoreAccess;
@@ -524,7 +523,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     } & (SessionMeta extends void ? object : {
         meta: SessionMeta;
     })): void;
-    handleSocketError(sessionId: string): void;
+    handleSocketError(sessionId: string, socket?: WebSocketMinimal): void;
     handleSocketMessage(sessionId: string, message: AllowSharedBufferSource | string): void;
     handleSocketResume(opts: {
         sessionId: string;

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -527,6 +527,33 @@ describe('ClientWebSocketAdapter', () => {
 			adapter.close()
 			expect(() => adapter.close()).not.toThrow()
 		})
+
+		it('[CW9][RM5] nothing runs after close: no status change, no reconnect, no further getUri call', async () => {
+			let uriCallCount = 0
+			const testAdapter = new ClientWebSocketAdapter(() => {
+				uriCallCount++
+				return 'ws://localhost:2233'
+			})
+			const onStatusChange = vi.fn()
+			testAdapter.onStatusChange(onStatusChange)
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			const callsBeforeClose = uriCallCount
+			onStatusChange.mockClear()
+
+			testAdapter.close()
+			// let the socket's own close event land, then run out any (leaked) reconnect timer
+			vi.useRealTimers()
+			await sleep(50)
+			vi.useFakeTimers()
+			vi.advanceTimersByTime(INACTIVE_MAX_DELAY)
+			vi.useRealTimers()
+			await sleep(20)
+			vi.useFakeTimers()
+
+			expect(onStatusChange).not.toHaveBeenCalled()
+			expect(uriCallCount).toBe(callsBeforeClose)
+			expect(testAdapter._ws).toBeNull()
+		})
 	})
 
 	describe('orphaned sockets (CW10)', () => {
@@ -774,6 +801,26 @@ describe('ReconnectManager', () => {
 
 		expect(fake.close).toHaveBeenCalled()
 		expect(adapter._ws).toBeNull()
+	})
+
+	it('[RM1][CW1] a rejecting getUri is retried on the backoff instead of stranding the connection', async () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		let attempts = 0
+		const testAdapter = new ClientWebSocketAdapter(async () => {
+			attempts++
+			if (attempts < 3) throw new Error('token endpoint unavailable')
+			return 'ws://localhost:2234'
+		})
+		try {
+			// each failure logs and schedules another attempt; the third succeeds
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			expect(attempts).toBe(3)
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(2)
+			expect(testAdapter.connectionStatus).toBe('online')
+		} finally {
+			testAdapter.close()
+			consoleErrorSpy.mockRestore()
+		}
 	})
 
 	it('[RM5] close cancels timers and removes the reconnect event listeners', () => {

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -93,8 +93,12 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 	close() {
 		this.isDisposed = true
 		this._reconnectManager.close()
+		// orphan the socket before closing it (as _closeSocket does) so its onclose can't run
+		// _handleDisconnect after disposal — that would notify listeners and schedule a reconnect
+		const ws = this._ws
+		this._ws = null
 		//  WebSocket.close() is idempotent
-		this._ws?.close()
+		ws?.close()
 	}
 
 	/**
@@ -239,8 +243,6 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 		this._ws = null
 		this._handleDisconnect('manual')
 	}
-
-	// TLPersistentClientSocket stuff
 
 	_connectionStatus: Atom<TLPersistentClientSocketStatus | 'initial'> = atom(
 		'websocket connection status',
@@ -516,18 +518,30 @@ export class ReconnectManager {
 	private scheduleAttempt() {
 		assert(this.state === 'pendingAttempt')
 		debug('scheduling a connection attempt')
-		Promise.resolve(this.getUri()).then((uri) => {
-			// this can happen if the promise gets resolved too late
-			if (this.state !== 'pendingAttempt' || this.isDisposed) return
-			assert(
-				this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
-				'There should be no connection attempts while already connected'
-			)
+		Promise.resolve()
+			.then(() => this.getUri())
+			.then((uri) => {
+				// this can happen if the promise gets resolved too late
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				assert(
+					this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
+					'There should be no connection attempts while already connected'
+				)
 
-			this.lastAttemptStart = Date.now()
-			this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
-			this.state = 'pendingAttemptResult'
-		})
+				this.lastAttemptStart = Date.now()
+				this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
+				this.state = 'pendingAttemptResult'
+			})
+			.catch((error) => {
+				// getUri is host code (often an auth-token fetch) and can reject or throw. Without
+				// this handler the manager would sit in 'pendingAttempt' with no timer and no
+				// socket, so nothing but a browser online/visibility hint could ever start another
+				// attempt. Treat it as a failed attempt and retry on the usual backoff instead.
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				console.error('Failed to get the websocket URI, retrying', error)
+				this.state = 'delay'
+				this.reconnectTimeout = setTimeout(() => this.disconnected(), this.intendedDelay)
+			})
 	}
 
 	private getMaxDelay() {
@@ -641,6 +655,7 @@ export class ReconnectManager {
 		debug('ReconnectManager.disconnected')
 		// This either means we're freshly disconnected, or the last connection attempt failed;
 		// either way, time to try again.
+		if (this.isDisposed) return
 
 		// Guard against delayed notifications and recheck synchronously
 		if (

--- a/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
@@ -51,6 +51,27 @@ describe('InMemorySyncStorage', () => {
 			expect(storage.getClock()).toBe(25)
 		})
 
+		it('[IM1] handles snapshots with far more records and tombstones than fit in a spread call', () => {
+			const documents = []
+			for (let i = 0; i < 150_000; i++) {
+				documents.push({
+					state: { ...contractRecords[0], id: `shape:${i}` } as TLRecord,
+					lastChangedClock: i,
+				})
+			}
+			const tombstones: Record<string, number> = {}
+			for (let i = 0; i < 150_000; i++) tombstones[`shape:gone-${i}`] = 150_000 + i
+			const storage = new InMemorySyncStorage<TLRecord>({
+				snapshot: makeContractSnapshot(contractRecords, {
+					documents,
+					tombstones,
+					documentClock: 0,
+					tombstoneHistoryStartsAtClock: 0,
+				}),
+			})
+			expect(storage.getClock()).toBe(299_999)
+		})
+
 		it('[IM2] clamps tombstoneHistoryStartsAtClock down to the document clock', () => {
 			const storage = new InMemorySyncStorage<TLRecord>({
 				snapshot: makeContractSnapshot(contractRecords, {

--- a/packages/sync-core/src/lib/InMemorySyncStorage.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.ts
@@ -153,11 +153,15 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown
 	} = {}) {
 		this.objectTypes = new Set(objectTypes ?? [])
-		const maxClockValue = Math.max(
-			0,
-			...Object.values(snapshot.tombstones ?? {}),
-			...Object.values(snapshot.documents.map((d) => d.lastChangedClock))
-		)
+		// a loop rather than `Math.max(0, ...clocks)`: spreading a large room's clocks as call
+		// arguments overflows the stack at roughly 100k+ records/tombstones
+		let maxClockValue = 0
+		for (const clock of Object.values(snapshot.tombstones ?? {})) {
+			if (clock > maxClockValue) maxClockValue = clock
+		}
+		for (const doc of snapshot.documents) {
+			if (doc.lastChangedClock > maxClockValue) maxClockValue = doc.lastChangedClock
+		}
 		// route snapshot entries into their partitions (a seed snapshot may carry object-lane
 		// records merged in, e.g. loaded from a separate persistence lane)
 		const toEntry = (

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
@@ -272,5 +272,34 @@ describe('NodeSqliteWrapper', () => {
 			// the write was rolled back
 			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
 		})
+
+		it('[NW2] rolls back when COMMIT itself fails, so the connection is not left inside a transaction', () => {
+			// simulate a COMMIT failure (SQLITE_BUSY, I/O error) at the driver level
+			const failingDb = {
+				exec: (sql: string) => {
+					if (sql === 'COMMIT') throw new Error('SQLITE_BUSY: database is locked')
+					return db.exec(sql)
+				},
+				prepare: (sql: string) => db.prepare(sql),
+			}
+			const failingWrapper = new NodeSqliteWrapper(failingDb as any)
+
+			expect(() =>
+				failingWrapper.transaction(() => {
+					failingWrapper
+						.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)')
+						.run(1, 'alice', 100)
+				})
+			).toThrow('SQLITE_BUSY')
+
+			// rolled back, and the next transaction can BEGIN normally
+			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
+			expect(() =>
+				wrapper.transaction(() => {
+					wrapper.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)').run(2, 'bob', 200)
+				})
+			).not.toThrow()
+			expect(wrapper.prepare<{ id: number }>('SELECT id FROM test').all()).toEqual([{ id: 2 }])
+		})
 	})
 })

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.ts
@@ -89,11 +89,14 @@ export class NodeSqliteWrapper implements TLSyncSqliteWrapper {
 		let result: T
 		try {
 			result = callback()
+			// COMMIT itself can fail (SQLITE_BUSY from another connection, I/O errors); without a
+			// ROLLBACK the connection would stay inside the transaction and every later BEGIN
+			// would throw "cannot start a transaction within a transaction"
+			this.db.exec('COMMIT')
 		} catch (e) {
 			this.db.exec('ROLLBACK')
 			throw e
 		}
-		this.db.exec('COMMIT')
 		return result
 	}
 }

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -394,7 +394,6 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 			const documentClock = snapshot.documentClock ?? snapshot.clock ?? 0
 			const tombstoneHistoryStartsAtClock = snapshot.tombstoneHistoryStartsAtClock ?? documentClock
 
-			// Clear existing data
 			this.sql.exec(`
 				DELETE FROM ${documentsTable};
 				DELETE FROM ${objectsTable};
@@ -410,14 +409,12 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 				table.insert.run(doc.state.id, encodeState(doc.state), doc.lastChangedClock)
 			}
 
-			// Insert tombstones
 			if (snapshot.tombstones) {
 				for (const [id, clock] of objectMapEntries(snapshot.tombstones)) {
 					this.stmts.insertTombstone.run(id, clock)
 				}
 			}
 
-			// Insert metadata row
 			this.stmts.updateMetadata.run(
 				documentClock,
 				tombstoneHistoryStartsAtClock,
@@ -513,18 +510,29 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 	/** @internal */
 	pruneTombstones = throttle(
 		() => {
-			const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
-			if (tombstoneCount > MAX_TOMBSTONES) {
-				// Get all tombstones sorted by clock ascending (oldest first)
-				const tombstones = this.stmts.iterateTombstones.all()
+			// Runs from a timer, so a host that closed the database right after the last delete
+			// (e.g. `room.close(); db.close()` in onSessionRemoved) would otherwise get an uncaught
+			// throw from here; pruning is best-effort and simply runs again on the next delete.
+			try {
+				const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
+				if (tombstoneCount > MAX_TOMBSTONES) {
+					// Get all tombstones sorted by clock ascending (oldest first)
+					const tombstones = this.stmts.iterateTombstones.all()
 
-				const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
-				if (result) {
-					this.stmts.setTombstoneHistoryStartsAtClock.run(result.newTombstoneHistoryStartsAtClock)
-					// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
-					// This works because computeTombstonePruning ensures we never split a clock value.
-					this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+					const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
+					if (result) {
+						this.sql.transaction(() => {
+							this.stmts.setTombstoneHistoryStartsAtClock.run(
+								result.newTombstoneHistoryStartsAtClock
+							)
+							// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
+							// This works because computeTombstonePruning ensures we never split a clock value.
+							this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+						})
+					}
 				}
+			} catch (e) {
+				console.error('Failed to prune tombstones', e)
 			}
 		},
 		1000,

--- a/packages/sync-core/src/lib/ServerSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ServerSocketAdapter.test.ts
@@ -86,4 +86,20 @@ describe('ServerSocketAdapter', () => {
 		adapter.close(1001, 'Going away')
 		expect(ws.close).toHaveBeenLastCalledWith(1001, 'Going away')
 	})
+
+	it('[SA3] close truncates a reason longer than 123 UTF-8 bytes rather than letting the socket throw', () => {
+		const ws = new MockWebSocket()
+		const adapter = new ServerSocketAdapter({ ws })
+
+		const longAscii = 'x'.repeat(200)
+		adapter.close(4099, longAscii)
+		expect(ws.close).toHaveBeenLastCalledWith(4099, 'x'.repeat(123))
+
+		// multi-byte characters are never cut in half
+		const emoji = '\u{1F600}' // 4 bytes
+		adapter.close(4099, emoji.repeat(40))
+		const sent = (ws.close as any).mock.calls.at(-1)[1] as string
+		expect(new TextEncoder().encode(sent).length).toBeLessThanOrEqual(123)
+		expect(sent).toBe(emoji.repeat(30))
+	})
 })

--- a/packages/sync-core/src/lib/ServerSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ServerSocketAdapter.ts
@@ -163,9 +163,25 @@ export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocke
 	 * Closes the WebSocket connection with an optional close code and reason.
 	 *
 	 * @param code - Optional close code (default: 1000 for normal closure)
-	 * @param reason - Optional human-readable reason for closing
+	 * @param reason - Optional human-readable reason for closing. WebSocket close reasons are
+	 * capped at 123 UTF-8 bytes; a longer reason is truncated to fit rather than letting the
+	 * socket's own `close()` throw, which would leave the socket open with its session gone.
 	 */
 	close(code?: number, reason?: string) {
-		this.opts.ws.close(code, reason)
+		this.opts.ws.close(code, reason === undefined ? undefined : truncateCloseReason(reason))
 	}
+}
+
+const MAX_CLOSE_REASON_BYTES = 123
+const closeReasonEncoder = new TextEncoder()
+
+function truncateCloseReason(reason: string) {
+	if (closeReasonEncoder.encode(reason).length <= MAX_CLOSE_REASON_BYTES) return reason
+	// step back by code point so a multi-byte character is never cut in half
+	let out = ''
+	for (const char of reason) {
+		if (closeReasonEncoder.encode(out + char).length > MAX_CLOSE_REASON_BYTES) break
+		out += char
+	}
+	return out
 }

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -988,6 +988,11 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 */
 	close() {
 		this.room.close()
+		// the room forgets its sessions on close and emits no session_removed for them, so drop
+		// our entries (and their socket listeners) here rather than leaving them for the lifetime
+		// of the closed room
+		this.sessions.forEach((session) => session.unlisten())
+		this.sessions.clear()
 		for (const sessionId of this.snapshotTimers.keys()) {
 			this.clearSnapshotTimer(sessionId)
 		}

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -273,13 +273,16 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 				})
 			)
 		}
+		// The default logger belongs to both layers: TLSyncRoom is where authorizer throws and
+		// vetoes are logged, and a host that passes no `log` would otherwise never see them.
+		this.log = 'log' in opts ? opts.log : { error: console.error }
 		this.room = new TLSyncRoom<R, SessionMeta>({
 			onPresenceChange: opts.onPresenceChange,
 			onCommittedChanges: opts.onCommittedChanges,
 			objectTypes: opts.objectTypes,
 			authorizeRecord: opts.authorizeRecord,
 			schema: opts.schema ?? (createTLSchema() as any),
-			log: opts.log,
+			log: this.log,
 			storage,
 			clientTimeout: opts.clientTimeout,
 		})
@@ -295,7 +298,6 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 				})
 			}
 		})
-		this.log = 'log' in opts ? opts.log : { error: console.error }
 	}
 
 	/**
@@ -354,9 +356,12 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 		const { sessionId, socket, isReadonly = false, objectAccess = 'write' } = opts
 		const handleSocketMessage = (event: MessageEvent) =>
 			this.handleSocketMessage(sessionId, event.data)
-		const handleSocketError = this.handleSocketError.bind(this, sessionId)
-		const handleSocketClose = this.handleSocketClose.bind(this, sessionId)
+		const handleSocketError = () => this.handleSocketError(sessionId, socket)
+		const handleSocketClose = () => this.handleSocketClose(sessionId, socket)
 
+		// A reconnect reuses the session id (useSync always sends its tab id). Detach the previous
+		// socket's listeners so its late close/error can't be taken for the new socket's.
+		this.retireSocketEntry(sessionId)
 		this.sessions.set(sessionId, {
 			assembler: new JsonChunkAssembler(),
 			socket,
@@ -371,24 +376,43 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 			sessionId,
 			isReadonly,
 			objectAccess,
-			socket: new ServerSocketAdapter({
-				ws: socket,
-				onBeforeSendMessage: this.opts.onBeforeSendMessage
-					? (message, stringified) =>
-							this.opts.onBeforeSendMessage!({
-								sessionId,
-								message,
-								stringified,
-								meta: this.room.sessions.get(sessionId)?.meta as SessionMeta,
-							})
-					: undefined,
-			}),
+			socket: this.createSocketAdapter(sessionId, socket),
 			meta: 'meta' in opts ? (opts.meta as any) : undefined,
 		})
 
 		socket.addEventListener?.('message', handleSocketMessage)
 		socket.addEventListener?.('close', handleSocketClose)
 		socket.addEventListener?.('error', handleSocketError)
+	}
+
+	private createSocketAdapter(sessionId: string, socket: WebSocketMinimal) {
+		return new ServerSocketAdapter<R>({
+			ws: socket,
+			onBeforeSendMessage: this.opts.onBeforeSendMessage
+				? (message, stringified) =>
+						this.opts.onBeforeSendMessage!({
+							sessionId,
+							message,
+							stringified,
+							meta: this.room.sessions.get(sessionId)?.meta as SessionMeta,
+						})
+				: undefined,
+		})
+	}
+
+	private retireSocketEntry(sessionId: string) {
+		this.sessions.get(sessionId)?.unlisten()
+	}
+
+	/**
+	 * A close/error reported for a socket that is no longer the session's socket comes from a
+	 * connection this session id has since moved on from (a reconnect that raced the old
+	 * socket's teardown). Acting on it would cancel the healthy replacement session.
+	 */
+	private isStaleSocketEvent(sessionId: string, socket: WebSocketMinimal | undefined) {
+		if (!socket) return false
+		const current = this.sessions.get(sessionId)?.socket
+		return current !== undefined && current !== socket
 	}
 
 	private clearSnapshotTimer(sessionId: string) {
@@ -493,17 +517,23 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 * where socket event listeners cannot be attached directly. This will initiate cleanup
 	 * and session removal for the affected client.
 	 *
+	 * Pass the socket the event came from whenever you have it: a client that reconnects under
+	 * the same session id can leave its previous socket to close later, and that late event is
+	 * then ignored instead of tearing down the new connection.
+	 *
 	 * @param sessionId - Session identifier matching the one used in handleSocketConnect
+	 * @param socket - The socket that errored, when known
 	 *
 	 * @example
 	 * ```ts
 	 * // In a custom WebSocket handler
 	 * socket.addEventListener('error', () => {
-	 *   room.handleSocketError(sessionId)
+	 *   room.handleSocketError(sessionId, socket)
 	 * })
 	 * ```
 	 */
-	handleSocketError(sessionId: string) {
+	handleSocketError(sessionId: string, socket?: WebSocketMinimal) {
+		if (this.isStaleSocketEvent(sessionId, socket)) return
 		this.clearSnapshotTimer(sessionId)
 		this.room.handleClose(sessionId)
 	}
@@ -513,17 +543,23 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 * environments where socket event listeners cannot be attached directly. This will
 	 * initiate cleanup and session removal for the disconnected client.
 	 *
+	 * Pass the socket the event came from whenever you have it: a client that reconnects under
+	 * the same session id can leave its previous socket to close later, and that late event is
+	 * then ignored instead of tearing down the new connection.
+	 *
 	 * @param sessionId - Session identifier matching the one used in handleSocketConnect
+	 * @param socket - The socket that closed, when known
 	 *
 	 * @example
 	 * ```ts
 	 * // In a custom WebSocket handler
 	 * socket.addEventListener('close', () => {
-	 *   room.handleSocketClose(sessionId)
+	 *   room.handleSocketClose(sessionId, socket)
 	 * })
 	 * ```
 	 */
-	handleSocketClose(sessionId: string) {
+	handleSocketClose(sessionId: string, socket?: WebSocketMinimal) {
+		if (this.isStaleSocketEvent(sessionId, socket)) return
 		this.clearSnapshotTimer(sessionId)
 		this.room.handleClose(sessionId)
 	}
@@ -569,6 +605,21 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	) {
 		const { sessionId, socket, snapshot } = opts
 
+		// Hosts resume a socket they are about to close so the room can broadcast its presence
+		// removal. If a newer, open socket already owns this session id, that resume would displace
+		// the live session and its close would then cancel it — ignore the closing socket. (Two open
+		// sockets for one id, e.g. on a hibernation wake-up, keep the last-resumed-wins behaviour.)
+		const current = this.sessions.get(sessionId)?.socket
+		if (
+			current &&
+			current !== socket &&
+			socket.readyState !== 1 /* OPEN */ &&
+			current.readyState === 1 /* OPEN */
+		) {
+			return
+		}
+
+		this.retireSocketEntry(sessionId)
 		this.sessions.set(sessionId, {
 			assembler: new JsonChunkAssembler(),
 			socket,
@@ -588,18 +639,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 			presenceRecord: snapshot.presenceRecord,
 			requiresLegacyRejection: snapshot.requiresLegacyRejection,
 			supportsStringAppend: snapshot.supportsStringAppend,
-			socket: new ServerSocketAdapter({
-				ws: socket,
-				onBeforeSendMessage: this.opts.onBeforeSendMessage
-					? (message, stringified) =>
-							this.opts.onBeforeSendMessage!({
-								sessionId,
-								message,
-								stringified,
-								meta: this.room.sessions.get(sessionId)?.meta as SessionMeta,
-							})
-					: undefined,
-			}),
+			socket: this.createSocketAdapter(sessionId, socket),
 			meta: 'meta' in opts ? (opts.meta as any) : undefined,
 		})
 	}
@@ -854,12 +894,11 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 		if (this.isClosed()) {
 			throw new Error('Cannot update store on a closed room')
 		}
+		// read through the transaction rather than getSnapshot(): the document snapshot excludes the
+		// object-store lane, which would make object-lane records invisible (and undeletable) here
+		const records = this.storage.transaction((txn) => Object.fromEntries(txn.entries())).result
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
-		const ctx = new StoreUpdateContext<R>(
-			// eslint-disable-next-line @typescript-eslint/no-deprecated
-			Object.fromEntries(this.getCurrentSnapshot().documents.map((d) => [d.state.id, d.state])),
-			this.room.schema
-		)
+		const ctx = new StoreUpdateContext<R>(records, this.room.schema)
 		try {
 			await updater(ctx)
 		} finally {

--- a/packages/sync-core/src/lib/TLSyncClient.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.test.ts
@@ -375,6 +375,99 @@ describe('TLSyncClient', () => {
 			expect(pushWithPage!.diff![localPage.id][0]).toBe(RecordOpType.Put)
 		})
 
+		it('[CL5] a reconnect flushes pending store history first, so a change queued behind the frame throttle is neither lost nor resurrected', () => {
+			connectClient()
+
+			socket.mockConnectionStatus('offline')
+			const localPage = makePage('Offline Page')
+			store.put([localPage]) // reaches speculativeChanges
+
+			// In the browser the store delivers history on the next animation frame, so the client's
+			// view of speculative changes can lag the store. Hold the next flush back the same way.
+			const flushHistory = store._flushHistory
+			store._flushHistory = () => {}
+			store.remove([localPage.id]) // ...so this delete is still queued when we reconnect
+			store._flushHistory = flushHistory
+
+			socket.mockConnectionStatus('online')
+			socket.mockServerMessage(
+				createConnectMessage({ hydrationType: 'wipe_presence', serverClock: 2, diff: {} })
+			)
+			vi.advanceTimersByTime(100)
+
+			// the user deleted the page: it must not come back, and must not be pushed as a put
+			expect(store.get(localPage.id)).toBeUndefined()
+			expect(
+				getSentPushes().some((msg) => msg.diff?.[localPage.id]?.[0] === RecordOpType.Put)
+			).toBe(false)
+		})
+
+		it('[CL5][CL8] a connect diff that fails to apply resets the connection and keeps local changes tracked', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			try {
+				client = createClient()
+				// a local change made before the handshake completes
+				const localPage = makePage('Local Page')
+				store.put([localPage])
+
+				const badPage = { ...makePage('Bad Page', 'a3'), index: 123 } as any
+				socket.mockServerMessage(
+					createConnectMessage({ diff: { ...documentScopeDiff(), [badPage.id]: ['put', badPage] } })
+				)
+
+				// not stuck half-connected: the client resets and the socket restarts
+				expect(client.isConnectedToRoom).toBe(false)
+				expect(consoleSpy).toHaveBeenCalled()
+				expect(store.get(localPage.id)).toEqual(localPage)
+				vi.advanceTimersByTime(1)
+				socket.clearSentMessages()
+				expect(client.latestConnectRequestId).not.toBeNull()
+
+				// once a good connect arrives, the local change is still speculative and gets pushed
+				const serverDiff = documentScopeDiff()
+				delete serverDiff[localPage.id] // the server never saw it
+				socket.mockServerMessage(createConnectMessage({ diff: serverDiff }))
+				vi.advanceTimersByTime(100)
+				expect(client.isConnectedToRoom).toBe(true)
+				expect(store.get(localPage.id)).toEqual(localPage)
+				expect(
+					getSentPushes().some((msg) => msg.diff?.[localPage.id]?.[0] === RecordOpType.Put)
+				).toBe(true)
+			} finally {
+				consoleSpy.mockRestore()
+			}
+		})
+
+		it('[CL3][CL8] onLoad is held back while the connect response cannot be applied, and the client gives up after repeated failures', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			try {
+				client = createClient()
+				const badPage = { ...makePage('Bad Page', 'a3'), index: 123 } as any
+				const badConnect = () =>
+					createConnectMessage({ diff: { ...documentScopeDiff(), [badPage.id]: ['put', badPage] } })
+
+				socket.mockServerMessage(badConnect())
+				expect(onLoad).not.toHaveBeenCalled()
+				expect(onSyncError).not.toHaveBeenCalled()
+
+				// each failure restarts the socket and sends a fresh connect request
+				vi.advanceTimersByTime(1)
+				socket.mockServerMessage(badConnect())
+				vi.advanceTimersByTime(1)
+				expect(onSyncError).not.toHaveBeenCalled()
+
+				// the third consecutive failure surfaces a sync error instead of looping forever
+				socket.clearSentMessages()
+				socket.mockServerMessage(badConnect())
+				expect(onSyncError).toHaveBeenCalledWith('UNKNOWN_ERROR')
+				expect(onLoad).not.toHaveBeenCalled()
+				vi.advanceTimersByTime(1000)
+				expect(socket.getSentMessages().filter((m) => m.type === 'connect')).toHaveLength(0)
+			} finally {
+				consoleSpy.mockRestore()
+			}
+		})
+
 		it('[CL6] wipe_all reconnect wipes document records before applying the server diff', () => {
 			client = createClient()
 

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -4,6 +4,7 @@ import {
 	RecordsDiff,
 	Store,
 	UnknownRecord,
+	createEmptyRecordsDiff,
 	reverseRecordsDiff,
 	squashRecordDiffsMutable,
 } from '@tldraw/store'
@@ -284,6 +285,19 @@ export interface TLPersistentClientSocket<
 	close(): void
 }
 
+/**
+ * `lastServerClock` before any server contact. Sent as-is on connect, it lands below any
+ * tombstone-history start, so storage answers with a full `wipe_all` hydration.
+ */
+const NO_SERVER_CLOCK = -1
+
+/**
+ * How many consecutive connect responses may fail to apply before the client gives up and
+ * reports a sync error. Each failure restarts the socket, so without a cap a record that never
+ * applies (schema skew, a corrupt record) would re-hydrate the whole room every few hundred ms.
+ */
+const MAX_CONSECUTIVE_HYDRATION_FAILURES = 3
+
 const PING_INTERVAL = 5000
 const MAX_TIME_TO_WAIT_FOR_SERVER_INTERACTION_BEFORE_RESETTING_CONNECTION = PING_INTERVAL * 2
 /**
@@ -371,7 +385,7 @@ function getPresenceOp<R extends UnknownRecord>(
  */
 export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>> {
 	/** The last clock time from the most recent server update */
-	private lastServerClock = -1
+	private lastServerClock = NO_SERVER_CLOCK
 	private lastServerInteractionTimestamp = Date.now()
 	/**
 	 * Send time of the oldest outstanding ping; answered iff `lastServerInteractionTimestamp >= it`
@@ -391,11 +405,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * take this diff, reverse it, and apply that to the store, our store will match exactly the most
 	 * recent state of the server that we know about
 	 */
-	private speculativeChanges: RecordsDiff<R> = {
-		added: {} as any,
-		updated: {} as any,
-		removed: {} as any,
-	}
+	private speculativeChanges: RecordsDiff<R> = createEmptyRecordsDiff<R>()
 
 	private disposables: Array<() => void> = []
 
@@ -458,6 +468,12 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	) => void
 
 	private readonly onCustomMessageReceived?: TLCustomMessageHandler
+	private readonly onSyncError: (reason: string) => void
+
+	/** Consecutive connect responses that threw while being applied; reset on success. */
+	private hydrationFailures = 0
+	/** Set while the connect response just handled failed to apply, so onLoad is held back. */
+	private didHydrationFail = false
 
 	private isDebugging = false
 	private debug(...args: any[]) {
@@ -560,6 +576,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.socket = config.socket
 		this.onAfterConnect = config.onAfterConnect
 		this.onCustomMessageReceived = config.onCustomMessageReceived
+		this.onSyncError = config.onSyncError
 
 		let didLoad = false
 
@@ -582,13 +599,14 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				if (this.didCancel?.()) return this.close()
 				this.debug('received message from server', msg)
 				this.handleServerEvent(msg)
-				// the first time we receive a message from the server, we should trigger
-
-				// one of the load callbacks
-				if (!didLoad) {
+				// the first time we receive a message from the server, we should trigger one of the
+				// load callbacks — unless that message was a connect response we failed to apply, in
+				// which case the store is not hydrated and the app must not mount on it yet
+				if (!didLoad && !this.didHydrationFail) {
 					didLoad = true
 					config.onLoad(this)
 				}
+				this.didHydrationFail = false
 			}),
 			// handle switching between online and offline
 			this.socket.onStatusChange((ev) => {
@@ -708,7 +726,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	private resetConnection(hard = false) {
 		this.debug('resetting connection')
 		if (hard) {
-			this.lastServerClock = 0
+			// forget everything we know about the server so the next connect re-hydrates from scratch
+			this.lastServerClock = NO_SERVER_CLOCK
 		}
 		// kill all presence state
 		const keys = Object.keys(this.store.serialize('presence')) as any
@@ -752,66 +771,89 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			this.resetConnection(true)
 			return
 		}
+		// Local changes reach `push` (and so `speculativeChanges`) on the store's frame-throttled
+		// history flush. Anything still queued there would be neither reverted below nor
+		// re-applied on top of the server state, so bring speculativeChanges up to date first.
+		this.store._flushHistory()
+
 		// at the end of this process we want to have at most one pending push request
 		// based on anything inside this.speculativeChanges
-		transact(() => {
-			// Now our goal is to rebase on the server's state.
-			// This means wiping away any peer presence data, which the server will replace in full on every connect.
-			// If the server does not have enough history to give us a partial document state hydration we will
-			// also need to wipe away all of our document state before hydrating with the server's state from scratch.
-			const stashedChanges = this.speculativeChanges
-			this.speculativeChanges = { added: {} as any, updated: {} as any, removed: {} as any }
-
-			this.store.mergeRemoteChanges(() => {
-				// gather records to delete in a NetworkDiff
-				const wipeDiff: NetworkDiff<R> = {}
-				const wipeAll = event.hydrationType === 'wipe_all'
-				if (!wipeAll) {
-					// if we're only wiping presence data, undo the speculative changes first
-					this.store.applyDiff(reverseRecordsDiff(stashedChanges), { runCallbacks: false })
-				}
-
-				// now wipe all presence data and, if needed, all document data
-				for (const [id, record] of objectMapEntries(this.store.serialize('all'))) {
-					if (
-						(wipeAll && this.store.scopedTypes.document.has(record.typeName)) ||
-						record.typeName === this.presenceType
-					) {
-						wipeDiff[id] = [RecordOpType.Remove]
+		//
+		// Now our goal is to rebase on the server's state.
+		// This means wiping away any peer presence data, which the server will replace in full on every connect.
+		// If the server does not have enough history to give us a partial document state hydration we will
+		// also need to wipe away all of our document state before hydrating with the server's state from scratch.
+		const stashedChanges = this.speculativeChanges
+		this.speculativeChanges = createEmptyRecordsDiff<R>()
+		try {
+			transact(() => {
+				this.store.mergeRemoteChanges(() => {
+					// gather records to delete in a NetworkDiff
+					const wipeDiff: NetworkDiff<R> = {}
+					const wipeAll = event.hydrationType === 'wipe_all'
+					if (!wipeAll) {
+						// if we're only wiping presence data, undo the speculative changes first
+						this.store.applyDiff(reverseRecordsDiff(stashedChanges), { runCallbacks: false })
 					}
+
+					// now wipe all presence data and, if needed, all document data
+					for (const [id, record] of objectMapEntries(this.store.serialize('all'))) {
+						if (
+							(wipeAll && this.store.scopedTypes.document.has(record.typeName)) ||
+							record.typeName === this.presenceType
+						) {
+							wipeDiff[id] = [RecordOpType.Remove]
+						}
+					}
+
+					// then apply the upstream changes
+					this.applyNetworkDiff({ ...wipeDiff, ...event.diff }, true)
+
+					this.isConnectedToRoom = true
+
+					// now re-apply the speculative changes creating a new push request with the
+					// appropriate diff
+					const networkDiff = getNetworkDiff(stashedChanges)
+					if (!networkDiff) return
+					const speculativeChanges = this.store.filterChangesByScope(
+						this.store.extractingChanges(() => {
+							this.applyNetworkDiff(networkDiff, true)
+						}),
+						'document'
+					)
+					if (speculativeChanges) this.push(speculativeChanges)
+				})
+
+				this.onAfterConnect?.(this, {
+					isReadonly: event.isReadonly,
+					objectAccess: event.objectAccess ?? 'write',
+				})
+				const presence = this.presenceState?.get()
+				if (presence) {
+					this.pushPresence(presence)
 				}
-
-				// then apply the upstream changes
-				this.applyNetworkDiff({ ...wipeDiff, ...event.diff }, true)
-
-				this.isConnectedToRoom = true
-
-				// now re-apply the speculative changes creating a new push request with the
-				// appropriate diff
-				const networkDiff = getNetworkDiff(stashedChanges)
-				if (!networkDiff) return
-				const speculativeChanges = this.store.filterChangesByScope(
-					this.store.extractingChanges(() => {
-						this.applyNetworkDiff(networkDiff, true)
-					}),
-					'document'
-				)
-				if (speculativeChanges) this.push(speculativeChanges)
 			})
-
-			// this.isConnectedToRoom = true
-			// this.store.applyDiff(stashedChanges, false)
-
-			this.onAfterConnect?.(this, {
-				isReadonly: event.isReadonly,
-				objectAccess: event.objectAccess ?? 'write',
-			})
-			const presence = this.presenceState?.get()
-			if (presence) {
-				this.pushPresence(presence)
+		} catch (e) {
+			// The transaction rolled the store back to its pre-connect state, which still holds the
+			// stashed local changes; put them back under tracking so they are neither orphaned nor
+			// lost. (No ensureStoreIsUsable here: on a first connect the store is empty, and the
+			// default records it would create would be pushed over the server's on the next try.)
+			console.error(e)
+			this.speculativeChanges = stashedChanges
+			this.didHydrationFail = true
+			if (++this.hydrationFailures >= MAX_CONSECUTIVE_HYDRATION_FAILURES) {
+				// the same response keeps failing: give up rather than re-hydrating the room forever
+				this.onSyncError(TLSyncErrorCloseEventReason.UNKNOWN_ERROR)
+				this.close()
+				return
 			}
-		})
+			// start over rather than sitting half-connected forever (no ping loop runs until we're
+			// connected, so nothing else would recover the socket)
+			this.resetConnection()
+			return
+		}
 
+		this.hydrationFailures = 0
 		this.lastServerClock = event.serverClock
 	}
 
@@ -900,7 +942,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		// in offline mode, we only accumulate in speculativeChanges
 		if (!this.isConnectedToRoom) return
 		if (!this.unsentChanges.nextDiff) {
-			this.unsentChanges.nextDiff = { added: {} as any, updated: {} as any, removed: {} as any }
+			this.unsentChanges.nextDiff = createEmptyRecordsDiff<R>()
 		}
 		// records are immutable, so sharing their references with `change` is fine — the
 		// squash gives nextDiff its own containers and tuples without deep-cloning records
@@ -920,7 +962,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 */
 	private applyNetworkDiff(diff: NetworkDiff<R>, runCallbacks: boolean) {
 		this.debug('applyNetworkDiff', diff)
-		const changes: RecordsDiff<R> = { added: {} as any, updated: {} as any, removed: {} as any }
+		const changes: RecordsDiff<R> = createEmptyRecordsDiff<R>()
 		type k = keyof typeof changes.updated
 		let hasChanges = false
 		for (const [id, op] of objectMapEntries(diff)) {
@@ -1011,7 +1053,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				} catch (e) {
 					console.error(e)
 					// throw away the speculative changes and start over
-					this.speculativeChanges = { added: {} as any, updated: {} as any, removed: {} as any }
+					this.speculativeChanges = createEmptyRecordsDiff<R>()
 					this.resetConnection()
 				}
 			})

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -258,7 +258,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}, 1000)
 
 	private scheduleFollowUpPrune() {
-		if (this.pruneTimer) return
+		// no new timers once closed: a late socket close would otherwise resurrect pruning and emit
+		// session_removed / room_became_empty against a room the host has already torn down
+		if (this._isClosed || this.pruneTimer) return
 		this.pruneTimer = setTimeout(this.pruneSessions, SESSION_REMOVAL_WAIT_TIME + 100)
 	}
 
@@ -273,11 +275,27 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * and stops background processes.
 	 */
 	close() {
+		this._isClosed = true
 		this.disposables.forEach((d) => d())
 		this.sessions.forEach((session) => {
-			session.socket.close()
+			// a debounced flush firing after the sockets are closed would call send() on a closed
+			// socket, which throws on some runtimes (Cloudflare) from inside a timer
+			this.clearDebounceTimer(session)
+			try {
+				session.socket.close()
+			} catch {
+				// noop, one bad socket must not leave the rest open
+			}
 		})
-		this._isClosed = true
+		this.sessions.clear()
+	}
+
+	private clearDebounceTimer(session: RoomSession<R, SessionMeta>) {
+		if (session.state === RoomSessionState.Connected && session.debounceTimer !== null) {
+			clearTimeout(session.debounceTimer)
+			session.debounceTimer = null
+			session.outstandingDataMessages = []
+		}
 	}
 
 	/**
@@ -519,6 +537,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			// place, so sockets that defer serialization don't see an emptied array
 			const data = session.outstandingDataMessages
 			session.outstandingDataMessages = []
+			if (!session.socket.isOpen) {
+				// same as the immediate-send path: a closed socket cancels the session rather
+				// than making us send into it (which throws on some runtimes)
+				this.cancelSession(sessionId)
+				return
+			}
 			session.socket.sendMessage({ type: 'data', data })
 		}
 	}
@@ -532,6 +556,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		}
 
 		this.sessions.delete(sessionId)
+		this.clearDebounceTimer(session)
 
 		try {
 			if (fatalReason) {
@@ -570,6 +595,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			return
 		}
 
+		this.clearDebounceTimer(session)
 		this.sessions.set(sessionId, {
 			state: RoomSessionState.AwaitingRemoval,
 			sessionId,
@@ -607,9 +633,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		networkDiff?: NetworkDiff<R> | null,
 		sourceSessionId?: string
 	) {
-		// Pre-compute network diff if not provided
-		const unmigrated = networkDiff ?? toNetworkDiff(diff)
-		if (!unmigrated) return this
+		// Computed once and shared by every session that needs no down-migration; the push path
+		// hands us the diff it already computed (in legacy append mode when needed), and re-deriving
+		// it per session would both repeat the diffing work and lose that legacy handling.
+		const legacyAppendMode = !this.getCanEmitStringAppend()
+		const unmigrated = networkDiff ?? toNetworkDiff(diff, legacyAppendMode)
 
 		this.sessions.forEach((session) => {
 			if (session.state !== RoomSessionState.Connected) return
@@ -623,7 +651,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				session.sessionId,
 				session.serializedSchema,
 				session.requiresDownMigrations,
-				diff
+				diff,
+				unmigrated,
+				legacyAppendMode
 			)
 			if (!diffResult.ok) return
 
@@ -693,6 +723,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}) {
 		const { sessionId, socket, meta, isReadonly, objectAccess } = opts
 		const existing = this.sessions.get(sessionId)
+		if (existing) this.clearDebounceTimer(existing)
 		this.sessions.set(sessionId, {
 			state: RoomSessionState.AwaitingConnectMessage,
 			sessionId,
@@ -761,6 +792,17 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			supportsStringAppend,
 		})
 
+		// The server may have changed builds while the socket slept, so re-run the handshake's
+		// schema checks (HS3): a schema we can no longer reconcile must not be served raw diffs.
+		if (!migrations.ok) {
+			this.rejectSession(sessionId, this.getVersionMismatchReason(serializedSchema))
+			return
+		}
+		if (migrations.value.some((m) => m.scope !== 'record' || !m.down)) {
+			this.rejectSession(sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
+			return
+		}
+
 		if (presenceRecord && presenceId) {
 			this.presenceStore.set(presenceId, presenceRecord as R)
 		}
@@ -798,6 +840,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * @param requiresDownMigrations - Whether the client needs down migrations
 	 * @param diff - The TLSyncForwardDiff containing full records to migrate
 	 * @param unmigrated - Optional pre-computed NetworkDiff for when no migration is needed
+	 * @param legacyAppendMode - Emit string appends as puts (SES5); defaults to the room-wide state
 	 * @returns A NetworkDiff with migrated records, or a migration failure
 	 */
 	private migrateDiffOrRejectSession(
@@ -805,10 +848,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		serializedSchema: SerializedSchema,
 		requiresDownMigrations: boolean,
 		diff: TLSyncForwardDiff<R>,
-		unmigrated?: NetworkDiff<R>
+		unmigrated?: NetworkDiff<R>,
+		legacyAppendMode = !this.getCanEmitStringAppend()
 	): Result<NetworkDiff<R>, MigrationFailureReason> {
 		if (!requiresDownMigrations) {
-			return Result.ok(unmigrated ?? toNetworkDiff(diff) ?? {})
+			return Result.ok(unmigrated ?? toNetworkDiff(diff, legacyAppendMode))
 		}
 
 		const result: NetworkDiff<R> = {}
@@ -828,7 +872,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					this.rejectSession(sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 					return Result.err(toResult.reason)
 				}
-				const patch = diffRecord(fromResult.value, toResult.value)
+				const patch = diffRecord(fromResult.value, toResult.value, legacyAppendMode)
 				if (patch) {
 					result[id] = [RecordOpType.Patch, patch]
 				}
@@ -1055,7 +1099,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 
 		const requiresDownMigrations = migrations.value.length > 0
 
-		const connect = async (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+		const connect = (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+			// broadcastChanges may have force-reconnected everyone (wipeAll) while we were in the
+			// transaction, removing this very session; re-adding it would resurrect a session whose
+			// socket is already closed and emit a second `session_removed` for it later
+			if (this.sessions.get(session.sessionId) !== session) return
 			this.sessions.set(session.sessionId, {
 				state: RoomSessionState.Connected,
 				sessionId: session.sessionId,
@@ -1139,7 +1187,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		if (session && session.state !== RoomSessionState.Connected) {
 			return
 		}
-		// update the last interaction time
 		if (session) {
 			session.lastInteractionTime = Date.now()
 		}
@@ -1196,7 +1243,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			}
 			let { value: state } = res
 
-			// Get the existing document, if any
 			const doc =
 				prevDoc !== undefined ? (prevDoc ?? undefined) : (storage.get(id) as R | undefined)
 
@@ -1212,7 +1258,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				// If there's an existing document, replace it with the new state
 				// but propagate a diff rather than the entire value
 				const recordType = assertExists(getOwnProperty(this.schema.types, doc.typeName))
-				const diff = diffAndValidateRecord(doc, state, recordType)
+				const diff = diffAndValidateRecord(doc, state, recordType, legacyAppendMode)
 				if (diff) {
 					storage.set(id, state)
 					propagateOp(changes, id, [RecordOpType.Patch, diff], doc, state)
@@ -1330,6 +1376,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 					!session ||
 					(this.objectTypes.has(typeName) ? session.objectAccess !== 'read' : !session.isReadonly)
 
+				// what authorizers see of the pushing session, shared by every authorized op in this push
+				const authSession = session
+					? { sessionId: session.sessionId, isReadonly: session.isReadonly, meta: session.meta }
+					: null
+
 				if (message.diff) {
 					// The push request was for the document scope.
 					for (const [id, op] of objectMapEntriesIterable(message.diff!)) {
@@ -1380,26 +1431,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 										authorize = (prevRec, next) => {
 											const result = authorizePut(
 												prevRec
-													? {
-															session: {
-																sessionId: session.sessionId,
-																isReadonly: session.isReadonly,
-																meta: session.meta,
-															},
-															type: 'update',
-															prev: prevRec,
-															next,
-														}
-													: {
-															session: {
-																sessionId: session.sessionId,
-																isReadonly: session.isReadonly,
-																meta: session.meta,
-															},
-															type: 'create',
-															prev: null,
-															next,
-														}
+													? { session: authSession!, type: 'update', prev: prevRec, next }
+													: { session: authSession!, type: 'create', prev: null, next }
 											)
 											if (!result) {
 												this.log?.warn?.(
@@ -1431,11 +1464,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								const authorize = authorizePatch
 									? (prev: R, next: R) => {
 											const result = authorizePatch({
-												session: {
-													sessionId: session.sessionId,
-													isReadonly: session.isReadonly,
-													meta: session.meta,
-												},
+												session: authSession!,
 												type: 'update',
 												prev,
 												next,
@@ -1469,16 +1498,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								const authorizeRemove = session && this.authorizerFor(doc.typeName)
 								if (
 									authorizeRemove &&
-									!authorizeRemove({
-										session: {
-											sessionId: session.sessionId,
-											isReadonly: session.isReadonly,
-											meta: session.meta,
-										},
-										type: 'delete',
-										prev: doc,
-										next: null,
-									})
+									!authorizeRemove({ session: authSession!, type: 'delete', prev: doc, next: null })
 								) {
 									this.log?.warn?.(
 										'authorizer vetoed delete',
@@ -1510,7 +1530,10 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		let pushResult: TLSocketServerSentEvent<R> | undefined
 		if (changes && session) {
 			// txn did not apply verbatim so we should broadcast the actual changes
-			result.docChanges.diffs = { networkDiff: toNetworkDiff(changes) ?? {}, diff: changes }
+			result.docChanges.diffs = {
+				networkDiff: toNetworkDiff(changes, legacyAppendMode),
+				diff: changes,
+			}
 		}
 
 		if (isEqual(result.docChanges.diffs?.networkDiff, message.diff)) {
@@ -1535,7 +1558,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				session.serializedSchema,
 				session.requiresDownMigrations,
 				result.docChanges.diffs.diff,
-				result.docChanges.diffs.networkDiff
+				result.docChanges.diffs.networkDiff,
+				legacyAppendMode
 			)
 			if (diff.ok) {
 				pushResult = {

--- a/packages/sync-core/src/lib/TLSyncStorage.ts
+++ b/packages/sync-core/src/lib/TLSyncStorage.ts
@@ -1,6 +1,6 @@
 import { StoreSchema, SynchronousStorage, UnknownRecord } from '@tldraw/store'
+import { TLStoreSnapshot } from '@tldraw/tlschema'
 import { assert, isEqual, objectMapEntriesIterable, objectMapValues } from '@tldraw/utils'
-import { TLStoreSnapshot } from 'tldraw'
 import { diffRecord, NetworkDiff, RecordOpType } from './diff'
 import { RoomSnapshot } from './TLSyncRoom'
 
@@ -146,13 +146,18 @@ export interface TLSyncForwardDiff<R extends UnknownRecord> {
 }
 
 /**
+ * @param legacyAppendMode - When true, string appends are emitted as puts (see `diffRecord`); the
+ * room sets this whenever a connected client predates string-append support.
  * @internal
  */
-export function toNetworkDiff<R extends UnknownRecord>(diff: TLSyncForwardDiff<R>): NetworkDiff<R> {
+export function toNetworkDiff<R extends UnknownRecord>(
+	diff: TLSyncForwardDiff<R>,
+	legacyAppendMode = false
+): NetworkDiff<R> {
 	const networkDiff: NetworkDiff<R> = {}
 	for (const [id, put] of objectMapEntriesIterable(diff.puts)) {
 		if (Array.isArray(put)) {
-			const patch = diffRecord(put[0], put[1])
+			const patch = diffRecord(put[0], put[1], legacyAppendMode)
 			if (patch) {
 				networkDiff[id] = [RecordOpType.Patch, patch]
 			}
@@ -205,7 +210,9 @@ export function loadSnapshotIntoStorage<R extends UnknownRecord>(
 		if (isEqual(existing, doc.state)) continue
 		txn.set(doc.state.id, doc.state as R)
 	}
-	for (const id of txn.keys()) {
+	// materialize the keys first: some SQLite drivers (better-sqlite3) refuse writes while a
+	// statement iterator is open, so deleting during `keys()` would throw
+	for (const id of Array.from(txn.keys())) {
 		if (!docIds.has(id)) {
 			txn.delete(id)
 		}

--- a/packages/sync-core/src/lib/chunk.test.ts
+++ b/packages/sync-core/src/lib/chunk.test.ts
@@ -134,6 +134,33 @@ describe('chunk (CH1–CH3)', () => {
 		`)
 		})
 	})
+
+	describe('surrogate pairs (CH9)', () => {
+		it('[CH9] never splits a surrogate pair across two chunks', () => {
+			// WebSocket.send converts each chunk to a USVString, so a lone surrogate would arrive
+			// as U+FFFD and the reassembled message would carry corrupted text
+			const emoji = '\u{1F600}'
+			const isHigh = (code: number) => code >= 0xd800 && code <= 0xdbff
+			const isLow = (code: number) => code >= 0xdc00 && code <= 0xdfff
+			for (let padding = 0; padding < 8; padding++) {
+				const msg = 'x'.repeat(padding) + emoji + 'y'.repeat(6) + emoji
+				for (const maxSize of [3, 4, 5, 6, 7, 8]) {
+					const chunks = chunk(msg, maxSize)
+					const bodies = chunks.map((c) => c.slice(c.indexOf('_') + 1))
+					expect(bodies.join('')).toBe(msg)
+					for (const [i, body] of bodies.entries()) {
+						expect(body.length).toBeGreaterThan(0)
+						expect(isHigh(body.charCodeAt(body.length - 1))).toBe(false)
+						expect(isLow(body.charCodeAt(0))).toBe(false)
+						// keeping a pair whole may cost one character over maxSize, never more
+						expect(chunks[i].length).toBeLessThanOrEqual(
+							Math.max(maxSize, chunks[i].indexOf('_') + 2) + 1
+						)
+					}
+				}
+			}
+		})
+	})
 })
 
 const testObject = {} as any

--- a/packages/sync-core/src/lib/chunk.ts
+++ b/packages/sync-core/src/lib/chunk.ts
@@ -38,13 +38,33 @@ export function chunk(msg: string, maxSafeMessageSize = MAX_SAFE_MESSAGE_SIZE) {
 		let offset = msg.length
 		while (offset > 0) {
 			const prefix = `${chunkNumber}_`
-			const chunkSize = Math.max(Math.min(maxSafeMessageSize - prefix.length, offset), 1)
+			let chunkSize = Math.max(Math.min(maxSafeMessageSize - prefix.length, offset), 1)
+			// Never split a surrogate pair across chunks: WebSocket.send converts each chunk to a
+			// USVString, turning a lone surrogate into U+FFFD, and the reassembled JSON would then
+			// carry corrupted text (e.g. an emoji becoming '\uFFFD\uFFFD') without any error.
+			// Shrink the chunk by one so the pair moves whole into the preceding chunk; when the
+			// chunk is already a single character, grow it by one instead (as CH3 already permits).
+			if (
+				chunkSize < offset &&
+				isLowSurrogate(msg.charCodeAt(offset - chunkSize)) &&
+				isHighSurrogate(msg.charCodeAt(offset - chunkSize - 1))
+			) {
+				chunkSize += chunkSize > 1 ? -1 : 1
+			}
 			chunks.unshift(prefix + msg.slice(offset - chunkSize, offset))
 			offset -= chunkSize
 			chunkNumber++
 		}
 		return chunks
 	}
+}
+
+function isHighSurrogate(code: number) {
+	return code >= 0xd800 && code <= 0xdbff
+}
+
+function isLowSurrogate(code: number) {
+	return code >= 0xdc00 && code <= 0xdfff
 }
 
 // The 's' flag (dotAll) makes '.' match any character including line terminators

--- a/packages/sync-core/src/lib/diff.test.ts
+++ b/packages/sync-core/src/lib/diff.test.ts
@@ -39,6 +39,42 @@ describe('computing diffs (D)', () => {
 			expect(patch).toEqual({ c: [ValueOpType.Put, 3] })
 			expect(applyObjectDiff(a, patch!)).toEqual(b)
 		})
+
+		it('[D2] treats a key whose value is undefined as absent', () => {
+			// undefined does not survive JSON, so `['put', undefined]` would arrive as
+			// `['put', null]` and fail validators that only accept the key being missing
+			const present = { a: 1, props: { foo: 'x' } }
+			const explicitlyUndefined = { a: 1, props: { foo: undefined } }
+			const absent = { a: 1, props: {} }
+
+			expect(diffRecord(present, explicitlyUndefined)).toEqual({
+				props: [ValueOpType.Patch, { foo: [ValueOpType.Delete] }],
+			})
+			expect(diffRecord(explicitlyUndefined, present)).toEqual({
+				props: [ValueOpType.Patch, { foo: [ValueOpType.Put, 'x'] }],
+			})
+			expect(diffRecord(absent, explicitlyUndefined)).toBeNull()
+			expect(diffRecord(explicitlyUndefined, absent)).toBeNull()
+			expect(diffRecord({ a: undefined }, { a: undefined })).toBeNull()
+		})
+
+		it('[D2] only considers own keys, not Object.prototype members', () => {
+			const withCtor = { meta: { constructor: 1, toString: 2 } }
+			const without = { meta: {} }
+
+			expect(diffRecord(withCtor, without)).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ constructor: [ValueOpType.Delete], toString: [ValueOpType.Delete] },
+				],
+			})
+			expect(diffRecord(without, withCtor)).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ constructor: [ValueOpType.Put, 1], toString: [ValueOpType.Put, 2] },
+				],
+			})
+		})
 	})
 
 	describe('top-level keys vs props/meta (D3)', () => {
@@ -102,7 +138,8 @@ describe('computing diffs (D)', () => {
 
 			const diff = diffRecord(prev, next)
 			expect(diff).toBeTruthy()
-			expect(diff!.optional).toEqual([ValueOpType.Put, undefined])
+			// undefined is not representable on the wire, so it reads as the key being absent (D2)
+			expect(diff!.optional).toEqual([ValueOpType.Delete])
 			expect(diff!.nullable).toEqual([ValueOpType.Put, 'value'])
 		})
 	})
@@ -377,6 +414,25 @@ describe('computing diffs (D)', () => {
 			expect(diffRecord(prev, next)).toEqual({
 				arr: [ValueOpType.Patch, { '0': [ValueOpType.Put, null] }],
 			})
+		})
+
+		it('[D6] puts a changed index when an item switches between array and object', () => {
+			// index deletes and named puts don't apply cleanly across shapes, so a patch would
+			// leave the receiver with a sparse array / an object where an array is expected
+			const arrayItem = { meta: { items: [[1, 2]] } }
+			const objectItem = { meta: { items: [{ x: 1 }] } }
+
+			const toObject = diffRecord(arrayItem, objectItem)!
+			expect(toObject).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ items: [ValueOpType.Patch, { '0': [ValueOpType.Put, { x: 1 }] }] },
+				],
+			})
+			expect(applyObjectDiff(arrayItem, toObject)).toEqual(objectItem)
+
+			const toArray = diffRecord(objectItem, arrayItem)!
+			expect(applyObjectDiff(objectItem, toArray)).toEqual(arrayItem)
 		})
 	})
 
@@ -746,6 +802,30 @@ describe('applying diffs (AD)', () => {
 			const diff: ObjectDiff = { b: [ValueOpType.Delete] }
 
 			expect(applyObjectDiff(obj, diff)).toBe(obj)
+		})
+
+		it('[AD5] deleting an inherited key has no effect', () => {
+			const obj = { a: 1 }
+			// `toString` collides with Object.prototype's own member in the literal's type, hence the cast
+			const diff = { toString: [ValueOpType.Delete] } as unknown as ObjectDiff
+
+			expect(applyObjectDiff(obj, diff)).toBe(obj)
+		})
+	})
+
+	describe('untrusted keys (AD8)', () => {
+		it('[AD8] ignores __proto__ keys instead of changing the prototype', () => {
+			// JSON.parse produces '__proto__' as an own key, so a peer can put it in a diff
+			const obj = { a: 1, props: { b: 2 } }
+			const diff: ObjectDiff = JSON.parse(
+				'{"__proto__":["put",{"isAdmin":true}],"props":["patch",{"__proto__":["put",{"polluted":1}]}]}'
+			)
+
+			const result: any = applyObjectDiff(obj, diff)
+			expect(result).toBe(obj)
+			expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+			expect(result.isAdmin).toBeUndefined()
+			expect(result.props.polluted).toBeUndefined()
 		})
 	})
 

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -1,5 +1,5 @@
 import { RecordsDiff, UnknownRecord } from '@tldraw/store'
-import { isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
+import { hasOwnProperty, isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
 
 /**
  * Constants representing the types of operations that can be applied to records in network diffs.
@@ -200,15 +200,19 @@ function diffObject(
 		return null
 	}
 	let result: ObjectDiff | null = null
+	// Own-property checks throughout: `in` would see Object.prototype members, so a user key named
+	// e.g. 'constructor' would never diff as an add or delete. And a key whose value is `undefined`
+	// is treated as absent: `undefined` doesn't survive JSON, so `['put', undefined]` would arrive
+	// as `['put', null]` and fail validators that accept only the missing key.
 	for (const key of Object.keys(prev)) {
-		// if key is not in next then it was deleted
-		if (!(key in next)) {
+		const prevValue = (prev as any)[key]
+		if (prevValue === undefined) continue
+		const nextValue = hasOwnProperty(next, key) ? (next as any)[key] : undefined
+		if (nextValue === undefined) {
 			if (!result) result = {}
 			result[key] = [ValueOpType.Delete]
 			continue
 		}
-		const prevValue = (prev as any)[key]
-		const nextValue = (next as any)[key]
 		if (
 			nestedKeys?.has(key) ||
 			(Array.isArray(prevValue) && Array.isArray(nextValue)) ||
@@ -226,10 +230,12 @@ function diffObject(
 		}
 	}
 	for (const key of Object.keys(next)) {
+		const nextValue = (next as any)[key]
+		if (nextValue === undefined) continue
 		// if key is in next but not in prev then it was added
-		if (!(key in prev)) {
+		if (!hasOwnProperty(prev, key) || (prev as any)[key] === undefined) {
 			if (!result) result = {}
-			result[key] = [ValueOpType.Put, (next as any)[key]]
+			result[key] = [ValueOpType.Put, nextValue]
 		}
 	}
 	return result
@@ -245,7 +251,15 @@ function diffValue(valueA: unknown, valueB: unknown, legacyAppendMode: boolean):
 			return [ValueOpType.Append, appendedText, valueA.length]
 		}
 		return [ValueOpType.Put, valueB]
-	} else if (!valueA || !valueB || typeof valueA !== 'object' || typeof valueB !== 'object') {
+	} else if (
+		!valueA ||
+		!valueB ||
+		typeof valueA !== 'object' ||
+		typeof valueB !== 'object' ||
+		// an array on one side and a plain object on the other can't be expressed as a patch:
+		// index deletes and named puts don't apply cleanly to either shape
+		Array.isArray(valueA) !== Array.isArray(valueB)
+	) {
 		return isEqual(valueA, valueB) ? null : [ValueOpType.Put, valueB]
 	} else {
 		const diff = diffObject(valueA, valueB, undefined, legacyAppendMode)
@@ -348,6 +362,10 @@ export function applyObjectDiff<T extends object>(object: T, objectDiff: ObjectD
 		}
 	}
 	for (const [key, op] of Object.entries(objectDiff)) {
+		// Diffs come off the wire from untrusted peers. `newObject['__proto__'] = v` would set the
+		// record's prototype (JSON.parse creates '__proto__' as an own key), so a client could give
+		// server-held records attacker-controlled inherited fields; skip such keys outright.
+		if (key === '__proto__') continue
 		switch (op[0]) {
 			case ValueOpType.Put: {
 				const value = op[1]
@@ -383,7 +401,7 @@ export function applyObjectDiff<T extends object>(object: T, objectDiff: ObjectD
 				break
 			}
 			case ValueOpType.Delete: {
-				if (key in object) {
+				if (hasOwnProperty(object, key)) {
 					if (!newObject) {
 						if (isArray) {
 							console.error("Can't delete array item yet (this should never happen)")

--- a/packages/sync-core/src/test/TLSocketRoom.test.ts
+++ b/packages/sync-core/src/test/TLSocketRoom.test.ts
@@ -522,6 +522,67 @@ describe('28. TLSocketRoom (SR)', () => {
 			expect(room.getSessions()[0].isConnected).toBe(false)
 			expect(socket.close).toHaveBeenCalled()
 		})
+
+		it('[SR6] ignores a close/error reported for a socket the session has moved on from', () => {
+			const oldSocket = createMockSocket()
+			connectSession(room, 'test-session', oldSocket)
+			// the client reconnects under the same session id before the old socket's close lands
+			const newSocket = createMockSocket()
+			connectSession(room, 'test-session', newSocket)
+			expect(room.getSessions()[0].isConnected).toBe(true)
+
+			room.handleSocketClose('test-session', oldSocket)
+			room.handleSocketError('test-session', oldSocket)
+			expect(room.getSessions()[0].isConnected).toBe(true)
+			expect(newSocket.close).not.toHaveBeenCalled()
+
+			// the current socket's close still cancels the session
+			room.handleSocketClose('test-session', newSocket)
+			expect(room.getSessions()[0].isConnected).toBe(false)
+			expect(newSocket.close).toHaveBeenCalled()
+		})
+
+		it('[SR4][SR6] a stale close delivered through the attached listeners does not cancel the replacement session', () => {
+			// mock sockets that actually dispatch to the listeners TLSocketRoom attaches (SR4)
+			function createListeningSocket() {
+				const listeners: Record<string, ((e: any) => void)[]> = {}
+				const s: WebSocketMinimal & { fire(type: string): void } = {
+					send: vi.fn(),
+					close: vi.fn(() => {
+						s.readyState = WebSocket.CLOSED
+					}),
+					readyState: WebSocket.OPEN,
+					addEventListener: vi.fn((type: string, fn: (e: any) => void) => {
+						;(listeners[type] ??= []).push(fn)
+					}),
+					removeEventListener: vi.fn((type: string, fn: (e: any) => void) => {
+						listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn)
+					}),
+					fire(type: string) {
+						for (const fn of listeners[type] ?? []) fn({})
+					},
+				}
+				return s
+			}
+			const w1 = createListeningSocket()
+			connectSession(room, 'S', w1)
+			// w1's network died silently: the client reconnects on w2 with the same session id
+			w1.readyState = WebSocket.CLOSED
+			const w2 = createListeningSocket()
+			connectSession(room, 'S', w2)
+			expect(w1.removeEventListener).toHaveBeenCalledTimes(3)
+
+			// the old socket's close event finally fires — the live session on w2 must survive
+			w1.fire('close')
+			w1.fire('error')
+			expect(room.getSessions()).toEqual([
+				expect.objectContaining({ sessionId: 'S', isConnected: true }),
+			])
+			expect(w2.close).not.toHaveBeenCalled()
+
+			w2.fire('close')
+			expect(room.getSessions()[0].isConnected).toBe(false)
+		})
 	})
 
 	describe('session reporting', () => {
@@ -1120,6 +1181,42 @@ describe('28. TLSocketRoom (SR)', () => {
 	})
 
 	describe('handleSocketResume', () => {
+		it('[SR14] ignores a resume of a stale socket while a live socket owns the session id', () => {
+			const room = new TLSocketRoom({})
+			const oldSocket = createMockSocket()
+			connectSession(room, 'S', oldSocket)
+			const snapshot = room.getSessionSnapshot('S')!
+
+			// the client reconnected on a new socket and is mid-handshake
+			const newSocket = createMockSocket()
+			room.handleSocketConnect({ sessionId: 'S', socket: newSocket })
+
+			// the host now sees the old socket close and resumes it briefly before closing it (as
+			// hibernation hosts do to broadcast the presence removal)
+			oldSocket.readyState = WebSocket.CLOSED
+			room.handleSocketResume({ sessionId: 'S', socket: oldSocket, snapshot })
+			room.handleSocketClose('S', oldSocket)
+
+			// the live socket's handshake still completes on the live socket
+			room.handleSocketMessage(
+				'S',
+				JSON.stringify({
+					type: 'connect',
+					connectRequestId: 'connect-S',
+					lastServerClock: 0,
+					protocolVersion: getTlsyncProtocolVersion(),
+					schema: createTLSchema().serialize(),
+				})
+			)
+			expect(room.getSessions()).toEqual([
+				expect.objectContaining({ sessionId: 'S', isConnected: true }),
+			])
+			expect(newSocket.close).not.toHaveBeenCalled()
+			expect(vi.mocked(newSocket.send).mock.calls.map((c) => JSON.parse(c[0]).type)).toContain(
+				'connect'
+			)
+		})
+
 		it('[SR14] creates a connected session that handles pings', () => {
 			const room = new TLSocketRoom({})
 			const socket = createMockSocket()

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -1949,6 +1949,67 @@ describe('25. Messaging and broadcast (RB)', () => {
 		expect(socketB.sendMessage).not.toHaveBeenCalled()
 	})
 
+	it('[RB3] a debounced flush into a socket that closed meanwhile cancels the session instead of sending', () => {
+		vi.useFakeTimers()
+		const { room, socketB } = setupTwoSessions()
+		const newPage = makePage('page_3', 'v1')
+
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 1,
+			diff: { [newPage.id]: ['put', newPage] },
+		} as TLPushRequest<TLRecord>)
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 2,
+			diff: { [newPage.id]: ['patch', { name: ['put', 'v2'] }] },
+		} as TLPushRequest<TLRecord>)
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+
+		// the socket closes while the second message sits in the debounce buffer
+		socketB.isOpen = false
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+		expect(room.sessions.get('b')?.state).toBe(RoomSessionState.AwaitingRemoval)
+	})
+
+	it('[RC7] close() drops pending debounced flushes so nothing is sent into closed sockets afterwards', () => {
+		vi.useFakeTimers()
+		const { room, socketB } = setupTwoSessions()
+		const newPage = makePage('page_3', 'v1')
+
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 1,
+			diff: { [newPage.id]: ['put', newPage] },
+		} as TLPushRequest<TLRecord>)
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 2,
+			diff: { [newPage.id]: ['patch', { name: ['put', 'v2'] }] },
+		} as TLPushRequest<TLRecord>)
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+
+		room.close()
+		expect(room.isClosed()).toBe(true)
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+		expect(socketB.close).toHaveBeenCalled()
+	})
+
+	it('[RC7] close() closes every socket even when one of them throws on close', () => {
+		const { room, socketA, socketB } = setupTwoSessions()
+		socketA.close.mockImplementationOnce(() => {
+			throw new Error('already closing')
+		})
+
+		expect(() => room.close()).not.toThrow()
+		expect(room.isClosed()).toBe(true)
+		expect(socketB.close).toHaveBeenCalled()
+	})
+
 	it('[RB4] a per-session migration failure during broadcast rejects only the affected session', () => {
 		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 		try {
@@ -2304,6 +2365,84 @@ describe('26. Session lifecycle (SES)', () => {
 		// the resumed session handles messages like any connected session
 		room.handleMessage('resumed', { type: 'ping' })
 		expect(socket.__lastMessage).toEqual({ type: 'pong' })
+	})
+
+	it('[SES5] no session receives string-append ops while a client without append support is connected', () => {
+		vi.useFakeTimers()
+		const { room } = makeRoom()
+		const v8 = connectSession(room, 'v8', { protocolVersion: getTlsyncProtocolVersion() })
+		const v7 = connectSession(room, 'v7', { protocolVersion: 7 })
+		expect(room.getCanEmitStringAppend()).toBe(false)
+
+		const hasAppend = (msg: any) => JSON.stringify(msg).includes('"append"')
+
+		// a full put over an existing record whose only change is a string append
+		room.handleMessage('v8', {
+			type: 'push',
+			clientClock: 1,
+			diff: { [pageRecord.id]: ['put', { ...pageRecord, name: pageRecord.name + ' more' }] },
+		} as TLPushRequest<TLRecord>)
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+		expect(sentDataMessages(v7)).toEqual([
+			{
+				type: 'patch',
+				diff: { [pageRecord.id]: ['patch', { name: ['put', pageRecord.name + ' more'] }] },
+				serverClock: 1,
+			},
+		])
+		expect(sentDataMessages(v8).some(hasAppend)).toBe(false)
+		clearSocket(v7)
+		clearSocket(v8)
+
+		// a patch whose recomputed broadcast would otherwise be an append
+		room.handleMessage('v8', {
+			type: 'push',
+			clientClock: 2,
+			diff: { [pageRecord.id]: ['patch', { name: ['put', pageRecord.name + ' more and more'] }] },
+		} as TLPushRequest<TLRecord>)
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+		expect(sentDataMessages(v7)).toEqual([
+			{
+				type: 'patch',
+				diff: {
+					[pageRecord.id]: ['patch', { name: ['put', pageRecord.name + ' more and more'] }],
+				},
+				serverClock: 2,
+			},
+		])
+		expect(sentDataMessages(v8)).toEqual([
+			{ type: 'push_result', clientClock: 2, serverClock: 2, action: 'commit' },
+		])
+	})
+
+	it('[SES6] handleResumedSession rejects a session whose schema the server can no longer reconcile', () => {
+		const { room } = makeRoom()
+		const socket = makeSocket()
+		const newerSchema: SerializedSchemaV2 = {
+			schemaVersion: 2,
+			sequences: {
+				...(room.serializedSchema as SerializedSchemaV2).sequences,
+				'com.tldraw.store': 999,
+			},
+		}
+
+		room.handleResumedSession({
+			sessionId: 'resumed',
+			socket,
+			meta: undefined,
+			isReadonly: false,
+			serializedSchema: newerSchema,
+			presenceId: null,
+			presenceRecord: null,
+			requiresLegacyRejection: false,
+			supportsStringAppend: true,
+		})
+
+		expect(room.sessions.has('resumed')).toBe(false)
+		expect(socket.close).toHaveBeenCalledWith(
+			TLSyncErrorCloseEventCode,
+			TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+		)
 	})
 
 	it('[SES7] a message from an unknown session id logs a warning and is ignored', () => {

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -8,6 +8,7 @@ import {
 	TLSocketServerSentEvent,
 	getTlsyncProtocolVersion,
 } from '../lib/protocol'
+import { TLSocketRoom } from '../lib/TLSocketRoom'
 import { TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason } from '../lib/TLSyncClient'
 import { RoomSnapshot, TLRoomSocket, TLSyncRoom } from '../lib/TLSyncRoom'
 
@@ -353,6 +354,40 @@ describe('object store lane', () => {
 			const late = connectSession(room, 'late', { clear: false })
 			const connectMsg = late.__messages.find((m: any) => m.type === 'connect') as any
 			expect(Object.keys(connectMsg.diff).sort()).toEqual([doc.id, note.id].sort())
+		})
+
+		it('[US1][US3] updateStore sees and can delete object-lane records', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			const socketRoom = new TLSocketRoom<R, void>({
+				schema,
+				storage: new InMemorySyncStorage<R>({
+					snapshot: { documents: [], clock: 0, documentClock: 0, schema: schema.serialize() },
+					objectTypes: ['note'],
+				}),
+				objectTypes: ['note'],
+			})
+			disposables.push(() => socketRoom.close())
+			const doc = Doc.create({ title: 'canvas' })
+			const note = Note.create({ text: 'annotation' })
+			socketRoom.storage.transaction((txn) => {
+				txn.set(doc.id, doc)
+				txn.set(note.id, note)
+			})
+
+			// the update context reads both lanes, not just the document snapshot
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			await socketRoom.updateStore((store) => {
+				expect(store.get(note.id)).toEqual(note)
+				expect(
+					store
+						.getAll()
+						.map((r) => r.id)
+						.sort()
+				).toEqual([doc.id, note.id].sort())
+				store.delete(note.id)
+			})
+			expect(socketRoom.getRecord(note.id)).toBeUndefined()
+			expect(socketRoom.getRecord(doc.id)).toEqual(doc)
 		})
 	})
 

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -274,10 +274,6 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				TLSocketServerSentEvent<TLRecord>
 			>
 		} else if (uri) {
-			if (connect) {
-				throw new Error('uri and connect cannot be used together')
-			}
-
 			socket = new ClientWebSocketAdapter(async () => {
 				const uriString = typeof uri === 'string' ? uri : await uri()
 
@@ -349,8 +345,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
-				// Merge so we don't clobber objectAccess if onAfterConnect ran first.
-				setState((prev) => ({ ...prev, readyClient: client }))
+				// Keep objectAccess (onAfterConnect always runs first for this client) but drop the
+				// rest: an `error` left behind by a previous client (e.g. NOT_FOUND on the old uri)
+				// would otherwise keep the hook reporting status 'error' for the new, healthy room.
+				setState((prev) => ({ readyClient: client, objectAccess: prev?.objectAccess }))
 			},
 			onSyncError(reason) {
 				console.error('sync error', reason)

--- a/packages/sync/src/useSyncDemo.test.ts
+++ b/packages/sync/src/useSyncDemo.test.ts
@@ -120,6 +120,19 @@ describe('useSyncDemo', () => {
 			)
 			expect(result).toEqual({ src: 'https://demo.server.com/uploads/unique-123-test-file-jpg' })
 		})
+
+		it('should reject the upload when the server responds with an error status', async () => {
+			useSyncDemo({ roomId: 'test-room', host: 'https://demo.server.com' })
+
+			const useSyncCall = vi.mocked(useSync).mock.calls[0][0]
+			const assetStore = useSyncCall.assets
+			const file = new File(['test content'], 'test-file.jpg')
+
+			// a rejected upload resolves the fetch; the asset must not point at a URL that was never stored
+			vi.mocked(mockFetch).mockResolvedValueOnce(new Response(null, { status: 409 }))
+
+			await expect(assetStore.upload({} as TLAsset, file)).rejects.toThrow('409')
+		})
 	})
 
 	describe('bookmark asset creation', () => {

--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -187,10 +187,15 @@ function createDemoAssetStore(host: string): TLAssetStore {
 			const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
 			const url = `${host}/uploads/${objectName}`
 
-			await fetch(url, {
+			const response = await fetch(url, {
 				method: 'POST',
 				body: file,
 			})
+			// a rejected upload (invalid name, duplicate, server error) resolves the fetch; without
+			// this the asset would point at a URL that was never stored
+			if (!response.ok) {
+				throw new Error(`Failed to upload asset (${response.status})`)
+			}
 
 			return { src: url }
 		},

--- a/templates/sync-cloudflare/worker/TldrawDurableObject.ts
+++ b/templates/sync-cloudflare/worker/TldrawDurableObject.ts
@@ -140,7 +140,11 @@ export class TldrawDurableObject extends DurableObject {
 		const attachment = ws.deserializeAttachment() as SocketAttachment | null
 		if (!attachment?.sessionId) return
 
-		this.sessionIdToWs.delete(attachment.sessionId)
+		// only forget the mapping if it still points at this socket: a reconnect under the same
+		// session id may already have replaced it
+		if (this.sessionIdToWs.get(attachment.sessionId) === ws) {
+			this.sessionIdToWs.delete(attachment.sessionId)
+		}
 
 		const room = this.getOrCreateRoom()
 
@@ -155,6 +159,7 @@ export class TldrawDurableObject extends DurableObject {
 			})
 		}
 
-		room[method](attachment.sessionId)
+		// pass the socket so a close from a superseded socket can't cancel a reconnected session
+		room[method](attachment.sessionId, ws)
 	}
 }


### PR DESCRIPTION
In order to make multiplayer and local persistence hold up under the messy real-world conditions they actually run in — sockets that die silently and reconnect under the same tab id, transactions that roll back, tabs closing mid-write, old clients sharing a room with new ones — this PR fixes a batch of correctness bugs found by a deep review of `packages/sync`, `packages/sync-core`, and the local IndexedDB sync client. Every fix has a regression test that reproduces the original failure.

Most of these are quiet: nothing throws, the room just ends up desynced, a page comes back after you deleted it, or the last few edits before you closed the tab never made it to disk. They are grouped below by where they bite.

### Server: rooms and sessions

- **A reconnect under the same session id could be torn down by its predecessor.** `useSync` always sends `TAB_ID` as the session id. When a socket dies silently (sleep/wake, network switch) and the client reconnects, the old socket's listeners stayed attached and `handleSocketClose(sessionId)` was keyed by id only, so the old socket's eventual `close` cancelled the healthy new session. On Cloudflare the same race could rebind a mid-handshake session to the dead socket, leaving the tab hung. `TLSocketRoom` now detaches the previous socket's listeners on reconnect, `handleSocketClose`/`handleSocketError` take the originating socket and ignore stale ones, and `handleSocketResume` won't let a closing socket displace an open one. Both hibernation hosts (`TLFileDurableObject`, the `sync-cloudflare` template) pass the socket through and only drop their `sessionId → ws` mapping when it still points at the closing socket.
- **Protocol-7 clients received string `append` ops.** `broadcastPatch` re-derived the network diff per session without the push's legacy-append flag, and `addDocument`'s put-over-existing path ignored it. A v7 client's `applyObjectDiff` drops the op silently, so its text stayed stale until an unrelated whole-value put. The already-computed legacy-safe diff is now threaded through `broadcastPatch`, `migrateDiffOrRejectSession`, `toNetworkDiff`, and `addDocument` (also removing an O(sessions × records) redundant re-diff per broadcast).
- **`TLSyncRoom.close()` ordering.** It now marks closed first, clears per-session debounce timers, tolerates a throwing socket, forgets sessions, and schedules no further prunes — a late socket close was able to resurrect pruning and emit `session_removed` / `room_became_empty` against a room the host had already torn down. The debounced flush no longer sends into a closed socket (throws on Cloudflare), a session removed during its own handshake isn't resurrected by its `connect` callback, and a resumed session re-runs the handshake's schema checks in case the server changed builds while the socket slept.
- **Storage.** `InMemorySyncStorage` computed the max clock with `Math.max(0, ...clocks)`, which overflows the stack at ~120k records/tombstones — a big room became permanently unopenable. `loadSnapshotIntoStorage` and `StoreSchema.migrateStorage` deleted while iterating, which better-sqlite3 (used by the simple-server and socketio templates) rejects, so `room.loadSnapshot()` failed on that backend. `SQLiteSyncStorage.pruneTombstones` is transactional and can't throw from a timer after `db.close()`; `NodeSqliteWrapper` rolls back when `COMMIT` fails. `TLSocketRoom.updateStore` reads both storage lanes (object-lane records were invisible and undeletable). `ServerSocketAdapter.close` truncates reasons over 123 UTF-8 bytes instead of throwing and leaving the socket open. `TLSocketRoom` shares its default logger with `TLSyncRoom`, so authorizer throws are no longer silently swallowed when no `log` is passed.

### Client: `TLSyncClient`, `ClientWebSocketAdapter`, `useSync`

- **`didReconnect` skipped changes still queued behind the store's frame throttle.** `rebase()` flushes history first; `didReconnect` didn't, so a change queued behind rAF was neither reverted nor re-applied on top of the server state. Offline put-then-delete of a page: the delete squashed away and the page came back for good. Now flushes first.
- **`didReconnect` had no error handling.** A connect diff that failed to apply (custom-shape schema skew, one corrupt record) threw out of the socket handler, leaving the client half-connected forever: `isConnectedToRoom` false, no ping loop, `speculativeChanges` already emptied while the store rolled back to a state that still held those edits, `useSync` stuck at `loading` (dotcom uses `clientTimeout: Infinity`, so the server kept the session too). The transaction is now caught, the stashed changes are restored under tracking, `onLoad` is held back, the socket restarts, and after 3 consecutive failures the client fires `onSyncError('UNKNOWN_ERROR')` and closes rather than re-hydrating the whole room every 500 ms.
- **`ReconnectManager` stalled permanently if `getUri` rejected.** In the documented `useSync` pattern `getUri` is an auth-token fetch; one 500 left the manager in `pendingAttempt` with no timer and no socket. Failures now retry on the usual backoff. `ClientWebSocketAdapter.close()` also orphans the socket first so its `onclose` can't notify listeners and schedule a reconnect (calling the app's `getUri`) after disposal.
- **`useSync` reported a stale error for a new, healthy room.** `onLoad` merged into the previous state (`{...prev, readyClient}`, from #9471), so an `error` left by a previous client (`NOT_FOUND`, `RATE_LIMITED`) was never cleared when the `uri` changed without a remount. `onLoad` now keeps only this client's `objectAccess`. Removed an unreachable `if (connect)` branch. `useSyncDemo`'s upload checks `response.ok` so a rejected upload doesn't produce an asset pointing at a URL that was never stored.

### Store: rolled-back transactions leaked to listeners

`transact(() => { store.put([a]); throw })` left `{added: [a]}` in the history accumulator, so on the next flush every listener — `TLSyncClient`, `TLLocalSyncClient` — received a change for a record the store never kept. The sync client pushed it, and on the `commit` push result re-applied its own diff, resurrecting the rolled-back record for everyone. Accumulator entries are now tagged with the history counter, and entries recorded past a counter that was later rolled back are dropped.

### Wire format: `diff.ts` and `chunk.ts`

- `diffObject` emitted `['put', undefined]` for undefined values, which JSON turns into `['put', null]`; optional-prop validators reject it, so the server kicked the session with `INVALID_RECORD`, and the client re-pushed the same speculative change on every reconnect. Undefined is now treated as absent.
- `diffObject` used `in`, so `Object.prototype` members never diffed as adds/deletes, and `applyObjectDiff` assigned untrusted keys with `newObject[k] = v` — a peer could set a server-held record's prototype via a `__proto__` key. Own-key checks; `__proto__` ignored. Array↔object item switches now produce a `put` instead of an unapplyable patch.
- `chunk()` sliced at arbitrary UTF-16 code-unit boundaries; a surrogate pair straddling a chunk edge became two lone surrogates that `WebSocket.send`'s USVString conversion turns into U+FFFD — corrupted text that still parses as valid JSON on the server. Boundaries never split a pair now.

### Local persistence: `LocalIndexedDb` and `TLLocalSyncClient`

- `LocalIndexedDb.close()` flipped `isClosed` before draining, and `tx()` then aborted any transaction whose callback finished after that while resolving as success; combined with `TLLocalSyncClient.close()` dropping the queued diffs, the last ~350 ms of edits before an unmount were silently lost. In-flight transactions now complete before the DB closes, `close()` flushes the queue (waiting for any in-flight write), `.finally` no longer leaks an unhandled rejection per failed write, and `close()` tolerates a DB that never opened (which previously skipped `connectedInstances` cleanup and aborted `hardReset`).
- BroadcastChannel messages were only listened to after `db.load()` resolved, but the first persist is a full-snapshot write, so a diff another tab broadcast during the load window was dropped and then erased from IndexedDB. Messages received while loading are buffered and applied after load; nothing persists until loaded; a tab that reports a schema mismatch stops writing rather than persisting its older schema over the newer tab's records.

### Reported but not fixed here

- `apps/bemo-worker/src/BemoDO.ts` treats a failed R2 load like a missing room, boots the default document, and later persists it back over the real content. Real data-loss risk, but outside the sync packages and needs DO-level handling.
- `JsonChunkAssembler` buffers chunks with no cap on count, size, or age, so one client can grow server memory unbounded. Needs a decided limit rather than an ad-hoc constant.
- Policy items: `SESSION_IDLE_TIMEOUT` (20 s) still kicks hidden tabs pinging once a minute for hosts on the default timeout; no client-side handshake watchdog; `SQLiteSyncStorage` routes reads by id prefix but writes by `typeName`; `clientTimeout: 0` meaning "instant timeout".

Overlaps with open PRs: #9514 adds `close()` to the storage classes to cancel the tombstone prune, which is the fuller fix for the `pruneTombstones`-after-`db.close()` case guarded here; #10073 and #10089 touch `useSync.ts` / `useSyncDemo.ts` and the cloudflare template DO respectively, so expect small conflicts whichever lands second.

`packages/sync-core/SPEC.md` and `packages/store/SPEC.md` are updated where behaviour was refined (D2, AD5, AD8, CH9, H1, SES5, HS3).

### Change type

- [x] `bugfix`

### Test plan

1. Open a synced room in two tabs; put one to sleep (or switch networks) long enough for its socket to die silently, wake it, and confirm the reconnected tab keeps working after the old socket's close arrives.
2. Go offline, create a page, delete it, go back online — the page must stay deleted.
3. Make edits and immediately close the tab; reopen and confirm the last edits persisted.
4. Open the same local document in two tabs quickly; an edit in the first tab made while the second is loading must survive the second tab's first save.

- [x] Unit tests

### Release notes

- Fix a reconnect under the same session id being cancelled by the previous socket's late close
- Fix rolled-back store transactions leaking changes to sync and persistence listeners
- Fix `TLSyncClient` hanging at "loading" or losing queued changes when a connect response fails to apply or arrives while changes are frame-throttled
- Fix protocol-7 clients silently desyncing on string append ops
- Fix `useSync` reporting a previous room's error for a new, healthy room
- Fix `ClientWebSocketAdapter` stalling permanently when `getUri` rejects
- Fix corrupted text when a chunk boundary splits an emoji, and `undefined` values kicking the session with `INVALID_RECORD`
- Fix the last edits before closing a tab being dropped by local IndexedDB persistence, and cross-tab edits during load being erased
- Fix large rooms failing to load in `InMemorySyncStorage` and `loadSnapshot` failing on better-sqlite3

### API changes

- Changed `TLSocketRoom.handleSocketClose(sessionId, socket?)` and `TLSocketRoom.handleSocketError(sessionId, socket?)` to accept the originating socket; hosts that attach their own listeners (hibernation APIs) should pass it so a superseded socket's late close is ignored
- `loadSnapshotIntoStorage` now imports `TLStoreSnapshot` from `@tldraw/tlschema` instead of `tldraw` (type-identical; removes a devDependency leak from the API report)

### Code changes

| Section         | LOC change   |
| --------------- | ------------ |
| Core code       | +602 / -297  |
| Tests           | +760 / -1    |
| Automated files | +3 / -4      |
| Apps            | +7 / -2      |
| Templates       | +7 / -2      |
