### PR TITLE
chore(sync): import TLStoreSnapshot from tlschema instead of tldraw

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -22,7 +22,6 @@ import { TLDocument } from 'tldraw';
 import { TLPage } from 'tldraw';
 import { TLRecord } from '@tldraw/tlschema';
 import { TLStoreSnapshot } from '@tldraw/tlschema';
-import { TLStoreSnapshot as TLStoreSnapshot_2 } from 'tldraw';
 import { UnknownRecord } from '@tldraw/store';
 
 // @internal
@@ -161,7 +160,7 @@ export class JsonChunkAssembler {
 }
 
 // @public
-export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot_2): void;
+export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot): void;
 
 // @internal (undocumented)
 export interface MinimalDocStore<R extends UnknownRecord> {

--- a/packages/sync-core/src/lib/TLSyncStorage.ts
+++ b/packages/sync-core/src/lib/TLSyncStorage.ts
@@ -1,6 +1,6 @@
 import { StoreSchema, SynchronousStorage, UnknownRecord } from '@tldraw/store'
+import { TLStoreSnapshot } from '@tldraw/tlschema'
 import { assert, isEqual, objectMapEntriesIterable, objectMapValues } from '@tldraw/utils'
-import { TLStoreSnapshot } from 'tldraw'
 import { diffRecord, NetworkDiff, RecordOpType } from './diff'
 import { RoomSnapshot } from './TLSyncRoom'
 


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR removes a `tldraw` devDependency leak from `sync-core`'s public API.

### Before

`loadSnapshotIntoStorage` imported `TLStoreSnapshot` from `tldraw`, so the API report referenced a type from a devDependency (`TLStoreSnapshot_2`).

### After

The import comes from `@tldraw/tlschema`, which is the same type.

Split out of #10092.

### Change type

- [x] `other`

### API changes

- `loadSnapshotIntoStorage` now imports `TLStoreSnapshot` from `@tldraw/tlschema` instead of `tldraw` (type-identical)

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +1 / -1 |
| Automated files | +1 / -2 |
