### PR TITLE
fix(sync): harden TLSyncRoom close and session lifecycle against late socket events

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -208,7 +208,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **RC4** Storage `onChange` notifications carrying a foreign transaction id make the room broadcast the new changes to all connected clients. The room's own transactions (id `'TLSyncRoom.txn'`) do not re-broadcast this way.
 - **RC5** If an external change leaves the storage unable to produce an incremental diff (`wipeAll`), the room closes every session so clients reconnect and re-hydrate.
 - **RC6** The idle timeout defaults to `SESSION_IDLE_TIMEOUT` (20s) and is configurable via `clientTimeout`. A finite positive timeout starts a periodic prune interval of `min(2000, timeout/4)` ms; `Infinity` or 0 disables the interval (pruning then only happens on message activity or via the follow-up prune scheduled when a socket close/error cancels a session, per SES2).
-- **RC7** `close()` closes every session's socket and stops background work; `isClosed()` reports it.
+- **RC7** `close()` marks the room closed, stops background work and pending per-session flush timers, closes every session's socket (a socket that throws on close does not stop the others) and forgets the sessions without emitting `session_removed`; no prune timers are scheduled afterwards, so late socket events cannot emit lifecycle events on a closed room. `isClosed()` reports it.
 
 ## 23. `TLSyncRoom` — connect handshake (HS)
 
@@ -217,7 +217,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **HS3** A connect message without a schema, with a schema the server cannot migrate from, or whose migrations include any non-record-scope or down-less migration, is rejected `CLIENT_TOO_OLD`.
 - **HS4** The connect response echoes `connectRequestId` and `isReadonly`, carries the server's schema and current clock, and `hydrationType: 'wipe_all'` when storage cannot produce an incremental diff since the client's `lastServerClock` (including when that clock is in the future), else `'wipe_presence'`.
 - **HS5** The connect response diff contains every _other_ session's presence record — the connecting session's own presence is excluded — plus the document changes since the client's `lastServerClock` (the full document set in the `wipe_all` case), all down-migrated when the client's schema is older.
-- **HS6** A successful handshake moves the session to `Connected`.
+- **HS6** A successful handshake moves the session to `Connected` — unless the session was removed while the handshake's transaction ran (RC5 force-reconnect), in which case it stays removed rather than being resurrected.
 
 ## 24. `TLSyncRoom` — push handling (RP)
 
@@ -239,7 +239,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 
 - **RB1** Data messages (`patch`, `push_result`) to a session are debounced: the first is sent immediately wrapped as `{ type: 'data', data: [msg] }`; messages within the following `DATA_MESSAGE_DEBOUNCE_INTERVAL` (1000/60 ms) are buffered and flushed together as one `data` message. The array handed to the socket is not mutated afterwards, so sockets may serialize lazily.
 - **RB2** Non-data messages flush any buffered data messages first, preserving order — except `pong`, which skips the flush.
-- **RB3** Sending to a session whose socket is closed cancels that session.
+- **RB3** Sending to a session whose socket is closed cancels that session — on the debounced flush path as well as the immediate one.
 - **RB4** Broadcasts are migrated per session (MG1); a migration failure rejects only the affected session, and the broadcast proceeds for the others.
 - **RB5** `sendCustomMessage` delivers `{ type: 'custom', data }` to a connected session; sending to an unknown or not-yet-connected session logs a warning and does nothing.
 
@@ -250,7 +250,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **SES3** Removal deletes the session, closes the socket (with code 4099 and the reason when fatal), deletes the session's presence record and broadcasts that deletion to everyone, emits `session_removed`, and emits `room_became_empty` when it was the last session.
 - **SES4** `rejectSession` with a reason: legacy sessions (protocol ≤ 6) receive a deprecated `incompatibility_error` message (reason mapped: `CLIENT_TOO_OLD` → `clientTooOld`, `SERVER_TOO_OLD` → `serverTooOld`, `INVALID_RECORD` → `invalidRecord`, anything else → `invalidOperation`) and are then removed without a close code; modern sessions are closed with code 4099 and the reason string. Without a reason it is a plain removal.
 - **SES5** `getCanEmitStringAppend()` is false when any connected session has `supportsStringAppend: false`; pushes handled in that state use legacy append mode (D5) so broadcast diffs avoid string-append ops.
-- **SES6** `handleResumedSession` registers a session directly in `Connected` state (no handshake): `requiresDownMigrations` is recomputed from the supplied schema, and a supplied presence record is restored into the presence store.
+- **SES6** `handleResumedSession` registers a session directly in `Connected` state (no handshake): `requiresDownMigrations` is recomputed from the supplied schema, and a supplied presence record is restored into the presence store. The handshake's schema checks (HS3) are re-applied — a schema the server can no longer reconcile rejects the resumed session instead of being served unmigrated diffs.
 - **SES7** A message from an unknown session id logs a warning and is ignored.
 
 ## 27. Migrations over the wire (MG)

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -258,7 +258,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}, 1000)
 
 	private scheduleFollowUpPrune() {
-		if (this.pruneTimer) return
+		// no new timers once closed: a late socket close would otherwise resurrect pruning and emit
+		// session_removed / room_became_empty against a room the host has already torn down
+		if (this._isClosed || this.pruneTimer) return
 		this.pruneTimer = setTimeout(this.pruneSessions, SESSION_REMOVAL_WAIT_TIME + 100)
 	}
 
@@ -273,11 +275,27 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * and stops background processes.
 	 */
 	close() {
+		this._isClosed = true
 		this.disposables.forEach((d) => d())
 		this.sessions.forEach((session) => {
-			session.socket.close()
+			// a debounced flush firing after the sockets are closed would call send() on a closed
+			// socket, which throws on some runtimes (Cloudflare) from inside a timer
+			this.clearDebounceTimer(session)
+			try {
+				session.socket.close()
+			} catch {
+				// noop, one bad socket must not leave the rest open
+			}
 		})
-		this._isClosed = true
+		this.sessions.clear()
+	}
+
+	private clearDebounceTimer(session: RoomSession<R, SessionMeta>) {
+		if (session.state === RoomSessionState.Connected && session.debounceTimer !== null) {
+			clearTimeout(session.debounceTimer)
+			session.debounceTimer = null
+			session.outstandingDataMessages = []
+		}
 	}
 
 	/**
@@ -519,6 +537,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			// place, so sockets that defer serialization don't see an emptied array
 			const data = session.outstandingDataMessages
 			session.outstandingDataMessages = []
+			if (!session.socket.isOpen) {
+				// same as the immediate-send path: a closed socket cancels the session rather
+				// than making us send into it (which throws on some runtimes)
+				this.cancelSession(sessionId)
+				return
+			}
 			session.socket.sendMessage({ type: 'data', data })
 		}
 	}
@@ -532,6 +556,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		}
 
 		this.sessions.delete(sessionId)
+		this.clearDebounceTimer(session)
 
 		try {
 			if (fatalReason) {
@@ -570,6 +595,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			return
 		}
 
+		this.clearDebounceTimer(session)
 		this.sessions.set(sessionId, {
 			state: RoomSessionState.AwaitingRemoval,
 			sessionId,
@@ -693,6 +719,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	}) {
 		const { sessionId, socket, meta, isReadonly, objectAccess } = opts
 		const existing = this.sessions.get(sessionId)
+		if (existing) this.clearDebounceTimer(existing)
 		this.sessions.set(sessionId, {
 			state: RoomSessionState.AwaitingConnectMessage,
 			sessionId,
@@ -760,6 +787,17 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			requiresLegacyRejection,
 			supportsStringAppend,
 		})
+
+		// The server may have changed builds while the socket slept, so re-run the handshake's
+		// schema checks (HS3): a schema we can no longer reconcile must not be served raw diffs.
+		if (!migrations.ok) {
+			this.rejectSession(sessionId, this.getVersionMismatchReason(serializedSchema))
+			return
+		}
+		if (migrations.value.some((m) => m.scope !== 'record' || !m.down)) {
+			this.rejectSession(sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
+			return
+		}
 
 		if (presenceRecord && presenceId) {
 			this.presenceStore.set(presenceId, presenceRecord as R)
@@ -1055,7 +1093,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 
 		const requiresDownMigrations = migrations.value.length > 0
 
-		const connect = async (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+		const connect = (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+			// broadcastChanges may have force-reconnected everyone (wipeAll) while we were in the
+			// transaction, removing this very session; re-adding it would resurrect a session whose
+			// socket is already closed and emit a second `session_removed` for it later
+			if (this.sessions.get(session.sessionId) !== session) return
 			this.sessions.set(session.sessionId, {
 				state: RoomSessionState.Connected,
 				sessionId: session.sessionId,
@@ -1139,7 +1181,6 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		if (session && session.state !== RoomSessionState.Connected) {
 			return
 		}
-		// update the last interaction time
 		if (session) {
 			session.lastInteractionTime = Date.now()
 		}

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -1949,6 +1949,67 @@ describe('25. Messaging and broadcast (RB)', () => {
 		expect(socketB.sendMessage).not.toHaveBeenCalled()
 	})
 
+	it('[RB3] a debounced flush into a socket that closed meanwhile cancels the session instead of sending', () => {
+		vi.useFakeTimers()
+		const { room, socketB } = setupTwoSessions()
+		const newPage = makePage('page_3', 'v1')
+
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 1,
+			diff: { [newPage.id]: ['put', newPage] },
+		} as TLPushRequest<TLRecord>)
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 2,
+			diff: { [newPage.id]: ['patch', { name: ['put', 'v2'] }] },
+		} as TLPushRequest<TLRecord>)
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+
+		// the socket closes while the second message sits in the debounce buffer
+		socketB.isOpen = false
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+		expect(room.sessions.get('b')?.state).toBe(RoomSessionState.AwaitingRemoval)
+	})
+
+	it('[RC7] close() drops pending debounced flushes so nothing is sent into closed sockets afterwards', () => {
+		vi.useFakeTimers()
+		const { room, socketB } = setupTwoSessions()
+		const newPage = makePage('page_3', 'v1')
+
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 1,
+			diff: { [newPage.id]: ['put', newPage] },
+		} as TLPushRequest<TLRecord>)
+		room.handleMessage('a', {
+			type: 'push',
+			clientClock: 2,
+			diff: { [newPage.id]: ['patch', { name: ['put', 'v2'] }] },
+		} as TLPushRequest<TLRecord>)
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+
+		room.close()
+		expect(room.isClosed()).toBe(true)
+		vi.advanceTimersByTime(DATA_MESSAGE_DEBOUNCE_INTERVAL + 1)
+
+		expect(socketB.sendMessage).toHaveBeenCalledTimes(1)
+		expect(socketB.close).toHaveBeenCalled()
+	})
+
+	it('[RC7] close() closes every socket even when one of them throws on close', () => {
+		const { room, socketA, socketB } = setupTwoSessions()
+		socketA.close.mockImplementationOnce(() => {
+			throw new Error('already closing')
+		})
+
+		expect(() => room.close()).not.toThrow()
+		expect(room.isClosed()).toBe(true)
+		expect(socketB.close).toHaveBeenCalled()
+	})
+
 	it('[RB4] a per-session migration failure during broadcast rejects only the affected session', () => {
 		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 		try {
@@ -2304,6 +2365,36 @@ describe('26. Session lifecycle (SES)', () => {
 		// the resumed session handles messages like any connected session
 		room.handleMessage('resumed', { type: 'ping' })
 		expect(socket.__lastMessage).toEqual({ type: 'pong' })
+	})
+
+	it('[SES6] handleResumedSession rejects a session whose schema the server can no longer reconcile', () => {
+		const { room } = makeRoom()
+		const socket = makeSocket()
+		const newerSchema: SerializedSchemaV2 = {
+			schemaVersion: 2,
+			sequences: {
+				...(room.serializedSchema as SerializedSchemaV2).sequences,
+				'com.tldraw.store': 999,
+			},
+		}
+
+		room.handleResumedSession({
+			sessionId: 'resumed',
+			socket,
+			meta: undefined,
+			isReadonly: false,
+			serializedSchema: newerSchema,
+			presenceId: null,
+			presenceRecord: null,
+			requiresLegacyRejection: false,
+			supportsStringAppend: true,
+		})
+
+		expect(room.sessions.has('resumed')).toBe(false)
+		expect(socket.close).toHaveBeenCalledWith(
+			TLSyncErrorCloseEventCode,
+			TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+		)
 	})
 
 	it('[SES7] a message from an unknown session id logs a warning and is ignored', () => {


### PR DESCRIPTION
**Risk: medium · Importance: low**

This PR fixes a bug where a room that had already been closed could still fire lifecycle events and throw from timers. It also stops a session removed mid-handshake from coming back, and stops a resumed session being served diffs its schema can't handle.

### Before

`close()` closed sockets before setting `_isClosed`, left per-session debounce timers running, and kept the session map, so a late socket close could reschedule pruning and emit `session_removed` / `room_became_empty` against a closed room; a debounced flush could call `send()` on a closed socket (which throws on Cloudflare from inside a timer); one socket throwing on close left the rest open; a session removed during its own handshake (RC5 force-reconnect) was resurrected by its `connect` callback and emitted a second `session_removed` later; and a resumed session skipped the handshake's schema checks, so a server that changed builds while the socket slept served unmigrated diffs.

### After

`close()` marks the room closed first, clears per-session debounce timers, tolerates a throwing socket, and forgets its sessions; `scheduleFollowUpPrune` is a no-op once closed; the debounced flush cancels the session instead of sending into a closed socket; the handshake's `connect` callback bails if the session was removed meanwhile; and `handleResumedSession` re-runs the HS3 schema checks and rejects a session it can no longer reconcile.

Split out of #10092. `packages/sync-core/SPEC.md` is updated for RC7, HS6, RB3, and SES6.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix `TLSyncRoom.close()` leaving timers that could send into closed sockets or emit lifecycle events on a closed room

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +50 / -9   |
| Tests     | +91 / -0   |
