### PR TITLE
chore(dotcom): drop the wal-size postgres health sub-check

### DIFF
--- a/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
+++ b/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
@@ -71,7 +71,7 @@ export const healthCheckRoutes = createRouter<Environment>()
 			await db.destroy()
 		}
 	})
-	// Combined postgres health check: db size, changelog size, WAL retention, and replication slots.
+	// Combined postgres health check: db size, changelog size, and replication slots.
 	// Grouped into a single endpoint because updown.io charges per check invocation.
 	// Failures include the sub-check name so alerts remain distinguishable.
 	.get('/health-check/postgres', async (_, env) => {
@@ -109,38 +109,6 @@ export const healthCheckRoutes = createRouter<Environment>()
 				}
 			} catch (_e) {
 				failures.push('changelog-size: query failed')
-			}
-
-			// wal-size
-			try {
-				const thresholdMb = parseFloat(env.HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB ?? '1024')
-				const result = await sql<{
-					slot_name: string
-					retained_bytes: string
-				}>`
-					SELECT slot_name, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS retained_bytes
-					FROM pg_replication_slots
-				`.execute(db)
-				const overThreshold = result.rows.filter(
-					(row) => parseInt(row.retained_bytes, 10) / (1024 * 1024) > thresholdMb
-				)
-				if (overThreshold.length > 0) {
-					const details = overThreshold
-						.map((r) => {
-							const mb = (parseInt(r.retained_bytes, 10) / (1024 * 1024)).toFixed(0)
-							return `${r.slot_name}: ${mb} MB`
-						})
-						.join(', ')
-					failures.push(`wal-size: ${details} > ${thresholdMb} MB threshold`)
-				} else {
-					const maxMb = result.rows.reduce(
-						(max, r) => Math.max(max, parseInt(r.retained_bytes, 10) / (1024 * 1024)),
-						0
-					)
-					okDetails.push(`wal: ${maxMb.toFixed(0)} MB`)
-				}
-			} catch (_e) {
-				failures.push('wal-size: query failed')
 			}
 
 			// replication-slots

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -79,7 +79,6 @@ export interface Environment {
 	HEALTH_CHECK_BEARER_TOKEN: string | undefined
 	HEALTH_CHECK_DB_SIZE_THRESHOLD_GB: string | undefined
 	HEALTH_CHECK_CHANGELOG_SIZE_THRESHOLD_MB: string | undefined
-	HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB: string | undefined
 
 	ANALYTICS_API_URL: string | undefined
 	ANALYTICS_API_TOKEN: string | undefined

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -149,7 +149,6 @@ workers_dev = false
 [env.staging.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "4"
 HEALTH_CHECK_CHANGELOG_SIZE_THRESHOLD_MB = "1024"
-HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB = "1024"
 MCP_SCREENSHOT_RENDER_ORIGIN = "https://staging.tldraw.com"
 MCP_SERVER_URL = "https://staging.tldraw.com/api/app/mcp"
 MCP_SCREENSHOT_ENABLED = "true"
@@ -162,7 +161,6 @@ workers_dev = false
 [env.production.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "10"
 HEALTH_CHECK_CHANGELOG_SIZE_THRESHOLD_MB = "1024"
-HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB = "2048"
 MCP_SCREENSHOT_RENDER_ORIGIN = "https://www.tldraw.com"
 MCP_SERVER_URL = "https://www.tldraw.com/api/app/mcp"
 MCP_SCREENSHOT_ENABLED = "true"


### PR DESCRIPTION
The `wal-size` sub-check in `/health-check/postgres` fired today because the legacy `TLPostgresReplicator` slot (`tlpr_…`, inactive since #9894 removed the binding) kept retaining WAL (2.1 GB and growing). We're dropping that slot manually (runbook in #9899), after which the only slot left is Zero's, and its WAL retention is already observable via `zero_replication_slot_retained_wal_bytes` in the zero-fly-health Grafana dashboard. The `replication-slots` sub-check still catches a `lost`/`unreserved` Zero slot.

Removes the sub-check, its `HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB` env var (types + staging/prod wrangler vars), and updates the endpoint comment.

Audit of the other health checks: the tlpr-specific sub-check was already removed in #9894; `db-size`, `changelog-size`, `replication-slots` and `/health-check/zero-replicator` are all Zero or general, nothing else legacy-specific left.

### Change type

- [x] `other`

### Test plan

1. `GET /health-check/postgres` returns `ok (db: …, changelog: …, slots: 1 ok)` on staging

### Release notes

- Internal: removed the WAL retention sub-check from the tldraw.com postgres health check.