### PR TITLE
fix(state): cache a throw from a computed's first derive

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -66,7 +66,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 
 ## 7. Errors in computed signals (CE)
 
-- **CE1** If the compute function throws, the thrown value is cached: subsequent `get()` calls rethrow the same value without re-running the compute function, until a parent changes.
+- **CE1** If the compute function throws, the thrown value is cached: subsequent `get()` calls rethrow the same value without re-running the compute function, until a parent changes. This includes a throw from the very first computation.
 - **CE2** Entering the error state counts as a change: downstream effects re-run (and observe the throw). Throwing again on a subsequent recomputation, while already in the error state, does _not_ count as a change — consecutive errors do not re-trigger effects.
 - **CE3** Entering the error state discards the previous value: when the computed later recovers, the compute function receives `UNINITIALIZED` as `previousValue`, and the error state clears.
 - **CE4** Entering the error state clears the computed's history buffer; `getDiffSince` spanning the error returns `RESET_VALUE`.

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -316,6 +316,7 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 			return this.state
 		} catch (e) {
+			// if a derived value throws an error, we reset the state to UNINITIALIZED
 			const epoch = getGlobalEpoch()
 			// Entering the error state (from a value, or from never having computed) is a change;
 			// throwing again while already in it is not. Checking `error` rather than `state` matters
@@ -327,6 +328,7 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 				this.lastChangedEpoch = epoch
 			}
 			this.lastCheckedEpoch = epoch
+			// we also clear the history buffer if an error was thrown
 			if (this.historyBuffer) {
 				this.historyBuffer.clear()
 			}

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -316,14 +316,17 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 
 			return this.state
 		} catch (e) {
-			// if a derived value throws an error, we reset the state to UNINITIALIZED
 			const epoch = getGlobalEpoch()
-			if (this.state !== UNINITIALIZED) {
+			// Entering the error state (from a value, or from never having computed) is a change;
+			// throwing again while already in it is not. Checking `error` rather than `state` matters
+			// for a first run that throws: `state` is already UNINITIALIZED then, and leaving
+			// `lastChangedEpoch` at GLOBAL_START_EPOCH would keep `isNew` true and re-run `derive` on
+			// every read instead of rethrowing the cached error.
+			if (this.error === null) {
 				this.state = UNINITIALIZED as unknown as Value
 				this.lastChangedEpoch = epoch
 			}
 			this.lastCheckedEpoch = epoch
-			// we also clear the history buffer if an error was thrown
 			if (this.historyBuffer) {
 				this.historyBuffer.clear()
 			}

--- a/packages/state/src/lib/__tests__/errors.test.ts
+++ b/packages/state/src/lib/__tests__/errors.test.ts
@@ -36,6 +36,30 @@ describe('computed signals that throw (CE)', () => {
 		expect(b.get()).toBe(3)
 	})
 
+	it('[CE1] cache a throw from the very first computation too', () => {
+		let numComputations = 0
+		const a = atom('', 1)
+		const b = computed('', () => {
+			numComputations++
+			if (a.get() === 1) throw new Error('test')
+			return a.get()
+		})
+
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(numComputations).toBe(1)
+
+		// an unrelated change doesn't re-run it either
+		atom('', 0).set(1)
+		expect(() => b.get()).toThrowErrorMatchingInlineSnapshot(`[Error: test]`)
+		expect(numComputations).toBe(1)
+
+		a.set(2)
+		expect(b.get()).toBe(2)
+		expect(numComputations).toBe(2)
+	})
+
 	it('[CE2] entering the error state notifies effects, but consecutive errors do not', () => {
 		const a = atom('', 1)
 		let numComputations = 0


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a computed whose very first derive throws re-ran the compute function on every `get()` instead of rethrowing the cached error.

### Before

The error path only advanced `lastChangedEpoch` when `state !== UNINITIALIZED`. On a first-run throw `state` is already `UNINITIALIZED`, so `lastChangedEpoch` stayed at `GLOBAL_START_EPOCH`, `isNew` stayed true, and every read (including every `haveParentsChanged` probe from an effect) re-derived. Three `c.get()` calls ran the compute function three times.

### After

The path checks `error === null` — entering the error state is a change whether it comes from a value or from never having computed; throwing again while already in it is not. SPEC rule CE1 updated.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix computeds re-running their compute function on every read after their first derive throws

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +6 / -3 |
| Tests | +24 / -0 |
| Documentation | +1 / -1 |
