### PR TITLE
fix(state): let @computed subclass overrides call super and accept @computed()

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -60,8 +60,8 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **C5** If recomputation produces a value equal (EQ) to the previous one, the computed keeps the previous value object and its `lastChangedEpoch`; downstream children observe no change. The signal's `isEqual` is never invoked for the first computation.
 - **C6** A chain of computeds re-runs minimally: each computed in the chain recomputes at most once per relevant change, and value-level deduplication (C5) stops propagation early.
 - **C7** `computed.isActivelyListening` is true exactly when the computed has at least one attached child (effect or actively-listening computed downstream).
-- **C8** The `@computed` decorator on a class method makes that method behave as `Computed.get()` for a per-instance computed signal: cached, reactive, with options (`isEqual`, `historyLength`, etc.) honored. Both legacy and TC39 decorator protocols are supported.
-- **C9** `getComputedInstance(obj, propertyName)` returns the underlying `Computed` instance for a decorated method, creating it on demand if the method has not been called yet.
+- **C8** The `@computed` decorator on a class method makes that method behave as `Computed.get()` for a per-instance computed signal: cached, reactive, with options (`isEqual`, `historyLength`, etc.) honored. `@computed()` with no options is equivalent to `@computed`. Both legacy and TC39 decorator protocols are supported. A subclass may override a `@computed` method with another `@computed` method and call `super.method()`: each decoration has its own per-instance computed.
+- **C9** `getComputedInstance(obj, propertyName)` returns the underlying `Computed` instance for the nearest decorated method on `obj`'s prototype chain, creating it on demand if the method has not been called yet. Its value type is the method's return type.
 - **C10** Using `@computed` on a _getter_ (legacy decorators only) still works but logs a one-time deprecation warning per process.
 
 ## 7. Errors in computed signals (CE)

--- a/packages/state/api-report.api.md
+++ b/packages/state/api-report.api.md
@@ -121,7 +121,7 @@ export interface EffectSchedulerOptions {
 export const EMPTY_ARRAY: [];
 
 // @public
-export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(obj: Obj, propertyName: Prop): Computed<Obj[Prop]>;
+export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(obj: Obj, propertyName: Prop): Computed<Obj[Prop] extends () => infer Value ? Value : Obj[Prop]>;
 
 // @public
 export function isAtom(value: unknown): value is Atom<unknown>;

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -374,20 +374,23 @@ export const _Computed = singleton('Computed', () => __UNSAFE__Computed)
  */
 export type _Computed = InstanceType<typeof __UNSAFE__Computed>
 
-function computedMethodLegacyDecorator(
-	options: ComputedOptions<any, any> = {},
-	_target: any,
-	key: string,
-	descriptor: PropertyDescriptor
-) {
-	const originalMethod = descriptor.value
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + key)
+// Set on every decorated wrapper: the symbol its per-instance computed is stored under.
+const derivationKeyKey = '@@__computedDerivationKey__@@'
 
-	descriptor.value = function (this: any) {
+/**
+ * Builds the method (or getter) body that `@computed` installs: a per-instance, lazily-created
+ * computed over the original method. The storage symbol is unique per decoration rather than
+ * `Symbol.for(name)` so that a subclass which overrides a `@computed` method and calls
+ * `super.method()` reaches the superclass's computed instead of re-entering its own.
+ */
+function makeComputedWrapper(name: string, compute: () => any, options: ComputedOptions<any, any>) {
+	const derivationKey = Symbol('__@tldraw/state__computed__' + name)
+
+	const wrapper = function (this: any) {
 		let d = this[derivationKey] as Computed<any> | undefined
 
 		if (!d) {
-			d = new _Computed(key, originalMethod!.bind(this) as any, options)
+			d = new _Computed(name, compute.bind(this) as any, options)
 			Object.defineProperty(this, derivationKey, {
 				enumerable: false,
 				configurable: false,
@@ -396,63 +399,9 @@ function computedMethodLegacyDecorator(
 			})
 		}
 		return d.get()
-	}
-	descriptor.value[isComputedMethodKey] = true
-
-	return descriptor
-}
-
-function computedGetterLegacyDecorator(
-	options: ComputedOptions<any, any> = {},
-	_target: any,
-	key: string,
-	descriptor: PropertyDescriptor
-) {
-	const originalMethod = descriptor.get
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + key)
-
-	descriptor.get = function (this: any) {
-		let d = this[derivationKey] as Computed<any> | undefined
-
-		if (!d) {
-			d = new _Computed(key, originalMethod!.bind(this) as any, options)
-			Object.defineProperty(this, derivationKey, {
-				enumerable: false,
-				configurable: false,
-				writable: false,
-				value: d,
-			})
-		}
-		return d.get()
-	}
-
-	return descriptor
-}
-
-function computedMethodTc39Decorator<This extends object, Value>(
-	options: ComputedOptions<Value, any>,
-	compute: () => Value,
-	context: ClassMethodDecoratorContext<This, () => Value>
-) {
-	assert(context.kind === 'method', '@computed can only be used on methods')
-	const derivationKey = Symbol.for('__@tldraw/state__computed__' + String(context.name))
-
-	const fn = function (this: any) {
-		let d = this[derivationKey] as Computed<any> | undefined
-
-		if (!d) {
-			d = new _Computed(String(context.name), compute.bind(this) as any, options)
-			Object.defineProperty(this, derivationKey, {
-				enumerable: false,
-				configurable: false,
-				writable: false,
-				value: d,
-			})
-		}
-		return d.get()
-	}
-	fn[isComputedMethodKey] = true
-	return fn
+	} as any
+	wrapper[derivationKeyKey] = derivationKey
+	return wrapper
 }
 
 function computedDecorator(
@@ -463,19 +412,19 @@ function computedDecorator(
 ) {
 	if (args.length === 2) {
 		const [originalMethod, context] = args
-		return computedMethodTc39Decorator(options, originalMethod, context)
+		assert(context.kind === 'method', '@computed can only be used on methods')
+		return makeComputedWrapper(String(context.name), originalMethod, options)
 	} else {
 		const [_target, key, descriptor] = args
 		if (descriptor.get) {
 			logComputedGetterWarning()
-			return computedGetterLegacyDecorator(options, _target, key, descriptor)
+			descriptor.get = makeComputedWrapper(key, descriptor.get, options)
 		} else {
-			return computedMethodLegacyDecorator(options, _target, key, descriptor)
+			descriptor.value = makeComputedWrapper(key, descriptor.value, options)
 		}
+		return descriptor
 	}
 }
-
-const isComputedMethodKey = '@@__isComputedMethod__@@'
 
 /**
  * Retrieves the underlying computed instance for a given property created with the `computed`
@@ -506,19 +455,29 @@ const isComputedMethodKey = '@@__isComputedMethod__@@'
 export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
 	obj: Obj,
 	propertyName: Prop
-): Computed<Obj[Prop]> {
-	const key = Symbol.for('__@tldraw/state__computed__' + propertyName.toString())
-	let inst = obj[key as keyof typeof obj] as Computed<Obj[Prop]> | undefined
-	if (!inst) {
-		// deref to make sure it exists first
-		const val = obj[propertyName]
-		if (typeof val === 'function' && (val as any)[isComputedMethodKey]) {
-			val.call(obj)
-		}
+): Computed<Obj[Prop] extends () => infer Value ? Value : Obj[Prop]> {
+	// The nearest decorated wrapper (a method, or a legacy getter) on the prototype chain knows
+	// which symbol the instance's computed is stored under.
+	for (let proto: any = obj; proto; proto = Object.getPrototypeOf(proto)) {
+		const descriptor = Object.getOwnPropertyDescriptor(proto, propertyName)
+		const wrapper = descriptor?.get ?? descriptor?.value
+		const key = wrapper?.[derivationKeyKey]
+		if (!key) continue
 
-		inst = obj[key as keyof typeof obj] as Computed<Obj[Prop]> | undefined
+		let inst = (obj as any)[key]
+		if (!inst) {
+			// calling the wrapper creates the computed (before it first derives, so a throwing derive
+			// still leaves the instance behind)
+			try {
+				wrapper.call(obj)
+			} catch {
+				// the caller asked for the instance, not its value
+			}
+			inst = (obj as any)[key]
+		}
+		return inst
 	}
-	return inst as any
+	return undefined as any
 }
 
 /**
@@ -665,7 +624,8 @@ export function computed<Value, Diff = unknown>(
  * @public
  */
 export function computed() {
-	if (arguments.length === 1) {
+	if (arguments.length <= 1) {
+		// decorator factory: `@computed(options)` or `@computed()`
 		const options = arguments[0]
 		return (...args: any) => computedDecorator(options, args)
 	} else if (typeof arguments[0] === 'string') {

--- a/packages/state/src/lib/__tests__/computed.test.ts
+++ b/packages/state/src/lib/__tests__/computed.test.ts
@@ -333,4 +333,79 @@ describe('the computed decorator (C8, C9, C10)', () => {
 
 		warn.mockRestore()
 	})
+
+	it('[C8] can be applied as a factory with no options', () => {
+		// the options argument is optional, so `@computed()` must work like `@computed`
+		class Foo {
+			a = atom('a', 1)
+			@computed()
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+
+		const foo = new Foo()
+		expect(foo.getB()).toBe(2)
+		foo.a.set(2)
+		expect(foo.getB()).toBe(4)
+	})
+
+	it('[C8] a subclass override can call the superclass computed via super', () => {
+		// each decoration stores its computed under its own key; keying by method name made the
+		// super call re-enter the subclass's own computed and overflow the stack
+		class Base {
+			a = atom('a', 1)
+			@computed
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+		class Sub extends Base {
+			@computed
+			override getB() {
+				return super.getB() + 1
+			}
+		}
+
+		const sub = new Sub()
+		expect(sub.getB()).toBe(3)
+		sub.a.set(2)
+		expect(sub.getB()).toBe(5)
+		expect(new Base().getB()).toBe(2)
+	})
+
+	it('[C9] getComputedInstance resolves the nearest decorated method on the prototype chain', () => {
+		class Base {
+			a = atom('a', 1)
+			@computed
+			getB() {
+				return this.a.get() * 2
+			}
+		}
+		class Sub extends Base {
+			@computed
+			override getB() {
+				return super.getB() + 1
+			}
+		}
+		class PlainSub extends Base {
+			override getB() {
+				return super.getB() + 100
+			}
+		}
+
+		const sub = new Sub()
+		const subInst = getComputedInstance(sub, 'getB')
+		expect(subInst.get()).toBe(3)
+		sub.a.set(2)
+		expect(subInst.get()).toBe(5)
+
+		// a plain (undecorated) override still exposes the superclass's computed
+		const plain = new PlainSub()
+		expect(getComputedInstance(plain, 'getB').get()).toBe(2)
+
+		// the returned type unwraps the method's return type
+		const n: number = getComputedInstance(new Base(), 'getB').get()
+		expect(n).toBe(2)
+	})
 })


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a subclass that overrides a `@computed` method with another `@computed` method and calls `super.method()` overflowed the stack. It also fixes `@computed()` (zero-arg factory, allowed by the `options?` overload) crashing at class-definition time, and `getComputedInstance` returning `Computed<() => Value>` instead of `Computed<Value>` for a decorated method, so its own JSDoc example did not type-check.

### Before

All three decorator paths stored the per-instance computed under `Symbol.for('__@tldraw/state__computed__' + name)` — keyed by method name, not by decoration — so the subclass's wrapper and the superclass's wrapper shared one slot and `super.method()` re-entered the subclass's computed. `computed()` dispatched on `arguments.length === 1`, so zero args fell into the legacy-decorator branch and dereferenced an undefined descriptor.

### After

The three decorator helpers collapse into one `makeComputedWrapper` that uses a fresh `Symbol` per decoration and records it on the wrapper; `getComputedInstance` walks the prototype chain to the nearest decorated wrapper, unwraps the method's return type, and returns the instance even if its first derive throws. `computed()` treats `arguments.length <= 1` as the decorator factory. SPEC rules C8 and C9 updated.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the three new tests fail on `main` and pass with this change

### Release notes

- Fix `@computed` on a subclass override that calls `super`, and `@computed()` with no arguments

### API changes

- Changed `getComputedInstance()` to return `Computed<Value>` for a decorated method `() => Value` instead of `Computed<() => Value>`

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +43 / -83 |
| Tests | +75 / -0 |
| Automated files | +1 / -1 |
| Documentation | +2 / -2 |
