### PR TITLE
fix(store): drop rolled-back transaction changes from the listener history

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -75,7 +75,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 ## 8. History and listeners (H)
 
-- **H1** `store.history` is an atom that increments by exactly one for each committed change-set, carrying the `RecordsDiff` as its history diff (`historyLength` 1000).
+- **H1** `store.history` is an atom that increments by exactly one for each committed change-set, carrying the `RecordsDiff` as its history diff (`historyLength` 1000). Change-sets made inside a transaction that rolls back are never delivered to listeners: the rollback resets the counter, and accumulated entries recorded past it are discarded (interceptors, H8, still saw them synchronously).
 - **H2** `listen(fn, filters?)` registers a listener and returns a remover. Listener notification is asynchronous: accumulated entries are flushed on the next frame, not synchronously with the change.
 - **H3** A flush squashes adjacent same-source entries: a listener called after changes `[user, user, remote, user]` receives three entries (`user`, `remote`, `user`), each with the squashed (D3) diff and its source.
 - **H4** `filters.source` (`'user' | 'remote' | 'all'`) drops entries from other sources. `filters.scope` (`'document' | 'session' | 'presence' | 'all'`) filters each entry's diff down to records of that scope; if nothing remains, the listener is not called for that entry.

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -518,7 +518,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	public _flushHistory() {
 		// If we have accumulated history, flush it and update listeners
 		if (this.historyAccumulator.hasChanges()) {
-			const entries = this.historyAccumulator.flush()
+			const entries = this.historyAccumulator.flush(this.history.get())
 			for (const { changes, source } of entries) {
 				// Filtered diffs are computed at most once per scope per entry, and shared by every
 				// listener watching that scope.
@@ -570,14 +570,18 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * @param changes - The changes to add to the history.
 	 */
 	private updateHistory(changes: RecordsDiff<R>): void {
-		this.historyAccumulator.add({
-			changes,
-			source: this.isMergingRemoteChanges ? 'remote' : 'user',
-		})
+		const historyCounter = this.history.get() + 1
+		this.historyAccumulator.add(
+			{
+				changes,
+				source: this.isMergingRemoteChanges ? 'remote' : 'user',
+			},
+			historyCounter
+		)
 		if (this.listeners.size === 0) {
 			this.historyAccumulator.clear()
 		}
-		this.history.set(this.history.get() + 1, changes)
+		this.history.set(historyCounter, changes)
 	}
 
 	validate(phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests') {
@@ -1318,15 +1322,30 @@ function squashHistoryEntries<T extends UnknownRecord>(
 }
 
 /**
- * Internal class that accumulates history entries before they are flushed to listeners.
- * Handles batching and squashing of adjacent entries from the same source.
+ * Buffers change-sets between listener flushes, squashing adjacent entries from the same source.
+ * Each entry is tagged with the store's `history` counter at the time it was recorded: a
+ * transaction that rolls back resets that counter, so entries tagged at or beyond a value the
+ * counter later reaches again (or that a flush finds ahead of it) belong to changes the store no
+ * longer holds and must not reach listeners — otherwise a sync client would push, and local
+ * persistence would save, records the store never kept.
  *
  * @internal
  */
 class HistoryAccumulator<T extends UnknownRecord> {
 	private _history: HistoryEntry<T>[] = []
+	private _historyCounters: number[] = []
 
 	private _interceptors: Set<(entry: HistoryEntry<T>) => void> = new Set()
+
+	/** Drop every entry recorded at or after `historyCounter` (they were rolled back). */
+	private dropFrom(historyCounter: number) {
+		let end = this._historyCounters.length
+		while (end > 0 && this._historyCounters[end - 1] >= historyCounter) end--
+		if (end < this._historyCounters.length) {
+			this._history.length = end
+			this._historyCounters.length = end
+		}
+	}
 
 	/**
 	 * Add an interceptor that will be called for each history entry.
@@ -1343,8 +1362,10 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 * Add a history entry to the accumulator.
 	 * Calls all registered interceptors with the entry.
 	 */
-	add(entry: HistoryEntry<T>) {
+	add(entry: HistoryEntry<T>, historyCounter: number) {
+		this.dropFrom(historyCounter)
 		this._history.push(entry)
+		this._historyCounters.push(historyCounter)
 		for (const interceptor of this._interceptors) {
 			interceptor(entry)
 		}
@@ -1353,10 +1374,15 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	/**
 	 * Flush all accumulated history entries, squashing adjacent entries from the same source.
 	 * Clears the internal history buffer.
+	 *
+	 * @param historyCounter - The store's current history counter; entries recorded beyond it
+	 * were rolled back and are discarded.
 	 */
-	flush() {
+	flush(historyCounter: number) {
+		this.dropFrom(historyCounter + 1)
 		const history = squashHistoryEntries(this._history)
 		this._history = []
+		this._historyCounters = []
 		return history
 	}
 
@@ -1365,6 +1391,7 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 */
 	clear() {
 		this._history = []
+		this._historyCounters = []
 	}
 
 	/**

--- a/packages/store/src/lib/StoreListeners.test.ts
+++ b/packages/store/src/lib/StoreListeners.test.ts
@@ -99,6 +99,31 @@ describe('the history atom (H)', () => {
 })
 
 describe('listeners (H)', () => {
+	it('[H1] change-sets from a rolled-back transaction never reach listeners', async () => {
+		const listener = vi.fn()
+		store.listen(listener, { source: 'user', scope: 'document' })
+		const phantom = Book.create({ title: 'never committed', author: Author.createId('a') })
+
+		expect(() =>
+			transact(() => {
+				store.put([phantom])
+				throw new Error('boom')
+			})
+		).toThrow('boom')
+		expect(store.has(phantom.id)).toBe(false)
+
+		// flushing right after the rollback delivers nothing
+		store._flushHistory()
+		expect(listener).not.toHaveBeenCalled()
+
+		// and a later legitimate change does not drag the phantom along with it
+		const real = Book.create({ title: 'committed', author: Author.createId('a') })
+		store.put([real])
+		store._flushHistory()
+		expect(listener).toHaveBeenCalledTimes(1)
+		expect(Object.keys(listener.mock.calls[0][0].changes.added)).toEqual([real.id])
+	})
+
 	it('[H2] listen returns a remover and notification is deferred to the next frame', async () => {
 		try {
 			// @ts-expect-error - test-only escape hatch


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where a transaction that threw still pushed its changes to sync and local persistence, resurrecting records the store never kept.

### Before

`transact(() => { store.put([a]); throw })` left `{added: [a]}` in the history accumulator. On the next flush every listener — `TLSyncClient`, `TLLocalSyncClient` — received a change for a record the store never held. The sync client pushed it, and on the `commit` push result re-applied its own diff, resurrecting the rolled-back record for everyone in the room; local persistence wrote it to IndexedDB.

### After

Each accumulator entry is tagged with the store's history counter at the time it was recorded. A rollback resets that counter, so `add()` drops entries tagged at or beyond the new counter and `flush()` drops entries tagged beyond the current one. Interceptors (H8) still see entries synchronously, as before.

Split out of #10092. `packages/store/SPEC.md` H1 is updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change

### Release notes

- Fix rolled-back store transactions leaking changes to sync and persistence listeners

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +38 / -11  |
| Tests     | +25 / -0   |

