### PR TITLE
fix(sync): truncate over-long close reasons and share the default logger with TLSyncRoom

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -263,7 +263,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 
 - **SR1** Providing both `storage` and `initialSnapshot` throws. With neither, an `InMemorySyncStorage` seeded from `DEFAULT_INITIAL_SNAPSHOT` is created; `initialSnapshot` (deprecated) accepts both room and store snapshots.
 - **SR2** The deprecated `onDataChange` callback is wired to `storage.onChange` (fires on a microtask after document changes, including programmatic ones).
-- **SR3** `log` defaults to `{ error: console.error }` only when the `log` key is absent from the options object; an explicitly passed `log: undefined` leaves the room without a logger.
+- **SR3** `log` defaults to `{ error: console.error }` only when the `log` key is absent from the options object; an explicitly passed `log: undefined` leaves the room without a logger. The same logger is handed to the inner `TLSyncRoom`, so authorizer failures and vetoes are logged under the default too.
 - **SR4** `handleSocketConnect` registers the session (readonly defaults to false), attaches `message`/`close`/`error` listeners when the socket supports `addEventListener`, and creates a chunk assembler for the session.
 - **SR5** `handleSocketMessage` assembles chunks (CH rules), then for each complete message: invokes `onAfterReceiveMessage`, forwards to the room, and runs a prune pass (after handling, so a session is never evicted by its own message). Assembly errors close the socket via the error path; a thrown exception rejects the session with `UNKNOWN_ERROR`.
 - **SR6** `handleSocketError` and `handleSocketClose` cancel the session (grace period applies per SES2) and clear any pending session-snapshot timer.

--- a/packages/sync-core/src/lib/ServerSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ServerSocketAdapter.test.ts
@@ -86,4 +86,20 @@ describe('ServerSocketAdapter', () => {
 		adapter.close(1001, 'Going away')
 		expect(ws.close).toHaveBeenLastCalledWith(1001, 'Going away')
 	})
+
+	it('[SA3] close truncates a reason longer than 123 UTF-8 bytes rather than letting the socket throw', () => {
+		const ws = new MockWebSocket()
+		const adapter = new ServerSocketAdapter({ ws })
+
+		const longAscii = 'x'.repeat(200)
+		adapter.close(4099, longAscii)
+		expect(ws.close).toHaveBeenLastCalledWith(4099, 'x'.repeat(123))
+
+		// multi-byte characters are never cut in half
+		const emoji = '\u{1F600}' // 4 bytes
+		adapter.close(4099, emoji.repeat(40))
+		const sent = (ws.close as any).mock.calls.at(-1)[1] as string
+		expect(new TextEncoder().encode(sent).length).toBeLessThanOrEqual(123)
+		expect(sent).toBe(emoji.repeat(30))
+	})
 })

--- a/packages/sync-core/src/lib/ServerSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ServerSocketAdapter.ts
@@ -163,9 +163,25 @@ export class ServerSocketAdapter<R extends UnknownRecord> implements TLRoomSocke
 	 * Closes the WebSocket connection with an optional close code and reason.
 	 *
 	 * @param code - Optional close code (default: 1000 for normal closure)
-	 * @param reason - Optional human-readable reason for closing
+	 * @param reason - Optional human-readable reason for closing. WebSocket close reasons are
+	 * capped at 123 UTF-8 bytes; a longer reason is truncated to fit rather than letting the
+	 * socket's own `close()` throw, which would leave the socket open with its session gone.
 	 */
 	close(code?: number, reason?: string) {
-		this.opts.ws.close(code, reason)
+		this.opts.ws.close(code, reason === undefined ? undefined : truncateCloseReason(reason))
 	}
+}
+
+const MAX_CLOSE_REASON_BYTES = 123
+const closeReasonEncoder = new TextEncoder()
+
+function truncateCloseReason(reason: string) {
+	if (closeReasonEncoder.encode(reason).length <= MAX_CLOSE_REASON_BYTES) return reason
+	// step back by code point so a multi-byte character is never cut in half
+	let out = ''
+	for (const char of reason) {
+		if (closeReasonEncoder.encode(out + char).length > MAX_CLOSE_REASON_BYTES) break
+		out += char
+	}
+	return out
 }

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -273,13 +273,16 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 				})
 			)
 		}
+		// The default logger belongs to both layers: TLSyncRoom is where authorizer throws and
+		// vetoes are logged, and a host that passes no `log` would otherwise never see them.
+		this.log = 'log' in opts ? opts.log : { error: console.error }
 		this.room = new TLSyncRoom<R, SessionMeta>({
 			onPresenceChange: opts.onPresenceChange,
 			onCommittedChanges: opts.onCommittedChanges,
 			objectTypes: opts.objectTypes,
 			authorizeRecord: opts.authorizeRecord,
 			schema: opts.schema ?? (createTLSchema() as any),
-			log: opts.log,
+			log: this.log,
 			storage,
 			clientTimeout: opts.clientTimeout,
 		})
@@ -295,7 +298,6 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 				})
 			}
 		})
-		this.log = 'log' in opts ? opts.log : { error: console.error }
 	}
 
 	/**


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a long close reason left a socket open after its session was gone. It also makes authorizer errors visible when `TLSocketRoom` is created without a `log` option.

### Before

WebSocket close reasons are capped at 123 UTF-8 bytes; a longer reason made the underlying `ws.close()` throw, leaving the socket open while its session was already gone. Separately, `TLSocketRoom` defaulted its own `log` to `{ error: console.error }` but passed `opts.log` (undefined) to `TLSyncRoom`, so authorizer throws and vetoes were silently swallowed for any host that didn't pass `log`.

### After

`close()` truncates the reason to 123 bytes on a code-point boundary; the default logger is created before the `TLSyncRoom` is constructed and handed to it.

Split out of #10092. `packages/sync-core/SPEC.md` SR3 is updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix `ServerSocketAdapter.close` throwing on long close reasons, and authorizer errors being swallowed when `TLSocketRoom` has no `log` option

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +23 / -5   |
| Tests     | +16 / -0   |
