### PR TITLE
fix(sync): reject failed uploads in useSyncDemo's asset store

### DIFF
--- a/packages/sync/src/useSyncDemo.test.ts
+++ b/packages/sync/src/useSyncDemo.test.ts
@@ -120,6 +120,19 @@ describe('useSyncDemo', () => {
 			)
 			expect(result).toEqual({ src: 'https://demo.server.com/uploads/unique-123-test-file-jpg' })
 		})
+
+		it('should reject the upload when the server responds with an error status', async () => {
+			useSyncDemo({ roomId: 'test-room', host: 'https://demo.server.com' })
+
+			const useSyncCall = vi.mocked(useSync).mock.calls[0][0]
+			const assetStore = useSyncCall.assets
+			const file = new File(['test content'], 'test-file.jpg')
+
+			// a rejected upload resolves the fetch; the asset must not point at a URL that was never stored
+			vi.mocked(mockFetch).mockResolvedValueOnce(new Response(null, { status: 409 }))
+
+			await expect(assetStore.upload({} as TLAsset, file)).rejects.toThrow('409')
+		})
 	})
 
 	describe('bookmark asset creation', () => {

--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -187,10 +187,15 @@ function createDemoAssetStore(host: string): TLAssetStore {
 			const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
 			const url = `${host}/uploads/${objectName}`
 
-			await fetch(url, {
+			const response = await fetch(url, {
 				method: 'POST',
 				body: file,
 			})
+			// a rejected upload (invalid name, duplicate, server error) resolves the fetch; without
+			// this the asset would point at a URL that was never stored
+			if (!response.ok) {
+				throw new Error(`Failed to upload asset (${response.status})`)
+			}
 
 			return { src: url }
 		},


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a failed upload in `useSyncDemo` produced an asset pointing at a URL that was never stored.

### Before

The demo asset store's `upload` awaited the `fetch` but never checked the response status. A rejected upload (invalid name, duplicate, server error) resolves the fetch, so the asset was created with a `src` that 404s.

### After

`upload` throws when `response.ok` is false, so the caller sees the failure instead of a broken asset.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change

### Release notes

- Fix `useSyncDemo` creating assets for uploads the server rejected

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +6 / -1 |
| Tests | +13 / -0 |

