### PR TITLE
fix(sync): stop InMemorySyncStorage overflowing the stack on large snapshots

### DIFF
--- a/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.test.ts
@@ -51,6 +51,27 @@ describe('InMemorySyncStorage', () => {
 			expect(storage.getClock()).toBe(25)
 		})
 
+		it('[IM1] handles snapshots with far more records and tombstones than fit in a spread call', () => {
+			const documents = []
+			for (let i = 0; i < 150_000; i++) {
+				documents.push({
+					state: { ...contractRecords[0], id: `shape:${i}` } as TLRecord,
+					lastChangedClock: i,
+				})
+			}
+			const tombstones: Record<string, number> = {}
+			for (let i = 0; i < 150_000; i++) tombstones[`shape:gone-${i}`] = 150_000 + i
+			const storage = new InMemorySyncStorage<TLRecord>({
+				snapshot: makeContractSnapshot(contractRecords, {
+					documents,
+					tombstones,
+					documentClock: 0,
+					tombstoneHistoryStartsAtClock: 0,
+				}),
+			})
+			expect(storage.getClock()).toBe(299_999)
+		})
+
 		it('[IM2] clamps tombstoneHistoryStartsAtClock down to the document clock', () => {
 			const storage = new InMemorySyncStorage<TLRecord>({
 				snapshot: makeContractSnapshot(contractRecords, {

--- a/packages/sync-core/src/lib/InMemorySyncStorage.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.ts
@@ -153,11 +153,15 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown
 	} = {}) {
 		this.objectTypes = new Set(objectTypes ?? [])
-		const maxClockValue = Math.max(
-			0,
-			...Object.values(snapshot.tombstones ?? {}),
-			...Object.values(snapshot.documents.map((d) => d.lastChangedClock))
-		)
+		// a loop rather than `Math.max(0, ...clocks)`: spreading a large room's clocks as call
+		// arguments overflows the stack at roughly 100k+ records/tombstones
+		let maxClockValue = 0
+		for (const clock of Object.values(snapshot.tombstones ?? {})) {
+			if (clock > maxClockValue) maxClockValue = clock
+		}
+		for (const doc of snapshot.documents) {
+			if (doc.lastChangedClock > maxClockValue) maxClockValue = doc.lastChangedClock
+		}
 		// route snapshot entries into their partitions (a seed snapshot may carry object-lane
 		// records merged in, e.g. loaded from a separate persistence lane)
 		const toEntry = (


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where very large rooms could no longer be opened with `InMemorySyncStorage`.

### Before

The constructor computed the max clock with `Math.max(0, ...clocks)`, spreading every document and tombstone clock as call arguments. At roughly 120k records/tombstones that overflows the stack, so the room threw on load every time.

### After

The max clock is computed with a plain loop.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change

### Release notes

- Fix large rooms failing to load in `InMemorySyncStorage`

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +9 / -5 |
| Tests | +21 / -0 |

