### PR TITLE
fix(state): don't re-run a zero-dependency effect on every start()

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -91,7 +91,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 9. Effects: EffectScheduler, react, reactor (E)
 
 - **E1** `react(name, fn)` runs `fn` immediately and unconditionally, then re-runs it whenever any signal captured during its previous run changes. It returns a stop function; after stopping, changes no longer re-run `fn`.
-- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated.
+- **E2** `reactor(name, fn)` does not run `fn` until `.start()`. `.start()` runs the effect if it has never run or if any parent changed while stopped; otherwise — including for an effect that captured no parents — it does not run. `.start({ force: true })` always runs it. `.stop()` detaches. Start/stop may be repeated.
 - **E3** One state change produces at most one run of a given effect, even if the change affected several of its parents (e.g. several atoms set in one transaction, or a diamond dependency graph).
 - **E4** An effect re-runs only when a parent's value actually changed (per EQ and C5). Equal-value sets and unrelated epoch advances do not re-run it.
 - **E5** The effect function receives the epoch at which the effect last ran. This enables the incremental pattern `signal.getDiffSince(lastReactedEpoch)` inside effects. The epoch passed is the one captured _before_ the run, so an effect that updates atoms during its own run remains eligible to be scheduled again.

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -95,12 +95,16 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 		// bail out if no atoms have changed since the last time we ran this effect
 		if (this.lastReactedEpoch === getGlobalEpoch()) return
 
-		// bail out if we have parents and they have not changed since last time
-		if (this.parents.length && !haveParentsChanged(this)) {
+		// An effect that has run before (or captured parents before throwing) only needs to run
+		// again if one of those parents changed; that includes an effect that captured no parents at
+		// all. An effect that has never run always runs.
+		if (
+			(this.lastReactedEpoch !== GLOBAL_START_EPOCH || this.parents.length > 0) &&
+			!haveParentsChanged(this)
+		) {
 			this.lastReactedEpoch = getGlobalEpoch()
 			return
 		}
-		// if we don't have parents it's probably the first time this is running.
 		this.scheduleEffect()
 	}
 

--- a/packages/state/src/lib/__tests__/EffectScheduler.test.ts
+++ b/packages/state/src/lib/__tests__/EffectScheduler.test.ts
@@ -233,6 +233,24 @@ describe('reactor (E)', () => {
 		r.scheduler.maybeScheduleEffect()
 		expect(rfn).toHaveBeenCalledTimes(1)
 	})
+
+	it('[E2][E9] an effect that captured no parents does not re-run on start() after unrelated changes', () => {
+		const unrelated = atom('', 0)
+		const rfn = vi.fn()
+		const r = reactor('', rfn)
+
+		r.start()
+		expect(rfn).toHaveBeenCalledTimes(1)
+
+		r.stop()
+		unrelated.set(1)
+		r.start()
+		// no parent changed (there are none), so there is nothing to react to
+		expect(rfn).toHaveBeenCalledTimes(1)
+
+		r.start({ force: true })
+		expect(rfn).toHaveBeenCalledTimes(2)
+	})
 })
 
 describe('custom scheduling (E6, E7)', () => {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where an effect that captured no parents re-ran on every `reactor.start()` (and every `maybeScheduleEffect()`) after any unrelated epoch advance — a wasted re-render for a tracked React component with no signal dependencies.

### Before

`maybeScheduleEffect` used `parents.length` as its "has this effect ever run?" test, so an effect with zero parents always looked like a first run and was scheduled whenever the global epoch had moved.

### After

The test is `lastReactedEpoch !== GLOBAL_START_EPOCH` (or parents captured before a throwing first run). An effect that has never run still always runs; one that has run re-runs only if a parent changed, which for zero parents is never. `start({ force: true })` is unaffected. SPEC rule E2 updated.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix effects with no signal dependencies re-running on every `start()`

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +7 / -3 |
| Tests | +18 / -0 |
| Documentation | +1 / -1 |
