### PR TITLE
fix(sync): make tombstone pruning transactional and safe after the database closes

### DIFF
--- a/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync } from 'node:sqlite'
 import { DocumentRecordType, PageRecordType, TLDOCUMENT_ID, TLRecord } from '@tldraw/tlschema'
 import { ZERO_INDEX_KEY } from '@tldraw/utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
 	contractRecords,
 	contractSchema,
@@ -9,6 +9,7 @@ import {
 	makePage,
 	registerStorageContractTests,
 } from '../test/storageContractSuite'
+import { MAX_TOMBSTONES } from './InMemorySyncStorage'
 import { NodeSqliteWrapper } from './NodeSqliteWrapper'
 import { SQLiteSyncStorage } from './SQLiteSyncStorage'
 
@@ -261,6 +262,64 @@ describe('SQLiteSyncStorage', () => {
 				.prepare<{ migrationVersion: number }>('SELECT migrationVersion FROM metadata')
 				.all()[0]
 			expect(row?.migrationVersion).toBe(3)
+		})
+	})
+
+	describe('tombstone pruning robustness', () => {
+		const makeTombstones = (count: number) => {
+			const tombstones: Record<string, number> = {}
+			for (let i = 0; i < count; i++) tombstones[`shape:doc${i}`] = i + 1
+			return tombstones
+		}
+		function makeOverfullStorage() {
+			const db = new DatabaseSync(':memory:')
+			const storage = new SQLiteSyncStorage<TLRecord>({
+				sql: new NodeSqliteWrapper(db),
+				snapshot: makeContractSnapshot(contractRecords, {
+					tombstones: makeTombstones(MAX_TOMBSTONES + 500),
+					documentClock: MAX_TOMBSTONES + 501,
+					tombstoneHistoryStartsAtClock: 0,
+				}),
+			})
+			return { db, storage, prune: (storage as any).pruneTombstones as { (): void; flush(): void } }
+		}
+
+		it('[SS18] a prune that fires after the database was closed does not throw', () => {
+			const { db, storage, prune } = makeOverfullStorage()
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			try {
+				// a delete schedules the throttled prune; the host then closes everything
+				storage.transaction((txn) => txn.delete(contractRecords[1].id))
+				db.close()
+				// the throttle timer fires later, from outside any caller that could catch it
+				expect(() => prune.flush()).not.toThrow()
+				expect(consoleSpy).toHaveBeenCalledWith('Failed to prune tombstones', expect.anything())
+			} finally {
+				consoleSpy.mockRestore()
+			}
+		})
+
+		it('[SS18] a prune whose delete fails leaves the history clock where it was', () => {
+			const { storage, prune } = makeOverfullStorage()
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			try {
+				const stmts = (storage as any).stmts
+				const originalRun = stmts.deleteTombstonesBefore.run
+				stmts.deleteTombstonesBefore.run = () => {
+					throw new Error('SQLITE_BUSY: database is locked')
+				}
+				prune()
+				expect(() => prune.flush()).not.toThrow()
+				stmts.deleteTombstonesBefore.run = originalRun
+
+				// neither half of the prune applied: the history start was not advanced past
+				// tombstones that still exist
+				const snapshot = storage.getSnapshot()
+				expect(snapshot.tombstoneHistoryStartsAtClock).toBe(0)
+				expect(Object.keys(snapshot.tombstones!).length).toBe(MAX_TOMBSTONES + 500)
+			} finally {
+				consoleSpy.mockRestore()
+			}
 		})
 	})
 })

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -394,7 +394,6 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 			const documentClock = snapshot.documentClock ?? snapshot.clock ?? 0
 			const tombstoneHistoryStartsAtClock = snapshot.tombstoneHistoryStartsAtClock ?? documentClock
 
-			// Clear existing data
 			this.sql.exec(`
 				DELETE FROM ${documentsTable};
 				DELETE FROM ${objectsTable};
@@ -410,14 +409,12 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 				table.insert.run(doc.state.id, encodeState(doc.state), doc.lastChangedClock)
 			}
 
-			// Insert tombstones
 			if (snapshot.tombstones) {
 				for (const [id, clock] of objectMapEntries(snapshot.tombstones)) {
 					this.stmts.insertTombstone.run(id, clock)
 				}
 			}
 
-			// Insert metadata row
 			this.stmts.updateMetadata.run(
 				documentClock,
 				tombstoneHistoryStartsAtClock,
@@ -513,18 +510,29 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 	/** @internal */
 	pruneTombstones = throttle(
 		() => {
-			const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
-			if (tombstoneCount > MAX_TOMBSTONES) {
-				// Get all tombstones sorted by clock ascending (oldest first)
-				const tombstones = this.stmts.iterateTombstones.all()
+			// Runs from a timer, so a host that closed the database right after the last delete
+			// (e.g. `room.close(); db.close()` in onSessionRemoved) would otherwise get an uncaught
+			// throw from here; pruning is best-effort and simply runs again on the next delete.
+			try {
+				const tombstoneCount = this.stmts.countTombstones.all()[0].count as number
+				if (tombstoneCount > MAX_TOMBSTONES) {
+					// Get all tombstones sorted by clock ascending (oldest first)
+					const tombstones = this.stmts.iterateTombstones.all()
 
-				const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
-				if (result) {
-					this.stmts.setTombstoneHistoryStartsAtClock.run(result.newTombstoneHistoryStartsAtClock)
-					// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
-					// This works because computeTombstonePruning ensures we never split a clock value.
-					this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+					const result = computeTombstonePruning({ tombstones, documentClock: this.getClock() })
+					if (result) {
+						this.sql.transaction(() => {
+							this.stmts.setTombstoneHistoryStartsAtClock.run(
+								result.newTombstoneHistoryStartsAtClock
+							)
+							// Delete all tombstones with clock < newTombstoneHistoryStartsAtClock in one operation.
+							// This works because computeTombstonePruning ensures we never split a clock value.
+							this.stmts.deleteTombstonesBefore.run(result.newTombstoneHistoryStartsAtClock)
+						})
+					}
 				}
+			} catch (e) {
+				console.error('Failed to prune tombstones', e)
 			}
 		},
 		1000,


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `SQLiteSyncStorage`'s tombstone pruning could throw from a timer after the host closed the database. It also makes the prune atomic.

### Before

`pruneTombstones` is throttled, so it runs from a timer. A host that does `room.close(); db.close()` right after the last delete got an uncaught throw from inside that timer. The two statements (move the history start, delete older tombstones) also ran outside a transaction, so a failure between them left the history start ahead of the surviving tombstones.

### After

The prune runs inside `sql.transaction` and is wrapped in try/catch that logs; pruning is best-effort and re-runs on the next delete. #9514 adds `close()` to the storage classes, which is the fuller fix for the timer case.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change (added in the follow-up commit)

### Release notes

- Fix tombstone pruning throwing after the SQLite database is closed

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +22 / -14 |

