### PR TITLE
fix(sync): roll back when COMMIT fails in NodeSqliteWrapper

### DIFF
--- a/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.test.ts
@@ -272,5 +272,34 @@ describe('NodeSqliteWrapper', () => {
 			// the write was rolled back
 			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
 		})
+
+		it('[NW2] rolls back when COMMIT itself fails, so the connection is not left inside a transaction', () => {
+			// simulate a COMMIT failure (SQLITE_BUSY, I/O error) at the driver level
+			const failingDb = {
+				exec: (sql: string) => {
+					if (sql === 'COMMIT') throw new Error('SQLITE_BUSY: database is locked')
+					return db.exec(sql)
+				},
+				prepare: (sql: string) => db.prepare(sql),
+			}
+			const failingWrapper = new NodeSqliteWrapper(failingDb as any)
+
+			expect(() =>
+				failingWrapper.transaction(() => {
+					failingWrapper
+						.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)')
+						.run(1, 'alice', 100)
+				})
+			).toThrow('SQLITE_BUSY')
+
+			// rolled back, and the next transaction can BEGIN normally
+			expect(wrapper.prepare('SELECT * FROM test').all()).toEqual([])
+			expect(() =>
+				wrapper.transaction(() => {
+					wrapper.prepare('INSERT INTO test (id, name, value) VALUES (?, ?, ?)').run(2, 'bob', 200)
+				})
+			).not.toThrow()
+			expect(wrapper.prepare<{ id: number }>('SELECT id FROM test').all()).toEqual([{ id: 2 }])
+		})
 	})
 })

--- a/packages/sync-core/src/lib/NodeSqliteWrapper.ts
+++ b/packages/sync-core/src/lib/NodeSqliteWrapper.ts
@@ -89,11 +89,14 @@ export class NodeSqliteWrapper implements TLSyncSqliteWrapper {
 		let result: T
 		try {
 			result = callback()
+			// COMMIT itself can fail (SQLITE_BUSY from another connection, I/O errors); without a
+			// ROLLBACK the connection would stay inside the transaction and every later BEGIN
+			// would throw "cannot start a transaction within a transaction"
+			this.db.exec('COMMIT')
 		} catch (e) {
 			this.db.exec('ROLLBACK')
 			throw e
 		}
-		this.db.exec('COMMIT')
 		return result
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a failed `COMMIT` in `NodeSqliteWrapper` left the connection stuck inside a transaction.

### Before

`transaction()` only rolled back when the callback threw. `COMMIT` itself can fail (`SQLITE_BUSY` from another connection, I/O errors); without a `ROLLBACK` the connection stayed inside the transaction and every later `BEGIN` threw "cannot start a transaction within a transaction".

### After

`COMMIT` runs inside the try block, so its failure rolls back and rethrows.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change

### Release notes

- Fix `NodeSqliteWrapper` getting stuck in a transaction when `COMMIT` fails

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +4 / -1 |
| Tests | +29 / -0 |

