### PR TITLE
fix(state): stale computed reads, re-entrant effects, nested transaction commits

### DIFF
--- a/packages/state/ARCHITECTURE.md
+++ b/packages/state/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# @tldraw/state Architecture
+# @tldraw/state architecture
 
 This document provides a machine-readable guide to the @tldraw/state package structure, optimized for AI agents and automated tools.
 
-## Package Overview
+## Package overview
 
 **Package Name**: @tldraw/state  
 **Purpose**: Reactive state management library using signals  
@@ -27,17 +27,20 @@ packages/state/
 │       ├── types.ts                # Core type definitions
 │       ├── constants.ts            # System constants
 │       ├── helpers.ts              # Utility functions
-│       ├── isSignal.ts            # Type guards
-│       ├── warnings.ts            # Development warnings
-│       └── __tests__/             # Test files
+│       ├── isSignal.ts             # Type guards
+│       ├── isComputed.ts           # Computed brand check (no import of Computed.ts)
+│       ├── localStorageAtom.ts     # Atom persisted to localStorage
+│       ├── warnings.ts             # Development warnings
+│       └── __tests__/              # Test files
 ├── DOCS.md                        # Human-readable documentation
 ├── README.md                      # Package introduction
-└── ARCHITECTURE.md               # This file
+├── SPEC.md                        # Behavior specification (rule IDs referenced by tests)
+└── ARCHITECTURE.md                # This file
 ```
 
-## Core Modules
+## Core modules
 
-### Primary API Modules
+### Primary API modules
 
 #### `Atom.ts`
 
@@ -57,10 +60,10 @@ packages/state/
 
 - **Exports**: `EffectScheduler`, `react()`, `reactor()`, `EffectSchedulerOptions`, `Reactor`
 - **Purpose**: Side effects and reaction management
-- **Key Classes**: `__EffectScheduler__`, `_Reactor`
+- **Key Classes**: `__EffectScheduler__` (`reactor()` returns a plain object wrapping one)
 - **Dependencies**: ArraySet, capture, helpers, transactions, types
 
-### Supporting Infrastructure
+### Supporting infrastructure
 
 #### `types.ts`
 
@@ -74,13 +77,15 @@ packages/state/
 - **Purpose**: Dependency tracking and debugging
 - **Key Classes**: `CaptureStackFrame`
 - **Role**: Manages parent-child relationships between signals
+- **Dependencies**: helpers, isComputed, types (deliberately not Computed.ts, to avoid a cycle)
 
 #### `transactions.ts`
 
 - **Exports**: `transact()`, `transaction()`, `deferAsyncEffects()`
-- **Purpose**: Batched updates with rollback capability
+- **Purpose**: Batched updates with rollback capability, the global epoch, and the reaction phase (`flushChanges`)
 - **Key Classes**: `Transaction`
 - **Role**: Ensures atomic state updates
+- **Dependencies**: Atom, constants, helpers, types
 
 #### `helpers.ts`
 
@@ -96,10 +101,10 @@ packages/state/
 
 #### `HistoryBuffer.ts`
 
-- **Purpose**: Change tracking for time-travel debugging
-- **Role**: Stores diffs for getDiffSince functionality
+- **Purpose**: Ring buffer of recent diffs
+- **Role**: Stores diffs for `getDiffSince`, so incremental computeds and effects can update from diffs
 
-## Export Mapping
+## Export mapping
 
 ```typescript
 // Core reactive primitives
@@ -109,9 +114,9 @@ react(name, fn, options?) -> () => void
 reactor(name, fn) -> Reactor<T>
 
 // Transaction management
-transact(fn) -> void
-transaction(fn) -> void
-deferAsyncEffects(fn) -> void
+transact(fn) -> T
+transaction(fn) -> T
+deferAsyncEffects(fn) -> Promise<T>
 
 // Debugging and utilities
 unsafe__withoutCapture(fn) -> T
@@ -127,9 +132,12 @@ withDiff(value, diff) -> WithDiff
 UNINITIALIZED -> symbol
 RESET_VALUE -> symbol
 EMPTY_ARRAY -> readonly array
+localStorageAtom(name, initialValue, options?) -> [Atom<T>, cleanup]
+EffectScheduler -> class (low-level effect runner)
+ArraySet -> class (internal)
 ```
 
-## Dependency Graph
+## Dependency graph
 
 ```
 index.ts
@@ -146,6 +154,7 @@ index.ts
 │   ├── capture.ts
 │   ├── constants.ts
 │   ├── helpers.ts
+│   ├── isComputed.ts
 │   ├── transactions.ts
 │   ├── types.ts
 │   └── warnings.ts
@@ -157,114 +166,121 @@ index.ts
 │   ├── transactions.ts
 │   └── types.ts
 ├── capture.ts
-│   ├── Computed.ts
 │   ├── helpers.ts
+│   ├── isComputed.ts
 │   └── types.ts
+├── isSignal.ts
+│   ├── Atom.ts
+│   └── Computed.ts
+├── localStorageAtom.ts
+│   ├── Atom.ts
+│   └── EffectScheduler.ts
 └── transactions.ts
     ├── Atom.ts
-    ├── EffectScheduler.ts
     ├── constants.ts
     ├── helpers.ts
     └── types.ts
 ```
 
-## Key Architectural Patterns
+Atom.ts and transactions.ts import each other; neither uses the other at module-evaluation time, which is what keeps the cycle harmless.
 
-### Signal Interface Pattern
+## Key architectural patterns
+
+### Signal interface pattern
 
 - All reactive values implement `Signal<Value, Diff>` interface
 - Unified API: `get()`, `getDiffSince()`, `__unsafe__getWithoutCapture()`
 - Polymorphic handling of atoms and computed values
 
-### Dependency Tracking Pattern
+### Dependency tracking pattern
 
 - `capture.ts` manages parent-child relationships
 - `Child` interface for dependents, `ArraySet<Child>` for parents
 - Automatic dependency detection via `maybeCaptureParent()`
 
-### Lazy Evaluation Pattern
+### Lazy evaluation pattern
 
 - Computed values only recalculate when dependencies change
 - `lastChangedEpoch` tracking for invalidation
-- `haveParentsChanged()` for efficient dirty checking
+- `haveParentsChanged()` for dirty checking (O(parents)); an actively-listening computed skips it when it has not been traversed by a flush since it was last checked and no transaction is open
 
-### Transaction Pattern
+### Transaction pattern
 
 - Nested transaction support with rollback
 - `initialAtomValues` map for restoration
 - Deferred effect scheduling until commit
 
-### History Tracking Pattern
+### History tracking pattern
 
-- Optional `HistoryBuffer` for change tracking
+- Optional `HistoryBuffer` for diff history
 - `computeDiff` functions for incremental updates
 - `RESET_VALUE` for uncomputable diffs
 
-## Performance Optimizations
+## Performance optimizations
 
-### Memory Management
+### Memory management
 
 - `ArraySet` for efficient parent-child tracking
 - `EMPTY_ARRAY` singleton for empty dependencies
 - Lazy history buffer allocation
 
-### Computation Efficiency
+### Computation efficiency
 
 - Epoch-based invalidation system
 - `unsafe__withoutCapture` for hot paths
 - Singleton pattern for global state
 
-### Effect Scheduling
+### Effect scheduling
 
 - Pluggable `scheduleEffect` for batching
 - `deferAsyncEffects` for transaction control
 - `isActivelyListening` state management
 
-## API Categories by Use Case
+## API categories by use case
 
-### Basic State Management
+### Basic state management
 
 - `atom()` - mutable state
 - `computed()` - derived state
 - `react()` - side effects
 
-### Advanced Control
+### Advanced control
 
 - `reactor()` - controllable reactions
 - `transact()` - batched updates
 - `@computed` - class-based computed properties
 
-### Performance & Debugging
+### Performance & debugging
 
 - `unsafe__withoutCapture()` - performance optimization
 - `whyAmIRunning()` - dependency debugging
-- History tracking options for undo/redo
+- History tracking options for incremental computation
 
-### Type Guards & Utilities
+### Type guards & utilities
 
 - `isSignal()`, `isAtom()`, `isUninitialized()`
 - `UNINITIALIZED`, `RESET_VALUE` constants
 - `withDiff()` for incremental computation
 
-## Integration Points
+## Integration points
 
-### External Dependencies
+### External dependencies
 
 - `@tldraw/utils`: `registerTldrawLibraryVersion()`, `assert()`
 
-### Related Packages
+### Related packages
 
 - `@tldraw/state-react`: React integration layer
 - `@tldraw/store`: Record storage using @tldraw/state
 - `@tldraw/editor`: Canvas editor using reactive state
 
-### Extension Points
+### Extension points
 
 - `AtomOptions.isEqual` - custom equality functions
 - `ComputeDiff` - custom diff computation
 - `EffectSchedulerOptions.scheduleEffect` - custom scheduling
 
-## File Navigation Guide for AI Agents
+## File navigation guide for AI agents
 
 **To understand signals**: Start with `types.ts` → `Atom.ts` → `Computed.ts`  
 **To understand reactivity**: Start with `EffectScheduler.ts` → `capture.ts`  

--- a/packages/state/DOCS.md
+++ b/packages/state/DOCS.md
@@ -112,7 +112,7 @@ const activeUser = atom('activeUser', { id: 1, name: 'Bob' }, { isEqual: (a, b) 
 activeUser.set({ id: 1, name: 'Robert' })
 ```
 
-- `historyLength` & `computeDiff`: These options are used for tracking changes over time. See the "History and Diffs" section for more details.
+- `historyLength` & `computeDiff`: These options are used for tracking changes over time. See the "History and diffs" section for more details.
 
 ### Computeds: the derived values
 
@@ -163,7 +163,7 @@ Computed signals are evaluated **lazily**. The calculation function only runs wh
 
 #### Using `@computed` as a decorator
 
-For classes, you can use the `@computed` decorator to create a computed property from a getter method. This is a clean way to co-locate derived data with its related state.
+For classes, you can use the `@computed` decorator to create a computed property from a method. This is a clean way to co-locate derived data with its related state.
 
 ```ts
 class User {
@@ -345,7 +345,7 @@ console.log(lastName.get()) // "Doe" // The change was rolled back
 
 ### History and diffs
 
-@tldraw/state can automatically track the history of changes to a signal, which is invaluable for features like undo/redo or creating sync engines.
+@tldraw/state can automatically track the history of changes to a signal, which lets dependents update incrementally instead of recomputing from scratch.
 
 To enable history, you must provide the `historyLength` option when creating an atom or computed.
 

--- a/packages/state/DOCS.md
+++ b/packages/state/DOCS.md
@@ -1,4 +1,4 @@
-# @tldraw/state Documentation
+# @tldraw/state documentation
 
 ## 1. Introduction
 
@@ -18,7 +18,7 @@ npm install @tldraw/state
 
 @tldraw/state is written in TypeScript and provides excellent type safety out of the box. No additional types package needed.
 
-### Quick Example
+### Quick example
 
 Here's a simple example to show how tldraw state works:
 
@@ -31,7 +31,7 @@ const greeting = computed('greeting', () => `Hello, ${name.get()}!`)
 
 // React to changes
 react('update page title', () => {
-	window.alert(greeting.get())
+	document.title = greeting.get()
 })
 
 // Update the state
@@ -39,7 +39,7 @@ name.set('tldraw state')
 // Page title automatically updates to "Hello, tldraw state!"
 ```
 
-In just a few lines, you've created reactive state that automatically alerts the user when it changes.
+In just a few lines, you've created reactive state that automatically updates the page when it changes.
 
 ## 2. Signals
 
@@ -50,11 +50,11 @@ In @tldraw/state, there are two types of signals:
 - An **Atom** is the basic type of signal that acts as a container for a single value.
 - A **Computed** is a signal that derives its value from several other signals (atoms or other computeds).
 
-### Atoms: The State Containers
+### Atoms: the state containers
 
 Atoms are the foundation of your application's state. They contain "raw" values that the rest of your application will use and react to.
 
-#### Creating Atoms
+#### Creating atoms
 
 You create an atom using the atom function. You must give it a name and an initial value.
 
@@ -67,7 +67,7 @@ const user = atom('user', { name: 'Alice', age: 30 })
 
 > Tip: The name is used for debugging purposes, specifically for the `whyAmIRunning` function described later in these docs.
 
-#### Reading an Atom's Value
+#### Reading an atom's value
 
 To get the current value of an atom, use its `.get()` method.
 
@@ -78,7 +78,7 @@ console.log(user.get().name) // 'Alice'
 
 > Tip: When you call `.get()` inside the function body of computed or a reaction, the library automatically **captures** that signal as a dependency.
 
-#### Updating an Atom's Value
+#### Updating an atom's value
 
 You can change an atom's value in two ways:
 
@@ -98,7 +98,7 @@ console.log(count.get()) // 2
 
 > Tip: If you try to set an atom to a value that is equal to its current value, the update will be skipped, and no reactions will be triggered.
 
-#### Atom Options
+#### Atom options
 
 You can pass an options object as the third argument to atom to customize its behavior.
 
@@ -114,11 +114,11 @@ activeUser.set({ id: 1, name: 'Robert' })
 
 - `historyLength` & `computeDiff`: These options are used for tracking changes over time. See the "History and Diffs" section for more details.
 
-### Computeds: The Derived Values
+### Computeds: the derived values
 
 A Computed is a signal whose value is derived from other signals. You can use computed signals to create complex data models that automatically stay in sync.
 
-#### Creating Computeds
+#### Creating computeds
 
 You create a computed signal using the `computed` function. It takes a name and a function that calculates its value. Inside this function, you can `.get()` the value of other signals.
 
@@ -153,15 +153,15 @@ firstName.set('Sam')
 console.log(greeting.get()) // "Hello, Sam Doe!"
 ```
 
-#### Dependency Capture
+#### Dependency capture
 
 This automatic dependency tracking works through a process called **dependency capture**. When the `fullName` function runs, the library actively "listens" for any calls to `.get()`. Each signal that is "gotten" is automatically registered as a dependency of `fullName`. The list of dependencies is updated every time the function re-runs, so they can even change dynamically.
 
-#### Lazy Evaluation
+#### Lazy evaluation
 
 Computed signals are evaluated **lazily**. The calculation function only runs when you call `.get()` on the computed _and_ one of its captured signal dependencies has changed since the last time it was gotten. If nothing has changed, the computed returns its previous cached value.
 
-#### Using `@computed` as a Decorator
+#### Using `@computed` as a decorator
 
 For classes, you can use the `@computed` decorator to create a computed property from a getter method. This is a clean way to co-locate derived data with its related state.
 
@@ -191,11 +191,11 @@ const fullNameComputed = getComputedInstance(user, 'getFullName')
 console.log(fullNameComputed.get()) // "John Doe"
 ```
 
-## 3. Reactivity and Side Effects
+## 3. Reactivity and side effects
 
 Reading and deriving state is only half the story. The other half is performing actions, called _side effects_, that run when state changes. Side effects can be used for anything: updating the DOM, logging to the console, making a network request, and so on.
 
-### Simple Reactions with `react`
+### Simple reactions with `react`
 
 The easiest way to create a side effect is with the `react` function. You give it a name and a function to run. The library automatically **captures** which signals the function `.get()`s as dependencies and will re-run it whenever any of them change.
 
@@ -224,7 +224,7 @@ color.set('green')
 
 > Tip: The stop function is perfect for "fire-and-forget" effects, especially within UI components (e.g., in a useEffect hook in React).
 
-### Controlled Reactions with `reactor`
+### Controlled reactions with `reactor`
 
 For more control over the lifecycle of an effect, you can use `reactor`. It's similar to `react` but it doesn't start automatically. Instead, it returns a Reactor object with `.start()` and `.stop()` methods.
 
@@ -253,15 +253,15 @@ name.set('universe')
 
 > Tip: A reactor is useful when you have a long-lived effect that needs to be paused and resumed based on application logic.
 
-## 4. Advanced Topics
+## 4. Advanced topics
 
-### Transactions: Batching State Updates
+### Transactions: batching state updates
 
-When you update multiple atoms that are dependencies of the same reaction, you might cause the reaction to re-run multiple times. transacts solve this by batching all state changes into a single, atomic update, after which reactions will execute.
+When you update multiple atoms that are dependencies of the same reaction, you might cause the reaction to re-run multiple times. Transactions solve this by batching all state changes into a single, atomic update, after which reactions will execute.
 
 #### Using transact()
 
-The `transact` function takes a callback. All state updates inside this callback are queued. Reactions are only triggered _after_ the callback has finished executing successfully.
+The `transact` function takes a callback. All state updates inside this callback are queued. Reactions are only triggered _after_ the callback has finished executing — once, whether the transaction commits or (see below) is rolled back.
 
 ```ts
 const firstName = atom('firstName', 'John')
@@ -283,7 +283,7 @@ transact(() => {
 // Logs: "Hello, Jane Smith!"
 ```
 
-#### Aborting and Rolling Back
+#### Aborting and rolling back
 
 Transactions may be aborted. Aborting a transaction will restore previous values of all signals modified inside of the transaction.
 
@@ -293,7 +293,7 @@ Rollbacks also occur automatically if an error is thrown inside the transaction.
 const name = atom('name', 'Alice')
 
 try {
-	transact((rollback) => {
+	transaction(() => {
 		name.set('Bob')
 		throw new Error('Something went wrong')
 	})
@@ -304,12 +304,12 @@ try {
 console.log(name.get()) // "Alice"
 ```
 
-You can also abort a transaction manually by calling the `rollback` function, which is passed to the transaction callback.
+You can also abort a transaction manually by calling the `rollback` function, which `transaction` (but not `transact`) passes to its callback.
 
 ```ts
 const name = atom('name', 'Alice')
 
-transact((rollback) => {
+transaction((rollback) => {
 	name.set('Bob')
 	rollback() // Discard the change
 })
@@ -317,9 +317,9 @@ transact((rollback) => {
 console.log(name.get()) // "Alice"
 ```
 
-Aborting a transaction will _only_ restore the values of the signals that were modified inside of the transaction. Other types of data or parts of your application will not be affected.
+Aborting a transaction will _only_ restore the values of the signals that were modified inside of the transaction. Other types of data or parts of your application will not be affected. Reactions that depend on those signals still run once after the rollback, observing the restored values.
 
-#### Nested Transactions
+#### Nested transactions
 
 You can call `transact` inside of another transaction. A new transaction will only be created if there is not already one in progress.
 
@@ -343,7 +343,7 @@ console.log(firstName.get()) // "Jane"
 console.log(lastName.get()) // "Doe" // The change was rolled back
 ```
 
-### History and Diffs
+### History and diffs
 
 @tldraw/state can automatically track the history of changes to a signal, which is invaluable for features like undo/redo or creating sync engines.
 
@@ -359,14 +359,12 @@ const count = atom('count', 0, {
 
 The `historyLength` option defines the maximum number of diffs to keep in the history buffer. If you expect the atom to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10). Otherwise, set this to a higher number based on your usage pattern and memory constraints.
 
-#### Retrieving Diffs
+#### Retrieving diffs
 
-Once history is enabled, you can use `getDiffSince(epoch)` to get an array of diffs that occurred since a specific point in time.
+Once history is enabled, you can use `getDiffSince(epoch)` to get an array of diffs that occurred since a specific point in time. Every signal exposes `lastChangedEpoch`, the epoch at which it last changed, which is the natural point to measure from.
 
 ```ts
-import { getGlobalEpoch } from '@tldraw/state'
-
-const startEpoch = getGlobalEpoch()
+const startEpoch = count.lastChangedEpoch
 
 count.set(5) // diff is 5
 count.set(12) // diff is 7
@@ -377,35 +375,35 @@ console.log(diffs) // [5, 7]
 
 If the library doesn't have enough history to compute the diffs, it will return the special `RESET_VALUE` symbol. This tells you that you need to re-compute the state from scratch instead of applying patches.
 
-### Computed Options
+### Computed options
 
-Similar to atoms, you can provide a `ComputedOptions` object as the second argument to the `computed` function.
+Similar to atoms, you can provide a `ComputedOptions` object as the third argument to the `computed` function.
 
 ```ts
-const fullName = computed('fullName', () => {
-	return (`${firstName.get()} ${lastName.get()}`, { isEqual: (a, b) => a === b })
+const fullName = computed('fullName', () => `${firstName.get()} ${lastName.get()}`, {
+	isEqual: (a, b) => a === b,
 })
 ```
 
-You also can pass in a `ComputedOptions` when used the `@computed` decorator.
+You also can pass in a `ComputedOptions` when using the `@computed` decorator.
 
 ```ts
 class Counter {
 	max = 100
-	count = atom<number>(0)
+	count = atom('count', 0)
 
 	@computed({ isEqual: (a, b) => a === b })
-	get remaining() {
+	getRemaining() {
 		return this.max - this.count.get()
 	}
 }
 ```
 
-### Incremental Computation
+### Incremental computation
 
 Computed signals can take advantage of diffs to compute a value incrementally.
 
-In addition to the options described for atoms, you can also provide a `computeDiff` function. This function is used to compute the diff between the previous and new values of the computed signal.
+In addition to the options described for atoms, you can also provide a `computeDiff` function. This function is used to compute the diff between the previous and new values of the computed signal. As with atoms, diffs are only recorded when `historyLength` is set.
 
 ```ts
 const count = atom('count', 0)
@@ -414,24 +412,28 @@ const double = computed(
 	(prevValue) => {
 		return count.get() * 2
 	},
-	{ computeDiff: (a, b) => b - a }
+	{ historyLength: 10, computeDiff: (a, b) => b - a }
 )
 ```
 
-You can use the `withDiff` helper to wrap the return value of a computed signal function, indicating that the diff should be used instead of calculating a new one with `AtomOptions.computeDiff`.
+You can use the `withDiff` helper to wrap the return value of a computed signal function, indicating that the diff should be used instead of calculating a new one with `ComputedOptions.computeDiff`.
 
 ```ts
 const count = atom('count', 0)
-const double = computed('double', (prevValue) => {
-	const nextValue = count.get() * 2
-	if (isUninitialized(prevValue)) {
-		return nextValue
-	}
-	return withDiff(nextValue, nextValue - prevValue)
-})
+const double = computed(
+	'double',
+	(prevValue) => {
+		const nextValue = count.get() * 2
+		if (isUninitialized(prevValue)) {
+			return nextValue
+		}
+		return withDiff(nextValue, nextValue - prevValue)
+	},
+	{ historyLength: 10 }
+)
 ```
 
-#### Handling the First Computed Run
+#### Handling the first computed run
 
 Sometimes you need to know if a computed function is running for the very first time. The function is called with the previous value, which will be the special symbol `UNINITIALIZED` on the first run. You can check for this using the `isUninitialized` helper. This is particularly useful for incremental computations.
 
@@ -481,7 +483,7 @@ const stop = react(
 )
 ```
 
-### Performance Optimization
+### Performance optimization
 
 While @tldraw/state is fast by default, there are tools for fine-tuning performance in demanding situations.
 
@@ -505,13 +507,13 @@ react('log important changes', () => {
 frequentlyChangingValue.set(1)
 ```
 
-### Type Guards and Utilities
+### Type guards and utilities
 
 The library exports several type guard functions to help you work with signals in TypeScript.
 
 - `isSignal(value)`: Returns true if the value is an atom or a computed.
 - `isAtom(value)`: Returns true if the value is an atom.
-- `isComputed(value)`: Returns true if the value is a computed.
+- `isUninitialized(value)`: Returns true if the value is the `UNINITIALIZED` symbol passed to a computed function on its first run.
 
 ## 5. Debugging
 
@@ -519,7 +521,7 @@ Because @tldraw/state manages a graph of dependencies, it can sometimes be trick
 
 ### whyAmIRunning()
 
-If you're ever confused about what caused an effect to run, you can call `whyAmIRunning()` at the beginning of its function. It will log a detailed, hierarchical tree to the console, showing you exactly which atom(s) changed and triggered the update.
+If you're ever confused about what caused an effect to run, you can call `whyAmIRunning()` at the beginning of its function. From the next run on, it will log a detailed, hierarchical tree to the console, showing you exactly which atom(s) changed and triggered the update.
 
 ```ts
 import { atom, computed, react, whyAmIRunning } from '@tldraw/state'
@@ -539,8 +541,7 @@ react('log details', () => {
 	console.log(`${greeting.get()} is ${age.get()} years old.`)
 })
 
-// On the first run, it logs:
-// Effect(log details) was executed manually.
+// Nothing is logged on the first run (the run that arms whyAmIRunning).
 
 age.set(43)
 
@@ -552,8 +553,8 @@ name.set('Alice')
 
 // When name is updated, it logs:
 // Effect(log details) is executing because:
-// ↳ Computed(greeting) changed
-// ↳ Atom(name) changed
+//  ↳ Computed(greeting) changed
+//    ↳ Atom(name) changed
 ```
 
 This makes it much easier to trace the flow of data and updates through your application.

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -17,7 +17,7 @@ A `DOCS.md` file is included alongside this README in the published package, wit
 - **Fine-grained reactivity** - Only re-runs computations when their actual dependencies change
 - **High performance** - Lazy evaluation and efficient dependency tracking
 - **Automatic updates** - Derived values and side effects update automatically
-- **Time travel** - Built-in history tracking and transactions with rollback support
+- **Incremental updates** - Built-in diff history and transactions with rollback support
 - **Framework agnostic** - Works with any JavaScript framework or vanilla JS
 - **TypeScript first** - Excellent type safety with full TypeScript support
 
@@ -29,7 +29,7 @@ Perfect for building reactive UIs, real-time collaborative apps, and complex sta
 npm install @tldraw/state
 ```
 
-## Quick Start
+## Quick start
 
 ```ts
 import { atom, computed, react } from '@tldraw/state'
@@ -57,9 +57,9 @@ count.set(42)
 // Logs: "Hello, tldraw! Count: 42"
 ```
 
-## Core Concepts
+## Core concepts
 
-### Atoms - State Containers
+### Atoms - state containers
 
 Atoms hold raw values and are the foundation of your reactive state:
 
@@ -78,7 +78,7 @@ user.update((current) => ({ ...current, age: 31 }))
 theme.set('dark')
 ```
 
-### Computed Values - Automatic Derivation
+### Computed values - automatic derivation
 
 Computed signals derive their values from other signals and update automatically:
 
@@ -98,7 +98,7 @@ firstName.set('Jane')
 console.log(fullName.get()) // "Jane Doe" - automatically updated!
 ```
 
-### Reactions - Side Effects
+### Reactions - side effects
 
 Reactions run side effects when their dependencies change:
 
@@ -120,7 +120,7 @@ selectedId.set('shape-123')
 stop()
 ```
 
-### Transactions - Batched Updates
+### Transactions - batched updates
 
 Batch multiple updates to prevent intermediate reactions:
 
@@ -143,11 +143,11 @@ transact(() => {
 // Logs: "(10, 20)"
 ```
 
-## Advanced Features
+## Advanced features
 
-### History & Time Travel
+### History and diffs
 
-Track changes over time for undo/redo functionality:
+Track changes over time so that dependents can update incrementally instead of recomputing from scratch:
 
 ```ts
 const canvas = atom(
@@ -159,16 +159,17 @@ const canvas = atom(
 	}
 )
 
-// Make changes...
+// Remember where you are...
+const startEpoch = canvas.lastChangedEpoch
+
+// ... make changes ...
 canvas.update((state) => ({ shapes: [...state.shapes, newShape] }))
 
-// Get diffs since a point in time
-const startTime = getGlobalEpoch()
-// ... make more changes ...
-const diffs = canvas.getDiffSince(startTime)
+// ... and get the diffs since then (or RESET_VALUE if the history doesn't reach back that far)
+const diffs = canvas.getDiffSince(startEpoch)
 ```
 
-### Performance Optimization
+### Performance optimization
 
 Use `unsafe__withoutCapture` to read values without creating dependencies:
 
@@ -194,21 +195,18 @@ react('debug-reaction', () => {
 })
 ```
 
-## Integration Examples
+## Integration examples
 
 ### With tldraw SDK
 
 ```ts
-// In a tldraw application
-const editor = useEditor()
-
-// Create reactive state that works with tldraw
+// e.g. in Tldraw's onMount callback, which receives the editor
 const selectedShapes = computed('selectedShapes', () => {
 	return editor.getSelectedShapeIds().map((id) => editor.getShape(id))
 })
 
-// React to selection changes
-react('update-property-panel', () => {
+// React to selection changes; call the returned function to stop
+const stop = react('update-property-panel', () => {
 	const shapes = selectedShapes.get()
 	updatePropertyPanel(shapes)
 })
@@ -223,27 +221,28 @@ npm install @tldraw/state-react
 ```
 
 ```tsx
-import { useAtom, useComputed } from '@tldraw/state-react'
+import { track, useAtom, useComputed } from '@tldraw/state-react'
 
-function Counter() {
-	const [count, setCount] = useAtom(countAtom)
-	const doubled = useComputed(() => count * 2, [count])
+// track() re-renders the component when any signal it reads changes
+const Counter = track(function Counter() {
+	const count = useAtom('count', 0)
+	const doubled = useComputed('doubled', () => count.get() * 2, [count])
 
 	return (
 		<div>
-			<p>Count: {count}</p>
-			<p>Doubled: {doubled}</p>
-			<button onClick={() => setCount(count + 1)}>+</button>
+			<p>Count: {count.get()}</p>
+			<p>Doubled: {doubled.get()}</p>
+			<button onClick={() => count.set(count.get() + 1)}>+</button>
 		</div>
 	)
-}
+})
 ```
 
-## API Reference
+## API reference
 
 For complete API documentation, see [DOCS.md](./DOCS.md).
 
-### Core Functions
+### Core functions
 
 - `atom(name, initialValue, options?)` - Create a reactive state container
 - `computed(name, computeFn, options?)` - Create a derived value
@@ -260,16 +259,16 @@ For complete API documentation, see [DOCS.md](./DOCS.md).
 - `unsafe__withoutCapture(fn)` - Read state without creating dependencies
 - `whyAmIRunning()` - Debug what triggered an update
 - `getComputedInstance(obj, prop)` - Get underlying computed instance
-- `getGlobalEpoch()` - Get current time for history tracking
+- `signal.getDiffSince(epoch)` - Get the diffs recorded since an epoch (see `signal.lastChangedEpoch`)
 
-## Related Packages
+## Related packages
 
 - **[@tldraw/state-react](../state-react)** - React bindings for @tldraw/state
 - **[@tldraw/store](../store)** - Record storage built on @tldraw/state
 - **[@tldraw/editor](../editor)** - The tldraw canvas editor
 - **[@tldraw/tldraw](../tldraw)** - Complete tldraw UI components
 
-## Examples & Patterns
+## Examples & patterns
 
 Looking for more examples? Check out:
 

--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -109,7 +109,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **P5** If that loop fails to quiesce after 1000 passes, the flush throws `Reaction update depth limit exceeded`. An effect that unconditionally writes to one of its own parents hits this limit.
 - **P6** An effect that sets atoms inside a transaction (or `transact`/`transaction` call) during the reaction phase gets the same deferral: the inner transaction's effects are folded into the current reaction phase rather than flushed reentrantly.
 - **P7** Computeds read during the reaction phase are correct: an effect that sets an atom and then reads a computed depending on it sees the updated value (within the same pass), including when both happen inside a transaction the effect opened (T2).
-- **P8** An effect's run is never re-entered. A set during a run that happens outside the reaction phase (the first run of `react()`, `reactor.start()`, or a direct `execute()`) still flushes synchronously per P1, but if that flush reaches the running effect itself, the effect runs again after the current run finishes (repeatedly while its parents keep changing, subject to the P5 limit) instead of nesting a second run inside the first.
+- **P8** An effect's run is never re-entered by a flush. A set during a run that happens outside the reaction phase (the first run of `react()`, `reactor.start()`, or a direct `execute()`) still flushes synchronously per P1, but if that flush reaches the running effect itself, the effect runs again after the current run finishes (repeatedly while its parents keep changing, subject to the P5 limit) instead of nesting a second run inside the first.
 
 ## 11. Transactions (T)
 

--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -54,19 +54,19 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 6. Computed signals (C)
 
 - **C1** Computeds are lazy. The compute function does not run at creation time; it first runs on the first `get()`.
-- **C2** Computeds are cached. Repeated `get()` calls re-run the compute function only if at least one parent's `lastChangedEpoch` differs from the epoch recorded when that parent was last dereferenced. Epoch advances unrelated to the computed's parents never cause recomputation.
+- **C2** Computeds are cached. Repeated `get()` calls re-run the compute function only if at least one parent's `lastChangedEpoch` differs from the epoch recorded when that parent was last dereferenced. Epoch advances unrelated to the computed's parents never cause recomputation. A read is never stale: this holds for reads inside a transaction during the reaction phase, for a computed whose listening effect was scheduled but has not executed yet, and for a computed that regains a listener after its ancestors changed.
 - **C3** A computed whose first execution captured no parents never recomputes.
 - **C4** The compute function receives `(previousValue, lastComputedEpoch)`. On the first computation `previousValue` is the `UNINITIALIZED` symbol (test with `isUninitialized`); afterwards it is the previous value. `lastComputedEpoch` is the epoch at which the computed last finished computing.
 - **C5** If recomputation produces a value equal (EQ) to the previous one, the computed keeps the previous value object and its `lastChangedEpoch`; downstream children observe no change. The signal's `isEqual` is never invoked for the first computation.
 - **C6** A chain of computeds re-runs minimally: each computed in the chain recomputes at most once per relevant change, and value-level deduplication (C5) stops propagation early.
 - **C7** `computed.isActivelyListening` is true exactly when the computed has at least one attached child (effect or actively-listening computed downstream).
-- **C8** The `@computed` decorator on a class method makes that method behave as `Computed.get()` for a per-instance computed signal: cached, reactive, with options (`isEqual`, `historyLength`, etc.) honored. Both legacy and TC39 decorator protocols are supported.
-- **C9** `getComputedInstance(obj, propertyName)` returns the underlying `Computed` instance for a decorated method, creating it on demand if the method has not been called yet.
+- **C8** The `@computed` decorator on a class method makes that method behave as `Computed.get()` for a per-instance computed signal: cached, reactive, with options (`isEqual`, `historyLength`, etc.) honored. `@computed()` with no options is equivalent to `@computed`. Both legacy and TC39 decorator protocols are supported. A subclass may override a `@computed` method with another `@computed` method and call `super.method()`: each decoration has its own per-instance computed.
+- **C9** `getComputedInstance(obj, propertyName)` returns the underlying `Computed` instance for the nearest decorated method on `obj`'s prototype chain, creating it on demand if the method has not been called yet. Its value type is the method's return type.
 - **C10** Using `@computed` on a _getter_ (legacy decorators only) still works but logs a one-time deprecation warning per process.
 
 ## 7. Errors in computed signals (CE)
 
-- **CE1** If the compute function throws, the thrown value is cached: subsequent `get()` calls rethrow the same value without re-running the compute function, until a parent changes.
+- **CE1** If the compute function throws, the thrown value is cached: subsequent `get()` calls rethrow the same value without re-running the compute function, until a parent changes. This includes a throw from the very first computation.
 - **CE2** Entering the error state counts as a change: downstream effects re-run (and observe the throw). Throwing again on a subsequent recomputation, while already in the error state, does _not_ count as a change — consecutive errors do not re-trigger effects.
 - **CE3** Entering the error state discards the previous value: when the computed later recovers, the compute function receives `UNINITIALIZED` as `previousValue`, and the error state clears.
 - **CE4** Entering the error state clears the computed's history buffer; `getDiffSince` spanning the error returns `RESET_VALUE`.
@@ -76,8 +76,8 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 8. History and diffs (H)
 
 - **H1** A signal has a history buffer only if `historyLength` was passed at creation. `computeDiff` without `historyLength` does nothing.
-- **H2** When an atom with history changes, the recorded diff is chosen in priority order: the explicit `diff` argument to `set(value, diff)`, else `computeDiff(prev, next, lastChangedEpoch, currentEpoch)`, else `RESET_VALUE`.
-- **H3** When a computed with history changes, the recorded diff is chosen in priority order: the diff from a `withDiff(value, diff)` return value, else `computeDiff(...)`, else `RESET_VALUE`. No entry is recorded for the first computation.
+- **H2** When an atom with history changes, the recorded diff is chosen in priority order: the explicit `diff` argument to `set(value, diff)`, else `computeDiff(prev, next, lastChangedEpoch, currentEpoch)`, else `RESET_VALUE`. Only `undefined` means "not supplied"; an explicit `null` diff is recorded as a diff.
+- **H3** When a computed with history changes, the recorded diff is chosen in priority order: the diff from a `withDiff(value, diff)` return value, else `computeDiff(prev, next, lastCheckedEpoch, currentEpoch)`, else `RESET_VALUE`. No entry is recorded for the first computation. As for H2, only `undefined` means "not supplied".
 - **H4** Recording `RESET_VALUE` as a diff clears the entire history buffer. In particular, failing to supply a diff on a signal that has history but no `computeDiff` wipes its history.
 - **H5** `getDiffSince(epoch)` returns:
   - the shared frozen `EMPTY_ARRAY` if `epoch >= lastChangedEpoch` (nothing changed since);
@@ -91,13 +91,13 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 9. Effects: EffectScheduler, react, reactor (E)
 
 - **E1** `react(name, fn)` runs `fn` immediately and unconditionally, then re-runs it whenever any signal captured during its previous run changes. It returns a stop function; after stopping, changes no longer re-run `fn`.
-- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated.
+- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise — including for an effect that captured no parents — it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated, and `.start()` behaves the same when called from inside an effect during the reaction phase.
 - **E3** One state change produces at most one run of a given effect, even if the change affected several of its parents (e.g. several atoms set in one transaction, or a diamond dependency graph).
 - **E4** An effect re-runs only when a parent's value actually changed (per EQ and C5). Equal-value sets and unrelated epoch advances do not re-run it.
 - **E5** The effect function receives the epoch at which the effect last ran. This enables the incremental pattern `signal.getDiffSince(lastReactedEpoch)` inside effects. The epoch passed is the one captured _before_ the run, so an effect that updates atoms during its own run remains eligible to be scheduled again.
 - **E6** With a custom `scheduleEffect` option, scheduling and execution are decoupled: when the effect would run, `scheduleEffect(execute)` is called instead and nothing executes until the callback invokes `execute`. The initial run of `react()` is also routed through `scheduleEffect`. `scheduleCount` counts scheduling events, whether or not the effect later executes.
 - **E7** If an effect is detached after being scheduled but before the deferred `execute` callback runs, executing the callback is a no-op.
-- **E8** `EffectScheduler.attach()` does not by itself run the effect (`execute()` must be called the first time; afterwards changes schedule it per E3/E4). `detach()`/`attach()` cycles retain the captured parents: re-attaching does not re-run the effect unless a parent changed while detached (matching E2 since `reactor` is a thin wrapper).
+- **E8** `EffectScheduler.attach()` does not by itself run the effect (`execute()` must be called the first time; afterwards changes schedule it per E3/E4). `detach()`/`attach()` cycles retain the captured parents: re-attaching does not re-run the effect unless a parent changed while detached (matching E2 since `reactor` is a thin wrapper). `attach()` brings computed parents that went stale while nothing was listening up to date before listening to them again.
 - **E9** `maybeScheduleEffect` on a detached scheduler is a no-op. On an attached scheduler whose parents are unchanged it is a no-op (but marks the scheduler as up to date with the current epoch).
 
 ## 10. Change propagation and the reaction phase (P)
@@ -108,7 +108,8 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **P4** Effects may set atoms. Changes made during the reaction phase do not interrupt the current pass: affected effects are collected and run after the current pass completes, repeatedly, until the system quiesces.
 - **P5** If that loop fails to quiesce after 1000 passes, the flush throws `Reaction update depth limit exceeded`. An effect that unconditionally writes to one of its own parents hits this limit.
 - **P6** An effect that sets atoms inside a transaction (or `transact`/`transaction` call) during the reaction phase gets the same deferral: the inner transaction's effects are folded into the current reaction phase rather than flushed reentrantly.
-- **P7** Computeds read during the reaction phase are correct: an effect that sets an atom and then reads a computed depending on it sees the updated value (within the same pass).
+- **P7** Computeds read during the reaction phase are correct: an effect that sets an atom and then reads a computed depending on it sees the updated value (within the same pass), including when both happen inside a transaction the effect opened (T2).
+- **P8** An effect's run is never re-entered. A set during a run that happens outside the reaction phase (the first run of `react()`, `reactor.start()`, or a direct `execute()`) still flushes synchronously per P1, but if that flush reaches the running effect itself, the effect runs again after the current run finishes (repeatedly while its parents keep changing, subject to the P5 limit) instead of nesting a second run inside the first.
 
 ## 11. Transactions (T)
 
@@ -118,7 +119,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **T4** `fn` receives a `rollback` callback. Calling it (and then returning normally) aborts the transaction: every atom changed during the transaction is restored to the value it had when the transaction began.
 - **T5** If `fn` throws, the transaction aborts as in T4 and the exception propagates.
 - **T6** An aborted transaction still flushes effects: effects whose parents went through a change-and-restore round trip are scheduled, observe the restored values, and per E4 may run. Effects never observe intermediate in-transaction values.
-- **T7** Nested `transaction` calls roll back independently: an inner rollback restores to the _inner_ transaction's start. A committed inner transaction is still undone by an outer rollback (the inner transaction's initial values fold into the parent on commit).
+- **T7** Nested `transaction` calls roll back independently: an inner rollback restores to the _inner_ transaction's start. A committed inner transaction is still undone by an outer rollback (the inner transaction's initial values fold into the parent on commit), including when the transactions run inside an effect during the reaction phase.
 - **T8** Because `transact` joins rather than nests, a throw inside an inner `transact` does not restore anything by itself; if it propagates out of the outermost transaction, T5 applies there.
 - **T9** Abort clears the history buffers of every atom changed in the transaction (H7).
 - **T10** Mismatched transaction boundaries (committing a transaction that is not the innermost) throw `Transaction boundaries overlap`.
@@ -127,7 +128,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 
 - **AT1** `deferAsyncEffects(fn)` runs the async `fn` in a transaction context: atom changes are visible immediately to reads (T2 applies), but effects are deferred until the async transaction completes.
 - **AT2** It throws (rejects) if called while a synchronous transaction is in progress. Synchronous `transaction`/`transact` calls _inside_ the async body are fine and nest normally.
-- **AT3** If `fn` rejects or throws, all changes made during the async transaction are rolled back and the error propagates.
+- **AT3** If `fn` rejects or throws, all changes made during the async transaction are rolled back and the error propagates. The rollback is atomic from the point of view of effects (T6): they run once, after every atom has been restored.
 - **AT4** Calling `deferAsyncEffects` while another async transaction is in flight joins it: changes from both are batched together, and effects run only after the last participating process finishes. Async transaction state leaks across `await` boundaries between concurrent processes (no AsyncContext); the grouping of effects is the guarantee, not isolation.
 - **AT5** A `deferAsyncEffects` call kicked off during the reaction phase waits for the reaction phase to finish before starting.
 - **AT6** The returned promise resolves to `fn`'s return value.
@@ -150,6 +151,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **LS3** The atom's value is written to localStorage as JSON on creation and after every change.
 - **LS4** A `storage` event for the same key updates the atom with the parsed new value; a `storage` event with `newValue: null` resets the atom to `initialValue`; an unparseable `newValue` and events for other keys are ignored.
 - **LS5** `cleanup()` stops localStorage writes and storage-event handling. The atom itself keeps working as a plain atom. Atom `options` (equality, history) pass through per A/H rules.
+- **LS6** Without a `window` (Node, SSR) `localStorageAtom` does not throw: it behaves as a plain atom with `initialValue` and `cleanup()` is a no-op.
 
 ## 16. ArraySet — internal (AS)
 
@@ -163,6 +165,6 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 
 `HistoryBuffer` is the circular diff store behind H1–H5.
 
-- **HB1** `pushEntry(fromEpoch, toEpoch, diff)` stores a diff covering the epoch range; pushing `undefined` is ignored; pushing `RESET_VALUE` clears the buffer.
-- **HB2** `getChangesSince(epoch)` returns `[]` when the epoch is at or past the newest entry's `toEpoch`; the ordered diffs back to (and including) the entry whose range contains `epoch`, when the buffer reaches back that far; and `RESET_VALUE` otherwise (epoch too old, buffer empty, capacity exceeded, or cleared).
+- **HB1** `pushEntry(fromEpoch, toEpoch, diff)` stores a diff covering the epoch range. Pushing `RESET_VALUE` clears the buffer, and so does pushing `undefined` ("no diff available"): skipping the entry instead would leave a gap, and a later query from before the gap would return an incomplete diff list.
+- **HB2** `getChangesSince(epoch)` returns the shared frozen `EMPTY_ARRAY` when the epoch is at or past the newest entry's `toEpoch`; the ordered diffs back to (and including) the entry whose range contains `epoch`, when the buffer reaches back that far; and `RESET_VALUE` otherwise (epoch too old, buffer empty, capacity exceeded, or cleared).
 - **HB3** The buffer holds at most `capacity` entries; the oldest entries are overwritten, after which queries reaching past them return `RESET_VALUE`.

--- a/packages/state/api-report.api.md
+++ b/packages/state/api-report.api.md
@@ -121,7 +121,7 @@ export interface EffectSchedulerOptions {
 export const EMPTY_ARRAY: [];
 
 // @public
-export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(obj: Obj, propertyName: Prop): Computed<Obj[Prop]>;
+export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(obj: Obj, propertyName: Prop): Computed<Obj[Prop] extends () => infer Value ? Value : Obj[Prop]>;
 
 // @public
 export function isAtom(value: unknown): value is Atom<unknown>;

--- a/packages/state/src/lib/ArraySet.ts
+++ b/packages/state/src/lib/ArraySet.ts
@@ -10,7 +10,7 @@ export const ARRAY_SIZE_THRESHOLD = 8
  * instead. In either case, the same methods are used to get, set, remove, and visit the items.
  *
  * The backing array is allocated on the first `add`: most signals never get a child, and an
- * empty ArraySet is created for every atom and twice for every computed and effect.
+ * empty ArraySet is created for every atom and effect, and two for every computed.
  * @internal
  */
 export class ArraySet<T> {

--- a/packages/state/src/lib/ArraySet.ts
+++ b/packages/state/src/lib/ArraySet.ts
@@ -1,88 +1,46 @@
 /**
- * The maximum number of items that can be stored in an ArraySet in array mode before switching to Set mode.
+ * The number of items an ArraySet holds in array mode before switching to a Set.
  *
- * @public
- * @example
- * ```ts
- * import { ARRAY_SIZE_THRESHOLD } from '@tldraw/state'
- *
- * console.log(ARRAY_SIZE_THRESHOLD) // 8
- * ```
+ * @internal
  */
 export const ARRAY_SIZE_THRESHOLD = 8
 
 /**
  * An ArraySet operates as an array until it reaches a certain size, after which a Set is used
  * instead. In either case, the same methods are used to get, set, remove, and visit the items.
+ *
+ * The backing array is allocated on the first `add`: most signals never get a child, and an
+ * empty ArraySet is created for every atom and twice for every computed and effect.
  * @internal
  */
 export class ArraySet<T> {
 	private arraySize = 0
 
-	private array: (T | undefined)[] | null = Array(ARRAY_SIZE_THRESHOLD)
+	// Slots [0, arraySize) hold the items; slots beyond are undefined. `add`/`has` scan the whole
+	// array with indexOf, which is why `clear` and `remove` must blank vacated slots.
+	private array: (T | undefined)[] | null = null
 
 	private set: Set<T> | null = null
 
 	/**
 	 * Get whether this ArraySet has any elements.
-	 *
-	 * @returns True if this ArraySet has any elements, false otherwise.
 	 */
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get isEmpty() {
-		if (this.array) {
-			return this.arraySize === 0
-		}
-
 		if (this.set) {
 			return this.set.size === 0
 		}
 
-		throw new Error('no set or array')
+		return this.arraySize === 0
 	}
 
 	/**
 	 * Add an element to the ArraySet if it is not already present.
 	 *
-	 * @param elem - The element to add to the set
 	 * @returns `true` if the element was added, `false` if it was already present
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 *
-	 * console.log(arraySet.add('hello')) // true
-	 * console.log(arraySet.add('hello')) // false (already exists)
-	 * ```
 	 */
 	add(elem: T) {
-		if (this.array) {
-			const idx = this.array.indexOf(elem)
-
-			// Return false if the element is already in the array.
-			if (idx !== -1) {
-				return false
-			}
-
-			if (this.arraySize < ARRAY_SIZE_THRESHOLD) {
-				// If the array is below the size threshold, push items into the array.
-
-				// Insert the element into the array's next available slot.
-				this.array[this.arraySize] = elem
-				this.arraySize++
-
-				return true
-			} else {
-				// If the array is full, convert it to a set and remove the array.
-				this.set = new Set(this.array as any)
-				this.array = null
-				this.set.add(elem)
-
-				return true
-			}
-		}
-
 		if (this.set) {
-			// Return false if the element is already in the set.
 			if (this.set.has(elem)) {
 				return false
 			}
@@ -91,191 +49,121 @@ export class ArraySet<T> {
 			return true
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			this.array = Array(ARRAY_SIZE_THRESHOLD)
+		} else if (this.array.indexOf(elem) !== -1) {
+			return false
+		}
+
+		if (this.arraySize < ARRAY_SIZE_THRESHOLD) {
+			this.array[this.arraySize] = elem
+			this.arraySize++
+
+			return true
+		}
+
+		// The array is full: promote to a set.
+		this.set = new Set(this.array as T[])
+		this.array = null
+		this.set.add(elem)
+
+		return true
 	}
 
 	/**
 	 * Remove an element from the ArraySet if it is present.
 	 *
-	 * @param elem - The element to remove from the set
 	 * @returns `true` if the element was removed, `false` if it was not present
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 *
-	 * console.log(arraySet.remove('hello')) // true
-	 * console.log(arraySet.remove('hello')) // false (not present)
-	 * ```
 	 */
 	remove(elem: T) {
-		if (this.array) {
-			const idx = this.array.indexOf(elem)
-
-			// If the item is not in the array, return false.
-			if (idx === -1) {
-				return false
-			}
-
-			this.array[idx] = undefined
-			this.arraySize--
-
-			if (idx !== this.arraySize) {
-				// If the item is not the last item in the array, move the last item into the
-				// removed item's slot.
-				this.array[idx] = this.array[this.arraySize]
-				this.array[this.arraySize] = undefined
-			}
-
-			return true
-		}
-
 		if (this.set) {
-			// If the item is not in the set, return false.
-			if (!this.set.has(elem)) {
-				return false
-			}
-
-			this.set.delete(elem)
-
-			return true
+			return this.set.delete(elem)
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			return false
+		}
+
+		const idx = this.array.indexOf(elem)
+
+		if (idx === -1) {
+			return false
+		}
+
+		this.arraySize--
+
+		// Move the last item into the vacated slot so the items stay dense.
+		this.array[idx] = this.array[this.arraySize]
+		this.array[this.arraySize] = undefined
+
+		return true
 	}
 
 	/**
 	 * Execute a callback function for each element in the ArraySet.
-	 *
-	 * @param visitor - A function to call for each element in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 * arraySet.add('world')
-	 *
-	 * arraySet.visit((item) => {
-	 *   console.log(item) // 'hello', 'world'
-	 * })
-	 * ```
 	 */
 	visit(visitor: (item: T) => void) {
-		if (this.array) {
-			for (let i = 0; i < this.arraySize; i++) {
-				const elem = this.array[i]
-
-				if (typeof elem !== 'undefined') {
-					visitor(elem)
-				}
-			}
-
-			return
-		}
-
 		if (this.set) {
 			this.set.forEach(visitor)
 
 			return
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			return
+		}
+
+		for (let i = 0; i < this.arraySize; i++) {
+			visitor(this.array[i]!)
+		}
 	}
 
 	/**
 	 * Make the ArraySet iterable, allowing it to be used in for...of loops and with spread syntax.
-	 *
-	 * @returns An iterator that yields each element in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<number>()
-	 * arraySet.add(1)
-	 * arraySet.add(2)
-	 *
-	 * for (const item of arraySet) {
-	 *   console.log(item) // 1, 2
-	 * }
-	 *
-	 * const items = [...arraySet] // [1, 2]
-	 * ```
 	 */
 	*[Symbol.iterator]() {
-		if (this.array) {
-			for (let i = 0; i < this.arraySize; i++) {
-				const elem = this.array[i]
-
-				if (typeof elem !== 'undefined') {
-					yield elem
-				}
-			}
-		} else if (this.set) {
+		if (this.set) {
 			yield* this.set
-		} else {
-			throw new Error('no set or array')
+		} else if (this.array) {
+			for (let i = 0; i < this.arraySize; i++) {
+				yield this.array[i]!
+			}
 		}
 	}
 
 	/**
 	 * Check whether an element is present in the ArraySet.
-	 *
-	 * @param elem - The element to check for
-	 * @returns `true` if the element is present, `false` otherwise
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 *
-	 * console.log(arraySet.has('hello')) // true
-	 * console.log(arraySet.has('world')) // false
-	 * ```
 	 */
 	has(elem: T) {
-		if (this.array) {
-			return this.array.indexOf(elem) !== -1
-		} else {
-			return this.set!.has(elem)
+		if (this.set) {
+			return this.set.has(elem)
 		}
+
+		return this.array ? this.array.indexOf(elem) !== -1 : false
 	}
 
 	/**
 	 * Remove all elements from the ArraySet.
-	 *
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 * arraySet.add('world')
-	 *
-	 * arraySet.clear()
-	 * console.log(arraySet.size()) // 0
-	 * ```
 	 */
 	clear() {
 		if (this.set) {
 			this.set.clear()
-		} else {
+		} else if (this.array) {
+			// Blank the used slots in place rather than allocating a new array: this runs on every
+			// computed derive and effect run.
+			this.array.fill(undefined, 0, this.arraySize)
 			this.arraySize = 0
-			this.array = []
 		}
 	}
 
 	/**
 	 * Get the number of elements in the ArraySet.
-	 *
-	 * @returns The number of elements in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * console.log(arraySet.size()) // 0
-	 *
-	 * arraySet.add('hello')
-	 * console.log(arraySet.size()) // 1
-	 * ```
 	 */
 	size() {
 		if (this.set) {
 			return this.set.size
-		} else {
-			return this.arraySize
 		}
+
+		return this.arraySize
 	}
 }

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -13,7 +13,7 @@ export interface AtomOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need diffs, leave this as `undefined` and no history buffer will be created. Diffs passed to {@link Atom.set} or produced by {@link AtomOptions.computeDiff} are only recorded when this is set.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -87,34 +87,19 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		this.computeDiff = options.computeDiff
 	}
 
-	/**
-	 * Custom equality function for comparing values, or null to use default equality.
-	 * @internal
-	 */
+	/** @internal */
 	readonly isEqual: null | ((a: any, b: any) => boolean)
 
-	/**
-	 * Optional function to compute diffs between old and new values.
-	 * @internal
-	 */
+	/** @internal */
 	computeDiff?: ComputeDiff<Value, Diff>
 
-	/**
-	 * The global epoch when this atom was last changed.
-	 * @internal
-	 */
+	/** @internal */
 	lastChangedEpoch = getGlobalEpoch()
 
-	/**
-	 * Set of child signals that depend on this atom.
-	 * @internal
-	 */
+	/** @internal */
 	children = new ArraySet<Child>()
 
-	/**
-	 * Optional history buffer for tracking changes over time.
-	 * @internal
-	 */
+	/** @internal */
 	historyBuffer?: HistoryBuffer<Diff>
 
 	/**
@@ -158,9 +143,23 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	 * ```
 	 */
 	set(value: Value, diff?: Diff): Value {
-		// If the value has not changed, do nothing.
 		if (this.isEqual?.(this.current, value) ?? equals(this.current, value)) {
 			return this.current
+		}
+
+		// `computeDiff` is user code: run it before ticking the epoch, so that any signal it reads is
+		// checked against the epoch this write has not yet happened in. Reading a dependent computed
+		// after the tick would stamp it as checked at the new epoch while the atom was still being
+		// written, and it would then never see the change. Only `undefined` means "no diff
+		// supplied"; `null` can be a legitimate diff.
+		let historyDiff: Diff | RESET_VALUE | undefined
+		if (this.historyBuffer) {
+			historyDiff =
+				diff !== undefined
+					? diff
+					: this.computeDiff
+						? this.computeDiff(this.current, value, this.lastChangedEpoch, getGlobalEpoch() + 1)
+						: RESET_VALUE
 		}
 
 		// Tick forward the global epoch. This write belongs to that one epoch, so read it once and
@@ -169,22 +168,15 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		advanceGlobalEpoch()
 		const epoch = getGlobalEpoch()
 
-		// Add the diff to the history buffer.
 		if (this.historyBuffer) {
-			this.historyBuffer.pushEntry(
-				this.lastChangedEpoch,
-				epoch,
-				diff ?? this.computeDiff?.(this.current, value, this.lastChangedEpoch, epoch) ?? RESET_VALUE
-			)
+			this.historyBuffer.pushEntry(this.lastChangedEpoch, epoch, historyDiff)
 		}
 
-		// Update the atom's record of the epoch when last changed.
 		this.lastChangedEpoch = epoch
 
 		const oldValue = this.current
 		this.current = value
 
-		// Notify all children that this atom has changed.
 		atomDidChange(this as any, oldValue)
 
 		return value
@@ -216,7 +208,6 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	getDiffSince(epoch: number): RESET_VALUE | Diff[] {
 		maybeCaptureParent(this)
 
-		// If no changes have occurred since the given epoch, return an empty array.
 		if (epoch >= this.lastChangedEpoch) {
 			return EMPTY_ARRAY
 		}

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -270,13 +270,10 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 		if (
 			!isNew &&
 			(this.lastCheckedEpoch === globalEpoch ||
-				// Every change to an ancestor of an actively-listening computed traverses it (see
-				// `flushChanges`), so if it hasn't been traversed since it was last checked, no parent
-				// can have changed and the O(parents) scan below can be skipped. This holds only while
-				// no transaction is open (in-transaction changes are traversed at commit) and only if
-				// the computed was up to date when it became actively listening, which
-				// `EffectScheduler.attach` guarantees. Note `<=`, not "not traversed this reaction":
-				// a computed can be traversed in one flush and not re-checked before the next.
+				// Every ancestor change to an actively-listening computed traverses it (`flushChanges`),
+				// so if it hasn't been traversed since it was last checked the O(parents) scan can be
+				// skipped. Not valid while a transaction is open (changes traverse at commit), and only
+				// if it was up to date when attached (see `attach` in helpers.ts).
 				(this.isActivelyListening &&
 					!getIsInTransaction() &&
 					this.lastTraversedEpoch <= this.lastCheckedEpoch) ||

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -5,7 +5,7 @@ import { maybeCaptureParent, startCapturingParents, stopCapturingParents } from 
 import { GLOBAL_START_EPOCH } from './constants'
 import { EMPTY_ARRAY, equals, haveParentsChanged, singleton } from './helpers'
 import { HistoryBuffer } from './HistoryBuffer'
-import { getGlobalEpoch, getIsReacting, getReactionEpoch } from './transactions'
+import { getGlobalEpoch, getIsInTransaction } from './transactions'
 import { Child, ComputeDiff, RESET_VALUE, Signal } from './types'
 import { logComputedGetterWarning } from './warnings'
 
@@ -150,7 +150,7 @@ export interface ComputedOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need diffs, leave this as `undefined` and no history buffer will be created. Diffs supplied via {@link withDiff} or {@link ComputedOptions.computeDiff} are only recorded when this is set.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -216,9 +216,7 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 	__debug_ancestor_epochs__: Map<Signal<any, any>, number> | null = null
 
-	/**
-	 * The epoch when the reactor was last checked.
-	 */
+	// Advances on every check, including ones that find no change, unlike `lastChangedEpoch`.
 	private lastCheckedEpoch = GLOBAL_START_EPOCH
 
 	parentSet = new ArraySet<Signal<any, any>>()
@@ -272,9 +270,16 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 		if (
 			!isNew &&
 			(this.lastCheckedEpoch === globalEpoch ||
+				// Every change to an ancestor of an actively-listening computed traverses it (see
+				// `flushChanges`), so if it hasn't been traversed since it was last checked, no parent
+				// can have changed and the O(parents) scan below can be skipped. This holds only while
+				// no transaction is open (in-transaction changes are traversed at commit) and only if
+				// the computed was up to date when it became actively listening, which
+				// `EffectScheduler.attach` guarantees. Note `<=`, not "not traversed this reaction":
+				// a computed can be traversed in one flush and not re-checked before the next.
 				(this.isActivelyListening &&
-					getIsReacting() &&
-					this.lastTraversedEpoch < getReactionEpoch()) ||
+					!getIsInTransaction() &&
+					this.lastTraversedEpoch <= this.lastCheckedEpoch) ||
 				!haveParentsChanged(this))
 		) {
 			this.lastCheckedEpoch = globalEpoch
@@ -299,13 +304,16 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 			const epoch = getGlobalEpoch()
 			if (isUninitialized || !this.isEqual(this.state, newState)) {
 				if (this.historyBuffer && !isUninitialized) {
+					// Only `undefined` means "no diff supplied"; `null` can be a legitimate diff.
 					const diff = result instanceof WithDiff ? result.diff : undefined
 					this.historyBuffer.pushEntry(
 						this.lastChangedEpoch,
 						epoch,
-						diff ??
-							this.computeDiff?.(this.state, newState, this.lastCheckedEpoch, epoch) ??
-							RESET_VALUE
+						diff !== undefined
+							? diff
+							: this.computeDiff
+								? this.computeDiff(this.state, newState, this.lastCheckedEpoch, epoch)
+								: RESET_VALUE
 					)
 				}
 				this.lastChangedEpoch = epoch
@@ -316,14 +324,17 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 			return this.state
 		} catch (e) {
-			// if a derived value throws an error, we reset the state to UNINITIALIZED
 			const epoch = getGlobalEpoch()
-			if (this.state !== UNINITIALIZED) {
+			// Entering the error state (from a value, or from never having computed) is a change;
+			// throwing again while already in it is not. Checking `error` rather than `state` matters
+			// for a first run that throws: `state` is already UNINITIALIZED then, and leaving
+			// `lastChangedEpoch` at GLOBAL_START_EPOCH would keep `isNew` true and re-run `derive` on
+			// every read instead of rethrowing the cached error.
+			if (this.error === null) {
 				this.state = UNINITIALIZED as unknown as Value
 				this.lastChangedEpoch = epoch
 			}
 			this.lastCheckedEpoch = epoch
-			// we also clear the history buffer if an error was thrown
 			if (this.historyBuffer) {
 				this.historyBuffer.clear()
 			}
@@ -374,20 +385,23 @@ export const _Computed = singleton('Computed', () => __UNSAFE__Computed)
  */
 export type _Computed = InstanceType<typeof __UNSAFE__Computed>
 
-function computedMethodLegacyDecorator(
-	options: ComputedOptions<any, any> = {},
-	_target: any,
-	key: string,
-	descriptor: PropertyDescriptor
-) {
-	const originalMethod = descriptor.value
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + key)
+// Set on every decorated wrapper: the symbol its per-instance computed is stored under.
+const derivationKeyKey = '@@__computedDerivationKey__@@'
 
-	descriptor.value = function (this: any) {
+/**
+ * Builds the method (or getter) body that `@computed` installs: a per-instance, lazily-created
+ * computed over the original method. The storage symbol is unique per decoration rather than
+ * `Symbol.for(name)` so that a subclass which overrides a `@computed` method and calls
+ * `super.method()` reaches the superclass's computed instead of re-entering its own.
+ */
+function makeComputedWrapper(name: string, compute: () => any, options: ComputedOptions<any, any>) {
+	const derivationKey = Symbol('__@tldraw/state__computed__' + name)
+
+	const wrapper = function (this: any) {
 		let d = this[derivationKey] as Computed<any> | undefined
 
 		if (!d) {
-			d = new _Computed(key, originalMethod!.bind(this) as any, options)
+			d = new _Computed(name, compute.bind(this) as any, options)
 			Object.defineProperty(this, derivationKey, {
 				enumerable: false,
 				configurable: false,
@@ -396,63 +410,9 @@ function computedMethodLegacyDecorator(
 			})
 		}
 		return d.get()
-	}
-	descriptor.value[isComputedMethodKey] = true
-
-	return descriptor
-}
-
-function computedGetterLegacyDecorator(
-	options: ComputedOptions<any, any> = {},
-	_target: any,
-	key: string,
-	descriptor: PropertyDescriptor
-) {
-	const originalMethod = descriptor.get
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + key)
-
-	descriptor.get = function (this: any) {
-		let d = this[derivationKey] as Computed<any> | undefined
-
-		if (!d) {
-			d = new _Computed(key, originalMethod!.bind(this) as any, options)
-			Object.defineProperty(this, derivationKey, {
-				enumerable: false,
-				configurable: false,
-				writable: false,
-				value: d,
-			})
-		}
-		return d.get()
-	}
-
-	return descriptor
-}
-
-function computedMethodTc39Decorator<This extends object, Value>(
-	options: ComputedOptions<Value, any>,
-	compute: () => Value,
-	context: ClassMethodDecoratorContext<This, () => Value>
-) {
-	assert(context.kind === 'method', '@computed can only be used on methods')
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + String(context.name))
-
-	const fn = function (this: any) {
-		let d = this[derivationKey] as Computed<any> | undefined
-
-		if (!d) {
-			d = new _Computed(String(context.name), compute.bind(this) as any, options)
-			Object.defineProperty(this, derivationKey, {
-				enumerable: false,
-				configurable: false,
-				writable: false,
-				value: d,
-			})
-		}
-		return d.get()
-	}
-	fn[isComputedMethodKey] = true
-	return fn
+	} as any
+	wrapper[derivationKeyKey] = derivationKey
+	return wrapper
 }
 
 function computedDecorator(
@@ -463,19 +423,19 @@ function computedDecorator(
 ) {
 	if (args.length === 2) {
 		const [originalMethod, context] = args
-		return computedMethodTc39Decorator(options, originalMethod, context)
+		assert(context.kind === 'method', '@computed can only be used on methods')
+		return makeComputedWrapper(String(context.name), originalMethod, options)
 	} else {
 		const [_target, key, descriptor] = args
 		if (descriptor.get) {
 			logComputedGetterWarning()
-			return computedGetterLegacyDecorator(options, _target, key, descriptor)
+			descriptor.get = makeComputedWrapper(key, descriptor.get, options)
 		} else {
-			return computedMethodLegacyDecorator(options, _target, key, descriptor)
+			descriptor.value = makeComputedWrapper(key, descriptor.value, options)
 		}
+		return descriptor
 	}
 }
-
-const isComputedMethodKey = '@@__isComputedMethod__@@'
 
 /**
  * Retrieves the underlying computed instance for a given property created with the `computed`
@@ -485,7 +445,7 @@ const isComputedMethodKey = '@@__isComputedMethod__@@'
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom(0)
+ *   count = atom('count', 0)
  *
  *   @computed getRemaining() {
  *     return this.max - this.count.get()
@@ -506,19 +466,29 @@ const isComputedMethodKey = '@@__isComputedMethod__@@'
 export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
 	obj: Obj,
 	propertyName: Prop
-): Computed<Obj[Prop]> {
-	const key = Symbol.for('__@tldraw/state__computed__' + propertyName.toString())
-	let inst = obj[key as keyof typeof obj] as Computed<Obj[Prop]> | undefined
-	if (!inst) {
-		// deref to make sure it exists first
-		const val = obj[propertyName]
-		if (typeof val === 'function' && (val as any)[isComputedMethodKey]) {
-			val.call(obj)
-		}
+): Computed<Obj[Prop] extends () => infer Value ? Value : Obj[Prop]> {
+	// The nearest decorated wrapper (a method, or a legacy getter) on the prototype chain knows
+	// which symbol the instance's computed is stored under.
+	for (let proto: any = obj; proto; proto = Object.getPrototypeOf(proto)) {
+		const descriptor = Object.getOwnPropertyDescriptor(proto, propertyName)
+		const wrapper = descriptor?.get ?? descriptor?.value
+		const key = wrapper?.[derivationKeyKey]
+		if (!key) continue
 
-		inst = obj[key as keyof typeof obj] as Computed<Obj[Prop]> | undefined
+		let inst = (obj as any)[key]
+		if (!inst) {
+			// calling the wrapper creates the computed (before it first derives, so a throwing derive
+			// still leaves the instance behind)
+			try {
+				wrapper.call(obj)
+			} catch {
+				// the caller asked for the instance, not its value
+			}
+			inst = (obj as any)[key]
+		}
+		return inst
 	}
-	return inst as any
+	return undefined as any
 }
 
 /**
@@ -539,7 +509,7 @@ export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom<number>(0)
+ *   count = atom('count', 0)
  *
  *   @computed getRemaining() {
  *     return this.max - this.count.get()
@@ -553,7 +523,7 @@ export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom<number>(0)
+ *   count = atom('count', 0)
  *
  *   @computed({isEqual: (a, b) => a === b})
  *   getRemaining() {
@@ -665,7 +635,8 @@ export function computed<Value, Diff = unknown>(
  * @public
  */
 export function computed() {
-	if (arguments.length === 1) {
+	if (arguments.length <= 1) {
+		// decorator factory: `@computed(options)` or `@computed()`
 		const options = arguments[0]
 		return (...args: any) => computedDecorator(options, args)
 	} else if (typeof arguments[0] === 'string') {

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -115,16 +115,8 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 		if (this._scheduleEffect) {
 			// if the effect should be deferred (e.g. until a react render), do so
 			this._scheduleEffect(this.maybeExecute)
-		} else if (this._executeDepth > 0) {
-			// A set inside the running effect flushed synchronously and reached this scheduler again
-			// (only possible outside the reaction phase, e.g. during the initial run of `react()`).
-			// Executing now would open a second capture frame for a child whose frame is still open,
-			// and the two runs would corrupt each other's `parents` bookkeeping, so re-check once the
-			// current run has finished instead.
-			this._wasScheduledWhileExecuting = true
 		} else {
-			// otherwise execute right now!
-			this.execute()
+			this.maybeExecute()
 		}
 	}
 
@@ -133,7 +125,9 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	readonly maybeExecute = () => {
 		// bail out if we have been detached before this runs
 		if (!this._isActivelyListening) return
-		// a synchronous custom scheduler can land here mid-run; see `scheduleEffect`
+		// A set inside the running effect flushed synchronously back to this scheduler (only possible
+		// outside the reaction phase, e.g. the first run of `react()`). Running now would open a second
+		// capture frame inside the open one and corrupt `parents`, so re-check after the run instead.
 		if (this._executeDepth > 0) {
 			this._wasScheduledWhileExecuting = true
 			return
@@ -151,10 +145,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 		this._isActivelyListening = true
 		for (let i = 0, n = this.parents.length; i < n; i++) {
 			const parent = this.parents[i]
-			// A computed parent may have gone stale while nothing was listening to it. Bring it up to
-			// date before it becomes actively listening again: `Computed` trusts that an
-			// actively-listening computed was traversed whenever an ancestor changed, which is only
-			// true from the moment it was attached while up to date.
+			// a computed parent may have gone stale while nothing listened; see `attach` in helpers.ts
 			parent.__unsafe__getWithoutCapture(true)
 			attach(parent, this)
 		}
@@ -178,15 +169,14 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	 * @public
 	 */
 	execute(): Result {
-		// A direct re-entrant call (an effect calling its own scheduler's `execute()`) is unsupported:
-		// both runs share one set of `parents`, so the outer run's bookkeeping ends up wrong. It is
-		// left to run so that the outer run can at least finish normally.
+		// A direct re-entrant `execute()` from inside the effect is unsupported (both runs share one
+		// `parents`); it is left to run so the outer run can at least finish normally.
 		if (this._executeDepth > 0) return this.executeOnce()
 		// a run that threw may have left this set
 		this._wasScheduledWhileExecuting = false
 		let result = this.executeOnce()
-		// If a set inside the run reached this scheduler (see `scheduleEffect`), settle it now, the
-		// way the reaction phase's cleanup pass would: run again while the parents keep changing.
+		// If a set inside the run reached this scheduler (see `maybeExecute`), settle it now the way
+		// the reaction phase's cleanup pass would: run again while the parents keep changing.
 		for (let depth = 0; this._wasScheduledWhileExecuting; depth++) {
 			this._wasScheduledWhileExecuting = false
 			if (depth >= 1000) {

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -29,12 +29,9 @@ export interface EffectSchedulerOptions {
 	 * 	}
 	 * }
 	 * const stop = react('set page title', () => {
-	 * 	document.title = doc.title,
-	 * }, scheduleEffect)
+	 * 	document.title = doc.title
+	 * }, { scheduleEffect })
 	 * ```
-	 *
-	 * @param execute - A function that will execute the effect.
-	 * @returns void
 	 */
 	// eslint-disable-next-line tldraw/method-signature-style
 	scheduleEffect?: (execute: () => void) => void
@@ -60,6 +57,10 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 
 	/** @internal */
 	private _scheduleCount = 0
+	/** @internal */
+	private _executeDepth = 0
+	/** @internal */
+	private _wasScheduledWhileExecuting = false
 	/** @internal */
 	__debug_ancestor_epochs__: Map<Signal<any, any>, number> | null = null
 
@@ -95,12 +96,16 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 		// bail out if no atoms have changed since the last time we ran this effect
 		if (this.lastReactedEpoch === getGlobalEpoch()) return
 
-		// bail out if we have parents and they have not changed since last time
-		if (this.parents.length && !haveParentsChanged(this)) {
+		// An effect that has run before (or captured parents before throwing) only needs to run
+		// again if one of those parents changed; that includes an effect that captured no parents at
+		// all. An effect that has never run always runs.
+		if (
+			(this.lastReactedEpoch !== GLOBAL_START_EPOCH || this.parents.length > 0) &&
+			!haveParentsChanged(this)
+		) {
 			this.lastReactedEpoch = getGlobalEpoch()
 			return
 		}
-		// if we don't have parents it's probably the first time this is running.
 		this.scheduleEffect()
 	}
 
@@ -110,6 +115,13 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 		if (this._scheduleEffect) {
 			// if the effect should be deferred (e.g. until a react render), do so
 			this._scheduleEffect(this.maybeExecute)
+		} else if (this._executeDepth > 0) {
+			// A set inside the running effect flushed synchronously and reached this scheduler again
+			// (only possible outside the reaction phase, e.g. during the initial run of `react()`).
+			// Executing now would open a second capture frame for a child whose frame is still open,
+			// and the two runs would corrupt each other's `parents` bookkeeping, so re-check once the
+			// current run has finished instead.
+			this._wasScheduledWhileExecuting = true
 		} else {
 			// otherwise execute right now!
 			this.execute()
@@ -121,6 +133,11 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	readonly maybeExecute = () => {
 		// bail out if we have been detached before this runs
 		if (!this._isActivelyListening) return
+		// a synchronous custom scheduler can land here mid-run; see `scheduleEffect`
+		if (this._executeDepth > 0) {
+			this._wasScheduledWhileExecuting = true
+			return
+		}
 		this.execute()
 	}
 
@@ -133,7 +150,13 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	attach() {
 		this._isActivelyListening = true
 		for (let i = 0, n = this.parents.length; i < n; i++) {
-			attach(this.parents[i], this)
+			const parent = this.parents[i]
+			// A computed parent may have gone stale while nothing was listening to it. Bring it up to
+			// date before it becomes actively listening again: `Computed` trusts that an
+			// actively-listening computed was traversed whenever an ancestor changed, which is only
+			// true from the moment it was attached while up to date.
+			parent.__unsafe__getWithoutCapture(true)
+			attach(parent, this)
 		}
 	}
 
@@ -155,6 +178,33 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	 * @public
 	 */
 	execute(): Result {
+		// A direct re-entrant call (an effect calling its own scheduler's `execute()`) is unsupported:
+		// both runs share one set of `parents`, so the outer run's bookkeeping ends up wrong. It is
+		// left to run so that the outer run can at least finish normally.
+		if (this._executeDepth > 0) return this.executeOnce()
+		// a run that threw may have left this set
+		this._wasScheduledWhileExecuting = false
+		let result = this.executeOnce()
+		// If a set inside the run reached this scheduler (see `scheduleEffect`), settle it now, the
+		// way the reaction phase's cleanup pass would: run again while the parents keep changing.
+		for (let depth = 0; this._wasScheduledWhileExecuting; depth++) {
+			this._wasScheduledWhileExecuting = false
+			if (depth >= 1000) {
+				throw new Error('Reaction update depth limit exceeded')
+			}
+			if (!this._isActivelyListening) break
+			if (!haveParentsChanged(this)) {
+				this.lastReactedEpoch = getGlobalEpoch()
+				break
+			}
+			result = this.executeOnce()
+		}
+		return result
+	}
+
+	private executeOnce(): Result {
+		// A counter rather than a flag: a nested `execute()` must not mark the outer run as finished.
+		this._executeDepth++
 		try {
 			startCapturingParents(this)
 			// Important! We have to make a note of the current epoch before running the effect.
@@ -166,6 +216,7 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 			return result
 		} finally {
 			stopCapturingParents()
+			this._executeDepth--
 		}
 	}
 }

--- a/packages/state/src/lib/HistoryBuffer.ts
+++ b/packages/state/src/lib/HistoryBuffer.ts
@@ -1,19 +1,15 @@
+import { EMPTY_ARRAY } from './helpers'
 import { RESET_VALUE } from './types'
 
-/**
- * A tuple representing a range of epochs and the associated diff.
- * Used internally by HistoryBuffer to store change information.
- *
- * @internal
- */
 type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
 
 /**
- * A circular buffer that stores diffs between sequential values of an atom or computed signal.
- * This enables efficient change tracking and history retrieval for features like undo/redo.
+ * A ring buffer of the most recent diffs of an atom or computed signal, so that
+ * {@link Signal.getDiffSince} can hand incremental consumers the changes since the epoch they
+ * last saw instead of forcing them to recompute from the current value.
  *
- * The buffer uses a wrap-around strategy to maintain a fixed-size history of the most recent
- * changes, automatically overwriting older entries when the capacity is exceeded.
+ * Entries must be contiguous (`entry[k].toEpoch === entry[k+1].fromEpoch`); `getChangesSince`
+ * relies on that to find the entry covering an epoch.
  *
  * @example
  * ```ts
@@ -26,91 +22,39 @@ type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
  * @internal
  */
 export class HistoryBuffer<Diff> {
-	/**
-	 * Current write position in the circular buffer.
-	 * @internal
-	 */
 	private index = 0
 
-	/**
-	 * Circular buffer storing range tuples. Uses undefined to represent empty slots.
-	 * @internal
-	 */
 	buffer: Array<RangeTuple<Diff> | undefined>
 
-	/**
-	 * Creates a new HistoryBuffer with the specified capacity.
-	 *
-	 * capacity - Maximum number of diffs to store in the buffer
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<number>(10) // Store up to 10 diffs
-	 * ```
-	 */
 	constructor(private readonly capacity: number) {
 		this.buffer = new Array(capacity)
 	}
 
 	/**
-	 * Adds a diff entry to the history buffer, representing a change between two epochs.
-	 *
-	 * If the diff is undefined, the operation is ignored. If the diff is RESET_VALUE,
-	 * the entire buffer is cleared to indicate that historical tracking should restart.
-	 *
-	 * @param lastComputedEpoch - The epoch when the previous value was computed
-	 * @param currentEpoch - The epoch when the current value was computed
-	 * @param diff - The diff representing the change, or RESET_VALUE to clear history
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<string>(5)
-	 * buffer.pushEntry(0, 1, 'added text')
-	 * buffer.pushEntry(1, 2, RESET_VALUE) // Clears the buffer
-	 * ```
+	 * Records the diff covering `lastComputedEpoch` → `currentEpoch`. `RESET_VALUE` — or an
+	 * `undefined` diff, which also means "no diff available" — clears the buffer instead: silently
+	 * skipping an entry would leave a gap, and a later `getChangesSince` from before the gap would
+	 * return an incomplete diff list rather than `RESET_VALUE`.
 	 */
-	pushEntry(lastComputedEpoch: number, currentEpoch: number, diff: Diff | RESET_VALUE) {
-		if (diff === undefined) {
-			return
-		}
-
-		if (diff === RESET_VALUE) {
+	pushEntry(lastComputedEpoch: number, currentEpoch: number, diff: Diff | RESET_VALUE | undefined) {
+		if (diff === RESET_VALUE || diff === undefined) {
 			this.clear()
 			return
 		}
 
-		// Add the diff to the buffer as a range tuple.
 		this.buffer[this.index] = [lastComputedEpoch, currentEpoch, diff]
-
-		// Bump the index, wrapping around if necessary.
 		this.index = (this.index + 1) % this.capacity
 	}
 
-	/**
-	 * Clears all entries from the history buffer and resets the write position.
-	 * This is called when a RESET_VALUE diff is encountered.
-	 *
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<string>(5)
-	 * buffer.pushEntry(0, 1, 'change')
-	 * buffer.clear()
-	 * console.log(buffer.getChangesSince(0)) // RESET_VALUE
-	 * ```
-	 */
 	clear() {
 		this.index = 0
 		this.buffer.fill(undefined)
 	}
 
 	/**
-	 * Retrieves all diffs that occurred since the specified epoch.
+	 * The diffs since `sinceEpoch`, oldest first, or `RESET_VALUE` if the buffer no longer reaches
+	 * back that far (evicted, cleared, or never recorded).
 	 *
-	 * The method searches backwards through the circular buffer to find changes
-	 * that occurred after the given epoch. If insufficient history is available
-	 * or the requested epoch is too old, returns RESET_VALUE indicating that
-	 * a complete state rebuild is required.
-	 *
-	 * @param sinceEpoch - The epoch from which to retrieve changes
-	 * @returns Array of diffs since the epoch, or RESET_VALUE if history is insufficient
 	 * @example
 	 * ```ts
 	 * const buffer = new HistoryBuffer<string>(5)
@@ -124,25 +68,22 @@ export class HistoryBuffer<Diff> {
 	getChangesSince(sinceEpoch: number): RESET_VALUE | Diff[] {
 		const { index, capacity, buffer } = this
 
-		// For each item in the buffer...
+		// Walk backwards from the newest entry looking for the one whose range contains sinceEpoch.
 		for (let i = 0; i < capacity; i++) {
 			const offset = (index - 1 + capacity - i) % capacity
 
 			const elem = buffer[offset]
 
-			// If there's no element in the offset position, return the reset value
 			if (!elem) {
 				return RESET_VALUE
 			}
 
 			const [fromEpoch, toEpoch] = elem
 
-			// If the first element is already too early, bail
 			if (i === 0 && sinceEpoch >= toEpoch) {
-				return []
+				return EMPTY_ARRAY
 			}
 
-			// If the element is since the given epoch, return an array with all diffs from this element and all following elements
 			if (fromEpoch <= sinceEpoch && sinceEpoch < toEpoch) {
 				const len = i + 1
 				const result = new Array(len)
@@ -155,7 +96,6 @@ export class HistoryBuffer<Diff> {
 			}
 		}
 
-		// If we haven't returned yet, return the reset value
 		return RESET_VALUE
 	}
 }

--- a/packages/state/src/lib/__tests__/EffectScheduler.test.ts
+++ b/packages/state/src/lib/__tests__/EffectScheduler.test.ts
@@ -233,6 +233,50 @@ describe('reactor (E)', () => {
 		r.scheduler.maybeScheduleEffect()
 		expect(rfn).toHaveBeenCalledTimes(1)
 	})
+
+	it('[E2][E9] an effect that captured no parents does not re-run on start() after unrelated changes', () => {
+		const unrelated = atom('', 0)
+		const rfn = vi.fn()
+		const r = reactor('', rfn)
+
+		r.start()
+		expect(rfn).toHaveBeenCalledTimes(1)
+
+		r.stop()
+		unrelated.set(1)
+		r.start()
+		// no parent changed (there are none), so there is nothing to react to
+		expect(rfn).toHaveBeenCalledTimes(1)
+
+		r.start({ force: true })
+		expect(rfn).toHaveBeenCalledTimes(2)
+	})
+
+	it('[E2] start() inside a reaction phase runs the effect if a parent changed while stopped', () => {
+		// Regression: re-attaching during a reaction used to make a stale computed parent "actively
+		// listening" without refreshing it, and Computed's cache then served the stale value, so the
+		// restarted reactor never ran and the computed stayed wrong until its ancestor changed again.
+		const a = atom('a', 1)
+		const c = computed('c', () => a.get() * 2)
+		const seen: number[] = []
+		const r = reactor('r', () => {
+			seen.push(c.get())
+		})
+		r.start()
+		expect(seen).toEqual([2])
+		r.stop()
+
+		a.set(5) // nothing is listening to c now, so it goes stale
+
+		const trigger = atom('trigger', 0)
+		react('outer', () => {
+			if (trigger.get() === 1) r.start()
+		})
+		trigger.set(1) // r.start() runs inside this reaction phase
+
+		expect(seen).toEqual([2, 10])
+		expect(c.get()).toBe(10)
+	})
 })
 
 describe('custom scheduling (E6, E7)', () => {
@@ -399,5 +443,58 @@ describe('EffectScheduler attach/detach (E8)', () => {
 		expect(numReactions).toBe(3)
 		a.set(4)
 		expect(numReactions).toBe(4)
+	})
+
+	it('[E8] attach() brings stale computed parents up to date before listening to them', () => {
+		const a = atom('a', 1)
+		const c = computed('c', () => a.get() * 2)
+		const seen: number[] = []
+		const scheduler = new EffectScheduler('test', () => {
+			seen.push(c.get())
+		})
+		scheduler.attach()
+		scheduler.execute()
+		scheduler.detach()
+		a.set(5) // c is stale now
+
+		// the useStateTracking pattern: re-attach, then ask whether a run is needed, inside a reaction
+		const trigger = atom('trigger', 0)
+		react('outer', () => {
+			if (trigger.get() === 1) {
+				scheduler.attach()
+				scheduler.maybeScheduleEffect()
+			}
+		})
+		trigger.set(1)
+
+		expect(seen).toEqual([2, 10])
+	})
+})
+
+describe('effects that set atoms outside the reaction phase (P4)', () => {
+	it('[P4] an effect that sets one of its own parents during its first run re-runs afterwards instead of re-entering itself', () => {
+		// Regression: the initial run of react() happens outside a reaction phase, so a set inside
+		// it flushed synchronously and re-entered execute() for the same scheduler. The nested
+		// capture frame then truncated the parents captured by the outer run (b was dropped while
+		// b.children still held the effect).
+		const initialized = atom('initialized', false)
+		const b = atom('b', 0)
+		const seen: number[] = []
+		let depth = 0
+		let maxDepth = 0
+		react('r', () => {
+			depth++
+			maxDepth = Math.max(maxDepth, depth)
+			if (!initialized.get()) initialized.set(true)
+			seen.push(b.get())
+			depth--
+		})
+
+		expect(maxDepth).toBe(1)
+		// the set changed a parent read before it, so the effect runs once more, sequentially
+		expect(seen).toEqual([0, 0])
+
+		b.set(1)
+		expect(seen).toEqual([0, 0, 1])
 	})
 })

--- a/packages/state/src/lib/__tests__/HistoryBuffer.test.ts
+++ b/packages/state/src/lib/__tests__/HistoryBuffer.test.ts
@@ -47,13 +47,16 @@ describe('HistoryBuffer', () => {
 		expect(buf.getChangesSince(0)).toEqual(RESET_VALUE)
 	})
 
-	it('[HB1] ignores undefined diffs', () => {
+	it('[HB1] treats an undefined diff like RESET_VALUE: it clears rather than leaving a gap', () => {
 		const buf = new HistoryBuffer<string>(3)
 		buf.pushEntry(0, 1, 'a')
 		buf.pushEntry(1, 2, undefined as any)
+		buf.pushEntry(2, 3, 'c')
 
-		expect(buf.getChangesSince(0)).toEqual(['a'])
-		expect(buf.getChangesSince(1)).toEqual([])
+		// if the undefined entry had been skipped, this would be ['a', 'c'] with the 1 -> 2 change missing
+		expect(buf.getChangesSince(0)).toEqual(RESET_VALUE)
+		expect(buf.getChangesSince(1)).toEqual(RESET_VALUE)
+		expect(buf.getChangesSince(2)).toEqual(['c'])
 	})
 
 	it('[HB1] will clear if you push RESET_VALUE', () => {

--- a/packages/state/src/lib/__tests__/computed.test.ts
+++ b/packages/state/src/lib/__tests__/computed.test.ts
@@ -333,4 +333,79 @@ describe('the computed decorator (C8, C9, C10)', () => {
 
 		warn.mockRestore()
 	})
+
+	it('[C8] can be applied as a factory with no options', () => {
+		// the options argument is optional, so `@computed()` must work like `@computed`
+		class Foo {
+			a = atom('a', 1)
+			@computed()
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+
+		const foo = new Foo()
+		expect(foo.getB()).toBe(2)
+		foo.a.set(2)
+		expect(foo.getB()).toBe(4)
+	})
+
+	it('[C8] a subclass override can call the superclass computed via super', () => {
+		// each decoration stores its computed under its own key; keying by method name made the
+		// super call re-enter the subclass's own computed and overflow the stack
+		class Base {
+			a = atom('a', 1)
+			@computed
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+		class Sub extends Base {
+			@computed
+			override getB() {
+				return super.getB() + 1
+			}
+		}
+
+		const sub = new Sub()
+		expect(sub.getB()).toBe(3)
+		sub.a.set(2)
+		expect(sub.getB()).toBe(5)
+		expect(new Base().getB()).toBe(2)
+	})
+
+	it('[C9] getComputedInstance resolves the nearest decorated method on the prototype chain', () => {
+		class Base {
+			a = atom('a', 1)
+			@computed
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+		class Sub extends Base {
+			@computed
+			override getB() {
+				return super.getB() + 1
+			}
+		}
+		class PlainSub extends Base {
+			override getB() {
+				return super.getB() + 100
+			}
+		}
+
+		const sub = new Sub()
+		const subInst = getComputedInstance(sub, 'getB')
+		expect(subInst.get()).toBe(3)
+		sub.a.set(2)
+		expect(subInst.get()).toBe(5)
+
+		// a plain (undecorated) override still exposes the superclass's computed
+		const plain = new PlainSub()
+		expect(getComputedInstance(plain, 'getB').get()).toBe(2)
+
+		// the returned type unwraps the method's return type
+		const n: number = getComputedInstance(new Base(), 'getB').get()
+		expect(n).toBe(2)
+	})
 })

--- a/packages/state/src/lib/__tests__/deferAsyncEffects.test.ts
+++ b/packages/state/src/lib/__tests__/deferAsyncEffects.test.ts
@@ -112,6 +112,29 @@ describe('deferAsyncEffects (AT)', () => {
 		expect(b.get()).toBe(0)
 	})
 
+	it('[AT3][T6] effects never observe partially restored values when an async transaction aborts', async () => {
+		// Regression: the rollback used to run after the async transaction had been cleared, so each
+		// restoring set flushed effects on its own and they saw one atom restored but not the other.
+		const a = atom('', 1)
+		const b = atom('', 1)
+		const seen: string[] = []
+		react('', () => {
+			seen.push(`${a.get()},${b.get()}`)
+		})
+		seen.length = 0
+
+		await expect(
+			deferAsyncEffects(async () => {
+				a.set(2)
+				b.set(2)
+				await sleep(1)
+				throw new Error('boom')
+			})
+		).rejects.toThrow('boom')
+
+		expect(seen).toEqual(['1,1'])
+	})
+
 	it('[AT3][AT4] rolls back everything when a nested async transaction throws', async () => {
 		const a = atom('', 0)
 		const b = atom('', 0)

--- a/packages/state/src/lib/__tests__/errors.test.ts
+++ b/packages/state/src/lib/__tests__/errors.test.ts
@@ -36,6 +36,30 @@ describe('computed signals that throw (CE)', () => {
 		expect(b.get()).toBe(3)
 	})
 
+	it('[CE1] cache a throw from the very first computation too', () => {
+		let numComputations = 0
+		const a = atom('', 1)
+		const b = computed('', () => {
+			numComputations++
+			if (a.get() === 1) throw new Error('test')
+			return a.get()
+		})
+
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(numComputations).toBe(1)
+
+		// an unrelated change doesn't re-run it either
+		atom('', 0).set(1)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(numComputations).toBe(1)
+
+		a.set(2)
+		expect(b.get()).toBe(2)
+		expect(numComputations).toBe(2)
+	})
+
 	it('[CE2] entering the error state notifies effects, but consecutive errors do not', () => {
 		const a = atom('', 1)
 		let numComputations = 0

--- a/packages/state/src/lib/__tests__/fuzz.tlstate.test.ts
+++ b/packages/state/src/lib/__tests__/fuzz.tlstate.test.ts
@@ -79,7 +79,19 @@ interface FuzzSystemState {
 	derivations: Record<string, { derivation: Computed<Letter>; sneakyGet: () => Letter }>
 	derivationsInDerivations: Record<string, Computed<Computed<Letter>>>
 	atomsInDerivations: Record<string, Computed<Atom<Letter>>>
-	reactors: Record<string, { reactor: Reactor; result: string | null; dependencies: Signal<any>[] }>
+	reactors: Record<
+		string,
+		{
+			reactor: Reactor
+			result: string | null
+			dependencies: Signal<any>[]
+			// runs its body inside a transaction that first writes a fixed letter to an atom, so
+			// that reads inside transactions inside the reaction phase get exercised
+			transacting: boolean
+			// schedules through a queue drained by the `flush_deferred` op (like state-react does)
+			deferred: boolean
+		}
+	>
 }
 
 type Op =
@@ -91,6 +103,8 @@ type Op =
 	| { type: 'run_several_ops_in_transaction'; ops: Op[] }
 	| { type: 'start_reactor'; id: string }
 	| { type: 'stop_reactor'; id: string }
+	| { type: 'deref_derivation_in_transaction'; id: string; atomId: string; value: Letter }
+	| { type: 'flush_deferred' }
 
 const MAX_ATOMS = 10
 const MAX_ATOMS_IN_ATOMS = 10
@@ -103,6 +117,7 @@ const MAX_OPS_IN_TRANSACTION = 10
 
 class Test {
 	source: RandomSource
+	deferredExecutes: Array<() => void> = []
 	systemState: FuzzSystemState = {
 		atoms: {},
 		atomsInAtoms: {},
@@ -132,10 +147,13 @@ class Test {
 			expected: {},
 			actual: {},
 		}
-		for (const [reactorId, { reactor, result: actualResult, dependencies }] of Object.entries(
-			this.systemState.reactors
-		)) {
+		for (const [
+			reactorId,
+			{ reactor, result: actualResult, dependencies, deferred },
+		] of Object.entries(this.systemState.reactors)) {
 			if (!reactor.scheduler.isActivelyListening) continue
+			// a deferred reactor's result lags until its queued execute runs
+			if (deferred && this.deferredExecutes.length > 0) continue
 			result.expected[reactorId] = dependencies.map(this.unpack_sneaky).join(':')
 			result.actual[reactorId] = actualResult
 		}
@@ -202,6 +220,10 @@ class Test {
 			)
 		})
 
+		// atoms not yet claimed by a transacting reactor; two reactors writing different letters to
+		// the same atom would keep re-triggering each other
+		const writableAtoms = Object.values(this.systemState.atoms)
+
 		times(this.source.nextIntInRange(1, MAX_REACTORS), () => {
 			const reactorId = this.source.nextId()
 			const dependencies: Signal<any>[] = []
@@ -235,12 +257,39 @@ class Test {
 				dependencies.push(this.source.selectOne(Object.values(this.systemState.atoms)))
 			})
 
+			const transacting = writableAtoms.length > 0 && this.source.choice(0.3)
+			const deferred = !transacting && this.source.choice(0.3)
+			// A transacting reactor writes one fixed letter to its own atom before reading its
+			// dependencies, inside a transaction. Writing the same letter every run means it cannot
+			// keep re-triggering itself, and the oracle (which reads the atoms' current values)
+			// stays valid once the reaction phase has settled.
+			const writeAtom = transacting
+				? writableAtoms.splice(this.source.nextInt(writableAtoms.length), 1)[0]
+				: null
+			const writeLetter = this.source.selectOne(LETTERS)
+			const body = () => {
+				this.systemState.reactors[reactorId].result = dependencies.map(unpack).join(':')
+			}
+			const fn = writeAtom
+				? () => {
+						transact(() => {
+							writeAtom.set(writeLetter)
+							body()
+						})
+					}
+				: body
 			this.systemState.reactors[reactorId] = {
-				reactor: reactor(reactorId, () => {
-					this.systemState.reactors[reactorId].result = dependencies.map(unpack).join(':')
-				}),
+				reactor: reactor(
+					reactorId,
+					fn,
+					deferred
+						? { scheduleEffect: (execute) => this.deferredExecutes.push(execute) }
+						: undefined
+				),
 				result: '',
 				dependencies,
+				transacting,
+				deferred,
 			}
 		})
 	}
@@ -299,6 +348,17 @@ class Test {
 					id: this.source.selectOne(Object.keys(this.systemState.reactors)),
 				}
 			},
+			'deref derivation in transaction': () => {
+				return {
+					type: 'deref_derivation_in_transaction',
+					id: this.source.selectOne(Object.keys(this.systemState.derivations)),
+					atomId: this.source.selectOne(Object.keys(this.systemState.atoms)),
+					value: this.source.selectOne(LETTERS),
+				}
+			},
+			flush_deferred: () => {
+				return { type: 'flush_deferred' }
+			},
 		})
 	}
 
@@ -313,7 +373,14 @@ class Test {
 				break
 			}
 			case 'deref_derivation': {
-				this.systemState.derivations[op.id].derivation.get()
+				const { derivation, sneakyGet } = this.systemState.derivations[op.id]
+				const actual = derivation.get()
+				const expected = sneakyGet()
+				if (actual !== expected) {
+					throw new Error(
+						`derivation ${op.id} returned ${String(actual)}, expected ${String(expected)}`
+					)
+				}
 				break
 			}
 			case 'deref_derivation_in_derivation': {
@@ -336,6 +403,28 @@ class Test {
 			}
 			case 'stop_reactor': {
 				this.systemState.reactors[op.id].reactor.stop()
+				break
+			}
+			case 'deref_derivation_in_transaction': {
+				// T2: a read inside a transaction must see the in-transaction value, whether or not
+				// the derivation is actively listening
+				const { derivation, sneakyGet } = this.systemState.derivations[op.id]
+				transact(() => {
+					this.systemState.atoms[op.atomId].set(op.value)
+					const actual = derivation.get()
+					const expected = sneakyGet()
+					if (actual !== expected) {
+						throw new Error(
+							`derivation ${op.id} read inside a transaction returned ${String(actual)}, expected ${String(expected)}`
+						)
+					}
+				})
+				break
+			}
+			case 'flush_deferred': {
+				const executes = this.deferredExecutes
+				this.deferredExecutes = []
+				for (const execute of executes) execute()
 				break
 			}
 			default: {

--- a/packages/state/src/lib/__tests__/helpers.test.ts
+++ b/packages/state/src/lib/__tests__/helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ArraySet } from '../ArraySet'
 import { atom } from '../Atom'
 import { reactor } from '../EffectScheduler'
-import { attach, detach, equals, hasReactors, haveParentsChanged, singleton } from '../helpers'
+import { attach, detach, equals, haveParentsChanged, singleton } from '../helpers'
 import { Child } from '../types'
 
 // Unit tests for the internal helpers behind SPEC.md rules EQ1/EQ2 (equals),
@@ -132,25 +132,21 @@ describe('helpers', () => {
 		})
 	})
 
-	describe('hasReactors', () => {
-		it('returns false when signal has no actively listening children', () => {
-			const signal = atom('test', 1)
-			expect(hasReactors(signal)).toBe(false)
-		})
-
-		it('integrates correctly with real reactive signals', () => {
+	// CAP7: a signal's children set is non-empty exactly while something downstream is listening
+	describe('children', () => {
+		it('is empty unless something is actively listening', () => {
 			const baseAtom = atom('base', 1)
-			expect(hasReactors(baseAtom)).toBe(false)
+			expect(baseAtom.children.isEmpty).toBe(true)
 
 			const reactorInstance = reactor('test-reactor', () => {
 				baseAtom.get()
 			})
 
 			reactorInstance.start()
-			expect(hasReactors(baseAtom)).toBe(true)
+			expect(baseAtom.children.isEmpty).toBe(false)
 
 			reactorInstance.stop()
-			expect(hasReactors(baseAtom)).toBe(false)
+			expect(baseAtom.children.isEmpty).toBe(true)
 		})
 	})
 })

--- a/packages/state/src/lib/__tests__/history.test.ts
+++ b/packages/state/src/lib/__tests__/history.test.ts
@@ -1,8 +1,9 @@
+import { exhaustiveSwitchError } from '@tldraw/utils'
 import { vi } from 'vitest'
 import { atom } from '../Atom'
 import { Computed, UNINITIALIZED, computed, isUninitialized, withDiff } from '../Computed'
 import { react } from '../EffectScheduler'
-import { EMPTY_ARRAY, assertNever } from '../helpers'
+import { EMPTY_ARRAY } from '../helpers'
 import { getGlobalEpoch, transact, transaction } from '../transactions'
 import { RESET_VALUE, Signal } from '../types'
 
@@ -76,6 +77,35 @@ describe('atom history (H)', () => {
 		a.set(5)
 
 		expect(calls).toEqual([[1, 5, epochBeforeSet, getGlobalEpoch()]])
+	})
+
+	it('[H2][C2] a computed read inside computeDiff still sees the change afterwards', () => {
+		// computeDiff runs before the epoch ticks, so a dependent computed it reads is not stamped as
+		// checked at the epoch of the write that is still in progress.
+		const a = atom('', 1, {
+			historyLength: 10,
+			computeDiff: (prev, next) => {
+				c.get()
+				return next - prev
+			},
+		})
+		const c: Computed<number> = computed('', () => a.get() * 2)
+		const seen: number[] = []
+		react('', () => seen.push(c.get()))
+
+		a.set(2)
+
+		expect(c.get()).toBe(4)
+		expect(seen).toEqual([2, 4])
+		expect(a.getDiffSince(a.lastChangedEpoch - 1)).toEqual([1])
+	})
+
+	it('[H2] records an explicit null diff rather than treating it as missing', () => {
+		const a = atom<number, null | number>('', 1, { historyLength: 3 })
+		const startEpoch = a.lastChangedEpoch
+		a.set(2, 1)
+		a.set(3, null)
+		expect(a.getDiffSince(startEpoch)).toEqual([1, null])
 	})
 
 	it('[H4] clears the history buffer if no diff can be determined', () => {
@@ -383,7 +413,7 @@ function getIncrementalRecordMapper<In, Out>(
 					}
 					break
 				default:
-					assertNever(change)
+					exhaustiveSwitchError(change)
 			}
 		}
 

--- a/packages/state/src/lib/__tests__/propagation.test.ts
+++ b/packages/state/src/lib/__tests__/propagation.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import { atom } from '../Atom'
 import { computed } from '../Computed'
-import { react, reactor } from '../EffectScheduler'
+import { EffectScheduler, react, reactor } from '../EffectScheduler'
 import { transact, transaction } from '../transactions'
 
 // Tests for SPEC.md §10 (change propagation and the reaction phase).
@@ -275,5 +275,108 @@ describe('transactions during the reaction phase (P6)', () => {
 
 		expect(a.__unsafe__getWithoutCapture()).toBe(3)
 		expect(cChanged).toHaveBeenCalledTimes(2)
+	})
+
+	it('[P6][T2][P7] an actively-listening computed read inside a transaction during a reaction sees in-transaction values', () => {
+		// Regression: Computed's cache shortcut for actively-listening computeds ("not traversed this
+		// reaction, so unchanged") ignored that in-transaction changes are only traversed at commit,
+		// and served the pre-transaction value.
+		const a = atom('', 0)
+		const c = computed('', () => a.get() * 2)
+		react('listener', () => {
+			c.get()
+		})
+
+		const trigger = atom('', 0)
+		const seen: number[] = []
+		react('', () => {
+			if (trigger.get() === 0) return
+			transact(() => {
+				a.set(5)
+				seen.push(c.get())
+			})
+		})
+		trigger.set(1)
+
+		expect(seen).toEqual([10])
+		expect(c.get()).toBe(10)
+	})
+
+	it('[P6][T2] an incremental computed read inside a transaction during a reaction is not corrupted', () => {
+		// The stale read above also stamped the computed as checked at the current epoch, so an
+		// incremental computed would later ask for diffs since an epoch that skipped the change.
+		const log = atom<number[], number[]>('log', [], {
+			historyLength: 10,
+			computeDiff: (prev, next) => next.slice(prev.length),
+		})
+		const sum = computed<number>('sum', (prev, lastComputedEpoch) => {
+			if (typeof prev !== 'number') return log.get().reduce((a, b) => a + b, 0)
+			const diffs = log.getDiffSince(lastComputedEpoch)
+			if (typeof diffs === 'symbol') return log.get().reduce((a, b) => a + b, 0)
+			let s = prev
+			for (const diff of diffs) for (const n of diff) s += n
+			return s
+		})
+		react('listener', () => {
+			sum.get()
+		})
+
+		const trigger = atom('', 0)
+		const seen: number[] = []
+		let done = false
+		react('', () => {
+			if (trigger.get() === 0 || done) return
+			done = true
+			transact(() => {
+				log.update((l) => [...l, 10])
+				seen.push(sum.get())
+			})
+		})
+		trigger.set(1)
+		expect(seen).toEqual([10])
+
+		log.update((l) => [...l, 5])
+		expect(sum.get()).toBe(15)
+	})
+})
+
+describe('actively-listening computeds stay fresh (C2)', () => {
+	it('[C2][E6] a computed traversed for a deferred effect but not re-checked is not served stale', () => {
+		// Regression: with deferred scheduling (as in state-react), haveParentsChanged returns at the
+		// first changed parent, so a later computed parent is traversed but never re-checked; a read
+		// during a subsequent reaction then took the "not traversed this reaction" shortcut.
+		const a = atom('', 0)
+		const b = atom('', 0)
+		const c = computed('', () => a.get())
+		const deferred: (() => void)[] = []
+		const scheduler = new EffectScheduler(
+			'',
+			() => {
+				b.get()
+				c.get()
+			},
+			{ scheduleEffect: (execute) => deferred.push(execute) }
+		)
+		scheduler.attach()
+		scheduler.execute()
+
+		// b is checked first, changed, so c is traversed but not re-checked; the run is deferred
+		transact(() => {
+			b.set(1)
+			a.set(1)
+		})
+
+		const z = atom('', 0)
+		const seen: number[] = []
+		react('', () => {
+			if (z.get() > 0) seen.push(c.get())
+		})
+		z.set(1)
+
+		expect(seen).toEqual([1])
+		expect(c.get()).toBe(1)
+
+		deferred.forEach((execute) => execute())
+		expect(c.get()).toBe(1)
 	})
 })

--- a/packages/state/src/lib/__tests__/transactions.test.ts
+++ b/packages/state/src/lib/__tests__/transactions.test.ts
@@ -183,6 +183,29 @@ describe('transactions (T)', () => {
 		expect(a.get()).toBe('a')
 	})
 
+	it('[T7] an outer rollback undoes an inner transaction committed during the reaction phase', () => {
+		// Regression: committing a nested transaction inside an effect used to skip folding its
+		// initial values into the parent, so the outer rollback could not restore them.
+		const trigger = atom('', 0)
+		const a = atom('', 'a')
+		const b = atom('', 'b')
+
+		react('', () => {
+			if (trigger.get() === 0) return
+			transaction((rollback) => {
+				b.set('B')
+				transaction(() => {
+					a.set('A')
+				})
+				rollback()
+			})
+		})
+		trigger.set(1)
+
+		expect(a.get()).toBe('a')
+		expect(b.get()).toBe('b')
+	})
+
 	it('[T4] rollback restores computed signals too', () => {
 		const firstName = atom('', 'John')
 		const lastName = atom('', 'Doe')

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -24,10 +24,10 @@ const inst = singleton('capture', () => ({ stack: null as null | CaptureStackFra
  * @example
  * ```ts
  * const name = atom('name', 'Sam')
- * const time = atom('time', () => new Date().getTime())
+ * const time = atom('time', Date.now())
  *
  * setInterval(() => {
- *   time.set(new Date().getTime())
+ *   time.set(Date.now())
  * })
  *
  * react('log name changes', () => {
@@ -149,13 +149,9 @@ export function stopCapturingParents() {
  */
 export function maybeCaptureParent(p: Signal<any, any>) {
 	if (inst.stack) {
-		// if the child didn't deref this parent last time it executed, then idx will be -1
-		// if the child did deref this parent last time but in a different order relative to other parents, then idx will be greater than stack.offset
-		// if the child did deref this parent last time in the same order, then idx will be the same as stack.offset
-		// if the child did deref this parent already during this capture session then 0 <= idx < stack.offset
-
-		// `add` returns false when the parent was already captured. In array mode both `has` and
-		// `add` scan with indexOf, so going straight to `add` halves the scans per captured parent.
+		// `add` returns false when the parent was already captured this run. In array mode both
+		// `has` and `add` scan with indexOf, so going straight to `add` halves the scans per
+		// captured parent.
 		if (!inst.stack.child.parentSet.add(p)) {
 			return
 		}
@@ -164,6 +160,9 @@ export function maybeCaptureParent(p: Signal<any, any>) {
 			attach(p, inst.stack.child)
 		}
 
+		// Parents are recorded in deref order. If the slot at this offset held a different parent
+		// last run, that parent may have moved later in the order or been dropped; only
+		// stopCapturingParents can tell, so remember it for then.
 		if (inst.stack.offset < inst.stack.child.parents.length) {
 			const maybeRemovedParent = inst.stack.child.parents[inst.stack.offset]
 			if (maybeRemovedParent !== p) {
@@ -183,7 +182,8 @@ export function maybeCaptureParent(p: Signal<any, any>) {
 
 /**
  * A debugging tool that tells you why a computed signal or effect is running.
- * Call in the body of a computed signal or effect function.
+ * Call in the body of a computed signal or effect function. Nothing is logged for the run that
+ * calls it; from the next run on, each run logs the ancestors that changed.
  *
  * @example
  * ```ts
@@ -195,8 +195,8 @@ export function maybeCaptureParent(p: Signal<any, any>) {
  *
  * name.set('Alice')
  *
- * // 'greeting' is running because:
- * //     'name' changed => 'Alice'
+ * // Effect(greeting) is executing because:
+ * //  ↳ Atom(name) changed
  * ```
  *
  * @public

--- a/packages/state/src/lib/constants.ts
+++ b/packages/state/src/lib/constants.ts
@@ -1,26 +1,7 @@
 /**
- * The initial epoch value used to mark derivations (computed signals and effects) as dirty before their first computation.
+ * Sentinel below any real epoch. Derived signals and effects start with their epochs set to this
+ * so they are dirty until their first run; real epochs start at `GLOBAL_START_EPOCH + 1`.
  *
- * This constant ensures that all computed signals and effects start in a "dirty" state, guaranteeing they will
- * be computed/executed at least once when first accessed or started. The value -1 is used because:
- * - Global epoch starts at 0 (GLOBAL_START_EPOCH + 1)
- * - Any derived signal initialized with GLOBAL_START_EPOCH (-1) will be considered dirty when compared to any positive epoch
- * - This forces initial computation/execution without requiring special initialization logic
- *
- * Used by:
- * - Computed signals to track when they were last changed
- * - Effect schedulers to track when they were last executed
- * - Transaction system for initial global and reaction epoch values
- *
- * @example
- * ```ts
- * // In Computed class constructor
- * lastChangedEpoch = GLOBAL_START_EPOCH // -1, marking as dirty
- *
- * // When global epoch is 5, this computed will be dirty since -1 < 5
- * const needsComputation = this.lastChangedEpoch < globalEpoch
- * ```
- *
- * @public
+ * @internal
  */
 export const GLOBAL_START_EPOCH = -1

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -1,42 +1,23 @@
 import { Child, Signal } from './types'
 
-/**
- * Get whether the given value is a child.
- *
- * @param x The value to check.
- * @returns True if the value is a child, false otherwise.
- * @internal
- */
 function isChild(x: any): x is Child {
 	return x && typeof x === 'object' && 'parents' in x
 }
 
 /**
- * Checks if any of a child's parent signals have changed by comparing their current epochs
- * with the child's cached view of those epochs.
+ * Whether any of the child's parents changed since the child last recorded their epochs. O(parents);
+ * returns at the first changed parent, so parents after it are not brought up to date.
  *
- * This function is used internally to determine if a computed signal or effect needs to
- * be re-evaluated because one of its dependencies has changed.
- *
- * @param child - The child (computed signal or effect) to check for parent changes
- * @returns `true` if any parent signal has changed since the child last observed it, `false` otherwise
- * @example
- * ```ts
- * const childSignal = computed('child', () => parentAtom.get())
- * // Check if the child needs to recompute
- * if (haveParentsChanged(childSignal)) {
- *   // Recompute the child's value
- * }
- * ```
  * @internal
  */
 export function haveParentsChanged(child: Child): boolean {
 	for (let i = 0, n = child.parents.length; i < n; i++) {
-		// Get the parent's value without capturing it.
-		child.parents[i].__unsafe__getWithoutCapture(true)
+		const parent = child.parents[i]
+		// Bring the parent up to date first: a computed parent's `lastChangedEpoch` only moves when
+		// it is re-derived.
+		parent.__unsafe__getWithoutCapture(true)
 
-		// If the parent's epoch does not match the child's view of the parent's epoch, then the parent has changed.
-		if (child.parents[i].lastChangedEpoch !== child.parentEpochs[i]) {
+		if (parent.lastChangedEpoch !== child.parentEpochs[i]) {
 			return true
 		}
 	}
@@ -45,32 +26,17 @@ export function haveParentsChanged(child: Child): boolean {
 }
 
 /**
- * Detaches a child signal from its parent signal, removing the parent-child relationship
- * in the reactive dependency graph. If the parent has no remaining children and is itself
- * a child, it will recursively detach from its own parents.
+ * Removes `child` from `parent.children`. A computed parent that loses its last child stops
+ * listening itself, recursively, so a signal's `children` set is empty whenever nothing downstream
+ * is actively listening.
  *
- * This function is used internally to clean up the dependency graph when signals are no
- * longer needed or when dependencies change.
- *
- * @param parent - The parent signal to detach from
- * @param child - The child signal to detach
- * @example
- * ```ts
- * // When a computed signal's dependencies change
- * const oldParent = atom('old', 1)
- * const child = computed('child', () => oldParent.get())
- * // Later, detach the child from the old parent
- * detach(oldParent, child)
- * ```
  * @internal
  */
 export function detach(parent: Signal<any>, child: Child) {
-	// If the child is not attached to the parent, do nothing.
 	if (!parent.children.remove(child)) {
 		return
 	}
 
-	// If the parent has no more children, then detach the parent from its parents.
 	if (parent.children.isEmpty && isChild(parent)) {
 		for (let i = 0, n = parent.parents.length; i < n; i++) {
 			detach(parent.parents[i], parent)
@@ -79,32 +45,21 @@ export function detach(parent: Signal<any>, child: Child) {
 }
 
 /**
- * Attaches a child signal to its parent signal, establishing a parent-child relationship
- * in the reactive dependency graph. If the parent is itself a child, it will recursively
- * attach to its own parents to maintain the dependency chain.
+ * Adds `child` to `parent.children`. A computed parent that gains its first child starts
+ * listening itself, recursively, so that changes to any ancestor are traversed down to the child.
  *
- * This function is used internally when dependencies are captured during computed signal
- * evaluation or effect execution.
+ * `parent` must be up to date when it is attached: `Computed` assumes an actively-listening
+ * computed has been traversed for every ancestor change since it was last checked, which only
+ * holds from the moment it started listening. Capture attaches a parent right after reading it;
+ * `EffectScheduler.attach` refreshes its parents first.
  *
- * @param parent - The parent signal to attach to
- * @param child - The child signal to attach
- * @example
- * ```ts
- * // When a computed signal captures a new dependency
- * const parentAtom = atom('parent', 1)
- * const child = computed('child', () => parentAtom.get())
- * // Internally, attach is called to establish the dependency
- * attach(parentAtom, child)
- * ```
  * @internal
  */
 export function attach(parent: Signal<any>, child: Child) {
-	// If the child is already attached to the parent, do nothing.
 	if (!parent.children.add(child)) {
 		return
 	}
 
-	// If the parent itself is a child, add the parent to the parent's parents.
 	if (isChild(parent)) {
 		for (let i = 0, n = parent.parents.length; i < n; i++) {
 			attach(parent.parents[i], parent)
@@ -113,25 +68,10 @@ export function attach(parent: Signal<any>, child: Child) {
 }
 
 /**
- * Checks if two values are equal using the equality semantics of @tldraw/state.
+ * The default equality used for change detection: `===`, then `Object.is` (so `NaN` equals
+ * `NaN`; `0` and `-0` are already equal by `===`), then the old value's own `.equals(b)` method
+ * if it has one. Only the old value's `equals` is consulted.
  *
- * This function performs equality checks in the following order:
- * 1. Reference equality (`===`)
- * 2. `Object.is()` equality (handles NaN and -0/+0 cases)
- * 3. Custom `.equals()` method when the left-hand value provides one
- *
- * This is used internally to determine if a signal's value has actually changed
- * when setting new values, preventing unnecessary updates and re-computations.
- *
- * @param a - The first value to compare
- * @param b - The second value to compare
- * @returns `true` if the values are considered equal, `false` otherwise
- * @example
- * ```ts
- * equals(1, 1) // true
- * equals(NaN, NaN) // true (unlike === which returns false)
- * equals({ equals: (other: any) => other.id === 1 }, { id: 1 }) // Uses custom equals method
- * ```
  * @internal
  */
 export function equals(a: any, b: any): boolean {
@@ -139,32 +79,6 @@ export function equals(a: any, b: any): boolean {
 		a === b || Object.is(a, b) || Boolean(a && b && typeof a.equals === 'function' && a.equals(b))
 	return shallowEquals
 }
-
-/**
- * A TypeScript utility function for exhaustiveness checking in switch statements and
- * conditional branches. This function should never be called at runtime—it exists
- * purely for compile-time type checking and is `undefined` in emitted JavaScript.
- *
- * @param x - A value that should be of type `never`
- * @throws Always at runtime because the identifier is undefined
- * @example
- * ```ts
- * type Color = 'red' | 'blue'
- *
- * function handleColor(color: Color) {
- *   switch (color) {
- *     case 'red':
- *       return 'Stop'
- *     case 'blue':
- *       return 'Go'
- *     default:
- *       return assertNever(color) // TypeScript error if not all cases handled
- *   }
- * }
- * ```
- * @public
- */
-export declare function assertNever(x: never): never
 
 /**
  * Creates or retrieves a singleton instance using a global symbol registry.
@@ -199,37 +113,3 @@ export function singleton<T>(key: string, init: () => T): T {
  * @public
  */
 export const EMPTY_ARRAY: [] = singleton('empty_array', () => Object.freeze([]) as any)
-
-/**
- * Checks if a signal has any active reactors (effects or computed signals) that are
- * currently listening to it. This determines whether changes to the signal will
- * cause any side effects or recomputations to occur.
- *
- * A signal is considered to have active reactors if any of its child dependencies
- * are actively listening for changes.
- *
- * @param signal - The signal to check for active reactors
- * @returns `true` if the signal has active reactors, `false` otherwise
- * @example
- * ```ts
- * const count = atom('count', 0)
- *
- * console.log(hasReactors(count)) // false - no effects listening
- *
- * const stop = react('logger', () => console.log(count.get()))
- * console.log(hasReactors(count)) // true - effect is listening
- *
- * stop()
- * console.log(hasReactors(count)) // false - effect stopped
- * ```
- * @public
- */
-export function hasReactors(signal: Signal<any>) {
-	for (const child of signal.children) {
-		if (child.isActivelyListening) {
-			return true
-		}
-	}
-
-	return false
-}

--- a/packages/state/src/lib/localStorageAtom.ts
+++ b/packages/state/src/lib/localStorageAtom.ts
@@ -75,12 +75,18 @@ export function localStorageAtom<Value, Diff = unknown>(
 		}
 	}
 
-	window.addEventListener('storage', handleStorageEvent)
+	// The storage helpers above tolerate environments without localStorage (Node, SSR); do the
+	// same here rather than throwing on `window`.
+	const canListen = typeof window !== 'undefined'
+	if (canListen) {
+		window.addEventListener('storage', handleStorageEvent)
+	}
 
-	// Combined cleanup function
 	const cleanup = () => {
 		reactCleanup()
-		window.removeEventListener('storage', handleStorageEvent)
+		if (canListen) {
+			window.removeEventListener('storage', handleStorageEvent)
+		}
 	}
 
 	return [outAtom, cleanup]

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -82,17 +82,6 @@ export function getGlobalEpoch() {
 }
 
 /**
- * Checks whether any reactions are currently executing.
- * When true, the system is in the middle of processing effects and side effects.
- *
- * @returns True if reactions are currently running, false otherwise
- * @public
- */
-export function getIsReacting() {
-	return inst.globalIsReacting
-}
-
-/**
  * Whether a transaction (sync or async) is currently open. While one is, atom changes are
  * recorded but their children are not traversed until it commits.
  *

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -17,56 +17,45 @@ class Transaction {
 
 	initialAtomValues = new Map<_Atom, any>()
 
-	/**
-	 * Get whether this transaction is a root (no parents).
-	 *
-	 * @public
-	 */
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get isRoot() {
 		return this.parent === null
 	}
 
-	/**
-	 * Commit the transaction's changes.
-	 *
-	 * @public
-	 */
 	commit() {
-		if (inst.globalIsReacting) {
-			// if we're committing during a reaction we actually need to
-			// use the 'cleanup' reactors set to ensure we re-run effects if necessary
-			for (const atom of this.initialAtomValues.keys()) {
-				traverseAtomForCleanup(atom)
-			}
-		} else if (this.isRoot) {
-			// For root transactions, flush changed atoms
+		if (this.isRoot) {
 			flushChanges(this.initialAtomValues.keys())
-		} else {
-			// For transactions with parents, add the transaction's initial values to the parent's.
-			this.initialAtomValues.forEach((value, atom) => {
-				if (!this.parent!.initialAtomValues.has(atom)) {
-					this.parent!.initialAtomValues.set(atom, value)
-				}
-			})
+			return
 		}
+		// Fold this transaction's initial values into the parent so an outer rollback can still
+		// undo them (T7). This must come before any "are we reacting?" special case: a nested
+		// transaction committed by an effect during the reaction phase used to skip this fold and
+		// its changes survived the outer rollback.
+		const parentValues = this.parent!.initialAtomValues
+		if (parentValues.size === 0) {
+			this.parent!.initialAtomValues = this.initialAtomValues
+			return
+		}
+		this.initialAtomValues.forEach((value, atom) => {
+			if (!parentValues.has(atom)) {
+				parentValues.set(atom, value)
+			}
+		})
 	}
 
 	/**
-	 * Abort the transaction.
-	 *
-	 * @public
+	 * Restores every atom changed in this transaction to its initial value, then commits. Must be
+	 * called while this is still `inst.currentTransaction`, so that the restoring sets are
+	 * recorded against it instead of each flushing effects on their own.
 	 */
 	abort() {
 		inst.globalEpoch++
 
-		// Reset each of the transaction's atoms to its initial value.
 		this.initialAtomValues.forEach((value, atom) => {
 			atom.set(value)
 			atom.historyBuffer?.clear()
 		})
 
-		// Commit the changes.
 		this.commit()
 	}
 }
@@ -79,19 +68,7 @@ const inst = singleton('transactions', () => ({
 	currentTransaction: null as Transaction | null,
 
 	cleanupReactors: null as null | Set<Reactor>,
-	reactionEpoch: GLOBAL_START_EPOCH + 1,
 }))
-
-/**
- * Gets the current reaction epoch, which is used to track when reactions are running.
- * The reaction epoch is updated at the start of each reaction cycle.
- *
- * @returns The current reaction epoch number
- * @public
- */
-export function getReactionEpoch() {
-	return inst.reactionEpoch
-}
 
 /**
  * Gets the current global epoch, which is incremented every time any atom changes.
@@ -115,7 +92,19 @@ export function getIsReacting() {
 	return inst.globalIsReacting
 }
 
-// Reusable state for traverse to avoid closure allocation
+/**
+ * Whether a transaction (sync or async) is currently open. While one is, atom changes are
+ * recorded but their children are not traversed until it commits.
+ *
+ * @internal
+ */
+export function getIsInTransaction() {
+	return inst.currentTransaction !== null
+}
+
+// The set `traverseChild` collects reactors into. Module-level rather than a closure so that a
+// flush over thousands of atoms doesn't allocate a visitor per atom; traversal never runs user
+// code, so nothing can re-enter and swap it mid-walk.
 let traverseReactors: Set<Reactor>
 
 function traverseChild(child: Child) {
@@ -132,36 +121,32 @@ function traverseChild(child: Child) {
 	}
 }
 
-function traverse(reactors: Set<Reactor>, child: Child) {
-	traverseReactors = reactors
-	traverseChild(child)
-}
-
 /**
- * Collect all of the reactors that need to run for an atom and run them.
- *
- * @param atoms - The atoms to flush changes for.
+ * Runs the effects that depend on the given changed atoms. During the reaction phase the
+ * affected effects are instead queued for the cleanup pass, so a change made by an effect never
+ * interrupts the pass that is running (P4).
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {
-		throw new Error('flushChanges cannot be called during a reaction')
+		for (const atom of atoms) {
+			traverseAtomForCleanup(atom)
+		}
+		return
 	}
 
 	const outerTxn = inst.currentTransaction
 	try {
-		// clear the transaction stack
+		// Transactions started by effects must be roots: the committing transaction (if any) has
+		// already handed its changes to this flush.
 		inst.currentTransaction = null
 		inst.globalIsReacting = true
-		inst.reactionEpoch = inst.globalEpoch
 
-		// Collect all of the visited reactors.
 		const reactors = new Set<Reactor>()
-
+		traverseReactors = reactors
 		for (const atom of atoms) {
-			atom.children.visit((child) => traverse(reactors, child))
+			atom.children.visit(traverseChild)
 		}
 
-		// Run each reactor.
 		for (const r of reactors) {
 			r.maybeScheduleEffect()
 		}
@@ -185,45 +170,26 @@ function flushChanges(atoms: Iterable<_Atom>) {
 	}
 }
 
-/**
- * Handle a change to an atom.
- *
- * @param atom The atom that changed.
- * @param previousValue The atom's previous value.
- *
- * @internal
- */
+/** @internal */
 export function atomDidChange(atom: _Atom, previousValue: any) {
 	if (inst.currentTransaction) {
-		// If we are in a transaction, then all we have to do is preserve
-		// the value of the atom at the start of the transaction in case
-		// we need to roll back.
+		// Only the value at the start of the transaction matters, for rollback. Children are not
+		// traversed until the transaction commits, which is why `Computed` must not trust its
+		// traversal-based cache shortcut while a transaction is open.
 		if (!inst.currentTransaction.initialAtomValues.has(atom)) {
 			inst.currentTransaction.initialAtomValues.set(atom, previousValue)
 		}
-	} else if (inst.globalIsReacting) {
-		// If the atom changed during the reaction phase of flushChanges
-		// (and there are no transactions started inside the reaction phase)
-		// then we are past the point where a transaction can be aborted
-		// so we don't need to note down the previousValue.
-		traverseAtomForCleanup(atom)
 	} else {
-		// If there is no transaction, flush the changes immediately.
 		flushChanges([atom])
 	}
 }
 
 function traverseAtomForCleanup(atom: _Atom) {
-	const rs = (inst.cleanupReactors ??= new Set())
-	atom.children.visit((child) => traverse(rs, child))
+	traverseReactors = inst.cleanupReactors ??= new Set()
+	atom.children.visit(traverseChild)
 }
 
-/**
- * Advances the global epoch counter by one.
- * This is used internally to track when changes occur across the reactive system.
- *
- * @internal
- */
+/** @internal */
 export function advanceGlobalEpoch() {
 	inst.globalEpoch++
 }
@@ -251,7 +217,7 @@ export function advanceGlobalEpoch() {
  * // Logs "Hello, Jane Smith!"
  * ```
  *
- * If the function throws, the transaction is aborted and any signals that were updated during the transaction revert to their state before the transaction began.
+ * If the function throws, the transaction is aborted and any signals that were updated during the transaction revert to their state before the transaction began. An aborted transaction still flushes effects: effects whose parents went through a change-and-restore round trip are checked again and, if a parent's value differs from what they last saw (an atom they read directly always will), run once more with the restored values.
  *
  * @example
  * ```ts
@@ -269,8 +235,9 @@ export function advanceGlobalEpoch() {
  *  throw new Error('oops')
  * })
  *
- * // Does not log
  * // firstName.get() === 'John'
+ * // Logs "Hello, John Doe!" again: effects whose parents were changed and restored still run,
+ * // and observe the restored values.
  * ```
  *
  * A `rollback` callback is passed into the function.
@@ -293,9 +260,9 @@ export function advanceGlobalEpoch() {
  *  rollback()
  * })
  *
- * // Does not log
  * // firstName.get() === 'John'
  * // lastName.get() === 'Doe'
+ * // Logs "Hello, John Doe!" again, as above.
  * ```
  *
  * @param fn - The function to run in a transaction, called with a function to roll back the change.
@@ -305,7 +272,6 @@ export function advanceGlobalEpoch() {
 export function transaction<T>(fn: (rollback: () => void) => T) {
 	const txn = new Transaction(inst.currentTransaction, true)
 
-	// Set the current transaction to the transaction
 	inst.currentTransaction = txn
 
 	try {
@@ -313,10 +279,8 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 		let rollback = false
 
 		try {
-			// Run the function.
 			result = fn(() => (rollback = true))
 		} catch (e) {
-			// Abort the transaction if the function throws.
 			txn.abort()
 			throw e
 		}
@@ -326,7 +290,6 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 		}
 
 		if (rollback) {
-			// If the rollback was triggered, abort the transaction.
 			txn.abort()
 		} else {
 			txn.commit()
@@ -334,7 +297,6 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 
 		return result
 	} finally {
-		// Set the current transaction to the transaction's parent.
 		inst.currentTransaction = txn.parent
 	}
 }
@@ -420,32 +382,35 @@ export async function deferAsyncEffects<T>(fn: () => Promise<T>) {
 
 	let result = undefined as T | undefined
 
+	// `undefined` means "did not throw"; a thrown `undefined` is stored as `null` so it still counts.
 	let error = undefined as any
 	try {
-		// Run the function.
 		result = await fn()
 	} catch (e) {
-		// Abort the transaction if the function throws.
 		error = e ?? null
 	}
 
 	if (--txn.asyncProcessCount > 0) {
+		// Other processes still share this transaction; it settles when the last one finishes.
 		if (typeof error !== 'undefined') {
-			// If the rollback was triggered, abort the transaction.
 			throw error
 		} else {
 			return result
 		}
 	}
 
-	inst.currentTransaction = null
-
-	if (typeof error !== 'undefined') {
-		// If the rollback was triggered, abort the transaction.
-		txn.abort()
-		throw error
-	} else {
-		txn.commit()
-		return result
+	// Settle while this is still the current transaction (see `Transaction.abort`): clearing it
+	// first made every restoring set inside `abort()` flush effects on its own, so effects
+	// observed half-restored state.
+	try {
+		if (typeof error !== 'undefined') {
+			txn.abort()
+			throw error
+		} else {
+			txn.commit()
+			return result
+		}
+	} finally {
+		inst.currentTransaction = null
 	}
 }

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -9,12 +9,12 @@ import { ArraySet } from './ArraySet'
  *
  * @example
  * ```ts
- * import { atom, getGlobalEpoch, RESET_VALUE } from '@tldraw/state'
+ * import { atom, RESET_VALUE } from '@tldraw/state'
  *
- * const count = atom('count', 0, { historyLength: 3 })
- * const oldEpoch = getGlobalEpoch()
+ * const count = atom('count', 0, { historyLength: 3, computeDiff: (prev, next) => next - prev })
+ * const oldEpoch = count.lastChangedEpoch
  *
- * // Make many changes that exceed history length
+ * // Make more changes than the history length can hold
  * count.set(1)
  * count.set(2)
  * count.set(3)
@@ -183,8 +183,8 @@ export interface Child {
  * A function type that computes the difference between two values of a signal.
  *
  * This function is used to generate incremental diffs that can be applied to
- * reconstruct state changes over time. It's particularly useful for features
- * like undo/redo, synchronization, and change tracking.
+ * reconstruct state changes over time, so that downstream computeds and effects can
+ * update incrementally instead of recomputing from scratch.
  *
  * The function should analyze the previous and current values and return a
  * diff object that represents the change. If the diff cannot be computed
@@ -193,7 +193,7 @@ export interface Child {
  *
  * @param previousValue - The previous value of the signal
  * @param currentValue - The current value of the signal
- * @param lastComputedEpoch - The epoch when the previous value was set
+ * @param lastComputedEpoch - For an atom, the epoch when the previous value was set. For a computed, the epoch at which it was last checked (the same value its compute function receives), so that `other.getDiffSince(lastComputedEpoch)` yields exactly the changes not yet accounted for.
  * @param currentEpoch - The epoch when the current value was set
  * @returns A diff object representing the change, or the unique symbol RESET_VALUE if no diff can be computed
  *


### PR DESCRIPTION
**Risk: high · Importance: high**

This PR fixes a bug where computeds — including store indexes and other incremental computeds — returned stale values when read inside a transaction during an effect, or after a reactor restarted, and then stayed stale forever. It also fixes effects dropping dependencies when a `set` during their first run re-triggers them, nested transactions inside effects not rolling back with their parent, and a handful of smaller `@tldraw/state` bugs found in a full review of the package, and trims per-signal waste on the paths that scale with record count.

### Before

- `Computed`'s reaction-phase cache shortcut (`isActivelyListening && getIsReacting() && lastTraversedEpoch < reactionEpoch`) returned a stale value whenever a computed was read inside a transaction during an effect, when a deferred scheduler left a parent traversed-but-unchecked, or when a reactor was started inside a reaction after its ancestors had changed. Because the shortcut also stamped `lastCheckedEpoch`, an incremental computed using `getDiffSince(lastComputedEpoch)` then skipped the change for good.
- `EffectScheduler.execute()` was re-entrant: a `set` during a first run (`react()`, `reactor.start()`, `useQuickReactor`) nested a second run whose capture frame truncated the outer run's parents, so a dependency was silently dropped.
- Nested transactions committed inside an effect never folded into their parent, so an outer rollback left their changes in place. `deferAsyncEffects` abort flushed effects once per restored atom with half-restored state.
- `@computed` on a subclass override calling `super.method()` overflowed the stack; `@computed()` with zero args crashed at class definition. A computed whose first derive throws re-derived on every read instead of rethrowing the cached error.
- `Atom.set` ran `computeDiff` after advancing the epoch, so a dependent read inside it was stamped checked and never saw the change; an explicit `null` diff collapsed to `RESET_VALUE`. `HistoryBuffer.pushEntry` silently accepted `undefined`, producing incomplete diff lists.
- `localStorageAtom` threw in Node/SSR; zero-dependency effects re-ran on every `start()`.
- README/DOCS/ARCHITECTURE examples used nonexistent or unexported APIs (`useAtom` from `@tldraw/state`, `getGlobalEpoch`, `isComputed`), claimed rollback suppresses effects, and showed a wrong dependency graph.

### After

- The shortcut is `isActivelyListening && !getIsInTransaction() && lastTraversedEpoch <= lastCheckedEpoch`, and `EffectScheduler.attach()` refreshes parents before attaching so a stale computed can't become actively listening unverified. This also makes the shortcut valid outside reactions (React renders, event handlers), which is where the measured wins come from: at N=5000, a listening computed read after an unrelated change 6.4 µs → 0.2 µs; 200 listening computeds × 50 parents 31.6 µs → 2.9 µs; `reactor.stop()+start()` with 5000 parents 59 → 74 µs (the cost of the attach refresh). Re-derive, effect re-run, and propagation paths are unchanged.
- Re-entrant effect runs are deferred and settled after the run. Nested commits fold into the parent (adopting the child map when the parent's is empty); the abort path flushes once.
- The decorator, first-derive error, `Atom.set` diff ordering, `null` diff, `pushEntry`, `localStorageAtom`, and zero-dependency effect cases behave as described in the updated SPEC.
- `flushChanges` no longer allocates a closure per changed atom; `ArraySet` allocates its backing array lazily and clears in place (~100 B less per signal).
- Docs and SPEC rules match the code. Dead code removed: `assertNever`, `hasReactors`, `isComputedMethodKey`, `reactionEpoch`/`getReactionEpoch`, `getIsReacting`.

Not changed, for discussion: `react()` whose first run throws never returns its stop function; an effect throwing mid-flush starves later reactors in that pass; `transact` only forwards `rollback` at top level. These are pre-existing semantic choices. `isComputed` and `getGlobalEpoch` are tagged `@public` but not exported; docs now avoid them rather than widening the API.

Overlaps with #10073 (simplify pass over state), which touches the same files; whichever lands second rebases.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests (17) fail on `main` and pass with this change

### Release notes

- Fix computeds returning stale values when read inside a transaction during an effect or after a reactor restarts
- Fix effects losing dependencies when a set during their first run re-triggers them
- Fix nested transactions inside effects not rolling back with their parent
- Fix `@computed` on subclass overrides that call `super`, and `@computed()` with no arguments
- Fix `localStorageAtom` throwing outside the browser
- Reduce per-signal memory and speed up reads of listening computeds after unrelated changes

### API changes

- Changed `getComputedInstance()` to return `Computed<Value>` for a decorated method `() => Value` instead of `Computed<() => Value>`

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +332 / -683 |
| Tests           | +488 / -25  |
| Automated files | +1 / -1     |
| Documentation   | +173 / -155 |
