### PR TITLE
fix(sync): clear a previous client's error when useSync loads a new room

### DIFF
--- a/packages/sync/src/useSync.test.tsx
+++ b/packages/sync/src/useSync.test.tsx
@@ -1,0 +1,95 @@
+import { TLSyncClient } from '@tldraw/sync-core'
+import { act, createElement } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RemoteTLStoreWithStatus, useSync, UseSyncOptions } from './useSync'
+
+vi.mock('@tldraw/sync-core', async () => {
+	const actual = await vi.importActual<typeof import('@tldraw/sync-core')>('@tldraw/sync-core')
+	// capture each client's callbacks so the test can drive the handshake outcome directly
+	class MockTLSyncClient {
+		static instances: MockTLSyncClient[] = []
+		store: any
+		socket: any
+		constructor(public opts: any) {
+			this.store = opts.store
+			this.socket = opts.socket
+			MockTLSyncClient.instances.push(this)
+		}
+		close = vi.fn()
+	}
+	return { ...actual, TLSyncClient: MockTLSyncClient }
+})
+
+const Mock = TLSyncClient as unknown as {
+	instances: Array<{ opts: any; store: any; socket: any }>
+}
+
+const assets = { upload: vi.fn(), resolve: vi.fn() } as any
+
+function makeSocket() {
+	return {
+		connectionStatus: 'online' as const,
+		sendMessage: vi.fn(),
+		onReceiveMessage: vi.fn(() => () => {}),
+		onStatusChange: vi.fn(() => () => {}),
+		restart: vi.fn(),
+		close: vi.fn(),
+	}
+}
+
+describe('useSync', () => {
+	let root: Root
+	let container: HTMLDivElement
+	let latest: RemoteTLStoreWithStatus
+
+	function Harness(props: { opts: UseSyncOptions }) {
+		latest = useSync(props.opts)
+		return null
+	}
+	function render(opts: UseSyncOptions) {
+		act(() => root.render(createElement(Harness, { opts })))
+	}
+
+	beforeEach(() => {
+		;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+		Mock.instances.length = 0
+		container = document.createElement('div')
+		document.body.appendChild(container)
+		root = createRoot(container)
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+	afterEach(() => {
+		act(() => root.unmount())
+		container.remove()
+		vi.restoreAllMocks()
+	})
+
+	it("clears a previous client's error once a new room loads", () => {
+		const socketA = makeSocket()
+		render({ connect: () => socketA as any, roomId: 'a', assets })
+		expect(latest.status).toBe('loading')
+
+		// the first room is missing: the hook reports the error
+		act(() => Mock.instances[0].opts.onSyncError('NOT_FOUND'))
+		expect(latest.status).toBe('error')
+
+		// the caller switches to another room without remounting; a fresh client is created
+		const socketB = makeSocket()
+		render({ connect: () => socketB as any, roomId: 'b', assets })
+		expect(Mock.instances).toHaveLength(2)
+		const clientB = Mock.instances[1]
+
+		act(() => {
+			clientB.opts.onAfterConnect(clientB, { isReadonly: false, objectAccess: 'write' })
+			clientB.opts.onLoad(clientB)
+		})
+
+		// the healthy room must not inherit the old room's NOT_FOUND
+		expect(latest).toMatchObject({
+			status: 'synced-remote',
+			connectionStatus: 'online',
+			objectAccess: 'write',
+		})
+	})
+})

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -274,10 +274,6 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				TLSocketServerSentEvent<TLRecord>
 			>
 		} else if (uri) {
-			if (connect) {
-				throw new Error('uri and connect cannot be used together')
-			}
-
 			socket = new ClientWebSocketAdapter(async () => {
 				const uriString = typeof uri === 'string' ? uri : await uri()
 
@@ -349,8 +345,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
-				// Merge so we don't clobber objectAccess if onAfterConnect ran first.
-				setState((prev) => ({ ...prev, readyClient: client }))
+				// Keep objectAccess (onAfterConnect always runs first for this client) but drop the
+				// rest: an `error` left behind by a previous client (e.g. NOT_FOUND on the old uri)
+				// would otherwise keep the hook reporting status 'error' for the new, healthy room.
+				setState((prev) => ({ readyClient: client, objectAccess: prev?.objectAccess }))
 			},
 			onSyncError(reason) {
 				console.error('sync error', reason)


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where `useSync` kept reporting a previous room's error after switching to a healthy room.

### Before

`onLoad` merged into the previous state (`{...prev, readyClient}`, from #9471) so that `objectAccess` set by `onAfterConnect` survived. That also carried over an `error` left by a previous client (`NOT_FOUND`, `RATE_LIMITED`) when the `uri` changed without a remount, so the hook stayed at `status: 'error'` for the new room. There was also an unreachable `if (connect)` branch inside the `uri` path.

### After

`onLoad` keeps only this client's `objectAccess` and drops everything else. The dead branch is removed.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change (added in the follow-up commit)

### Release notes

- Fix `useSync` reporting a previous room's error for a new, healthy room

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +4 / -6 |

