### PR TITLE
ci(dotcom): shallow checkout and fail fast on stalled fetch

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -40,9 +40,10 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 0
+        env:
+          # Abort a stalled fetch so checkout's retry kicks in instead of hanging until the job timeout
+          GIT_HTTP_LOW_SPEED_LIMIT: 1000
+          GIT_HTTP_LOW_SPEED_TIME: 60
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
The dotcom deploy job regularly hangs on the "Check out code" step: `git fetch` stalls with no progress and nothing aborts it until the 15 minute job timeout. Today alone, 4 of 13 non-skipped runs took over 2 minutes on checkout, two of them hitting the timeout or needing a manual cancel and rerun.

The step was doing a full fetch (`fetch-depth: 0`, ~1.75 GiB packfile, ~1900 refs) plus `submodules: true`. Both are leftovers: full history was added in #5885 for a `git diff origin/base...HEAD` check that no longer exists, and the repo has no submodules. Nothing in the job needs history: lazyrepo hashes file contents, the deploy script takes the sha from the GitHub context, sentry doesn't use `set-commits`, vercel's git metadata only reads HEAD and is wrapped in try/catch, and the fly build context excludes `.git`.

Two layers:

- Default depth: far less to transfer, so less to stall on; happy path gets faster too.
- `GIT_HTTP_LOW_SPEED_LIMIT=1000` / `GIT_HTTP_LOW_SPEED_TIME=60` on the checkout step: a transfer under 1 KB/s for 60s errors out, and actions/checkout's built-in fetch retry (3 attempts, 10-20s backoff) reruns it. Worst case a dead network fails the job in ~4 minutes instead of 15.

Other workflows using `fetch-depth: 0` (publish, trigger-*, update-release-notes) genuinely need history and are left alone. `deploy-bemo`, `deploy-analytics` and `deploy-mcp-app` carry the same vestigial `submodules: true` but they aren't stalling, so left for a follow-up.

### Change type

- [x] `other`

### Test plan

1. Merge and watch the next few staging deploys: checkout should take well under 30s, and a stall should show a git retry in the step log rather than a hung job.