### PR TITLE
docs(skills): add before/after PR template for bug fixes and improvements

### DIFF
--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -61,7 +61,7 @@ A noun describing the affected area: `fix(editor):`, `feat(sync):`, `docs(exampl
 
 ## PR body
 
-Bug fix PRs (`fix` type, `bugfix` change type) use the bug fix template below. Everything else uses this one:
+Bug fix and improvement PRs (`bugfix` and `improvement` change types) use the before/after template below. Everything else uses this one:
 
 ```md
 <description paragraph>
@@ -94,9 +94,9 @@ Start with: "In order to X, this PR does Y." Follow the reviewer-first rules at 
 - Link related issues in the first paragraph
 - Don't expect readers to also read the linked issue
 
-### Bug fix PRs
+### Bug fix and improvement PRs
 
-Bug fix PRs use a fixed shape instead of the description paragraph. The same reviewer-first rules apply; the structure exists so a reviewer can see the symptom, the cause, and the fix without reading the diff.
+Bug fix and improvement PRs use a fixed shape instead of the description paragraph. The same reviewer-first rules apply; the structure exists so a reviewer can see what was wrong (or lacking), what it does now, and why, without reading the diff.
 
 ```md
 This PR fixes a bug where <symptom a user or developer would hit>.
@@ -115,7 +115,7 @@ This PR fixes a bug where <symptom a user or developer would hit>.
 
 ### Change type
 
-- [x] `bugfix`
+- [x] `bugfix` | `improvement`
 
 ### Test plan
 
@@ -123,7 +123,7 @@ This PR fixes a bug where <symptom a user or developer would hit>.
 
 ### Release notes
 
-- Fix <symptom>
+- Fix <symptom> | Improve <behavior>
 
 ### Code changes
 
@@ -133,13 +133,13 @@ This PR fixes a bug where <symptom a user or developer would hit>.
 | Tests     | +5 / -0    |
 ```
 
-- **Intro** — one sentence, "This PR fixes a bug where X." X is the observable symptom, not the cause or the fix. Link the issue here if there is one. If the PR fixes more than one thing, add a second sentence ("It also ...") rather than a list.
-- **Before** — the behavior before, and the mechanism that produced it. Name the function or path at fault; this is the one place a short description of *how* the old code went wrong belongs, because it is the cause the reviewer is checking the fix against.
+- **Intro** — one sentence. For a bug: "This PR fixes a bug where X," where X is the observable symptom, not the cause or the fix. For an improvement: "This PR improves X so that Y," where Y is what a user or developer can now do. Link the issue here if there is one. If the PR does more than one thing, add a second sentence ("It also ...") rather than a list.
+- **Before** — the behavior before, and the mechanism that produced it. For a bug, name the function or path at fault; this is the one place a short description of *how* the old code went wrong belongs, because it is the cause the reviewer is checking the fix against. For an improvement, describe what the user or developer had to do (or couldn't do) and what in the code made it that way.
 - **After** — the behavior after. State what the code now does, at the same level of detail as Before. Note any spec or doc that was updated alongside.
 - **Implementation notes** — optional. Include only when there is something the Before/After pair doesn't carry: an approach you chose over another, a subtlety in the change, a follow-up you deliberately left out. Skip the heading entirely when there is nothing to say; most small fixes have nothing.
-- The `### Change type` / `### Test plan` / `### Release notes` / `### API changes` / `### Code changes` blocks follow as usual. In the test plan, say whether the new tests fail on `main`.
+- The `### Change type` / `### Test plan` / `### Release notes` / `### API changes` / `### Code changes` blocks follow as usual. For bug fixes, say in the test plan whether the new tests fail on `main`.
 
-tldraw/tldraw#10117, #10118, and #10119 are worked examples.
+tldraw/tldraw#10117, #10118, and #10119 are worked examples of bug fixes in this shape.
 
 ### Change type
 

--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -61,7 +61,7 @@ A noun describing the affected area: `fix(editor):`, `feat(sync):`, `docs(exampl
 
 ## PR body
 
-Use this template:
+Bug fix PRs (`fix` type, `bugfix` change type) use the bug fix template below. Everything else uses this one:
 
 ```md
 <description paragraph>
@@ -93,6 +93,53 @@ Start with: "In order to X, this PR does Y." Follow the reviewer-first rules at 
 - Keep it specific - avoid vague phrases like "improve user experience"
 - Link related issues in the first paragraph
 - Don't expect readers to also read the linked issue
+
+### Bug fix PRs
+
+Bug fix PRs use a fixed shape instead of the description paragraph. The same reviewer-first rules apply; the structure exists so a reviewer can see the symptom, the cause, and the fix without reading the diff.
+
+```md
+This PR fixes a bug where <symptom a user or developer would hit>.
+
+### Before
+
+<what the code did and why that produced the symptom>
+
+### After
+
+<what the code does now>
+
+### Implementation notes
+
+<optional: what exactly changed and how — decisions, trade-offs, anything non-obvious>
+
+### Change type
+
+- [x] `bugfix`
+
+### Test plan
+
+- [x] Unit tests — the new test fails on `main` and passes with this change
+
+### Release notes
+
+- Fix <symptom>
+
+### Code changes
+
+| Section   | LOC change |
+| --------- | ---------- |
+| Core code | +10 / -2   |
+| Tests     | +5 / -0    |
+```
+
+- **Intro** — one sentence, "This PR fixes a bug where X." X is the observable symptom, not the cause or the fix. Link the issue here if there is one. If the PR fixes more than one thing, add a second sentence ("It also ...") rather than a list.
+- **Before** — the behavior before, and the mechanism that produced it. Name the function or path at fault; this is the one place a short description of *how* the old code went wrong belongs, because it is the cause the reviewer is checking the fix against.
+- **After** — the behavior after. State what the code now does, at the same level of detail as Before. Note any spec or doc that was updated alongside.
+- **Implementation notes** — optional. Include only when there is something the Before/After pair doesn't carry: an approach you chose over another, a subtlety in the change, a follow-up you deliberately left out. Skip the heading entirely when there is nothing to say; most small fixes have nothing.
+- The `### Change type` / `### Test plan` / `### Release notes` / `### API changes` / `### Code changes` blocks follow as usual. In the test plan, say whether the new tests fail on `main`.
+
+tldraw/tldraw#10117, #10118, and #10119 are worked examples.
 
 ### Change type
 


### PR DESCRIPTION
In order to make bug fix and improvement PRs consistent and quick to review, this PR adds a dedicated before/after template to the write-pr skill: a one-line intro ("This PR fixes a bug where X" / "This PR improves X so that Y"), a Before section describing the old behavior and its cause, an After section describing the new behavior, and an optional Implementation notes section. The standard Change type / Test plan / Release notes / API changes / Code changes blocks are unchanged and still follow. Feature, refactor, and other PRs keep the existing description paragraph format.

The shape is taken from #10117, #10118, and #10119, which the skill now cites as worked examples.

### Change type

- [x] `other`

### Test plan

- Read `skills/write-pr/SKILL.md` and confirm the new section reads correctly.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +48 / -1   |