### PR TITLE
fix(sync): harden diff and chunk wire format against undefined, prototype keys, and split surrogate pairs

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -25,11 +25,11 @@ Sections marked **internal** describe supporting machinery that has its own cont
 ## 3. Computing diffs: `diffRecord` (D)
 
 - **D1** `diffRecord(prev, next)` returns an `ObjectDiff` describing how to turn `prev` into `next`, or `null` when there is nothing to change (including when `prev === next`).
-- **D2** A key present in `prev` but missing from `next` produces `['delete']`. A key present in `next` but missing from `prev` produces `['put', value]`.
+- **D2** A key present in `prev` but missing from `next` produces `['delete']`. A key present in `next` but missing from `prev` produces `['put', value]`. Only own keys count (inherited `Object.prototype` members are never consulted), and a key whose value is `undefined` is treated as absent on both sides — `undefined` does not survive JSON, so it is never put.
 - **D3** `props` and `meta` are the only nested keys at the top level: changes inside them are expressed as `['patch', ...]` ops. Any other top-level key whose values are not both arrays or both strings is compared with deep equality and produces a whole-value `['put', next]` on change — even when both values are plain objects.
 - **D4** Inside a nested diff (within `props`/`meta` or deeper), object values are recursively patched; `null` and primitive values are put.
 - **D5** When both values are strings (at any level, including top-level keys) and `next` starts with `prev`, the diff is `['append', addedSuffix, prev.length]`. Other string changes are puts. With `legacyAppendMode` enabled, string appends become puts instead; array appends (D7) are unaffected by `legacyAppendMode`.
-- **D6** Same-length arrays: if no items changed, no op. If at most `max(length/5, 1)` items changed, the op is `['patch', { [index]: op }]` where each changed index gets a recursive diff when both old and new items are truthy objects, and a put otherwise. If more items changed, the whole array is put.
+- **D6** Same-length arrays: if no items changed, no op. If at most `max(length/5, 1)` items changed, the op is `['patch', { [index]: op }]` where each changed index gets a recursive diff when both old and new items are truthy objects of the same kind (both arrays or both plain objects), and a put otherwise. If more items changed, the whole array is put.
 - **D7** Different-length arrays: when the shared prefix is unchanged and the array grew, the op is `['append', addedItems, prev.length]`. Any change in the shared prefix (including truncation) puts the whole array.
 
 ## 4. Applying diffs: `applyObjectDiff` (AD)
@@ -38,9 +38,10 @@ Sections marked **internal** describe supporting machinery that has its own cont
 - **AD2** A `put` is applied only when the new value is not deep-equal to the current value.
 - **AD3** An `append` is applied only when the current value is an array/string of the matching type whose length equals the op's offset. On any mismatch the op is silently ignored.
 - **AD4** A `patch` is applied only when the current value is a truthy object; it recurses with AD1 semantics. Patching a missing or primitive value is silently ignored.
-- **AD5** A `delete` removes the key when present.
+- **AD5** A `delete` removes the key when it is an own key of the object.
 - **AD6** Patching a non-object (`null`, primitives) returns the input unchanged.
 - **AD7** Arrays are cloned as arrays; ops keyed by numeric strings index into them.
+- **AD8** Ops keyed `__proto__` are ignored: diffs arrive from untrusted peers and assigning that key would change the target's prototype.
 
 ## 5. Converting diffs (ND)
 
@@ -58,7 +59,8 @@ Sections marked **internal** describe supporting machinery that has its own cont
 
 - **CH1** `chunk(msg, maxSize)` returns `[msg]` when `msg.length < maxSize` (strictly less — a message exactly at `maxSize` is chunked).
 - **CH2** Chunks are prefixed `<n>_` where `n` counts down the chunks remaining after this one; the first chunk carries the highest number and the start of the message, and concatenating the chunk bodies in order reconstructs the message.
-- **CH3** Each chunk's total length is at most `maxSize`, except that every chunk carries at least one character of content even when the prefix alone exceeds `maxSize`.
+- **CH3** Each chunk's total length is at most `maxSize`, except that every chunk carries at least one character of content even when the prefix alone exceeds `maxSize`, and except for CH9.
+- **CH9** A UTF-16 surrogate pair is never split across two chunks (`WebSocket.send` would turn each lone half into U+FFFD): the boundary moves by one character, shrinking the chunk when it has more than one character of content and otherwise growing it by one.
 - **CH4** `JsonChunkAssembler.handleMessage`: input starting with `{` while idle is parsed immediately and returned as `{ data, stringified }`. Invalid JSON in this case throws synchronously (callers treat a throw as a fatal session error).
 - **CH5** Input starting with `{` mid-sequence returns `{ error: 'Unexpected non-chunk message' }`; the partial sequence and the JSON message are both discarded and the assembler resets to idle.
 - **CH6** Chunk inputs accumulate, returning `null` until the final (`0_`) chunk arrives, then the joined body is JSON-parsed and returned; a parse failure is returned as `{ error }`. Either way the assembler resets to idle.

--- a/packages/sync-core/src/lib/chunk.test.ts
+++ b/packages/sync-core/src/lib/chunk.test.ts
@@ -134,6 +134,33 @@ describe('chunk (CH1–CH3)', () => {
 		`)
 		})
 	})
+
+	describe('surrogate pairs (CH9)', () => {
+		it('[CH9] never splits a surrogate pair across two chunks', () => {
+			// WebSocket.send converts each chunk to a USVString, so a lone surrogate would arrive
+			// as U+FFFD and the reassembled message would carry corrupted text
+			const emoji = '\u{1F600}'
+			const isHigh = (code: number) => code >= 0xd800 && code <= 0xdbff
+			const isLow = (code: number) => code >= 0xdc00 && code <= 0xdfff
+			for (let padding = 0; padding < 8; padding++) {
+				const msg = 'x'.repeat(padding) + emoji + 'y'.repeat(6) + emoji
+				for (const maxSize of [3, 4, 5, 6, 7, 8]) {
+					const chunks = chunk(msg, maxSize)
+					const bodies = chunks.map((c) => c.slice(c.indexOf('_') + 1))
+					expect(bodies.join('')).toBe(msg)
+					for (const [i, body] of bodies.entries()) {
+						expect(body.length).toBeGreaterThan(0)
+						expect(isHigh(body.charCodeAt(body.length - 1))).toBe(false)
+						expect(isLow(body.charCodeAt(0))).toBe(false)
+						// keeping a pair whole may cost one character over maxSize, never more
+						expect(chunks[i].length).toBeLessThanOrEqual(
+							Math.max(maxSize, chunks[i].indexOf('_') + 2) + 1
+						)
+					}
+				}
+			}
+		})
+	})
 })
 
 const testObject = {} as any

--- a/packages/sync-core/src/lib/chunk.ts
+++ b/packages/sync-core/src/lib/chunk.ts
@@ -38,13 +38,33 @@ export function chunk(msg: string, maxSafeMessageSize = MAX_SAFE_MESSAGE_SIZE) {
 		let offset = msg.length
 		while (offset > 0) {
 			const prefix = `${chunkNumber}_`
-			const chunkSize = Math.max(Math.min(maxSafeMessageSize - prefix.length, offset), 1)
+			let chunkSize = Math.max(Math.min(maxSafeMessageSize - prefix.length, offset), 1)
+			// Never split a surrogate pair across chunks: WebSocket.send converts each chunk to a
+			// USVString, turning a lone surrogate into U+FFFD, and the reassembled JSON would then
+			// carry corrupted text (e.g. an emoji becoming '\uFFFD\uFFFD') without any error.
+			// Shrink the chunk by one so the pair moves whole into the preceding chunk; when the
+			// chunk is already a single character, grow it by one instead (as CH3 already permits).
+			if (
+				chunkSize < offset &&
+				isLowSurrogate(msg.charCodeAt(offset - chunkSize)) &&
+				isHighSurrogate(msg.charCodeAt(offset - chunkSize - 1))
+			) {
+				chunkSize += chunkSize > 1 ? -1 : 1
+			}
 			chunks.unshift(prefix + msg.slice(offset - chunkSize, offset))
 			offset -= chunkSize
 			chunkNumber++
 		}
 		return chunks
 	}
+}
+
+function isHighSurrogate(code: number) {
+	return code >= 0xd800 && code <= 0xdbff
+}
+
+function isLowSurrogate(code: number) {
+	return code >= 0xdc00 && code <= 0xdfff
 }
 
 // The 's' flag (dotAll) makes '.' match any character including line terminators

--- a/packages/sync-core/src/lib/diff.test.ts
+++ b/packages/sync-core/src/lib/diff.test.ts
@@ -39,6 +39,42 @@ describe('computing diffs (D)', () => {
 			expect(patch).toEqual({ c: [ValueOpType.Put, 3] })
 			expect(applyObjectDiff(a, patch!)).toEqual(b)
 		})
+
+		it('[D2] treats a key whose value is undefined as absent', () => {
+			// undefined does not survive JSON, so `['put', undefined]` would arrive as
+			// `['put', null]` and fail validators that only accept the key being missing
+			const present = { a: 1, props: { foo: 'x' } }
+			const explicitlyUndefined = { a: 1, props: { foo: undefined } }
+			const absent = { a: 1, props: {} }
+
+			expect(diffRecord(present, explicitlyUndefined)).toEqual({
+				props: [ValueOpType.Patch, { foo: [ValueOpType.Delete] }],
+			})
+			expect(diffRecord(explicitlyUndefined, present)).toEqual({
+				props: [ValueOpType.Patch, { foo: [ValueOpType.Put, 'x'] }],
+			})
+			expect(diffRecord(absent, explicitlyUndefined)).toBeNull()
+			expect(diffRecord(explicitlyUndefined, absent)).toBeNull()
+			expect(diffRecord({ a: undefined }, { a: undefined })).toBeNull()
+		})
+
+		it('[D2] only considers own keys, not Object.prototype members', () => {
+			const withCtor = { meta: { constructor: 1, toString: 2 } }
+			const without = { meta: {} }
+
+			expect(diffRecord(withCtor, without)).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ constructor: [ValueOpType.Delete], toString: [ValueOpType.Delete] },
+				],
+			})
+			expect(diffRecord(without, withCtor)).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ constructor: [ValueOpType.Put, 1], toString: [ValueOpType.Put, 2] },
+				],
+			})
+		})
 	})
 
 	describe('top-level keys vs props/meta (D3)', () => {
@@ -102,7 +138,8 @@ describe('computing diffs (D)', () => {
 
 			const diff = diffRecord(prev, next)
 			expect(diff).toBeTruthy()
-			expect(diff!.optional).toEqual([ValueOpType.Put, undefined])
+			// undefined is not representable on the wire, so it reads as the key being absent (D2)
+			expect(diff!.optional).toEqual([ValueOpType.Delete])
 			expect(diff!.nullable).toEqual([ValueOpType.Put, 'value'])
 		})
 	})
@@ -377,6 +414,25 @@ describe('computing diffs (D)', () => {
 			expect(diffRecord(prev, next)).toEqual({
 				arr: [ValueOpType.Patch, { '0': [ValueOpType.Put, null] }],
 			})
+		})
+
+		it('[D6] puts a changed index when an item switches between array and object', () => {
+			// index deletes and named puts don't apply cleanly across shapes, so a patch would
+			// leave the receiver with a sparse array / an object where an array is expected
+			const arrayItem = { meta: { items: [[1, 2]] } }
+			const objectItem = { meta: { items: [{ x: 1 }] } }
+
+			const toObject = diffRecord(arrayItem, objectItem)!
+			expect(toObject).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ items: [ValueOpType.Patch, { '0': [ValueOpType.Put, { x: 1 }] }] },
+				],
+			})
+			expect(applyObjectDiff(arrayItem, toObject)).toEqual(objectItem)
+
+			const toArray = diffRecord(objectItem, arrayItem)!
+			expect(applyObjectDiff(objectItem, toArray)).toEqual(arrayItem)
 		})
 	})
 
@@ -746,6 +802,30 @@ describe('applying diffs (AD)', () => {
 			const diff: ObjectDiff = { b: [ValueOpType.Delete] }
 
 			expect(applyObjectDiff(obj, diff)).toBe(obj)
+		})
+
+		it('[AD5] deleting an inherited key has no effect', () => {
+			const obj = { a: 1 }
+			// `toString` collides with Object.prototype's own member in the literal's type, hence the cast
+			const diff = { toString: [ValueOpType.Delete] } as unknown as ObjectDiff
+
+			expect(applyObjectDiff(obj, diff)).toBe(obj)
+		})
+	})
+
+	describe('untrusted keys (AD8)', () => {
+		it('[AD8] ignores __proto__ keys instead of changing the prototype', () => {
+			// JSON.parse produces '__proto__' as an own key, so a peer can put it in a diff
+			const obj = { a: 1, props: { b: 2 } }
+			const diff: ObjectDiff = JSON.parse(
+				'{"__proto__":["put",{"isAdmin":true}],"props":["patch",{"__proto__":["put",{"polluted":1}]}]}'
+			)
+
+			const result: any = applyObjectDiff(obj, diff)
+			expect(result).toBe(obj)
+			expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+			expect(result.isAdmin).toBeUndefined()
+			expect(result.props.polluted).toBeUndefined()
 		})
 	})
 

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -1,5 +1,5 @@
 import { RecordsDiff, UnknownRecord } from '@tldraw/store'
-import { isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
+import { hasOwnProperty, isEqual, objectMapEntries, objectMapValues } from '@tldraw/utils'
 
 /**
  * Constants representing the types of operations that can be applied to records in network diffs.
@@ -200,15 +200,19 @@ function diffObject(
 		return null
 	}
 	let result: ObjectDiff | null = null
+	// Own-property checks throughout: `in` would see Object.prototype members, so a user key named
+	// e.g. 'constructor' would never diff as an add or delete. And a key whose value is `undefined`
+	// is treated as absent: `undefined` doesn't survive JSON, so `['put', undefined]` would arrive
+	// as `['put', null]` and fail validators that accept only the missing key.
 	for (const key of Object.keys(prev)) {
-		// if key is not in next then it was deleted
-		if (!(key in next)) {
+		const prevValue = (prev as any)[key]
+		if (prevValue === undefined) continue
+		const nextValue = hasOwnProperty(next, key) ? (next as any)[key] : undefined
+		if (nextValue === undefined) {
 			if (!result) result = {}
 			result[key] = [ValueOpType.Delete]
 			continue
 		}
-		const prevValue = (prev as any)[key]
-		const nextValue = (next as any)[key]
 		if (
 			nestedKeys?.has(key) ||
 			(Array.isArray(prevValue) && Array.isArray(nextValue)) ||
@@ -226,10 +230,12 @@ function diffObject(
 		}
 	}
 	for (const key of Object.keys(next)) {
+		const nextValue = (next as any)[key]
+		if (nextValue === undefined) continue
 		// if key is in next but not in prev then it was added
-		if (!(key in prev)) {
+		if (!hasOwnProperty(prev, key) || (prev as any)[key] === undefined) {
 			if (!result) result = {}
-			result[key] = [ValueOpType.Put, (next as any)[key]]
+			result[key] = [ValueOpType.Put, nextValue]
 		}
 	}
 	return result
@@ -245,7 +251,15 @@ function diffValue(valueA: unknown, valueB: unknown, legacyAppendMode: boolean):
 			return [ValueOpType.Append, appendedText, valueA.length]
 		}
 		return [ValueOpType.Put, valueB]
-	} else if (!valueA || !valueB || typeof valueA !== 'object' || typeof valueB !== 'object') {
+	} else if (
+		!valueA ||
+		!valueB ||
+		typeof valueA !== 'object' ||
+		typeof valueB !== 'object' ||
+		// an array on one side and a plain object on the other can't be expressed as a patch:
+		// index deletes and named puts don't apply cleanly to either shape
+		Array.isArray(valueA) !== Array.isArray(valueB)
+	) {
 		return isEqual(valueA, valueB) ? null : [ValueOpType.Put, valueB]
 	} else {
 		const diff = diffObject(valueA, valueB, undefined, legacyAppendMode)
@@ -348,6 +362,10 @@ export function applyObjectDiff<T extends object>(object: T, objectDiff: ObjectD
 		}
 	}
 	for (const [key, op] of Object.entries(objectDiff)) {
+		// Diffs come off the wire from untrusted peers. `newObject['__proto__'] = v` would set the
+		// record's prototype (JSON.parse creates '__proto__' as an own key), so a client could give
+		// server-held records attacker-controlled inherited fields; skip such keys outright.
+		if (key === '__proto__') continue
 		switch (op[0]) {
 			case ValueOpType.Put: {
 				const value = op[1]
@@ -383,7 +401,7 @@ export function applyObjectDiff<T extends object>(object: T, objectDiff: ObjectD
 				break
 			}
 			case ValueOpType.Delete: {
-				if (key in object) {
+				if (hasOwnProperty(object, key)) {
 					if (!newObject) {
 						if (isArray) {
 							console.error("Can't delete array item yet (this should never happen)")


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where an `undefined` prop value got the session kicked with `INVALID_RECORD`. It also closes a prototype-pollution hole in applying diffs from peers, and fixes emoji being corrupted when they straddle a chunk boundary.

### Before

- `diffObject` emitted `['put', undefined]` for an undefined value. JSON turns that into `['put', null]`; optional-prop validators reject it, so the server kicked the session with `INVALID_RECORD` and the client re-pushed the same speculative change on every reconnect.
- `diffObject` used `in`, so `Object.prototype` members (`constructor`, `toString`) never diffed as adds/deletes, and `applyObjectDiff` assigned untrusted keys with `newObject[k] = v` — a peer could set a server-held record's prototype via a `__proto__` key (JSON.parse creates it as an own key). An item switching between array and object produced a patch that can't apply cleanly to either shape.
- `chunk()` sliced at arbitrary UTF-16 code-unit boundaries; a surrogate pair straddling a chunk edge became two lone surrogates that `WebSocket.send`'s USVString conversion turns into U+FFFD — corrupted text that still parses as valid JSON on the server.

### After

Undefined values are skipped on both sides (an explicitly-undefined key now diffs as `['delete']`); own-key checks via `hasOwnProperty`; `__proto__` ops are ignored outright; array↔object switches emit a whole-value `put`. `chunk()` moves the boundary by one character when it would land between a high and low surrogate.

Split out of #10092. `packages/sync-core/SPEC.md` is updated for D2, D6, AD5, AD8, and CH9.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix corrupted text when a chunk boundary splits an emoji, and `undefined` values kicking the session with `INVALID_RECORD`

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +54 / -14  |
| Tests     | +108 / -1  |
