### PR TITLE
fix(sync): retry rejected getUri, stop reconnecting after close, and clear stale useSync errors

### DIFF
--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -527,6 +527,33 @@ describe('ClientWebSocketAdapter', () => {
 			adapter.close()
 			expect(() => adapter.close()).not.toThrow()
 		})
+
+		it('[CW9][RM5] nothing runs after close: no status change, no reconnect, no further getUri call', async () => {
+			let uriCallCount = 0
+			const testAdapter = new ClientWebSocketAdapter(() => {
+				uriCallCount++
+				return 'ws://localhost:2233'
+			})
+			const onStatusChange = vi.fn()
+			testAdapter.onStatusChange(onStatusChange)
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			const callsBeforeClose = uriCallCount
+			onStatusChange.mockClear()
+
+			testAdapter.close()
+			// let the socket's own close event land, then run out any (leaked) reconnect timer
+			vi.useRealTimers()
+			await sleep(50)
+			vi.useFakeTimers()
+			vi.advanceTimersByTime(INACTIVE_MAX_DELAY)
+			vi.useRealTimers()
+			await sleep(20)
+			vi.useFakeTimers()
+
+			expect(onStatusChange).not.toHaveBeenCalled()
+			expect(uriCallCount).toBe(callsBeforeClose)
+			expect(testAdapter._ws).toBeNull()
+		})
 	})
 
 	describe('orphaned sockets (CW10)', () => {
@@ -774,6 +801,26 @@ describe('ReconnectManager', () => {
 
 		expect(fake.close).toHaveBeenCalled()
 		expect(adapter._ws).toBeNull()
+	})
+
+	it('[RM1][CW1] a rejecting getUri is retried on the backoff instead of stranding the connection', async () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		let attempts = 0
+		const testAdapter = new ClientWebSocketAdapter(async () => {
+			attempts++
+			if (attempts < 3) throw new Error('token endpoint unavailable')
+			return 'ws://localhost:2234'
+		})
+		try {
+			// each failure logs and schedules another attempt; the third succeeds
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			expect(attempts).toBe(3)
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(2)
+			expect(testAdapter.connectionStatus).toBe('online')
+		} finally {
+			testAdapter.close()
+			consoleErrorSpy.mockRestore()
+		}
 	})
 
 	it('[RM5] close cancels timers and removes the reconnect event listeners', () => {

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -93,8 +93,12 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 	close() {
 		this.isDisposed = true
 		this._reconnectManager.close()
+		// orphan the socket before closing it (as _closeSocket does) so its onclose can't run
+		// _handleDisconnect after disposal — that would notify listeners and schedule a reconnect
+		const ws = this._ws
+		this._ws = null
 		//  WebSocket.close() is idempotent
-		this._ws?.close()
+		ws?.close()
 	}
 
 	/**
@@ -239,8 +243,6 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 		this._ws = null
 		this._handleDisconnect('manual')
 	}
-
-	// TLPersistentClientSocket stuff
 
 	_connectionStatus: Atom<TLPersistentClientSocketStatus | 'initial'> = atom(
 		'websocket connection status',
@@ -516,18 +518,30 @@ export class ReconnectManager {
 	private scheduleAttempt() {
 		assert(this.state === 'pendingAttempt')
 		debug('scheduling a connection attempt')
-		Promise.resolve(this.getUri()).then((uri) => {
-			// this can happen if the promise gets resolved too late
-			if (this.state !== 'pendingAttempt' || this.isDisposed) return
-			assert(
-				this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
-				'There should be no connection attempts while already connected'
-			)
+		Promise.resolve()
+			.then(() => this.getUri())
+			.then((uri) => {
+				// this can happen if the promise gets resolved too late
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				assert(
+					this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
+					'There should be no connection attempts while already connected'
+				)
 
-			this.lastAttemptStart = Date.now()
-			this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
-			this.state = 'pendingAttemptResult'
-		})
+				this.lastAttemptStart = Date.now()
+				this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
+				this.state = 'pendingAttemptResult'
+			})
+			.catch((error) => {
+				// getUri is host code (often an auth-token fetch) and can reject or throw. Without
+				// this handler the manager would sit in 'pendingAttempt' with no timer and no
+				// socket, so nothing but a browser online/visibility hint could ever start another
+				// attempt. Treat it as a failed attempt and retry on the usual backoff instead.
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				console.error('Failed to get the websocket URI, retrying', error)
+				this.state = 'delay'
+				this.reconnectTimeout = setTimeout(() => this.disconnected(), this.intendedDelay)
+			})
 	}
 
 	private getMaxDelay() {
@@ -641,6 +655,7 @@ export class ReconnectManager {
 		debug('ReconnectManager.disconnected')
 		// This either means we're freshly disconnected, or the last connection attempt failed;
 		// either way, time to try again.
+		if (this.isDisposed) return
 
 		// Guard against delayed notifications and recheck synchronously
 		if (

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -274,10 +274,6 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				TLSocketServerSentEvent<TLRecord>
 			>
 		} else if (uri) {
-			if (connect) {
-				throw new Error('uri and connect cannot be used together')
-			}
-
 			socket = new ClientWebSocketAdapter(async () => {
 				const uriString = typeof uri === 'string' ? uri : await uri()
 
@@ -349,8 +345,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
-				// Merge so we don't clobber objectAccess if onAfterConnect ran first.
-				setState((prev) => ({ ...prev, readyClient: client }))
+				// Keep objectAccess (onAfterConnect always runs first for this client) but drop the
+				// rest: an `error` left behind by a previous client (e.g. NOT_FOUND on the old uri)
+				// would otherwise keep the hook reporting status 'error' for the new, healthy room.
+				setState((prev) => ({ readyClient: client, objectAccess: prev?.objectAccess }))
 			},
 			onSyncError(reason) {
 				console.error('sync error', reason)

--- a/packages/sync/src/useSyncDemo.test.ts
+++ b/packages/sync/src/useSyncDemo.test.ts
@@ -120,6 +120,19 @@ describe('useSyncDemo', () => {
 			)
 			expect(result).toEqual({ src: 'https://demo.server.com/uploads/unique-123-test-file-jpg' })
 		})
+
+		it('should reject the upload when the server responds with an error status', async () => {
+			useSyncDemo({ roomId: 'test-room', host: 'https://demo.server.com' })
+
+			const useSyncCall = vi.mocked(useSync).mock.calls[0][0]
+			const assetStore = useSyncCall.assets
+			const file = new File(['test content'], 'test-file.jpg')
+
+			// a rejected upload resolves the fetch; the asset must not point at a URL that was never stored
+			vi.mocked(mockFetch).mockResolvedValueOnce(new Response(null, { status: 409 }))
+
+			await expect(assetStore.upload({} as TLAsset, file)).rejects.toThrow('409')
+		})
 	})
 
 	describe('bookmark asset creation', () => {

--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -187,10 +187,15 @@ function createDemoAssetStore(host: string): TLAssetStore {
 			const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
 			const url = `${host}/uploads/${objectName}`
 
-			await fetch(url, {
+			const response = await fetch(url, {
 				method: 'POST',
 				body: file,
 			})
+			// a rejected upload (invalid name, duplicate, server error) resolves the fetch; without
+			// this the asset would point at a URL that was never stored
+			if (!response.ok) {
+				throw new Error(`Failed to upload asset (${response.status})`)
+			}
 
 			return { src: url }
 		},


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where sync stalled permanently when `getUri` rejected. It also fixes `useSync` reporting a previous room's error for a healthy room, and a failed demo upload producing an asset that points at nothing.

### Before

- `ReconnectManager` stalled permanently if `getUri` rejected: in the documented `useSync` pattern `getUri` is an auth-token fetch, and one 500 left the manager in `pendingAttempt` with no timer and no socket. After `close()`, the socket's `onclose` could still notify listeners and schedule a reconnect, calling the app's `getUri` after disposal.
- `useSync`'s `onLoad` merged into the previous state (`{...prev, readyClient}`, from #9471), so an `error` left by a previous client (`NOT_FOUND`, `RATE_LIMITED`) was never cleared when the `uri` changed without a remount, and the hook kept reporting `status: 'error'` for the new, healthy room. There was also an unreachable `if (connect)` branch.
- `useSyncDemo`'s upload ignored the response status, so a rejected upload produced an asset pointing at a URL that was never stored.

### After

`getUri` failures retry on the usual backoff; `close()` orphans the socket before closing it. `onLoad` keeps only this client's `objectAccess`; the dead branch is removed. The upload throws when `!response.ok`.

Split out of #10092. Overlaps with #10073, which also touches `useSync.ts` / `useSyncDemo.ts`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix `ClientWebSocketAdapter` stalling permanently when `getUri` rejects
- Fix `useSync` reporting a previous room's error for a new, healthy room

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +39 / -21  |
| Tests     | +60 / -0   |

### Related Sentry issues

- [LITE-43A](https://tldraw.sentry.io/issues/?query=issue:LITE-43A) — `sockets must only be orphaned when they are CLOSING or CLOSED, so they can't receive messages` (~790 events, ~670 users, mostly Edge/Chrome on Windows). Chromium does deliver already-queued `message` events after `close()`. Orphaning the socket in `close()` adds another site where this `onmessage` assert can fire after disposal, so `onmessage` should ignore orphaned sockets the same way `onclose`/`onerror` do.
- [LITE-6E9](https://tldraw.sentry.io/issues/?query=issue:LITE-6E9) — `InvalidStateError: 'send' on 'WebSocket': Still in CONNECTING state` from `TLSyncClient.sendUnsentChanges`. Adjacent reconnect-state bug in the same adapter: a socket that reaches `CLOSED` before its `onclose` task runs can be replaced by a CONNECTING socket via `maybeReconnected → disconnected → scheduleAttempt` without `_handleDisconnect` ever running, so `connectionStatus` stays `online`.
