### PR TITLE
chore(dotcom): drop legacy sync engine publication and tables

### DIFF
--- a/apps/dotcom/zero-cache/effect_outbox.test.ts
+++ b/apps/dotcom/zero-cache/effect_outbox.test.ts
@@ -24,7 +24,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 // points at a real local dev stack whose `public` schema holds real dev data, this suite
 // instead creates a throwaway database with CREATE DATABASE, and drops it in afterAll.
 //
-// Owning a whole database also means the REAL migration chain (000 → 048) can run
+// Owning a whole database also means the REAL migration chain (000 onward) can run
 // verbatim, exactly like migrate.ts applies it. Every trigger involved — the outbox
 // trigger, the group-delete cascade, the updatedAt bumper (005), the owner-details
 // denormalizers — is the shipped one, not a test copy, so a behavior change in any

--- a/apps/dotcom/zero-cache/migrations/049_drop_legacy_sync_tables.sql
+++ b/apps/dotcom/zero-cache/migrations/049_drop_legacy_sync_tables.sql
@@ -1,0 +1,10 @@
+-- Leftovers of the legacy custom sync engine, removed in #9894. The tables had no
+-- readers or writers since then and were never in the zero_data publication.
+-- "alltables" was the legacy replicator's FOR ALL TABLES publication; with no
+-- subscriber it retains no WAL, but it makes UPDATE/DELETE fail on any future
+-- table without a replica identity, so it goes too. Zero only uses zero_data.
+-- The tlpr_ replication slot is dropped manually per environment (see #9899).
+
+DROP PUBLICATION IF EXISTS alltables;
+DROP TABLE IF EXISTS public.user_mutation_number;
+DROP TABLE IF EXISTS public.replicator_boot_id;

--- a/apps/dotcom/zero-cache/migrations/049_drop_legacy_sync_tables.sql
+++ b/apps/dotcom/zero-cache/migrations/049_drop_legacy_sync_tables.sql
@@ -8,3 +8,4 @@
 DROP PUBLICATION IF EXISTS alltables;
 DROP TABLE IF EXISTS public.user_mutation_number;
 DROP TABLE IF EXISTS public.replicator_boot_id;
+DROP TABLE IF EXISTS public.user_boot_id;


### PR DESCRIPTION
Postgres cleanup after the legacy sync engine removal (#9894). #9899's runbook had this as manual SQL per environment; we decided to do it as a zero-cache migration instead so every environment converges on deploy and nothing depends on someone remembering to run it.

`049_drop_legacy_sync_tables.sql`:
- `DROP PUBLICATION IF EXISTS alltables`: the legacy replicator's `FOR ALL TABLES` publication from `000_seed.sql`. No subscriber so it retains no WAL, but `FOR ALL TABLES` makes `UPDATE`/`DELETE` fail on any future table without a replica identity. Zero only uses `zero_data` (`ZERO_APP_PUBLICATIONS`).
- `DROP TABLE IF EXISTS user_mutation_number`, `replicator_boot_id`, `user_boot_id`: no readers or writers since #9894, never in `zero_data`. Going through `migrate.ts` means `zero_0.update_schemas()` runs after the drop.

Not included: the inactive `tlpr_…` replication slot. That is per-environment state and `pg_drop_replication_slot` does not belong in a transactional migration, so it stays the one manual step (runbook in #9899). Independent of #9899's v12 DO class deletion; either order works.

### Change type

- [x] `other`

### Test plan

1. Staging deploy applies 049 cleanly; `\dRp` shows only `zero_data`, `user_mutation_number` / `replicator_boot_id` / `user_boot_id` gone
2. Zero replication manager stays healthy (no initial sync triggered)

### Release notes

- Internal: dropped the legacy sync engine's publication and tables from the tldraw.com database.

