### PR TITLE
fix(sync): let TLSocketRoom.updateStore see object-lane records

### DIFF
--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -854,12 +854,11 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 		if (this.isClosed()) {
 			throw new Error('Cannot update store on a closed room')
 		}
+		// read through the transaction rather than getSnapshot(): the document snapshot excludes the
+		// object-store lane, which would make object-lane records invisible (and undeletable) here
+		const records = this.storage.transaction((txn) => Object.fromEntries(txn.entries())).result
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
-		const ctx = new StoreUpdateContext<R>(
-			// eslint-disable-next-line @typescript-eslint/no-deprecated
-			Object.fromEntries(this.getCurrentSnapshot().documents.map((d) => [d.state.id, d.state])),
-			this.room.schema
-		)
+		const ctx = new StoreUpdateContext<R>(records, this.room.schema)
 		try {
 			await updater(ctx)
 		} finally {

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -8,6 +8,7 @@ import {
 	TLSocketServerSentEvent,
 	getTlsyncProtocolVersion,
 } from '../lib/protocol'
+import { TLSocketRoom } from '../lib/TLSocketRoom'
 import { TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason } from '../lib/TLSyncClient'
 import { RoomSnapshot, TLRoomSocket, TLSyncRoom } from '../lib/TLSyncRoom'
 
@@ -353,6 +354,40 @@ describe('object store lane', () => {
 			const late = connectSession(room, 'late', { clear: false })
 			const connectMsg = late.__messages.find((m: any) => m.type === 'connect') as any
 			expect(Object.keys(connectMsg.diff).sort()).toEqual([doc.id, note.id].sort())
+		})
+
+		it('[US1][US3] updateStore sees and can delete object-lane records', async () => {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			const socketRoom = new TLSocketRoom<R, void>({
+				schema,
+				storage: new InMemorySyncStorage<R>({
+					snapshot: { documents: [], clock: 0, documentClock: 0, schema: schema.serialize() },
+					objectTypes: ['note'],
+				}),
+				objectTypes: ['note'],
+			})
+			disposables.push(() => socketRoom.close())
+			const doc = Doc.create({ title: 'canvas' })
+			const note = Note.create({ text: 'annotation' })
+			socketRoom.storage.transaction((txn) => {
+				txn.set(doc.id, doc)
+				txn.set(note.id, note)
+			})
+
+			// the update context reads both lanes, not just the document snapshot
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			await socketRoom.updateStore((store) => {
+				expect(store.get(note.id)).toEqual(note)
+				expect(
+					store
+						.getAll()
+						.map((r) => r.id)
+						.sort()
+				).toEqual([doc.id, note.id].sort())
+				store.delete(note.id)
+			})
+			expect(socketRoom.getRecord(note.id)).toBeUndefined()
+			expect(socketRoom.getRecord(doc.id)).toEqual(doc)
 		})
 	})
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where `TLSocketRoom.updateStore` could not see or delete object-lane records.

### Before

`updateStore` built its `StoreUpdateContext` from `getCurrentSnapshot().documents`, which excludes the object-store lane. Object-lane records were invisible to the updater and could not be deleted through it.

### After

The context reads both lanes through `storage.transaction((txn) => txn.entries())`.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change

### Release notes

- Fix `TLSocketRoom.updateStore` not seeing object-lane records

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +4 / -5 |
| Tests | +35 / -0 |

