### PR TITLE
fix(state): don't serve stale values from actively-listening computeds

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -54,7 +54,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 6. Computed signals (C)
 
 - **C1** Computeds are lazy. The compute function does not run at creation time; it first runs on the first `get()`.
-- **C2** Computeds are cached. Repeated `get()` calls re-run the compute function only if at least one parent's `lastChangedEpoch` differs from the epoch recorded when that parent was last dereferenced. Epoch advances unrelated to the computed's parents never cause recomputation.
+- **C2** Computeds are cached. Repeated `get()` calls re-run the compute function only if at least one parent's `lastChangedEpoch` differs from the epoch recorded when that parent was last dereferenced. Epoch advances unrelated to the computed's parents never cause recomputation. A read is never stale: this holds for reads inside a transaction during the reaction phase, for a computed whose listening effect was scheduled but has not executed yet, and for a computed that regains a listener after its ancestors changed.
 - **C3** A computed whose first execution captured no parents never recomputes.
 - **C4** The compute function receives `(previousValue, lastComputedEpoch)`. On the first computation `previousValue` is the `UNINITIALIZED` symbol (test with `isUninitialized`); afterwards it is the previous value. `lastComputedEpoch` is the epoch at which the computed last finished computing.
 - **C5** If recomputation produces a value equal (EQ) to the previous one, the computed keeps the previous value object and its `lastChangedEpoch`; downstream children observe no change. The signal's `isEqual` is never invoked for the first computation.
@@ -91,13 +91,13 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 9. Effects: EffectScheduler, react, reactor (E)
 
 - **E1** `react(name, fn)` runs `fn` immediately and unconditionally, then re-runs it whenever any signal captured during its previous run changes. It returns a stop function; after stopping, changes no longer re-run `fn`.
-- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated.
+- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated, and `.start()` behaves the same when called from inside an effect during the reaction phase.
 - **E3** One state change produces at most one run of a given effect, even if the change affected several of its parents (e.g. several atoms set in one transaction, or a diamond dependency graph).
 - **E4** An effect re-runs only when a parent's value actually changed (per EQ and C5). Equal-value sets and unrelated epoch advances do not re-run it.
 - **E5** The effect function receives the epoch at which the effect last ran. This enables the incremental pattern `signal.getDiffSince(lastReactedEpoch)` inside effects. The epoch passed is the one captured _before_ the run, so an effect that updates atoms during its own run remains eligible to be scheduled again.
 - **E6** With a custom `scheduleEffect` option, scheduling and execution are decoupled: when the effect would run, `scheduleEffect(execute)` is called instead and nothing executes until the callback invokes `execute`. The initial run of `react()` is also routed through `scheduleEffect`. `scheduleCount` counts scheduling events, whether or not the effect later executes.
 - **E7** If an effect is detached after being scheduled but before the deferred `execute` callback runs, executing the callback is a no-op.
-- **E8** `EffectScheduler.attach()` does not by itself run the effect (`execute()` must be called the first time; afterwards changes schedule it per E3/E4). `detach()`/`attach()` cycles retain the captured parents: re-attaching does not re-run the effect unless a parent changed while detached (matching E2 since `reactor` is a thin wrapper).
+- **E8** `EffectScheduler.attach()` does not by itself run the effect (`execute()` must be called the first time; afterwards changes schedule it per E3/E4). `detach()`/`attach()` cycles retain the captured parents: re-attaching does not re-run the effect unless a parent changed while detached (matching E2 since `reactor` is a thin wrapper). `attach()` brings computed parents that went stale while nothing was listening up to date before listening to them again.
 - **E9** `maybeScheduleEffect` on a detached scheduler is a no-op. On an attached scheduler whose parents are unchanged it is a no-op (but marks the scheduler as up to date with the current epoch).
 
 ## 10. Change propagation and the reaction phase (P)
@@ -108,7 +108,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **P4** Effects may set atoms. Changes made during the reaction phase do not interrupt the current pass: affected effects are collected and run after the current pass completes, repeatedly, until the system quiesces.
 - **P5** If that loop fails to quiesce after 1000 passes, the flush throws `Reaction update depth limit exceeded`. An effect that unconditionally writes to one of its own parents hits this limit.
 - **P6** An effect that sets atoms inside a transaction (or `transact`/`transaction` call) during the reaction phase gets the same deferral: the inner transaction's effects are folded into the current reaction phase rather than flushed reentrantly.
-- **P7** Computeds read during the reaction phase are correct: an effect that sets an atom and then reads a computed depending on it sees the updated value (within the same pass).
+- **P7** Computeds read during the reaction phase are correct: an effect that sets an atom and then reads a computed depending on it sees the updated value (within the same pass), including when both happen inside a transaction the effect opened (T2).
 
 ## 11. Transactions (T)
 

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -5,7 +5,7 @@ import { maybeCaptureParent, startCapturingParents, stopCapturingParents } from 
 import { GLOBAL_START_EPOCH } from './constants'
 import { EMPTY_ARRAY, equals, haveParentsChanged, singleton } from './helpers'
 import { HistoryBuffer } from './HistoryBuffer'
-import { getGlobalEpoch, getIsReacting, getReactionEpoch } from './transactions'
+import { getGlobalEpoch, getIsInTransaction } from './transactions'
 import { Child, ComputeDiff, RESET_VALUE, Signal } from './types'
 import { logComputedGetterWarning } from './warnings'
 
@@ -216,9 +216,7 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 	__debug_ancestor_epochs__: Map<Signal<any, any>, number> | null = null
 
-	/**
-	 * The epoch when the reactor was last checked.
-	 */
+	// Advances on every check, including ones that find no change, unlike `lastChangedEpoch`.
 	private lastCheckedEpoch = GLOBAL_START_EPOCH
 
 	parentSet = new ArraySet<Signal<any, any>>()
@@ -272,9 +270,13 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 		if (
 			!isNew &&
 			(this.lastCheckedEpoch === globalEpoch ||
+				// Every ancestor change to an actively-listening computed traverses it (`flushChanges`),
+				// so if it hasn't been traversed since it was last checked the O(parents) scan can be
+				// skipped. Not valid while a transaction is open (changes traverse at commit), and only
+				// if it was up to date when attached (see `attach` in helpers.ts).
 				(this.isActivelyListening &&
-					getIsReacting() &&
-					this.lastTraversedEpoch < getReactionEpoch()) ||
+					!getIsInTransaction() &&
+					this.lastTraversedEpoch <= this.lastCheckedEpoch) ||
 				!haveParentsChanged(this))
 		) {
 			this.lastCheckedEpoch = globalEpoch

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -216,7 +216,10 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 	__debug_ancestor_epochs__: Map<Signal<any, any>, number> | null = null
 
-	// Advances on every check, including ones that find no change, unlike `lastChangedEpoch`.
+	/**
+	 * The epoch when the reactor was last checked. Advances on every check, including ones that
+	 * find no change, unlike `lastChangedEpoch`.
+	 */
 	private lastCheckedEpoch = GLOBAL_START_EPOCH
 
 	parentSet = new ArraySet<Signal<any, any>>()

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -133,7 +133,10 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	attach() {
 		this._isActivelyListening = true
 		for (let i = 0, n = this.parents.length; i < n; i++) {
-			attach(this.parents[i], this)
+			const parent = this.parents[i]
+			// a computed parent may have gone stale while nothing listened; see `attach` in helpers.ts
+			parent.__unsafe__getWithoutCapture(true)
+			attach(parent, this)
 		}
 	}
 

--- a/packages/state/src/lib/__tests__/EffectScheduler.test.ts
+++ b/packages/state/src/lib/__tests__/EffectScheduler.test.ts
@@ -233,6 +233,32 @@ describe('reactor (E)', () => {
 		r.scheduler.maybeScheduleEffect()
 		expect(rfn).toHaveBeenCalledTimes(1)
 	})
+
+	it('[E2] start() inside a reaction phase runs the effect if a parent changed while stopped', () => {
+		// Regression: re-attaching during a reaction used to make a stale computed parent "actively
+		// listening" without refreshing it, and Computed's cache then served the stale value, so the
+		// restarted reactor never ran and the computed stayed wrong until its ancestor changed again.
+		const a = atom('a', 1)
+		const c = computed('c', () => a.get() * 2)
+		const seen: number[] = []
+		const r = reactor('r', () => {
+			seen.push(c.get())
+		})
+		r.start()
+		expect(seen).toEqual([2])
+		r.stop()
+
+		a.set(5) // nothing is listening to c now, so it goes stale
+
+		const trigger = atom('trigger', 0)
+		react('outer', () => {
+			if (trigger.get() === 1) r.start()
+		})
+		trigger.set(1) // r.start() runs inside this reaction phase
+
+		expect(seen).toEqual([2, 10])
+		expect(c.get()).toBe(10)
+	})
 })
 
 describe('custom scheduling (E6, E7)', () => {
@@ -399,5 +425,30 @@ describe('EffectScheduler attach/detach (E8)', () => {
 		expect(numReactions).toBe(3)
 		a.set(4)
 		expect(numReactions).toBe(4)
+	})
+
+	it('[E8] attach() brings stale computed parents up to date before listening to them', () => {
+		const a = atom('a', 1)
+		const c = computed('c', () => a.get() * 2)
+		const seen: number[] = []
+		const scheduler = new EffectScheduler('test', () => {
+			seen.push(c.get())
+		})
+		scheduler.attach()
+		scheduler.execute()
+		scheduler.detach()
+		a.set(5) // c is stale now
+
+		// the useStateTracking pattern: re-attach, then ask whether a run is needed, inside a reaction
+		const trigger = atom('trigger', 0)
+		react('outer', () => {
+			if (trigger.get() === 1) {
+				scheduler.attach()
+				scheduler.maybeScheduleEffect()
+			}
+		})
+		trigger.set(1)
+
+		expect(seen).toEqual([2, 10])
 	})
 })

--- a/packages/state/src/lib/__tests__/fuzz.tlstate.test.ts
+++ b/packages/state/src/lib/__tests__/fuzz.tlstate.test.ts
@@ -79,7 +79,19 @@ interface FuzzSystemState {
 	derivations: Record<string, { derivation: Computed<Letter>; sneakyGet: () => Letter }>
 	derivationsInDerivations: Record<string, Computed<Computed<Letter>>>
 	atomsInDerivations: Record<string, Computed<Atom<Letter>>>
-	reactors: Record<string, { reactor: Reactor; result: string | null; dependencies: Signal<any>[] }>
+	reactors: Record<
+		string,
+		{
+			reactor: Reactor
+			result: string | null
+			dependencies: Signal<any>[]
+			// runs its body inside a transaction that first writes a fixed letter to an atom, so
+			// that reads inside transactions inside the reaction phase get exercised
+			transacting: boolean
+			// schedules through a queue drained by the `flush_deferred` op (like state-react does)
+			deferred: boolean
+		}
+	>
 }
 
 type Op =
@@ -91,6 +103,8 @@ type Op =
 	| { type: 'run_several_ops_in_transaction'; ops: Op[] }
 	| { type: 'start_reactor'; id: string }
 	| { type: 'stop_reactor'; id: string }
+	| { type: 'deref_derivation_in_transaction'; id: string; atomId: string; value: Letter }
+	| { type: 'flush_deferred' }
 
 const MAX_ATOMS = 10
 const MAX_ATOMS_IN_ATOMS = 10
@@ -103,6 +117,7 @@ const MAX_OPS_IN_TRANSACTION = 10
 
 class Test {
 	source: RandomSource
+	deferredExecutes: Array<() => void> = []
 	systemState: FuzzSystemState = {
 		atoms: {},
 		atomsInAtoms: {},
@@ -132,10 +147,13 @@ class Test {
 			expected: {},
 			actual: {},
 		}
-		for (const [reactorId, { reactor, result: actualResult, dependencies }] of Object.entries(
-			this.systemState.reactors
-		)) {
+		for (const [
+			reactorId,
+			{ reactor, result: actualResult, dependencies, deferred },
+		] of Object.entries(this.systemState.reactors)) {
 			if (!reactor.scheduler.isActivelyListening) continue
+			// a deferred reactor's result lags until its queued execute runs
+			if (deferred && this.deferredExecutes.length > 0) continue
 			result.expected[reactorId] = dependencies.map(this.unpack_sneaky).join(':')
 			result.actual[reactorId] = actualResult
 		}
@@ -202,6 +220,10 @@ class Test {
 			)
 		})
 
+		// atoms not yet claimed by a transacting reactor; two reactors writing different letters to
+		// the same atom would keep re-triggering each other
+		const writableAtoms = Object.values(this.systemState.atoms)
+
 		times(this.source.nextIntInRange(1, MAX_REACTORS), () => {
 			const reactorId = this.source.nextId()
 			const dependencies: Signal<any>[] = []
@@ -235,12 +257,39 @@ class Test {
 				dependencies.push(this.source.selectOne(Object.values(this.systemState.atoms)))
 			})
 
+			const transacting = writableAtoms.length > 0 && this.source.choice(0.3)
+			const deferred = !transacting && this.source.choice(0.3)
+			// A transacting reactor writes one fixed letter to its own atom before reading its
+			// dependencies, inside a transaction. Writing the same letter every run means it cannot
+			// keep re-triggering itself, and the oracle (which reads the atoms' current values)
+			// stays valid once the reaction phase has settled.
+			const writeAtom = transacting
+				? writableAtoms.splice(this.source.nextInt(writableAtoms.length), 1)[0]
+				: null
+			const writeLetter = this.source.selectOne(LETTERS)
+			const body = () => {
+				this.systemState.reactors[reactorId].result = dependencies.map(unpack).join(':')
+			}
+			const fn = writeAtom
+				? () => {
+						transact(() => {
+							writeAtom.set(writeLetter)
+							body()
+						})
+					}
+				: body
 			this.systemState.reactors[reactorId] = {
-				reactor: reactor(reactorId, () => {
-					this.systemState.reactors[reactorId].result = dependencies.map(unpack).join(':')
-				}),
+				reactor: reactor(
+					reactorId,
+					fn,
+					deferred
+						? { scheduleEffect: (execute) => this.deferredExecutes.push(execute) }
+						: undefined
+				),
 				result: '',
 				dependencies,
+				transacting,
+				deferred,
 			}
 		})
 	}
@@ -299,6 +348,17 @@ class Test {
 					id: this.source.selectOne(Object.keys(this.systemState.reactors)),
 				}
 			},
+			'deref derivation in transaction': () => {
+				return {
+					type: 'deref_derivation_in_transaction',
+					id: this.source.selectOne(Object.keys(this.systemState.derivations)),
+					atomId: this.source.selectOne(Object.keys(this.systemState.atoms)),
+					value: this.source.selectOne(LETTERS),
+				}
+			},
+			flush_deferred: () => {
+				return { type: 'flush_deferred' }
+			},
 		})
 	}
 
@@ -313,7 +373,14 @@ class Test {
 				break
 			}
 			case 'deref_derivation': {
-				this.systemState.derivations[op.id].derivation.get()
+				const { derivation, sneakyGet } = this.systemState.derivations[op.id]
+				const actual = derivation.get()
+				const expected = sneakyGet()
+				if (actual !== expected) {
+					throw new Error(
+						`derivation ${op.id} returned ${String(actual)}, expected ${String(expected)}`
+					)
+				}
 				break
 			}
 			case 'deref_derivation_in_derivation': {
@@ -336,6 +403,28 @@ class Test {
 			}
 			case 'stop_reactor': {
 				this.systemState.reactors[op.id].reactor.stop()
+				break
+			}
+			case 'deref_derivation_in_transaction': {
+				// T2: a read inside a transaction must see the in-transaction value, whether or not
+				// the derivation is actively listening
+				const { derivation, sneakyGet } = this.systemState.derivations[op.id]
+				transact(() => {
+					this.systemState.atoms[op.atomId].set(op.value)
+					const actual = derivation.get()
+					const expected = sneakyGet()
+					if (actual !== expected) {
+						throw new Error(
+							`derivation ${op.id} read inside a transaction returned ${String(actual)}, expected ${String(expected)}`
+						)
+					}
+				})
+				break
+			}
+			case 'flush_deferred': {
+				const executes = this.deferredExecutes
+				this.deferredExecutes = []
+				for (const execute of executes) execute()
 				break
 			}
 			default: {

--- a/packages/state/src/lib/__tests__/propagation.test.ts
+++ b/packages/state/src/lib/__tests__/propagation.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import { atom } from '../Atom'
 import { computed } from '../Computed'
-import { react, reactor } from '../EffectScheduler'
+import { EffectScheduler, react, reactor } from '../EffectScheduler'
 import { transact, transaction } from '../transactions'
 
 // Tests for SPEC.md §10 (change propagation and the reaction phase).
@@ -275,5 +275,108 @@ describe('transactions during the reaction phase (P6)', () => {
 
 		expect(a.__unsafe__getWithoutCapture()).toBe(3)
 		expect(cChanged).toHaveBeenCalledTimes(2)
+	})
+
+	it('[P6][T2][P7] an actively-listening computed read inside a transaction during a reaction sees in-transaction values', () => {
+		// Regression: Computed's cache shortcut for actively-listening computeds ("not traversed this
+		// reaction, so unchanged") ignored that in-transaction changes are only traversed at commit,
+		// and served the pre-transaction value.
+		const a = atom('', 0)
+		const c = computed('', () => a.get() * 2)
+		react('listener', () => {
+			c.get()
+		})
+
+		const trigger = atom('', 0)
+		const seen: number[] = []
+		react('', () => {
+			if (trigger.get() === 0) return
+			transact(() => {
+				a.set(5)
+				seen.push(c.get())
+			})
+		})
+		trigger.set(1)
+
+		expect(seen).toEqual([10])
+		expect(c.get()).toBe(10)
+	})
+
+	it('[P6][T2] an incremental computed read inside a transaction during a reaction is not corrupted', () => {
+		// The stale read above also stamped the computed as checked at the current epoch, so an
+		// incremental computed would later ask for diffs since an epoch that skipped the change.
+		const log = atom<number[], number[]>('log', [], {
+			historyLength: 10,
+			computeDiff: (prev, next) => next.slice(prev.length),
+		})
+		const sum = computed<number>('sum', (prev, lastComputedEpoch) => {
+			if (typeof prev !== 'number') return log.get().reduce((a, b) => a + b, 0)
+			const diffs = log.getDiffSince(lastComputedEpoch)
+			if (typeof diffs === 'symbol') return log.get().reduce((a, b) => a + b, 0)
+			let s = prev
+			for (const diff of diffs) for (const n of diff) s += n
+			return s
+		})
+		react('listener', () => {
+			sum.get()
+		})
+
+		const trigger = atom('', 0)
+		const seen: number[] = []
+		let done = false
+		react('', () => {
+			if (trigger.get() === 0 || done) return
+			done = true
+			transact(() => {
+				log.update((l) => [...l, 10])
+				seen.push(sum.get())
+			})
+		})
+		trigger.set(1)
+		expect(seen).toEqual([10])
+
+		log.update((l) => [...l, 5])
+		expect(sum.get()).toBe(15)
+	})
+})
+
+describe('actively-listening computeds stay fresh (C2)', () => {
+	it('[C2][E6] a computed traversed for a deferred effect but not re-checked is not served stale', () => {
+		// Regression: with deferred scheduling (as in state-react), haveParentsChanged returns at the
+		// first changed parent, so a later computed parent is traversed but never re-checked; a read
+		// during a subsequent reaction then took the "not traversed this reaction" shortcut.
+		const a = atom('', 0)
+		const b = atom('', 0)
+		const c = computed('', () => a.get())
+		const deferred: (() => void)[] = []
+		const scheduler = new EffectScheduler(
+			'',
+			() => {
+				b.get()
+				c.get()
+			},
+			{ scheduleEffect: (execute) => deferred.push(execute) }
+		)
+		scheduler.attach()
+		scheduler.execute()
+
+		// b is checked first, changed, so c is traversed but not re-checked; the run is deferred
+		transact(() => {
+			b.set(1)
+			a.set(1)
+		})
+
+		const z = atom('', 0)
+		const seen: number[] = []
+		react('', () => {
+			if (z.get() > 0) seen.push(c.get())
+		})
+		z.set(1)
+
+		expect(seen).toEqual([1])
+		expect(c.get()).toBe(1)
+
+		deferred.forEach((execute) => execute())
+		expect(c.get()).toBe(1)
 	})
 })

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -86,6 +86,11 @@ export function detach(parent: Signal<any>, child: Child) {
  * This function is used internally when dependencies are captured during computed signal
  * evaluation or effect execution.
  *
+ * `parent` must be up to date when it is attached: `Computed` assumes an actively-listening
+ * computed has been traversed for every ancestor change since it was last checked, which only
+ * holds from the moment it started listening. Capture attaches a parent right after reading it;
+ * `EffectScheduler.attach` refreshes its parents first.
+ *
  * @param parent - The parent signal to attach to
  * @param child - The child signal to attach
  * @example

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -79,19 +79,7 @@ const inst = singleton('transactions', () => ({
 	currentTransaction: null as Transaction | null,
 
 	cleanupReactors: null as null | Set<Reactor>,
-	reactionEpoch: GLOBAL_START_EPOCH + 1,
 }))
-
-/**
- * Gets the current reaction epoch, which is used to track when reactions are running.
- * The reaction epoch is updated at the start of each reaction cycle.
- *
- * @returns The current reaction epoch number
- * @public
- */
-export function getReactionEpoch() {
-	return inst.reactionEpoch
-}
 
 /**
  * Gets the current global epoch, which is incremented every time any atom changes.
@@ -105,14 +93,13 @@ export function getGlobalEpoch() {
 }
 
 /**
- * Checks whether any reactions are currently executing.
- * When true, the system is in the middle of processing effects and side effects.
+ * Whether a transaction (sync or async) is currently open. While one is, atom changes are
+ * recorded but their children are not traversed until it commits.
  *
- * @returns True if reactions are currently running, false otherwise
- * @public
+ * @internal
  */
-export function getIsReacting() {
-	return inst.globalIsReacting
+export function getIsInTransaction() {
+	return inst.currentTransaction !== null
 }
 
 // Reusable state for traverse to avoid closure allocation
@@ -152,7 +139,6 @@ function flushChanges(atoms: Iterable<_Atom>) {
 		// clear the transaction stack
 		inst.currentTransaction = null
 		inst.globalIsReacting = true
-		inst.reactionEpoch = inst.globalEpoch
 
 		// Collect all of the visited reactors.
 		const reactors = new Set<Reactor>()

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -181,9 +181,9 @@ function flushChanges(atoms: Iterable<_Atom>) {
  */
 export function atomDidChange(atom: _Atom, previousValue: any) {
 	if (inst.currentTransaction) {
-		// If we are in a transaction, then all we have to do is preserve
-		// the value of the atom at the start of the transaction in case
-		// we need to roll back.
+		// Only the value at the start of the transaction matters, for rollback. Children are not
+		// traversed until the transaction commits, which is why `Computed` must not trust its
+		// traversal-based cache shortcut while a transaction is open.
 		if (!inst.currentTransaction.initialAtomValues.has(atom)) {
 			inst.currentTransaction.initialAtomValues.set(atom, previousValue)
 		}

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -181,8 +181,10 @@ function flushChanges(atoms: Iterable<_Atom>) {
  */
 export function atomDidChange(atom: _Atom, previousValue: any) {
 	if (inst.currentTransaction) {
-		// Only the value at the start of the transaction matters, for rollback. Children are not
-		// traversed until the transaction commits, which is why `Computed` must not trust its
+		// If we are in a transaction, then all we have to do is preserve
+		// the value of the atom at the start of the transaction in case
+		// we need to roll back. Children are not traversed until the
+		// transaction commits, which is why `Computed` must not trust its
 		// traversal-based cache shortcut while a transaction is open.
 		if (!inst.currentTransaction.initialAtomValues.has(atom)) {
 			inst.currentTransaction.initialAtomValues.set(atom, previousValue)


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where an actively-listening computed could return a stale value, and — because the stale read also stamped it as checked — an incremental computed built on `getDiffSince(lastComputedEpoch)` (the store's indexes) then skipped that change forever.

### Before

`Computed.__unsafe__getWithoutCapture` skipped the O(parents) `haveParentsChanged` scan when `isActivelyListening && getIsReacting() && lastTraversedEpoch < reactionEpoch`, on the reasoning that any ancestor change during this reaction would have traversed it. That reasoning broke in three realistic ways:

- an effect that does `transact(() => { a.set(5); c.get() })`: in-transaction changes are only traversed at commit, so `c` returned the pre-transaction value;
- a deferred scheduler (the `state-react` pattern) with parents `[b, c]` and a transaction changing both: `haveParentsChanged` returns at `b`, so `c` is traversed but never re-checked, and a later reaction reads it stale;
- `reactor.start()` / `EffectScheduler.attach()` inside a reaction after the computed's ancestors changed while nothing listened: the computed became "actively listening" without being refreshed, so the restarted effect never ran.

### After

The shortcut is `isActivelyListening && !getIsInTransaction() && lastTraversedEpoch <= lastCheckedEpoch`, which is sound in and out of the reaction phase, and `EffectScheduler.attach()` brings computed parents up to date before attaching them (the invariant is documented on `attach` in `helpers.ts`). The now-unused `reactionEpoch`, `getReactionEpoch` and `getIsReacting` are removed.

A side effect is that the shortcut now also applies to reads outside reactions (React renders, event handlers). Measured at N=5000: a listening computed read after an unrelated change 6.4 µs → 0.2 µs; 200 listening computeds × 50 parents 31.6 µs → 2.9 µs; `reactor.stop()+start()` with 5000 parents 59 → 74 µs (the attach refresh). Re-derive and propagation paths are unchanged.

The fuzz harness now also exercises transacting reactors, deferred schedulers and in-transaction derefs; it catches the old bug and passes ~24k seeds on the new code.

Split out of #10144. SPEC rules C2, E2, E8 and P7 are updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the five new tests fail on `main` and pass with this change

### Release notes

- Fix computeds returning stale values when read inside a transaction during an effect, from a deferred effect, or after a reactor restarts

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +22 / -26 |
| Tests | +252 / -9 |
| Documentation | +4 / -4 |
