### PR TITLE
fix(editor): stop local IndexedDB persistence dropping the last edits before close and cross-tab edits during load

### DIFF
--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -239,4 +239,40 @@ describe('LocalIndexedDb', () => {
 			(await window.indexedDB.databases()).find((db) => db.name === 'TLDRAW_ASSET_STORE_v1test-0')
 		).toBeUndefined()
 	})
+
+	describe('#close', () => {
+		it('lets a write that is in flight finish instead of rolling it back', async () => {
+			const db = new LocalIndexedDb('test-0')
+			// start the write and close before it settles (as unmounting right after an edit does)
+			const write = db.storeChanges({
+				schema,
+				changes: {
+					added: { 'shape:1': { id: 'shape:1', type: 'rectangle' } },
+					updated: {},
+					removed: {},
+				},
+			})
+			const closed = db.close()
+			await write
+			await closed
+
+			const reopened = new LocalIndexedDb('test-0')
+			expect((await reopened.load()).records).toEqual([{ id: 'shape:1', type: 'rectangle' }])
+			await reopened.close()
+		})
+
+		it('resolves and releases the instance even when the database never opened', async () => {
+			const openSpy = vi.spyOn(window.indexedDB, 'open').mockImplementation(() => {
+				throw new Error('backing store unavailable')
+			})
+			try {
+				const db = new LocalIndexedDb('test-broken')
+				await expect(db.load()).rejects.toThrow('backing store unavailable')
+				await expect(db.close()).resolves.toBeUndefined()
+				expect(LocalIndexedDb.connectedInstances.has(db)).toBe(false)
+			} finally {
+				openSpy.mockRestore()
+			}
+		})
+	})
 })

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -128,7 +128,12 @@ export class LocalIndexedDb {
 		if (this.isClosed) return
 		this.isClosed = true
 		await this.pending()
-		;(await this.getDb()).close()
+		try {
+			;(await this.getDb()).close()
+		} catch {
+			// the database never opened, so there is nothing to close — but the instance must
+			// still be released, or hardReset() would abort on it before deleting anything
+		}
 		LocalIndexedDb.connectedInstances.delete(this)
 	}
 
@@ -152,15 +157,18 @@ export class LocalIndexedDb {
 			try {
 				return await cb(tx)
 			} finally {
-				if (!this.isClosed) {
-					await done
-				} else {
-					tx.abort()
-				}
+				// Always let the transaction finish, even when close() has been called meanwhile:
+				// close() waits for pending transactions before closing the database, and aborting
+				// here would roll back a write (e.g. the last persist before unmount) whose promise
+				// then resolved as if it had succeeded.
+				await done
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise))
+		// `.finally` would return a promise that rejects alongside txPromise and that nobody
+		// handles, surfacing every failed write as an unhandled rejection on top of the real one
+		const untrack = () => this.pendingTransactionSet.delete(txPromise)
+		txPromise.then(untrack, untrack)
 		return txPromise
 	}
 
@@ -208,31 +216,21 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
+			// issue every request up front and settle them together: awaiting each one would
+			// serialize the writes on the request's success event (see the idb readme)
+			const requests: Promise<unknown>[] = []
 			for (const [id, record] of Object.entries(changes.added)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
-
 			for (const [_prev, updated] of Object.values(changes.updated)) {
-				await recordsStore.put(updated, updated.id)
+				requests.push(recordsStore.put(updated, updated.id))
 			}
-
 			for (const id of Object.keys(changes.removed)) {
-				await recordsStore.delete(id)
+				requests.push(recordsStore.delete(id))
 			}
-
-			schemaStore.put(schema.serialize(), Table.Schema)
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			requests.push(schemaStore.put(schema.serialize(), Table.Schema))
+			requests.push(...putSessionState(sessionStateStore, sessionId, sessionStateSnapshot))
+			await Promise.all(requests)
 		})
 	}
 
@@ -252,26 +250,13 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
-			await recordsStore.clear()
-
+			const requests: Promise<unknown>[] = [recordsStore.clear()]
 			for (const [id, record] of Object.entries(snapshot)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
-
-			schemaStore.put(schema.serialize(), Table.Schema)
-
-			if (sessionStateSnapshot && sessionId) {
-				sessionStateStore.put(
-					{
-						snapshot: sessionStateSnapshot,
-						updatedAt: Date.now(),
-						id: sessionId,
-					} satisfies SessionStateSnapshotRow,
-					sessionId
-				)
-			} else if (sessionStateSnapshot || sessionId) {
-				console.error('sessionStateSnapshot and instanceId must be provided together')
-			}
+			requests.push(schemaStore.put(schema.serialize(), Table.Schema))
+			requests.push(...putSessionState(sessionStateStore, sessionId, sessionStateSnapshot))
+			await Promise.all(requests)
 		})
 	}
 
@@ -307,11 +292,34 @@ export class LocalIndexedDb {
 	async removeAssets(assetId: string[]) {
 		await this.tx('readwrite', [Table.Assets], async (tx) => {
 			const assetsStore = tx.objectStore(Table.Assets)
-			for (const id of assetId) {
-				await assetsStore.delete(id)
-			}
+			await Promise.all(assetId.map((id) => assetsStore.delete(id)))
 		})
 	}
+}
+
+function putSessionState(
+	sessionStateStore: {
+		put(value: SessionStateSnapshotRow, key: string): Promise<unknown>
+	},
+	sessionId: string | null | undefined,
+	sessionStateSnapshot: TLSessionStateSnapshot | null | undefined
+): Promise<unknown>[] {
+	if (sessionStateSnapshot && sessionId) {
+		return [
+			sessionStateStore.put(
+				{
+					snapshot: sessionStateSnapshot,
+					updatedAt: Date.now(),
+					id: sessionId,
+				} satisfies SessionStateSnapshotRow,
+				sessionId
+			),
+		]
+	}
+	if (sessionStateSnapshot || sessionId) {
+		console.error('sessionStateSnapshot and sessionId must be provided together')
+	}
+	return []
 }
 
 /** @internal */

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -131,8 +131,7 @@ export class LocalIndexedDb {
 		try {
 			;(await this.getDb()).close()
 		} catch {
-			// the database never opened, so there is nothing to close — but the instance must
-			// still be released, or hardReset() would abort on it before deleting anything
+			// never opened. still release the instance, or hardReset() aborts on it
 		}
 		LocalIndexedDb.connectedInstances.delete(this)
 	}
@@ -157,16 +156,13 @@ export class LocalIndexedDb {
 			try {
 				return await cb(tx)
 			} finally {
-				// Always let the transaction finish, even when close() has been called meanwhile:
-				// close() waits for pending transactions before closing the database, and aborting
-				// here would roll back a write (e.g. the last persist before unmount) whose promise
-				// then resolved as if it had succeeded.
+				// close() waits for pending transactions, so never abort here: that would roll
+				// back the write while its promise still resolved as success
 				await done
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		// `.finally` would return a promise that rejects alongside txPromise and that nobody
-		// handles, surfacing every failed write as an unhandled rejection on top of the real one
+		// not `.finally`: the promise it returns rejects too, and nobody handles it
 		const untrack = () => this.pendingTransactionSet.delete(txPromise)
 		txPromise.then(untrack, untrack)
 		return txPromise
@@ -216,8 +212,7 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
-			// issue every request up front and settle them together: awaiting each one would
-			// serialize the writes on the request's success event (see the idb readme)
+			// issue up front, settle together: awaiting each one serializes the writes
 			const requests: Promise<unknown>[] = []
 			for (const [id, record] of Object.entries(changes.added)) {
 				requests.push(recordsStore.put(record, id))

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -3,6 +3,7 @@ import { IndexKey, promiseWithResolve } from '@tldraw/utils'
 import { Mock, vi } from 'vitest'
 import { createTLStore } from '../../config/createTLStore'
 import { hardReset } from './hardReset'
+import { LocalIndexedDb } from './LocalIndexedDb'
 import { TLLocalSyncClient } from './TLLocalSyncClient'
 
 class BroadcastChannelMock {
@@ -272,4 +273,34 @@ test('close() before the initial load has finished never writes', async () => {
 	// a full-snapshot write of a not-yet-loaded store would wipe the saved document
 	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
 	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
+test('a client created on the same key while a closed client is still flushing does not load until that flush has landed', async () => {
+	const inFlightWrite = promiseWithResolve<void>()
+	const { client, tick } = testClient()
+	client.db.storeSnapshot.mockImplementationOnce(() => inFlightWrite)
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'first', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1) // in flight
+	client.store.put([PageRecordType.create({ name: 'during write', index: 'a1' as IndexKey })])
+	client.close()
+
+	// remount on the same key while the old client is still waiting to flush its queue
+	const loadSpy = vi.spyOn(LocalIndexedDb.prototype, 'load')
+	const next = testClient()
+	await tick()
+	// reading now would miss the queued edit, and the new client's first (full snapshot) write
+	// would then erase it
+	expect(loadSpy).not.toHaveBeenCalled()
+	expect(next.onLoad).not.toHaveBeenCalled()
+
+	inFlightWrite.resolve()
+	await tick()
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	for (let i = 0; i < 20; i++) await Promise.resolve()
+	await next.tick()
+	expect(loadSpy).toHaveBeenCalledTimes(1)
+	expect(next.onLoad).toHaveBeenCalledTimes(1)
+	loadSpy.mockRestore()
 })

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -172,3 +172,104 @@ test('writes that come in during a persist operation will get persisted afterwar
 	await tick()
 	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
 })
+
+test('a diff broadcast by another tab while the initial load is in flight is applied once loading finishes', async () => {
+	const { client, store, channel, tick } = testClient()
+	// nothing has loaded yet, but the channel is already listened to
+	expect(channel.onmessage).toBeDefined()
+	const page = PageRecordType.create({ name: 'from other tab', index: 'a5' as IndexKey })
+	channel.onmessage!({
+		data: {
+			type: 'diff',
+			storeId: 'other',
+			schema: client.serializedSchema,
+			changes: { added: { [page.id]: page }, updated: {}, removed: {} },
+		},
+	} as any)
+	expect(store.get(page.id)).toBeUndefined()
+
+	await tick()
+	// once loaded, the held-back diff is applied — the first (full snapshot) write must not
+	// erase what the other tab persisted meanwhile
+	expect(store.get(page.id)).toEqual(page)
+})
+
+test('a tab that reports a schema mismatch on load stops writing to the database', async () => {
+	const { client, channel, onLoadError, tick } = testClient()
+	await tick()
+	channel.onmessage?.({
+		data: {
+			type: 'announce',
+			schema: {
+				...client.serializedSchema,
+				schemaVersion: client.serializedSchema.schemaVersion + 1,
+			},
+		},
+	} as any)
+	expect(onLoadError).toHaveBeenCalled()
+
+	client.store.put([PageRecordType.create({ name: 'stale', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
+test('close() writes out changes that are still queued behind the persist throttle', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'last edit', index: 'a0' as IndexKey })])
+	// no throttle tick has elapsed yet
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+
+	client.close()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+})
+
+test('close() while a write is in flight still writes the edits queued behind it before closing the db', async () => {
+	const inFlightWrite = promiseWithResolve<void>()
+	const { client, tick } = testClient()
+	client.db.storeSnapshot.mockImplementationOnce(() => inFlightWrite)
+	await tick()
+
+	client.store.put([PageRecordType.create({ name: 'first', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1) // in flight
+	client.store.put([PageRecordType.create({ name: 'during write', index: 'a1' as IndexKey })])
+
+	const dbCloseSpy = vi.spyOn(client.db, 'close')
+	client.close()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+	expect(dbCloseSpy).not.toHaveBeenCalled()
+
+	inFlightWrite.resolve()
+	await tick()
+	// the queued edit was written once the in-flight write finished, then the db was closed
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	for (let i = 0; i < 10; i++) await Promise.resolve()
+	expect(dbCloseSpy).toHaveBeenCalledTimes(1)
+})
+
+test('a schema mismatch reported by a message held back during load is not overridden by onLoad', async () => {
+	const { client, channel, onLoad, onLoadError, tick } = testClient()
+	channel.onmessage!({
+		data: {
+			type: 'announce',
+			schema: {
+				...client.serializedSchema,
+				schemaVersion: client.serializedSchema.schemaVersion + 1,
+			},
+		},
+	} as any)
+	await tick()
+	expect(onLoadError).toHaveBeenCalledTimes(1)
+	expect(onLoad).not.toHaveBeenCalled()
+})
+
+test('close() before the initial load has finished never writes', async () => {
+	const { client } = testClient()
+	client.store.put([PageRecordType.create({ name: 'too early', index: 'a0' as IndexKey })])
+	client.close()
+	// a full-snapshot write of a not-yet-loaded store would wipe the saved document
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -63,6 +63,11 @@ export class BroadcastChannelMock {
 
 const BC = typeof BroadcastChannel === 'undefined' ? BroadcastChannelMock : BroadcastChannel
 
+// Flushes still running for a closed client, by persistence key. A client that mounts on the
+// same key right after (remount, StrictMode) must not read IndexedDB before that flush has landed:
+// its first persist is a full-snapshot write, so anything it did not read would be erased.
+const pendingFlushes = new Map<string, Promise<void>>()
+
 /** @internal */
 export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
@@ -167,6 +172,9 @@ export class TLLocalSyncClient {
 		this.disposables.add(() => {
 			this.channel.close()
 		})
+
+		await pendingFlushes.get(this.persistenceKey)
+		if (this.didDispose) return
 
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
@@ -292,7 +300,15 @@ export class TLLocalSyncClient {
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
-		void this.flushAndCloseDb()
+		const flush = Promise.allSettled([
+			pendingFlushes.get(this.persistenceKey),
+			this.flushAndCloseDb(),
+		]).then(() => {
+			if (pendingFlushes.get(this.persistenceKey) === flush) {
+				pendingFlushes.delete(this.persistenceKey)
+			}
+		})
+		pendingFlushes.set(this.persistenceKey, flush)
 	}
 
 	/**

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -68,6 +68,7 @@ export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
 	private diffQueue: Array<RecordsDiff<UnknownRecord> | typeof UPDATE_INSTANCE_STATE> = []
 	private didDispose = false
+	private didLoad = false
 	private shouldDoFullDBWrite = true
 	private isReloading = false
 	readonly persistenceKey: string
@@ -107,7 +108,6 @@ export class TLLocalSyncClient {
 		this.persistenceKey = persistenceKey
 		this.sessionId = sessionId
 		this.db = new LocalIndexedDb(persistenceKey)
-		this.disposables.add(() => this.db.close())
 
 		this.serializedSchema = this.store.schema.serialize()
 		this.$sessionStateSnapshot = createSessionStateSnapshotSignal(this.store)
@@ -156,6 +156,18 @@ export class TLLocalSyncClient {
 		this.debug('connecting')
 		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
 
+		// Listen from the start and hold messages until we have loaded. A diff another tab
+		// broadcasts while our load is in flight may not be in what we read (that tab persists on
+		// a throttle), and our first persist is a full snapshot write — so if we missed it here it
+		// would be erased from IndexedDB for good. Re-applying one we did read is a no-op.
+		const messagesReceivedWhileLoading: MessageEvent[] = []
+		this.channel.onmessage = (event) => {
+			messagesReceivedWhileLoading.push(event)
+		}
+		this.disposables.add(() => {
+			this.channel.close()
+		})
+
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
 		} catch (error: any) {
@@ -201,8 +213,11 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			this.didLoad = true
+			// anything queued while loading was held back by persistIfNeeded; write it now
+			if (this.diffQueue.length > 0) this.schedulePersist()
 
-			this.channel.onmessage = ({ data }) => {
+			const handleMessage = ({ data }: MessageEvent) => {
 				this.debug('got message', data)
 				const msg = data as Message
 				// if their schema is earlier than ours, we need to tell them so they can refresh
@@ -219,6 +234,10 @@ export class TLLocalSyncClient {
 						// the schema version (which we should never do)
 						// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
 						// check out an older commit. Dev server should be fine.
+						//
+						// Either way this tab must stop writing: persisting its older schema over the
+						// newer tab's records would corrupt the next load.
+						this.isReloading = true
 						onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
 						return
 					}
@@ -245,10 +264,14 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			this.channel.onmessage = handleMessage
+			for (const event of messagesReceivedWhileLoading) {
+				handleMessage(event)
+			}
+			// a held-back message may have found us out of date (onLoadError already reported it, or
+			// the page is reloading); don't report a successful load on top of that
+			if (this.isReloading) return
 			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-			this.disposables.add(() => {
-				this.channel.close()
-			})
 			onLoad(this)
 		} catch (e: any) {
 			this.debug('error loading data from store', e)
@@ -260,14 +283,39 @@ export class TLLocalSyncClient {
 
 	close() {
 		this.debug('closing')
+		if (this.scheduledPersistTimeout) {
+			clearTimeout(this.scheduledPersistTimeout)
+			this.scheduledPersistTimeout = null
+		}
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
+		void this.flushAndCloseDb()
+	}
+
+	/**
+	 * Write out whatever is still queued instead of throwing it away — the persist throttle means
+	 * the last few hundred milliseconds of edits before an unmount are usually still pending — and
+	 * only then close the database.
+	 */
+	private async flushAndCloseDb() {
+		// let a write that is already in flight finish first; edits made during it are queued
+		if (this.currentPersist) await this.currentPersist
+		if (
+			this.didLoad &&
+			!this.isReloading &&
+			!this.store.isPossiblyCorrupted() &&
+			(this.shouldDoFullDBWrite || this.diffQueue.length > 0)
+		) {
+			await this.doPersist()
+		}
+		await this.db.close()
 	}
 
 	private isPersisting = false
+	private currentPersist: Promise<void> | null = null
 	private didLastWriteError = false
 	// eslint-disable-next-line no-restricted-globals
 	private scheduledPersistTimeout: ReturnType<typeof setTimeout> | null = null
@@ -280,7 +328,7 @@ export class TLLocalSyncClient {
 	 */
 	private schedulePersist() {
 		this.debug('schedulePersist', this.scheduledPersistTimeout)
-		if (this.scheduledPersistTimeout) return
+		if (this.didDispose || this.scheduledPersistTimeout) return
 		// eslint-disable-next-line no-restricted-globals
 		this.scheduledPersistTimeout = setTimeout(
 			() => {
@@ -315,6 +363,10 @@ export class TLLocalSyncClient {
 			this.scheduledPersistTimeout = null
 		}
 
+		// until the initial load has merged what IndexedDB holds, the store is not the source of
+		// truth: writing it out now (the first write is a full snapshot) would wipe the saved document
+		if (!this.didLoad) return
+
 		// if a persist is already in progress, we don't need to do anything -
 		// if there are still outstanding changes once it's finished, it'll
 		// schedule another persist
@@ -329,7 +381,7 @@ export class TLLocalSyncClient {
 
 		// if we're scheduled for a full write or if we have changes outstanding, let's persist them!
 		if (this.shouldDoFullDBWrite || this.diffQueue.length > 0) {
-			this.doPersist()
+			void this.doPersist()
 		}
 	}
 
@@ -337,11 +389,20 @@ export class TLLocalSyncClient {
 	 * Actually persist to IndexedDB. If the write fails, then we'll retry with a full db write after
 	 * a short delay.
 	 */
-	private async doPersist() {
+	private doPersist(): Promise<void> {
 		assert(!this.isPersisting, 'persist already in progress')
-		if (this.didDispose) return
 		this.isPersisting = true
+		this.currentPersist = this.doPersistInner().finally(() => {
+			this.isPersisting = false
+			this.currentPersist = null
+			// changes might have come in between when we started the persist and
+			// now. we request another persist so any new changes can get written
+			this.schedulePersist()
+		})
+		return this.currentPersist
+	}
 
+	private async doPersistInner() {
 		this.debug('doPersist start')
 
 		// instantly empty the diff queue, but keep our own copy of it. this way
@@ -377,6 +438,9 @@ export class TLLocalSyncClient {
 			this.didLastWriteError = true
 			console.error('failed to store changes in indexed db', e)
 
+			// the final flush after close() must not alert or reload: the component is unmounting,
+			// and its user is no longer looking at this document
+			if (this.didDispose) return
 			showCantWriteToIndexDbAlert()
 			if (typeof window !== 'undefined') {
 				// adios
@@ -384,11 +448,6 @@ export class TLLocalSyncClient {
 			}
 		}
 
-		this.isPersisting = false
 		this.debug('doPersist end')
-
-		// changes might have come in between when we started the persist and
-		// now. we request another persist so any new changes can get written
-		this.schedulePersist()
 	}
 }

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -63,9 +63,8 @@ export class BroadcastChannelMock {
 
 const BC = typeof BroadcastChannel === 'undefined' ? BroadcastChannelMock : BroadcastChannel
 
-// Flushes still running for a closed client, by persistence key. A client that mounts on the
-// same key right after (remount, StrictMode) must not read IndexedDB before that flush has landed:
-// its first persist is a full-snapshot write, so anything it did not read would be erased.
+// Flushes still running for closed clients, by persistence key. A client remounting on the same
+// key must wait for one: its first persist is a full snapshot, so what it read too early is erased.
 const pendingFlushes = new Map<string, Promise<void>>()
 
 /** @internal */
@@ -161,10 +160,8 @@ export class TLLocalSyncClient {
 		this.debug('connecting')
 		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
 
-		// Listen from the start and hold messages until we have loaded. A diff another tab
-		// broadcasts while our load is in flight may not be in what we read (that tab persists on
-		// a throttle), and our first persist is a full snapshot write — so if we missed it here it
-		// would be erased from IndexedDB for good. Re-applying one we did read is a no-op.
+		// hold messages until we've loaded: a diff broadcast during the load may not be in what we
+		// read, and our first persist would erase it. re-applying one we did read is a no-op.
 		const messagesReceivedWhileLoading: MessageEvent[] = []
 		this.channel.onmessage = (event) => {
 			messagesReceivedWhileLoading.push(event)
@@ -243,8 +240,7 @@ export class TLLocalSyncClient {
 						// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
 						// check out an older commit. Dev server should be fine.
 						//
-						// Either way this tab must stop writing: persisting its older schema over the
-						// newer tab's records would corrupt the next load.
+						// either way, stop writing: our older schema would overwrite the newer tab's records
 						this.isReloading = true
 						onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
 						return
@@ -276,8 +272,7 @@ export class TLLocalSyncClient {
 			for (const event of messagesReceivedWhileLoading) {
 				handleMessage(event)
 			}
-			// a held-back message may have found us out of date (onLoadError already reported it, or
-			// the page is reloading); don't report a successful load on top of that
+			// a held-back message may have already reported an error; don't report a load over it
 			if (this.isReloading) return
 			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
 			onLoad(this)
@@ -312,12 +307,11 @@ export class TLLocalSyncClient {
 	}
 
 	/**
-	 * Write out whatever is still queued instead of throwing it away — the persist throttle means
-	 * the last few hundred milliseconds of edits before an unmount are usually still pending — and
-	 * only then close the database.
+	 * Write out what the persist throttle still has queued — the last few hundred milliseconds of
+	 * edits before an unmount — and only then close the database.
 	 */
 	private async flushAndCloseDb() {
-		// let a write that is already in flight finish first; edits made during it are queued
+		// let an in-flight write finish first; edits made during it are queued
 		if (this.currentPersist) await this.currentPersist
 		if (
 			this.didLoad &&
@@ -379,8 +373,7 @@ export class TLLocalSyncClient {
 			this.scheduledPersistTimeout = null
 		}
 
-		// until the initial load has merged what IndexedDB holds, the store is not the source of
-		// truth: writing it out now (the first write is a full snapshot) would wipe the saved document
+		// before the load merges what IndexedDB holds, a full-snapshot write wipes the saved document
 		if (!this.didLoad) return
 
 		// if a persist is already in progress, we don't need to do anything -
@@ -454,8 +447,7 @@ export class TLLocalSyncClient {
 			this.didLastWriteError = true
 			console.error('failed to store changes in indexed db', e)
 
-			// the final flush after close() must not alert or reload: the component is unmounting,
-			// and its user is no longer looking at this document
+			// the flush after close() must not alert or reload: we're unmounting
 			if (this.didDispose) return
 			showCantWriteToIndexDbAlert()
 			if (typeof window !== 'undefined') {


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where the last edits before closing a tab were lost from local persistence. It also fixes edits from another tab being erased when they arrive while this tab is still loading.

### Before

- `LocalIndexedDb.close()` flipped `isClosed` before draining, and `tx()` then aborted any transaction whose callback finished after that while still resolving as success; combined with `TLLocalSyncClient.close()` dropping its queued diffs, the last ~350 ms of edits before an unmount were silently lost. `.finally` leaked an unhandled rejection per failed write, and `close()` on a DB that never opened skipped `connectedInstances` cleanup and aborted `hardReset`.
- `TLLocalSyncClient` only listened to its BroadcastChannel after `db.load()` resolved, but its first persist is a full-snapshot write, so a diff another tab broadcast during the load window was dropped and then erased from IndexedDB.

### After

In-flight transactions complete before the DB closes; `close()` flushes the queue (waiting for any in-flight write) and tolerates a never-opened DB. Messages received while loading are buffered and applied after load; nothing persists until loaded; a tab that reports a schema mismatch stops writing rather than persisting its older schema over the newer tab's records.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

1. Make edits and immediately close the tab; reopen and confirm the last edits persisted.
2. Open the same local document in two tabs quickly; an edit in the first tab made while the second is loading must survive the second tab's first save.

- [x] Unit tests — the new tests (7) fail on `main` and pass with this change

### Release notes

- Fix the last edits before closing a tab being dropped by local IndexedDB persistence, and cross-tab edits during load being erased

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +128 / -61 |
| Tests     | +137 / -0  |

### Related Sentry issues

On `main`, `txPromise.finally(() => …delete(txPromise))` in `LocalIndexedDb.tx` creates a second, unhandled rejecting promise for every failed transaction, so IndexedDB write failures that callers already catch (`failed to store changes in indexed db`) also surface as `onunhandledrejection`. Switching to `.then(untrack, untrack)` should stop these from reporting (the underlying IDB failures remain and are still handled by the alert/reload path):

- [LITE-3FP](https://tldraw.sentry.io/issues/?query=issue:LITE-3FP) — `InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing` (~4.4k events, ~3.9k users)
- [LITE-65J](https://tldraw.sentry.io/issues/?query=issue:LITE-65J) — `DataCloneError: BlobURLs are not yet supported` in `storeAsset`
- [LITE-69F](https://tldraw.sentry.io/issues/?query=issue:LITE-69F), [LITE-69G](https://tldraw.sentry.io/issues/?query=issue:LITE-69G), [LITE-5ND](https://tldraw.sentry.io/issues/?query=issue:LITE-5ND) — `Error: db is closed`
- [LITE-6NF](https://tldraw.sentry.io/issues/?query=issue:LITE-6NF) — `TransactionInactiveError` in `storeChanges`

