### PR TITLE
fix(sync): retry a rejected getUri and stop reconnecting after ClientWebSocketAdapter.close()

### DIFF
--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -527,6 +527,33 @@ describe('ClientWebSocketAdapter', () => {
 			adapter.close()
 			expect(() => adapter.close()).not.toThrow()
 		})
+
+		it('[CW9][RM5] nothing runs after close: no status change, no reconnect, no further getUri call', async () => {
+			let uriCallCount = 0
+			const testAdapter = new ClientWebSocketAdapter(() => {
+				uriCallCount++
+				return 'ws://localhost:2233'
+			})
+			const onStatusChange = vi.fn()
+			testAdapter.onStatusChange(onStatusChange)
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			const callsBeforeClose = uriCallCount
+			onStatusChange.mockClear()
+
+			testAdapter.close()
+			// let the socket's own close event land, then run out any (leaked) reconnect timer
+			vi.useRealTimers()
+			await sleep(50)
+			vi.useFakeTimers()
+			vi.advanceTimersByTime(INACTIVE_MAX_DELAY)
+			vi.useRealTimers()
+			await sleep(20)
+			vi.useFakeTimers()
+
+			expect(onStatusChange).not.toHaveBeenCalled()
+			expect(uriCallCount).toBe(callsBeforeClose)
+			expect(testAdapter._ws).toBeNull()
+		})
 	})
 
 	describe('orphaned sockets (CW10)', () => {
@@ -774,6 +801,26 @@ describe('ReconnectManager', () => {
 
 		expect(fake.close).toHaveBeenCalled()
 		expect(adapter._ws).toBeNull()
+	})
+
+	it('[RM1][CW1] a rejecting getUri is retried on the backoff instead of stranding the connection', async () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		let attempts = 0
+		const testAdapter = new ClientWebSocketAdapter(async () => {
+			attempts++
+			if (attempts < 3) throw new Error('token endpoint unavailable')
+			return 'ws://localhost:2234'
+		})
+		try {
+			// each failure logs and schedules another attempt; the third succeeds
+			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+			expect(attempts).toBe(3)
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(2)
+			expect(testAdapter.connectionStatus).toBe('online')
+		} finally {
+			testAdapter.close()
+			consoleErrorSpy.mockRestore()
+		}
 	})
 
 	it('[RM5] close cancels timers and removes the reconnect event listeners', () => {

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -1,4 +1,4 @@
-import { warnOnce } from '@tldraw/utils'
+import { promiseWithResolve, warnOnce } from '@tldraw/utils'
 import { TLRecord, sleep } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -528,7 +528,19 @@ describe('ClientWebSocketAdapter', () => {
 			expect(() => adapter.close()).not.toThrow()
 		})
 
-		it('[CW9][RM5] nothing runs after close: no status change, no reconnect, no further getUri call', async () => {
+		it('[CW9][RM5] closing immediately does not start another getUri call', async () => {
+			const getUri = vi.fn(() => 'ws://localhost:2233')
+			const testAdapter = new ClientWebSocketAdapter(getUri)
+			testAdapter.close()
+			const callsAtClose = getUri.mock.calls.length
+
+			await vi.advanceTimersByTimeAsync(INACTIVE_MAX_DELAY)
+
+			expect(getUri).toHaveBeenCalledTimes(callsAtClose)
+			expect(testAdapter._ws).toBeNull()
+		})
+
+		it('[CW9][RM5] close reports offline without notifying listeners or reconnecting', async () => {
 			let uriCallCount = 0
 			const testAdapter = new ClientWebSocketAdapter(() => {
 				uriCallCount++
@@ -541,6 +553,7 @@ describe('ClientWebSocketAdapter', () => {
 			onStatusChange.mockClear()
 
 			testAdapter.close()
+			expect(testAdapter.connectionStatus).toBe('offline')
 			// let the socket's own close event land, then run out any (leaked) reconnect timer
 			vi.useRealTimers()
 			await sleep(50)
@@ -737,7 +750,7 @@ describe('ReconnectManager', () => {
 		// it's necessary to close the socket, as otherwise the websocket might stay half-open
 		connectedServerSocket.close()
 		wsServer.close()
-		await waitFor(() => adapter._ws?.readyState !== WebSocket.OPEN)
+		await waitFor(() => adapter.connectionStatus === 'offline')
 		expect(adapter._reconnectManager.intendedDelay).toBeGreaterThanOrEqual(INACTIVE_MIN_DELAY)
 
 		hiddenMock.mockReturnValue(false)
@@ -803,25 +816,31 @@ describe('ReconnectManager', () => {
 		expect(adapter._ws).toBeNull()
 	})
 
-	it('[RM1][CW1] a rejecting getUri is retried on the backoff instead of stranding the connection', async () => {
-		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-		let attempts = 0
-		const testAdapter = new ClientWebSocketAdapter(async () => {
-			attempts++
-			if (attempts < 3) throw new Error('token endpoint unavailable')
-			return 'ws://localhost:2234'
-		})
-		try {
-			// each failure logs and schedules another attempt; the third succeeds
-			await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
-			expect(attempts).toBe(3)
-			expect(consoleErrorSpy).toHaveBeenCalledTimes(2)
-			expect(testAdapter.connectionStatus).toBe('online')
-		} finally {
-			testAdapter.close()
-			consoleErrorSpy.mockRestore()
+	it.each(['throws', 'rejects'])(
+		'[RM1][CW1] getUri that %s is retried on the backoff instead of stranding the connection',
+		async (failure) => {
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			let attempts = 0
+			const testAdapter = new ClientWebSocketAdapter(() => {
+				attempts++
+				if (attempts < 3) {
+					const error = new Error('token endpoint unavailable')
+					if (failure === 'throws') throw error
+					return Promise.reject(error)
+				}
+				return 'ws://localhost:2234'
+			})
+			try {
+				await waitFor(() => testAdapter._ws?.readyState === WebSocket.OPEN)
+				expect(attempts).toBe(3)
+				expect(consoleErrorSpy).toHaveBeenCalledTimes(2)
+				expect(testAdapter.connectionStatus).toBe('online')
+			} finally {
+				testAdapter.close()
+				consoleErrorSpy.mockRestore()
+			}
 		}
-	})
+	)
 
 	it('[RM5] close cancels timers and removes the reconnect event listeners', () => {
 		const testAdapter = new ClientWebSocketAdapter(() => 'ws://localhost:2234')
@@ -839,5 +858,59 @@ describe('ReconnectManager', () => {
 
 		// closing again is safe
 		expect(() => manager.close()).not.toThrow()
+	})
+})
+
+describe('URI failure boundaries', () => {
+	it.each(['resolves', 'rejects'])('ignores getUri that %s after close', async (outcome) => {
+		const uri = promiseWithResolve<string>()
+		const getUri = vi.fn(() => uri)
+		const testAdapter = new ClientWebSocketAdapter(getUri)
+		const onStatusChange = vi.fn()
+		testAdapter.onStatusChange(onStatusChange)
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			await Promise.resolve()
+			testAdapter.close()
+			if (outcome === 'resolves') uri.resolve('ws://localhost:2234')
+			else uri.reject(new Error('token endpoint unavailable'))
+			await vi.advanceTimersByTimeAsync(INACTIVE_MAX_DELAY)
+
+			expect(getUri).toHaveBeenCalledTimes(1)
+			expect(testAdapter._ws).toBeNull()
+			expect(testAdapter.connectionStatus).toBe('offline')
+			expect(onStatusChange).not.toHaveBeenCalled()
+			expect(consoleError).not.toHaveBeenCalled()
+		} finally {
+			testAdapter.close()
+			consoleError.mockRestore()
+		}
+	})
+
+	it.each([
+		{ uri: 'not a URL', openSocket: false, error: 'Invalid URL' },
+		{
+			uri: 'ws://localhost:2234',
+			openSocket: true,
+			error: 'There should be no connection attempts while already connected',
+		},
+	])('does not treat $error as a getUri failure', async ({ uri, openSocket, error }) => {
+		let nextUri: string | Promise<string> = new Promise(() => {})
+		const testAdapter = new ClientWebSocketAdapter(() => nextUri)
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			await Promise.resolve()
+			nextUri = uri
+			if (openSocket) testAdapter._ws = mockSocket(WebSocket.OPEN)
+
+			const manager = testAdapter._reconnectManager as unknown as {
+				scheduleAttempt(): Promise<void>
+			}
+			await expect(manager.scheduleAttempt()).rejects.toThrow(error)
+			expect(consoleError).not.toHaveBeenCalled()
+		} finally {
+			testAdapter.close()
+			consoleError.mockRestore()
+		}
 	})
 })

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -93,8 +93,12 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 	close() {
 		this.isDisposed = true
 		this._reconnectManager.close()
+		// orphan the socket before closing it (as _closeSocket does) so its onclose can't run
+		// _handleDisconnect after disposal — that would notify listeners and schedule a reconnect
+		const ws = this._ws
+		this._ws = null
 		//  WebSocket.close() is idempotent
-		this._ws?.close()
+		ws?.close()
 	}
 
 	/**
@@ -239,8 +243,6 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 		this._ws = null
 		this._handleDisconnect('manual')
 	}
-
-	// TLPersistentClientSocket stuff
 
 	_connectionStatus: Atom<TLPersistentClientSocketStatus | 'initial'> = atom(
 		'websocket connection status',
@@ -516,18 +518,30 @@ export class ReconnectManager {
 	private scheduleAttempt() {
 		assert(this.state === 'pendingAttempt')
 		debug('scheduling a connection attempt')
-		Promise.resolve(this.getUri()).then((uri) => {
-			// this can happen if the promise gets resolved too late
-			if (this.state !== 'pendingAttempt' || this.isDisposed) return
-			assert(
-				this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
-				'There should be no connection attempts while already connected'
-			)
+		Promise.resolve()
+			.then(() => this.getUri())
+			.then((uri) => {
+				// this can happen if the promise gets resolved too late
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				assert(
+					this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
+					'There should be no connection attempts while already connected'
+				)
 
-			this.lastAttemptStart = Date.now()
-			this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
-			this.state = 'pendingAttemptResult'
-		})
+				this.lastAttemptStart = Date.now()
+				this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
+				this.state = 'pendingAttemptResult'
+			})
+			.catch((error) => {
+				// getUri is host code (often an auth-token fetch) and can reject or throw. Without
+				// this handler the manager would sit in 'pendingAttempt' with no timer and no
+				// socket, so nothing but a browser online/visibility hint could ever start another
+				// attempt. Treat it as a failed attempt and retry on the usual backoff instead.
+				if (this.state !== 'pendingAttempt' || this.isDisposed) return
+				console.error('Failed to get the websocket URI, retrying', error)
+				this.state = 'delay'
+				this.reconnectTimeout = setTimeout(() => this.disconnected(), this.intendedDelay)
+			})
 	}
 
 	private getMaxDelay() {
@@ -641,6 +655,7 @@ export class ReconnectManager {
 		debug('ReconnectManager.disconnected')
 		// This either means we're freshly disconnected, or the last connection attempt failed;
 		// either way, time to try again.
+		if (this.isDisposed) return
 
 		// Guard against delayed notifications and recheck synchronously
 		if (

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -99,6 +99,7 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 		this._ws = null
 		//  WebSocket.close() is idempotent
 		ws?.close()
+		this._connectionStatus.set('offline')
 	}
 
 	/**
@@ -515,33 +516,33 @@ export class ReconnectManager {
 		}
 	}
 
-	private scheduleAttempt() {
+	private async scheduleAttempt() {
 		assert(this.state === 'pendingAttempt')
+		if (this.isDisposed) return
 		debug('scheduling a connection attempt')
-		Promise.resolve()
-			.then(() => this.getUri())
-			.then((uri) => {
-				// this can happen if the promise gets resolved too late
-				if (this.state !== 'pendingAttempt' || this.isDisposed) return
-				assert(
-					this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
-					'There should be no connection attempts while already connected'
-				)
 
-				this.lastAttemptStart = Date.now()
-				this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
-				this.state = 'pendingAttemptResult'
-			})
-			.catch((error) => {
-				// getUri is host code (often an auth-token fetch) and can reject or throw. Without
-				// this handler the manager would sit in 'pendingAttempt' with no timer and no
-				// socket, so nothing but a browser online/visibility hint could ever start another
-				// attempt. Treat it as a failed attempt and retry on the usual backoff instead.
-				if (this.state !== 'pendingAttempt' || this.isDisposed) return
-				console.error('Failed to get the websocket URI, retrying', error)
-				this.state = 'delay'
-				this.reconnectTimeout = setTimeout(() => this.disconnected(), this.intendedDelay)
-			})
+		let uri: string
+		try {
+			uri = await this.getUri()
+		} catch (error) {
+			// A failed auth-token fetch must retry instead of leaving us with no socket or timer.
+			if (this.state !== 'pendingAttempt' || this.isDisposed) return
+			console.error('Failed to get the websocket URI, retrying', error)
+			this.state = 'delay'
+			this.reconnectTimeout = setTimeout(() => this.disconnected(), this.intendedDelay)
+			return
+		}
+
+		// this can happen if the promise gets resolved too late
+		if (this.state !== 'pendingAttempt' || this.isDisposed) return
+		assert(
+			this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
+			'There should be no connection attempts while already connected'
+		)
+
+		this.lastAttemptStart = Date.now()
+		this.socketAdapter._setNewSocket(new WebSocket(httpToWs(uri)))
+		this.state = 'pendingAttemptResult'
 	}
 
 	private getMaxDelay() {


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where sync stalled permanently when `getUri` rejected. It also stops a closed `ClientWebSocketAdapter` from reconnecting and calling the app's `getUri` after disposal.

### Before

In the documented `useSync` pattern `getUri` is an auth-token fetch. One rejected fetch left `ReconnectManager` in `pendingAttempt` with no timer and no socket, so the connection never recovered. Separately, `close()` closed the socket but left its `onclose` wired up, so it could still notify listeners and schedule a reconnect after disposal.

### After

A rejected `getUri` is treated like any other connection failure and retried on the normal backoff. `close()` orphans the socket's handlers before closing it.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change

### Release notes

- Fix `ClientWebSocketAdapter` stalling permanently when `getUri` rejects

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +29 / -14 |
| Tests | +47 / -0 |

