### PR TITLE
fix(sync): storage fixes for large rooms, better-sqlite3 iteration, tombstone pruning, and updateStore lanes

### DIFF
--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -626,10 +626,15 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 		// Clean up by filtering out any non-document records.
 		// This is mainly legacy support for extremely early days tldraw.
+		// Collect first: as above, deleting during a live iterator can throw on SQLite backends.
+		const idsToDelete: string[] = []
 		for (const [id, state] of storage.entries()) {
 			if (this.getType(state.typeName).scope !== 'document') {
-				storage.delete(id)
+				idsToDelete.push(id)
 			}
+		}
+		for (const id of idsToDelete) {
+			storage.delete(id)
 		}
 	}
 

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -22,7 +22,6 @@ import { TLDocument } from 'tldraw';
 import { TLPage } from 'tldraw';
 import { TLRecord } from '@tldraw/tlschema';
 import { TLStoreSnapshot } from '@tldraw/tlschema';
-import { TLStoreSnapshot as TLStoreSnapshot_2 } from 'tldraw';
 import { UnknownRecord } from '@tldraw/store';
 
 // @internal
@@ -161,7 +160,7 @@ export class JsonChunkAssembler {
 }
 
 // @public
-export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot_2): void;
+export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot): void;
 
 // @internal (undocumented)
 export interface MinimalDocStore<R extends UnknownRecord> {

--- a/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
@@ -51,6 +51,27 @@ describe('InMemorySyncStorage', () => {
 			expect(storage.getClock()).toBe(25)
 		})
 
+		it('[IM1] handles snapshots with far more records and tombstones than fit in a spread call', () => {
+			const documents = []
+			for (let i = 0; i < 150_000; i++) {
+				documents.push({
+					state: { ...contractRecords[0], id: `shape:${i}` } as TLRecord,
+					lastChangedClock: i,
+				})
+			}
+			const tombstones: Record<string, number> = {}
+			for (let i = 0; i < 150_000; i++) tombstones[`shape:gone-${i}`] = 150_000 + i
+			const storage = new InMemorySyncStorage<TLRecord>({
+				snapshot: makeContractSnapshot(contractRecords, {
+					documents,
+					tombstones,
+					documentClock: 0,
+					tombstoneHistoryStartsAtClock: 0,
+				}),
+			})
+			expect(storage.getClock()).toBe(299_999)
+		})
+
 		it('[IM2] clamps tombstoneHistoryStartsAtClock down to the document clock', () => {
 			const storage = new InMemorySyncStorage<TLRecord>({
 				snapshot: makeContractSnapshot(contractRecords, {

--- a/packages/sync-core/src/lib/InMemorySyncStorage.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.ts
@@ -153,11 +153,15 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown
 	} = {}) {
 		this.objectTypes = new Set(objectTypes ?? [])
-		const maxClockValue = Math.max(
-			0,
-			...Object.values(snapshot.tombstones ?? {}),
-			...Object.values(snapshot.documents.map((d) => d.lastChangedClock))
-		)
+		// a loop rather than `Math.max(0, ...clocks)`: spreading a large room's clocks as call
+		// arguments overflows the stack at roughly 100k+ records/tombstones
+		let maxClockValue = 0
+		for (const clock of Object.values(snapshot.tombstones ?? {})) {
+			if (clock > maxClockValue) maxClockValue = clock
+		}
+		for (const doc of snapshot.documents) {
+			if (doc.lastChangedClock > maxClockValue) maxClockValue = doc.lastChangedClock
+		}
 		// route snapshot entries into their partitions (a seed snapshot may carry object-lane
 		// records merged in, e.g. loaded from a separate persistence lane)
 		const toEntry = (

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
@@ -272,5 +272,34 @@ describe('NodeSqliteWrapper', () => {
 			// the write was rolled back
 			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
 		})
+
+		it('[NW2] rolls back when COMMIT itself fails, so the connection is not left inside a transaction', () => {
+			// simulate a COMMIT failure (SQLITE_BUSY, I/O error) at the driver level
+			const failingDb = {
+				exec: (sql: string) => {
+					if (sql === 'COMMIT') throw new Error('SQLITE_BUSY: database is locked')
+					return db.exec(sql)
+				},
+				prepare: (sql: string) => db.prepare(sql),
+			}
+			const failingWrapper = new NodeSqliteWrapper(failingDb as any)
+
+			expect(() =>
+				failingWrapper.transaction(() => {
+					failingWrapper
+						.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)')
+						.run(1, 'alice', 100)
+				})
+			).toThrow('SQLITE_BUSY')
+
+			// rolled back, and the next transaction can BEGIN normally
+			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
+			expect(() =>
+				wrapper.transaction(() => {
+					wrapper.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)').run(2, 'bob', 200)
+				})
+			).not.toThrow()
+			expect(wrapper.prepare<{ id: number }>('SELECT id FROM test').all()).toEqual([{ id: 2 }])
+		})
 	})
 })

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.ts
@@ -89,11 +89,14 @@ export class NodeSqliteWrapper implements TLSyncSqliteWrapper {
 		let result: T
 		try {
 			result = callback()
+			// COMMIT itself can fail (SQLITE_BUSY from another connection, I/O errors); without a
+			// ROLLBACK the connection would stay inside the transaction and every later BEGIN
+			// would throw "cannot start a transaction within a transaction"
+			this.db.exec('COMMIT')
 		} catch (e) {
 			this.db.exec('ROLLBACK')
 			throw e
 		}
-		this.db.exec('COMMIT')
 		return result
 	}
 }

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -394,7 +394,6 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 			const documentClock = snapshot.documentClock ?? snapshot.clock ?? 0
 			const tombstoneHistoryStartsAtClock = snapshot.tombstoneHistoryStartsAtClock ?? documentClock
 
-			// Clear existing data
 			this.sql.exec(`
 				DELETE FROM ${documentsTable};
 				DELETE FROM ${objectsTable};
@@ -410,14 +409,12 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 				table.insert.run(doc.state.id, encodeState(doc.state), doc.lastChangedClock)
 			}
 
-			// Insert tombstones
 			if (snapshot.tombstones) {
 				for (const [id, clock] of objectMapEntries(snapshot.tombstones)) {
 					this.stmts.insertTombstone.run(id, clock)
 				}
 			}
 
-			// Insert metadata row
 			this.stmts.updateMetadata.run(
 				documentClock,
 				tombstoneHistoryStartsAtClock,
@@ -513,18 +510,29 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 	/** @internal */
 	pruneTombstones = throttle(
 		() => {
-			const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
-			if (tombstoneCount > MAX_TOMBSTONES) {
-				// Get all tombstones sorted by clock ascending (oldest first)
-				const tombstones = this.stmts.iterateTombstones.all()
+			// Runs from a timer, so a host that closed the database right after the last delete
+			// (e.g. `room.close(); db.close()` in onSessionRemoved) would otherwise get an uncaught
+			// throw from here; pruning is best-effort and simply runs again on the next delete.
+			try {
+				const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
+				if (tombstoneCount > MAX_TOMBSTONES) {
+					// Get all tombstones sorted by clock ascending (oldest first)
+					const tombstones = this.stmts.iterateTombstones.all()
 
-				const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
-				if (result) {
-					this.stmts.setTombstoneHistoryStartsAtClock.run(result.newTombstoneHistoryStartsAtClock)
-					// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
-					// This works because computeTombstonePruning ensures we never split a clock value.
-					this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+					const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
+					if (result) {
+						this.sql.transaction(() => {
+							this.stmts.setTombstoneHistoryStartsAtClock.run(
+								result.newTombstoneHistoryStartsAtClock
+							)
+							// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
+							// This works because computeTombstonePruning ensures we never split a clock value.
+							this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+						})
+					}
 				}
+			} catch (e) {
+				console.error('Failed to prune tombstones', e)
 			}
 		},
 		1000,

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -854,12 +854,11 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 		if (this.isClosed()) {
 			throw new Error('Cannot update store on a closed room')
 		}
+		// read through the transaction rather than getSnapshot(): the document snapshot excludes the
+		// object-store lane, which would make object-lane records invisible (and undeletable) here
+		const records = this.storage.transaction((txn) => Object.fromEntries(txn.entries())).result
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
-		const ctx = new StoreUpdateContext<R>(
-			// eslint-disable-next-line @typescript-eslint/no-deprecated
-			Object.fromEntries(this.getCurrentSnapshot().documents.map((d) => [d.state.id, d.state])),
-			this.room.schema
-		)
+		const ctx = new StoreUpdateContext<R>(records, this.room.schema)
 		try {
 			await updater(ctx)
 		} finally {

--- a/packages/sync-core/src/lib/TLSyncStorage.ts
+++ b/packages/sync-core/src/lib/TLSyncStorage.ts
@@ -1,6 +1,6 @@
 import { StoreSchema, SynchronousStorage, UnknownRecord } from '@tldraw/store'
+import { TLStoreSnapshot } from '@tldraw/tlschema'
 import { assert, isEqual, objectMapEntriesIterable, objectMapValues } from '@tldraw/utils'
-import { TLStoreSnapshot } from 'tldraw'
 import { diffRecord, NetworkDiff, RecordOpType } from './diff'
 import { RoomSnapshot } from './TLSyncRoom'
 
@@ -205,7 +205,9 @@ export function loadSnapshotIntoStorage<R extends UnknownRecord>(
 		if (isEqual(existing, doc.state)) continue
 		txn.set(doc.state.id, doc.state as R)
 	}
-	for (const id of txn.keys()) {
+	// materialize the keys first: some SQLite drivers (better-sqlite3) refuse writes while a
+	// statement iterator is open, so deleting during `keys()` would throw
+	for (const id of Array.from(txn.keys())) {
 		if (!docIds.has(id)) {
 			txn.delete(id)
 		}

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -8,6 +8,7 @@ import {
 	TLSocketServerSentEvent,
 	getTlsyncProtocolVersion,
 } from '../lib/protocol'
+import { TLSocketRoom } from '../lib/TLSocketRoom'
 import { TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason } from '../lib/TLSyncClient'
 import { RoomSnapshot, TLRoomSocket, TLSyncRoom } from '../lib/TLSyncRoom'
 
@@ -353,6 +354,40 @@ describe('object store lane', () => {
 			const late = connectSession(room, 'late', { clear: false })
 			const connectMsg = late.__messages.find((m: any) => m.type === 'connect') as any
 			expect(Object.keys(connectMsg.diff).sort()).toEqual([doc.id, note.id].sort())
+		})
+
+		it('[US1][US3] updateStore sees and can delete object-lane records', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			const socketRoom = new TLSocketRoom<R, void>({
+				schema,
+				storage: new InMemorySyncStorage<R>({
+					snapshot: { documents: [], clock: 0, documentClock: 0, schema: schema.serialize() },
+					objectTypes: ['note'],
+				}),
+				objectTypes: ['note'],
+			})
+			disposables.push(() => socketRoom.close())
+			const doc = Doc.create({ title: 'canvas' })
+			const note = Note.create({ text: 'annotation' })
+			socketRoom.storage.transaction((txn) => {
+				txn.set(doc.id, doc)
+				txn.set(note.id, note)
+			})
+
+			// the update context reads both lanes, not just the document snapshot
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			await socketRoom.updateStore((store) => {
+				expect(store.get(note.id)).toEqual(note)
+				expect(
+					store
+						.getAll()
+						.map((r) => r.id)
+						.sort()
+				).toEqual([doc.id, note.id].sort())
+				store.delete(note.id)
+			})
+			expect(socketRoom.getRecord(note.id)).toBeUndefined()
+			expect(socketRoom.getRecord(doc.id)).toEqual(doc)
 		})
 	})
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where very large rooms could no longer be opened. It also fixes `loadSnapshot` failing on better-sqlite3, tombstone pruning throwing after the database was closed, and `updateStore` not seeing object-lane records.

### Before

- `InMemorySyncStorage` computed the max clock with `Math.max(0, ...clocks)`, which overflows the stack at ~120k records/tombstones — a big room became permanently unopenable.
- `loadSnapshotIntoStorage` and `StoreSchema.migrateStorage` deleted while iterating, which better-sqlite3 (used by the simple-server and socketio templates) rejects, so `room.loadSnapshot()` failed on that backend.
- `SQLiteSyncStorage.pruneTombstones` ran its two statements outside a transaction and could throw from its throttle timer after the host closed the database; `NodeSqliteWrapper` didn't roll back when `COMMIT` itself failed, leaving the connection inside a transaction so every later `BEGIN` threw.
- `TLSocketRoom.updateStore` built its context from the document snapshot, so object-lane records were invisible and undeletable.
- `loadSnapshotIntoStorage` imported `TLStoreSnapshot` from `tldraw`, leaking a devDependency into the API report.

### After

Max clock is computed with a loop; both delete-while-iterating sites collect ids first; `pruneTombstones` is transactional and catches/logs; `NodeSqliteWrapper` runs `COMMIT` inside the try so a failure rolls back; `updateStore` reads through `storage.transaction((txn) => txn.entries())`; the import comes from `@tldraw/tlschema` (type-identical).

Split out of #10092. #9514 adds `close()` to the storage classes to cancel the tombstone prune, which is the fuller fix for the `pruneTombstones`-after-`db.close()` case guarded here.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix large rooms failing to load in `InMemorySyncStorage` and `loadSnapshot` failing on better-sqlite3
- Fix `TLSocketRoom.updateStore` not seeing object-lane records

### API changes

- `loadSnapshotIntoStorage` now imports `TLStoreSnapshot` from `@tldraw/tlschema` instead of `tldraw` (type-identical)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +49 / -28  |
| Tests           | +85 / -0   |
| Automated files | +1 / -2    |
