### PR TITLE
fix(state): roll back deferAsyncEffects atomically

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -127,7 +127,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 
 - **AT1** `deferAsyncEffects(fn)` runs the async `fn` in a transaction context: atom changes are visible immediately to reads (T2 applies), but effects are deferred until the async transaction completes.
 - **AT2** It throws (rejects) if called while a synchronous transaction is in progress. Synchronous `transaction`/`transact` calls _inside_ the async body are fine and nest normally.
-- **AT3** If `fn` rejects or throws, all changes made during the async transaction are rolled back and the error propagates.
+- **AT3** If `fn` rejects or throws, all changes made during the async transaction are rolled back and the error propagates. The rollback is atomic from the point of view of effects (T6): they run once, after every atom has been restored.
 - **AT4** Calling `deferAsyncEffects` while another async transaction is in flight joins it: changes from both are batched together, and effects run only after the last participating process finishes. Async transaction state leaks across `await` boundaries between concurrent processes (no AsyncContext); the grouping of effects is the guarantee, not isolation.
 - **AT5** A `deferAsyncEffects` call kicked off during the reaction phase waits for the reaction phase to finish before starting.
 - **AT6** The returned promise resolves to `fn`'s return value.

--- a/packages/state/src/lib/__tests__/deferAsyncEffects.test.ts
+++ b/packages/state/src/lib/__tests__/deferAsyncEffects.test.ts
@@ -112,6 +112,29 @@ describe('deferAsyncEffects (AT)', () => {
 		expect(b.get()).toBe(0)
 	})
 
+	it('[AT3][T6] effects never observe partially restored values when an async transaction aborts', async () => {
+		// Regression: the rollback used to run after the async transaction had been cleared, so each
+		// restoring set flushed effects on its own and they saw one atom restored but not the other.
+		const a = atom('', 1)
+		const b = atom('', 1)
+		const seen: string[] = []
+		react('', () => {
+			seen.push(`${a.get()},${b.get()}`)
+		})
+		seen.length = 0
+
+		await expect(
+			deferAsyncEffects(async () => {
+				a.set(2)
+				b.set(2)
+				await sleep(1)
+				throw new Error('boom')
+			})
+		).rejects.toThrow('boom')
+
+		expect(seen).toEqual(['1,1'])
+	})
+
 	it('[AT3][AT4] rolls back everything when a nested async transaction throws', async () => {
 		const a = atom('', 0)
 		const b = atom('', 0)

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -53,9 +53,11 @@ class Transaction {
 	}
 
 	/**
-	 * Restores every atom changed in this transaction to its initial value, then commits. Must be
-	 * called while this is still `inst.currentTransaction`, so that the restoring sets are
-	 * recorded against it instead of each flushing effects on their own.
+	 * Abort the transaction. Restores every atom changed in this transaction to its initial
+	 * value, then commits. Must be called while this is still `inst.currentTransaction`, so that
+	 * the restoring sets are recorded against it instead of each flushing effects on their own.
+	 *
+	 * @public
 	 */
 	abort() {
 		inst.globalEpoch++
@@ -423,14 +425,17 @@ export async function deferAsyncEffects<T>(fn: () => Promise<T>) {
 	// `undefined` means "did not throw"; a thrown `undefined` is stored as `null` so it still counts.
 	let error = undefined as any
 	try {
+		// Run the function.
 		result = await fn()
 	} catch (e) {
+		// Abort the transaction if the function throws.
 		error = e ?? null
 	}
 
 	if (--txn.asyncProcessCount > 0) {
 		// Other processes still share this transaction; it settles when the last one finishes.
 		if (typeof error !== 'undefined') {
+			// If the rollback was triggered, abort the transaction.
 			throw error
 		} else {
 			return result
@@ -442,6 +447,7 @@ export async function deferAsyncEffects<T>(fn: () => Promise<T>) {
 	// observed half-restored state.
 	try {
 		if (typeof error !== 'undefined') {
+			// If the rollback was triggered, abort the transaction.
 			txn.abort()
 			throw error
 		} else {

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -53,9 +53,9 @@ class Transaction {
 	}
 
 	/**
-	 * Abort the transaction.
-	 *
-	 * @public
+	 * Restores every atom changed in this transaction to its initial value, then commits. Must be
+	 * called while this is still `inst.currentTransaction`, so that the restoring sets are
+	 * recorded against it instead of each flushing effects on their own.
 	 */
 	abort() {
 		inst.globalEpoch++
@@ -420,32 +420,35 @@ export async function deferAsyncEffects<T>(fn: () => Promise<T>) {
 
 	let result = undefined as T | undefined
 
+	// `undefined` means "did not throw"; a thrown `undefined` is stored as `null` so it still counts.
 	let error = undefined as any
 	try {
-		// Run the function.
 		result = await fn()
 	} catch (e) {
-		// Abort the transaction if the function throws.
 		error = e ?? null
 	}
 
 	if (--txn.asyncProcessCount > 0) {
+		// Other processes still share this transaction; it settles when the last one finishes.
 		if (typeof error !== 'undefined') {
-			// If the rollback was triggered, abort the transaction.
 			throw error
 		} else {
 			return result
 		}
 	}
 
-	inst.currentTransaction = null
-
-	if (typeof error !== 'undefined') {
-		// If the rollback was triggered, abort the transaction.
-		txn.abort()
-		throw error
-	} else {
-		txn.commit()
-		return result
+	// Settle while this is still the current transaction (see `Transaction.abort`): clearing it
+	// first made every restoring set inside `abort()` flush effects on its own, so effects
+	// observed half-restored state.
+	try {
+		if (typeof error !== 'undefined') {
+			txn.abort()
+			throw error
+		} else {
+			txn.commit()
+			return result
+		}
+	} finally {
+		inst.currentTransaction = null
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where an aborting `deferAsyncEffects` ran effects once per restored atom, with half-restored state.

### Before

`deferAsyncEffects` cleared `inst.currentTransaction` *before* calling `txn.abort()`, so each restoring `atom.set()` inside `abort()` saw no open transaction and flushed effects on its own. With `a = b = 1` and an effect logging both, `deferAsyncEffects(async () => { a.set(2); b.set(2); await 0; throw })` made the effect observe `1,2` and then `1,1`. With 5000 atoms that is 5000 flushes (~1 s).

### After

The transaction is settled (`abort()` or `commit()`) while it is still current, and `currentTransaction` is cleared in a `finally`. Effects run once, after every atom is restored (T6). SPEC rule AT3 updated.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix effects observing half-restored state when a `deferAsyncEffects` call throws

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +18 / -15 |
| Tests | +23 / -0 |
| Documentation | +1 / -1 |