### PR TITLE
fix(state): roll back nested transactions committed inside an effect

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -118,7 +118,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **T4** `fn` receives a `rollback` callback. Calling it (and then returning normally) aborts the transaction: every atom changed during the transaction is restored to the value it had when the transaction began.
 - **T5** If `fn` throws, the transaction aborts as in T4 and the exception propagates.
 - **T6** An aborted transaction still flushes effects: effects whose parents went through a change-and-restore round trip are scheduled, observe the restored values, and per E4 may run. Effects never observe intermediate in-transaction values.
-- **T7** Nested `transaction` calls roll back independently: an inner rollback restores to the _inner_ transaction's start. A committed inner transaction is still undone by an outer rollback (the inner transaction's initial values fold into the parent on commit).
+- **T7** Nested `transaction` calls roll back independently: an inner rollback restores to the _inner_ transaction's start. A committed inner transaction is still undone by an outer rollback (the inner transaction's initial values fold into the parent on commit), including when the transactions run inside an effect during the reaction phase.
 - **T8** Because `transact` joins rather than nests, a throw inside an inner `transact` does not restore anything by itself; if it propagates out of the outermost transaction, T5 applies there.
 - **T9** Abort clears the history buffers of every atom changed in the transaction (H7).
 - **T10** Mismatched transaction boundaries (committing a transaction that is not the innermost) throw `Transaction boundaries overlap`.

--- a/packages/state/src/lib/__tests__/transactions.test.ts
+++ b/packages/state/src/lib/__tests__/transactions.test.ts
@@ -183,6 +183,29 @@ describe('transactions (T)', () => {
 		expect(a.get()).toBe('a')
 	})
 
+	it('[T7] an outer rollback undoes an inner transaction committed during the reaction phase', () => {
+		// Regression: committing a nested transaction inside an effect used to skip folding its
+		// initial values into the parent, so the outer rollback could not restore them.
+		const trigger = atom('', 0)
+		const a = atom('', 'a')
+		const b = atom('', 'b')
+
+		react('', () => {
+			if (trigger.get() === 0) return
+			transaction((rollback) => {
+				b.set('B')
+				transaction(() => {
+					a.set('A')
+				})
+				rollback()
+			})
+		})
+		trigger.set(1)
+
+		expect(a.get()).toBe('a')
+		expect(b.get()).toBe('b')
+	})
+
 	it('[T4] rollback restores computed signals too', () => {
 		const firstName = atom('', 'John')
 		const lastName = atom('', 'Doe')

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -23,31 +23,27 @@ class Transaction {
 	}
 
 	commit() {
-		if (inst.globalIsReacting) {
-			// if we're committing during a reaction we actually need to
-			// use the 'cleanup' reactors set to ensure we re-run effects if necessary
-			for (const atom of this.initialAtomValues.keys()) {
-				traverseAtomForCleanup(atom)
-			}
-		} else if (this.isRoot) {
-			// For root transactions, flush changed atoms
+		if (this.isRoot) {
 			flushChanges(this.initialAtomValues.keys())
-		} else {
-			// For transactions with parents, add the transaction's initial values to the parent's.
-			// A parent that has recorded nothing yet adopts the map outright: this transaction is
-			// finished with it, and the common nested case is a single inner transaction doing all
-			// the writes.
-			const parentValues = this.parent!.initialAtomValues
-			if (parentValues.size === 0) {
-				this.parent!.initialAtomValues = this.initialAtomValues
-				return
-			}
-			this.initialAtomValues.forEach((value, atom) => {
-				if (!parentValues.has(atom)) {
-					parentValues.set(atom, value)
-				}
-			})
+			return
 		}
+		// Fold this transaction's initial values into the parent so an outer rollback can still
+		// undo them (T7). This must come before any "are we reacting?" special case: a nested
+		// transaction committed by an effect during the reaction phase used to skip this fold and
+		// its changes survived the outer rollback.
+		// A parent that has recorded nothing yet adopts the map outright: this transaction is
+		// finished with it, and the common nested case is a single inner transaction doing all
+		// the writes.
+		const parentValues = this.parent!.initialAtomValues
+		if (parentValues.size === 0) {
+			this.parent!.initialAtomValues = this.initialAtomValues
+			return
+		}
+		this.initialAtomValues.forEach((value, atom) => {
+			if (!parentValues.has(atom)) {
+				parentValues.set(atom, value)
+			}
+		})
 	}
 
 	/**
@@ -133,18 +129,22 @@ function traverseChild(child: Child) {
 }
 
 /**
- * Collect all of the reactors that need to run for an atom and run them.
- *
- * @param atoms - The atoms to flush changes for.
+ * Runs the effects that depend on the given changed atoms. During the reaction phase the
+ * affected effects are instead queued for the cleanup pass, so a change made by an effect never
+ * interrupts the pass that is running (P4).
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {
-		throw new Error('flushChanges cannot be called during a reaction')
+		for (const atom of atoms) {
+			traverseAtomForCleanup(atom)
+		}
+		return
 	}
 
 	const outerTxn = inst.currentTransaction
 	try {
-		// clear the transaction stack
+		// Transactions started by effects must be roots: the committing transaction (if any) has
+		// already handed its changes to this flush.
 		inst.currentTransaction = null
 		inst.globalIsReacting = true
 		inst.reactionEpoch = inst.globalEpoch
@@ -188,14 +188,7 @@ export function atomDidChange(atom: _Atom, previousValue: any) {
 		if (!inst.currentTransaction.initialAtomValues.has(atom)) {
 			inst.currentTransaction.initialAtomValues.set(atom, previousValue)
 		}
-	} else if (inst.globalIsReacting) {
-		// If the atom changed during the reaction phase of flushChanges
-		// (and there are no transactions started inside the reaction phase)
-		// then we are past the point where a transaction can be aborted
-		// so we don't need to note down the previousValue.
-		traverseAtomForCleanup(atom)
 	} else {
-		// If there is no transaction, flush the changes immediately.
 		flushChanges([atom])
 	}
 }

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -24,11 +24,12 @@ class Transaction {
 
 	commit() {
 		if (this.isRoot) {
+			// For root transactions, flush changed atoms
 			flushChanges(this.initialAtomValues.keys())
 			return
 		}
-		// Fold this transaction's initial values into the parent so an outer rollback can still
-		// undo them (T7). This must come before any "are we reacting?" special case: a nested
+		// For transactions with parents, add the transaction's initial values to the parent's, so
+		// an outer rollback can still undo them (T7). This must come before any "are we reacting?" special case: a nested
 		// transaction committed by an effect during the reaction phase used to skip this fold and
 		// its changes survived the outer rollback.
 		// A parent that has recorded nothing yet adopts the map outright: this transaction is
@@ -129,9 +130,11 @@ function traverseChild(child: Child) {
 }
 
 /**
- * Runs the effects that depend on the given changed atoms. During the reaction phase the
- * affected effects are instead queued for the cleanup pass, so a change made by an effect never
- * interrupts the pass that is running (P4).
+ * Collect all of the reactors that need to run for an atom and run them. During the reaction
+ * phase the affected effects are instead queued for the cleanup pass, so a change made by an
+ * effect never interrupts the pass that is running (P4).
+ *
+ * @param atoms - The atoms to flush changes for.
  */
 function flushChanges(atoms: Iterable<_Atom>) {
 	if (inst.globalIsReacting) {
@@ -143,8 +146,8 @@ function flushChanges(atoms: Iterable<_Atom>) {
 
 	const outerTxn = inst.currentTransaction
 	try {
-		// Transactions started by effects must be roots: the committing transaction (if any) has
-		// already handed its changes to this flush.
+		// clear the transaction stack. Transactions started by effects must be roots: the committing
+		// transaction (if any) has already handed its changes to this flush.
 		inst.currentTransaction = null
 		inst.globalIsReacting = true
 		inst.reactionEpoch = inst.globalEpoch
@@ -189,6 +192,7 @@ export function atomDidChange(atom: _Atom, previousValue: any) {
 			inst.currentTransaction.initialAtomValues.set(atom, previousValue)
 		}
 	} else {
+		// If there is no transaction, flush the changes immediately.
 		flushChanges([atom])
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a nested transaction committed inside an effect was not undone by its parent's rollback.

### Before

`Transaction.commit()` checked `globalIsReacting` before `isRoot`, so during the reaction phase every commit — root or nested — went straight to the cleanup-traversal branch and a nested transaction never folded its initial values into its parent. Inside an effect,

```ts
transaction((rollback) => {
	transaction(() => x.set(1))
	rollback()
})
```

left `x` at `1`; outside a reaction it is restored to `0`.

### After

`commit()` folds into the parent first and only a root transaction flushes. `flushChanges` now owns the "during the reaction phase, queue for the cleanup pass instead" rule (P4), which also lets `atomDidChange` drop its own copy of that special case. SPEC rule T7 updated.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix nested transactions inside effects not rolling back with their parent

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +21 / -27 |
| Tests | +23 / -0 |
| Documentation | +1 / -1 |
