### PR TITLE
fix(sync): don't resurrect a session removed during its own handshake

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -217,7 +217,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **HS3** A connect message without a schema, with a schema the server cannot migrate from, or whose migrations include any non-record-scope or down-less migration, is rejected `CLIENT_TOO_OLD`.
 - **HS4** The connect response echoes `connectRequestId` and `isReadonly`, carries the server's schema and current clock, and `hydrationType: 'wipe_all'` when storage cannot produce an incremental diff since the client's `lastServerClock` (including when that clock is in the future), else `'wipe_presence'`.
 - **HS5** The connect response diff contains every _other_ session's presence record — the connecting session's own presence is excluded — plus the document changes since the client's `lastServerClock` (the full document set in the `wipe_all` case), all down-migrated when the client's schema is older.
-- **HS6** A successful handshake moves the session to `Connected`.
+- **HS6** A successful handshake moves the session to `Connected` — unless the session was removed while the handshake's transaction ran (RC5 force-reconnect), in which case it stays removed rather than being resurrected.
 
 ## 24. `TLSyncRoom` — push handling (RP)
 

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -1055,7 +1055,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 
 		const requiresDownMigrations = migrations.value.length > 0
 
-		const connect = async (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+		const connect = (msg: Extract<TLSocketServerSentEvent<R>, { type: 'connect' }>) => {
+			// broadcastChanges may have force-reconnected everyone (wipeAll) while we were in the
+			// transaction, removing this very session; re-adding it would resurrect a session whose
+			// socket is already closed and emit a second `session_removed` for it later
+			if (this.sessions.get(session.sessionId) !== session) return
 			this.sessions.set(session.sessionId, {
 				state: RoomSessionState.Connected,
 				sessionId: session.sessionId,

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -1019,6 +1019,45 @@ describe('23. Connect handshake (HS)', () => {
 		expect(room.sessions.get('current-client-session')?.state).toBe(RoomSessionState.Connected)
 		expect(socket.__lastMessage?.type).toBe('connect')
 	})
+
+	it('[HS6] a session removed by a wipeAll during its own handshake stays removed', async () => {
+		const { room, storage } = makeRoom()
+		const socketA = connectSession(room, 'a')
+		const removed = vi.fn()
+		room.events.on('session_removed', removed)
+
+		// 'b' has opened its socket but not yet sent its connect message
+		const socketB = makeSocket()
+		room.handleNewSession({ sessionId: 'b', socket: socketB, meta: undefined, isReadonly: false })
+
+		// an external change makes an incremental diff impossible (RC5); the room hasn't seen
+		// it yet because the storage notifies on a microtask
+		const newPage = makePage('wipe_page', 'Wipe Page')
+		storage.transaction((txn) => {
+			txn.set(newPage.id, newPage)
+		})
+		storage.tombstoneHistoryStartsAtClock.set(storage.getClock())
+
+		// the handshake's own transaction runs broadcastChanges first, which force-reconnects
+		// everyone — including 'b' — before the connect response is assembled
+		room.handleMessage('b', {
+			type: 'connect',
+			connectRequestId: 'connect-b',
+			lastServerClock: 0,
+			protocolVersion: getTlsyncProtocolVersion(),
+			schema: room.serializedSchema,
+		} satisfies TLConnectRequest)
+
+		expect(socketA.close).toHaveBeenCalled()
+		expect(socketB.close).toHaveBeenCalled()
+		// 'b' must not come back in Connected state on a socket that is already closed
+		expect(room.sessions.has('b')).toBe(false)
+		expect(socketB.sendMessage).not.toHaveBeenCalled()
+
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(removed.mock.calls.map(([e]) => e.sessionId).sort()).toEqual(['a', 'b'])
+	})
 })
 
 describe('24. Push handling (RP)', () => {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a session removed during its own connect handshake was resurrected and later emitted a second `session_removed`.

### Before

`broadcastChanges` may force-reconnect everyone (RC5 `wipeAll`) while the handshake's storage transaction runs, removing the connecting session. The `connect` callback then unconditionally re-added it in `Connected` state with a socket that was already closed.

### After

The callback bails if the room's entry for that session id is no longer the one it started with. `SPEC.md` HS6 is updated.

Split out of #10092.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test (1) fails on `main` and passes with this change (added in the follow-up commit)

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +6 / -2 |

