### PR TITLE
fix(state): compute atom diffs before ticking the epoch and record null diffs

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -76,8 +76,8 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 ## 8. History and diffs (H)
 
 - **H1** A signal has a history buffer only if `historyLength` was passed at creation. `computeDiff` without `historyLength` does nothing.
-- **H2** When an atom with history changes, the recorded diff is chosen in priority order: the explicit `diff` argument to `set(value, diff)`, else `computeDiff(prev, next, lastChangedEpoch, currentEpoch)`, else `RESET_VALUE`.
-- **H3** When a computed with history changes, the recorded diff is chosen in priority order: the diff from a `withDiff(value, diff)` return value, else `computeDiff(...)`, else `RESET_VALUE`. No entry is recorded for the first computation.
+- **H2** When an atom with history changes, the recorded diff is chosen in priority order: the explicit `diff` argument to `set(value, diff)`, else `computeDiff(prev, next, lastChangedEpoch, currentEpoch)`, else `RESET_VALUE`. Only `undefined` means "not supplied"; an explicit `null` diff is recorded as a diff.
+- **H3** When a computed with history changes, the recorded diff is chosen in priority order: the diff from a `withDiff(value, diff)` return value, else `computeDiff(prev, next, lastCheckedEpoch, currentEpoch)`, else `RESET_VALUE`. No entry is recorded for the first computation. As for H2, only `undefined` means "not supplied".
 - **H4** Recording `RESET_VALUE` as a diff clears the entire history buffer. In particular, failing to supply a diff on a signal that has history but no `computeDiff` wipes its history.
 - **H5** `getDiffSince(epoch)` returns:
   - the shared frozen `EMPTY_ARRAY` if `epoch >= lastChangedEpoch` (nothing changed since);
@@ -163,6 +163,6 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 
 `HistoryBuffer` is the circular diff store behind H1–H5.
 
-- **HB1** `pushEntry(fromEpoch, toEpoch, diff)` stores a diff covering the epoch range; pushing `undefined` is ignored; pushing `RESET_VALUE` clears the buffer.
-- **HB2** `getChangesSince(epoch)` returns `[]` when the epoch is at or past the newest entry's `toEpoch`; the ordered diffs back to (and including) the entry whose range contains `epoch`, when the buffer reaches back that far; and `RESET_VALUE` otherwise (epoch too old, buffer empty, capacity exceeded, or cleared).
+- **HB1** `pushEntry(fromEpoch, toEpoch, diff)` stores a diff covering the epoch range. Pushing `RESET_VALUE` clears the buffer, and so does pushing `undefined` ("no diff available"): skipping the entry instead would leave a gap, and a later query from before the gap would return an incomplete diff list.
+- **HB2** `getChangesSince(epoch)` returns the shared frozen `EMPTY_ARRAY` when the epoch is at or past the newest entry's `toEpoch`; the ordered diffs back to (and including) the entry whose range contains `epoch`, when the buffer reaches back that far; and `RESET_VALUE` otherwise (epoch too old, buffer empty, capacity exceeded, or cleared).
 - **HB3** The buffer holds at most `capacity` entries; the oldest entries are overwritten, after which queries reaching past them return `RESET_VALUE`.

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -13,7 +13,7 @@ export interface AtomOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need diffs, leave this as `undefined` and no history buffer will be created. Diffs passed to {@link Atom.set} or produced by {@link AtomOptions.computeDiff} are only recorded when this is set.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -158,9 +158,23 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	 * ```
 	 */
 	set(value: Value, diff?: Diff): Value {
-		// If the value has not changed, do nothing.
 		if (this.isEqual?.(this.current, value) ?? equals(this.current, value)) {
 			return this.current
+		}
+
+		// `computeDiff` is user code: run it before ticking the epoch, so that any signal it reads is
+		// checked against the epoch this write has not yet happened in. Reading a dependent computed
+		// after the tick would stamp it as checked at the new epoch while the atom was still being
+		// written, and it would then never see the change. Only `undefined` means "no diff
+		// supplied"; `null` can be a legitimate diff.
+		let historyDiff: Diff | RESET_VALUE | undefined
+		if (this.historyBuffer) {
+			historyDiff =
+				diff !== undefined
+					? diff
+					: this.computeDiff
+						? this.computeDiff(this.current, value, this.lastChangedEpoch, getGlobalEpoch() + 1)
+						: RESET_VALUE
 		}
 
 		// Tick forward the global epoch. This write belongs to that one epoch, so read it once and
@@ -169,22 +183,15 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		advanceGlobalEpoch()
 		const epoch = getGlobalEpoch()
 
-		// Add the diff to the history buffer.
 		if (this.historyBuffer) {
-			this.historyBuffer.pushEntry(
-				this.lastChangedEpoch,
-				epoch,
-				diff ?? this.computeDiff?.(this.current, value, this.lastChangedEpoch, epoch) ?? RESET_VALUE
-			)
+			this.historyBuffer.pushEntry(this.lastChangedEpoch, epoch, historyDiff)
 		}
 
-		// Update the atom's record of the epoch when last changed.
 		this.lastChangedEpoch = epoch
 
 		const oldValue = this.current
 		this.current = value
 
-		// Notify all children that this atom has changed.
 		atomDidChange(this as any, oldValue)
 
 		return value

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -158,6 +158,7 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	 * ```
 	 */
 	set(value: Value, diff?: Diff): Value {
+		// If the value has not changed, do nothing.
 		if (this.isEqual?.(this.current, value) ?? equals(this.current, value)) {
 			return this.current
 		}
@@ -183,15 +184,18 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		advanceGlobalEpoch()
 		const epoch = getGlobalEpoch()
 
+		// Add the diff to the history buffer.
 		if (this.historyBuffer) {
 			this.historyBuffer.pushEntry(this.lastChangedEpoch, epoch, historyDiff)
 		}
 
+		// Update the atom's record of the epoch when last changed.
 		this.lastChangedEpoch = epoch
 
 		const oldValue = this.current
 		this.current = value
 
+		// Notify all children that this atom has changed.
 		atomDidChange(this as any, oldValue)
 
 		return value

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -150,7 +150,7 @@ export interface ComputedOptions<Value, Diff> {
 	/**
 	 * The maximum number of diffs to keep in the history buffer.
 	 *
-	 * If you don't need to compute diffs, or if you will supply diffs manually via {@link Atom.set}, you can leave this as `undefined` and no history buffer will be created.
+	 * If you don't need diffs, leave this as `undefined` and no history buffer will be created. Diffs supplied via {@link withDiff} or {@link ComputedOptions.computeDiff} are only recorded when this is set.
 	 *
 	 * If you expect the value to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10).
 	 *
@@ -299,13 +299,16 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 			const epoch = getGlobalEpoch()
 			if (isUninitialized || !this.isEqual(this.state, newState)) {
 				if (this.historyBuffer && !isUninitialized) {
+					// Only `undefined` means "no diff supplied"; `null` can be a legitimate diff.
 					const diff = result instanceof WithDiff ? result.diff : undefined
 					this.historyBuffer.pushEntry(
 						this.lastChangedEpoch,
 						epoch,
-						diff ??
-							this.computeDiff?.(this.state, newState, this.lastCheckedEpoch, epoch) ??
-							RESET_VALUE
+						diff !== undefined
+							? diff
+							: this.computeDiff
+								? this.computeDiff(this.state, newState, this.lastCheckedEpoch, epoch)
+								: RESET_VALUE
 					)
 				}
 				this.lastChangedEpoch = epoch

--- a/packages/state/src/lib/HistoryBuffer.ts
+++ b/packages/state/src/lib/HistoryBuffer.ts
@@ -1,19 +1,15 @@
+import { EMPTY_ARRAY } from './helpers'
 import { RESET_VALUE } from './types'
 
-/**
- * A tuple representing a range of epochs and the associated diff.
- * Used internally by HistoryBuffer to store change information.
- *
- * @internal
- */
 type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
 
 /**
- * A circular buffer that stores diffs between sequential values of an atom or computed signal.
- * This enables efficient change tracking and history retrieval for features like undo/redo.
+ * A ring buffer of the most recent diffs of an atom or computed signal, so that
+ * {@link Signal.getDiffSince} can hand incremental consumers the changes since the epoch they
+ * last saw instead of forcing them to recompute from the current value.
  *
- * The buffer uses a wrap-around strategy to maintain a fixed-size history of the most recent
- * changes, automatically overwriting older entries when the capacity is exceeded.
+ * Entries must be contiguous (`entry[k].toEpoch === entry[k+1].fromEpoch`); `getChangesSince`
+ * relies on that to find the entry covering an epoch.
  *
  * @example
  * ```ts
@@ -26,91 +22,39 @@ type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
  * @internal
  */
 export class HistoryBuffer<Diff> {
-	/**
-	 * Current write position in the circular buffer.
-	 * @internal
-	 */
 	private index = 0
 
-	/**
-	 * Circular buffer storing range tuples. Uses undefined to represent empty slots.
-	 * @internal
-	 */
 	buffer: Array<RangeTuple<Diff> | undefined>
 
-	/**
-	 * Creates a new HistoryBuffer with the specified capacity.
-	 *
-	 * capacity - Maximum number of diffs to store in the buffer
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<number>(10) // Store up to 10 diffs
-	 * ```
-	 */
 	constructor(private readonly capacity: number) {
 		this.buffer = new Array(capacity)
 	}
 
 	/**
-	 * Adds a diff entry to the history buffer, representing a change between two epochs.
-	 *
-	 * If the diff is undefined, the operation is ignored. If the diff is RESET_VALUE,
-	 * the entire buffer is cleared to indicate that historical tracking should restart.
-	 *
-	 * @param lastComputedEpoch - The epoch when the previous value was computed
-	 * @param currentEpoch - The epoch when the current value was computed
-	 * @param diff - The diff representing the change, or RESET_VALUE to clear history
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<string>(5)
-	 * buffer.pushEntry(0, 1, 'added text')
-	 * buffer.pushEntry(1, 2, RESET_VALUE) // Clears the buffer
-	 * ```
+	 * Records the diff covering `lastComputedEpoch` → `currentEpoch`. `RESET_VALUE` — or an
+	 * `undefined` diff, which also means "no diff available" — clears the buffer instead: silently
+	 * skipping an entry would leave a gap, and a later `getChangesSince` from before the gap would
+	 * return an incomplete diff list rather than `RESET_VALUE`.
 	 */
-	pushEntry(lastComputedEpoch: number, currentEpoch: number, diff: Diff | RESET_VALUE) {
-		if (diff === undefined) {
-			return
-		}
-
-		if (diff === RESET_VALUE) {
+	pushEntry(lastComputedEpoch: number, currentEpoch: number, diff: Diff | RESET_VALUE | undefined) {
+		if (diff === RESET_VALUE || diff === undefined) {
 			this.clear()
 			return
 		}
 
-		// Add the diff to the buffer as a range tuple.
 		this.buffer[this.index] = [lastComputedEpoch, currentEpoch, diff]
-
-		// Bump the index, wrapping around if necessary.
 		this.index = (this.index + 1) % this.capacity
 	}
 
-	/**
-	 * Clears all entries from the history buffer and resets the write position.
-	 * This is called when a RESET_VALUE diff is encountered.
-	 *
-	 * @example
-	 * ```ts
-	 * const buffer = new HistoryBuffer<string>(5)
-	 * buffer.pushEntry(0, 1, 'change')
-	 * buffer.clear()
-	 * console.log(buffer.getChangesSince(0)) // RESET_VALUE
-	 * ```
-	 */
 	clear() {
 		this.index = 0
 		this.buffer.fill(undefined)
 	}
 
 	/**
-	 * Retrieves all diffs that occurred since the specified epoch.
+	 * The diffs since `sinceEpoch`, oldest first, or `RESET_VALUE` if the buffer no longer reaches
+	 * back that far (evicted, cleared, or never recorded).
 	 *
-	 * The method searches backwards through the circular buffer to find changes
-	 * that occurred after the given epoch. If insufficient history is available
-	 * or the requested epoch is too old, returns RESET_VALUE indicating that
-	 * a complete state rebuild is required.
-	 *
-	 * @param sinceEpoch - The epoch from which to retrieve changes
-	 * @returns Array of diffs since the epoch, or RESET_VALUE if history is insufficient
 	 * @example
 	 * ```ts
 	 * const buffer = new HistoryBuffer<string>(5)
@@ -124,25 +68,22 @@ export class HistoryBuffer<Diff> {
 	getChangesSince(sinceEpoch: number): RESET_VALUE | Diff[] {
 		const { index, capacity, buffer } = this
 
-		// For each item in the buffer...
+		// Walk backwards from the newest entry looking for the one whose range contains sinceEpoch.
 		for (let i = 0; i < capacity; i++) {
 			const offset = (index - 1 + capacity - i) % capacity
 
 			const elem = buffer[offset]
 
-			// If there's no element in the offset position, return the reset value
 			if (!elem) {
 				return RESET_VALUE
 			}
 
 			const [fromEpoch, toEpoch] = elem
 
-			// If the first element is already too early, bail
 			if (i === 0 && sinceEpoch >= toEpoch) {
-				return []
+				return EMPTY_ARRAY
 			}
 
-			// If the element is since the given epoch, return an array with all diffs from this element and all following elements
 			if (fromEpoch <= sinceEpoch && sinceEpoch < toEpoch) {
 				const len = i + 1
 				const result = new Array(len)
@@ -155,7 +96,6 @@ export class HistoryBuffer<Diff> {
 			}
 		}
 
-		// If we haven't returned yet, return the reset value
 		return RESET_VALUE
 	}
 }

--- a/packages/state/src/lib/HistoryBuffer.ts
+++ b/packages/state/src/lib/HistoryBuffer.ts
@@ -1,12 +1,20 @@
 import { EMPTY_ARRAY } from './helpers'
 import { RESET_VALUE } from './types'
 
+/**
+ * A tuple representing a range of epochs and the associated diff.
+ * Used internally by HistoryBuffer to store change information.
+ *
+ * @internal
+ */
 type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
 
 /**
- * A ring buffer of the most recent diffs of an atom or computed signal, so that
- * {@link Signal.getDiffSince} can hand incremental consumers the changes since the epoch they
- * last saw instead of forcing them to recompute from the current value.
+ * A circular buffer that stores diffs between sequential values of an atom or computed signal.
+ * This enables efficient change tracking and history retrieval for features like undo/redo.
+ *
+ * The buffer uses a wrap-around strategy to maintain a fixed-size history of the most recent
+ * changes, automatically overwriting older entries when the capacity is exceeded.
  *
  * Entries must be contiguous (`entry[k].toEpoch === entry[k+1].fromEpoch`); `getChangesSince`
  * relies on that to find the entry covering an epoch.
@@ -22,19 +30,48 @@ type RangeTuple<Diff> = [fromEpoch: number, toEpoch: number, diff: Diff]
  * @internal
  */
 export class HistoryBuffer<Diff> {
+	/**
+	 * Current write position in the circular buffer.
+	 * @internal
+	 */
 	private index = 0
 
+	/**
+	 * Circular buffer storing range tuples. Uses undefined to represent empty slots.
+	 * @internal
+	 */
 	buffer: Array<RangeTuple<Diff> | undefined>
 
+	/**
+	 * Creates a new HistoryBuffer with the specified capacity.
+	 *
+	 * capacity - Maximum number of diffs to store in the buffer
+	 * @example
+	 * ```ts
+	 * const buffer = new HistoryBuffer<number>(10) // Store up to 10 diffs
+	 * ```
+	 */
 	constructor(private readonly capacity: number) {
 		this.buffer = new Array(capacity)
 	}
 
 	/**
-	 * Records the diff covering `lastComputedEpoch` → `currentEpoch`. `RESET_VALUE` — or an
-	 * `undefined` diff, which also means "no diff available" — clears the buffer instead: silently
-	 * skipping an entry would leave a gap, and a later `getChangesSince` from before the gap would
-	 * return an incomplete diff list rather than `RESET_VALUE`.
+	 * Adds a diff entry to the history buffer, representing a change between two epochs.
+	 *
+	 * If the diff is RESET_VALUE, or undefined (meaning no diff is available), the entire buffer is
+	 * cleared to indicate that historical tracking should restart. Silently skipping an entry would
+	 * leave a gap, and a later `getChangesSince` from before the gap would return an incomplete
+	 * diff list rather than RESET_VALUE.
+	 *
+	 * @param lastComputedEpoch - The epoch when the previous value was computed
+	 * @param currentEpoch - The epoch when the current value was computed
+	 * @param diff - The diff representing the change, or RESET_VALUE / undefined to clear history
+	 * @example
+	 * ```ts
+	 * const buffer = new HistoryBuffer<string>(5)
+	 * buffer.pushEntry(0, 1, 'added text')
+	 * buffer.pushEntry(1, 2, RESET_VALUE) // Clears the buffer
+	 * ```
 	 */
 	pushEntry(lastComputedEpoch: number, currentEpoch: number, diff: Diff | RESET_VALUE | undefined) {
 		if (diff === RESET_VALUE || diff === undefined) {
@@ -42,19 +79,40 @@ export class HistoryBuffer<Diff> {
 			return
 		}
 
+		// Add the diff to the buffer as a range tuple.
 		this.buffer[this.index] = [lastComputedEpoch, currentEpoch, diff]
+
+		// Bump the index, wrapping around if necessary.
 		this.index = (this.index + 1) % this.capacity
 	}
 
+	/**
+	 * Clears all entries from the history buffer and resets the write position.
+	 * This is called when a RESET_VALUE diff is encountered.
+	 *
+	 * @example
+	 * ```ts
+	 * const buffer = new HistoryBuffer<string>(5)
+	 * buffer.pushEntry(0, 1, 'change')
+	 * buffer.clear()
+	 * console.log(buffer.getChangesSince(0)) // RESET_VALUE
+	 * ```
+	 */
 	clear() {
 		this.index = 0
 		this.buffer.fill(undefined)
 	}
 
 	/**
-	 * The diffs since `sinceEpoch`, oldest first, or `RESET_VALUE` if the buffer no longer reaches
-	 * back that far (evicted, cleared, or never recorded).
+	 * Retrieves all diffs that occurred since the specified epoch.
 	 *
+	 * The method searches backwards through the circular buffer to find changes
+	 * that occurred after the given epoch. If insufficient history is available
+	 * or the requested epoch is too old, returns RESET_VALUE indicating that
+	 * a complete state rebuild is required.
+	 *
+	 * @param sinceEpoch - The epoch from which to retrieve changes
+	 * @returns Array of diffs since the epoch, or RESET_VALUE if history is insufficient
 	 * @example
 	 * ```ts
 	 * const buffer = new HistoryBuffer<string>(5)
@@ -68,22 +126,25 @@ export class HistoryBuffer<Diff> {
 	getChangesSince(sinceEpoch: number): RESET_VALUE | Diff[] {
 		const { index, capacity, buffer } = this
 
-		// Walk backwards from the newest entry looking for the one whose range contains sinceEpoch.
+		// For each item in the buffer...
 		for (let i = 0; i < capacity; i++) {
 			const offset = (index - 1 + capacity - i) % capacity
 
 			const elem = buffer[offset]
 
+			// If there's no element in the offset position, return the reset value
 			if (!elem) {
 				return RESET_VALUE
 			}
 
 			const [fromEpoch, toEpoch] = elem
 
+			// If the first element is already too early, bail
 			if (i === 0 && sinceEpoch >= toEpoch) {
 				return EMPTY_ARRAY
 			}
 
+			// If the element is since the given epoch, return an array with all diffs from this element and all following elements
 			if (fromEpoch <= sinceEpoch && sinceEpoch < toEpoch) {
 				const len = i + 1
 				const result = new Array(len)
@@ -96,6 +157,7 @@ export class HistoryBuffer<Diff> {
 			}
 		}
 
+		// If we haven't returned yet, return the reset value
 		return RESET_VALUE
 	}
 }

--- a/packages/state/src/lib/__tests__/HistoryBuffer.test.ts
+++ b/packages/state/src/lib/__tests__/HistoryBuffer.test.ts
@@ -47,13 +47,16 @@ describe('HistoryBuffer', () => {
 		expect(buf.getChangesSince(0)).toEqual(RESET_VALUE)
 	})
 
-	it('[HB1] ignores undefined diffs', () => {
+	it('[HB1] treats an undefined diff like RESET_VALUE: it clears rather than leaving a gap', () => {
 		const buf = new HistoryBuffer<string>(3)
 		buf.pushEntry(0, 1, 'a')
 		buf.pushEntry(1, 2, undefined as any)
+		buf.pushEntry(2, 3, 'c')
 
-		expect(buf.getChangesSince(0)).toEqual(['a'])
-		expect(buf.getChangesSince(1)).toEqual([])
+		// if the undefined entry had been skipped, this would be ['a', 'c'] with the 1 -> 2 change missing
+		expect(buf.getChangesSince(0)).toEqual(RESET_VALUE)
+		expect(buf.getChangesSince(1)).toEqual(RESET_VALUE)
+		expect(buf.getChangesSince(2)).toEqual(['c'])
 	})
 
 	it('[HB1] will clear if you push RESET_VALUE', () => {

--- a/packages/state/src/lib/__tests__/history.test.ts
+++ b/packages/state/src/lib/__tests__/history.test.ts
@@ -78,6 +78,35 @@ describe('atom history (H)', () => {
 		expect(calls).toEqual([[1, 5, epochBeforeSet, getGlobalEpoch()]])
 	})
 
+	it('[H2][C2] a computed read inside computeDiff still sees the change afterwards', () => {
+		// computeDiff runs before the epoch ticks, so a dependent computed it reads is not stamped as
+		// checked at the epoch of the write that is still in progress.
+		const a = atom('', 1, {
+			historyLength: 10,
+			computeDiff: (prev, next) => {
+				c.get()
+				return next - prev
+			},
+		})
+		const c: Computed<number> = computed('', () => a.get() * 2)
+		const seen: number[] = []
+		react('', () => seen.push(c.get()))
+
+		a.set(2)
+
+		expect(c.get()).toBe(4)
+		expect(seen).toEqual([2, 4])
+		expect(a.getDiffSince(a.lastChangedEpoch - 1)).toEqual([1])
+	})
+
+	it('[H2] records an explicit null diff rather than treating it as missing', () => {
+		const a = atom<number, null | number>('', 1, { historyLength: 3 })
+		const startEpoch = a.lastChangedEpoch
+		a.set(2, 1)
+		a.set(3, null)
+		expect(a.getDiffSince(startEpoch)).toEqual([1, null])
+	})
+
 	it('[H4] clears the history buffer if no diff can be determined', () => {
 		const a = atom('', 1, { historyLength: 3 })
 		const startEpoch = getGlobalEpoch()

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -193,7 +193,7 @@ export interface Child {
  *
  * @param previousValue - The previous value of the signal
  * @param currentValue - The current value of the signal
- * @param lastComputedEpoch - The epoch when the previous value was set
+ * @param lastComputedEpoch - For an atom, the epoch when the previous value was set. For a computed, the epoch at which it was last checked (the same value its compute function receives), so that `other.getDiffSince(lastComputedEpoch)` yields exactly the changes not yet accounted for.
  * @param currentEpoch - The epoch when the current value was set
  * @returns A diff object representing the change, or the unique symbol RESET_VALUE if no diff can be computed
  *


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a computed read inside an atom's `computeDiff` never saw that change afterwards. It also fixes an explicit `null` diff being treated as "no diff" (wiping history), and `HistoryBuffer.pushEntry` silently skipping an `undefined` diff, which left a gap that made later `getDiffSince` calls return an incomplete list instead of `RESET_VALUE`.

### Before

`Atom.set` called `advanceGlobalEpoch()` and then ran the user's `computeDiff`. A dependent computed read inside it was stamped as checked at the new epoch while the atom's value and `lastChangedEpoch` had not been written yet, so it cached the old value against the write's own epoch and its effect never ran. In `Atom.set` and `Computed`, `diff ?? computeDiff(...) ?? RESET_VALUE` collapsed `null` to `RESET_VALUE`. `pushEntry` returned early on `undefined`, so a buffer could hold `[0→1, 2→3]` and report `['a', 'c']` for `getChangesSince(0)` with the 1→2 change missing.

### After

`Atom.set` computes the diff before ticking the epoch (passing `getGlobalEpoch() + 1` as the current epoch). Both call sites use `diff !== undefined ? diff : …`, so only `undefined` means "not supplied". `pushEntry` treats `undefined` like `RESET_VALUE` and clears, and `getChangesSince` returns the shared `EMPTY_ARRAY` rather than a fresh `[]`. The `historyLength` option docs on `AtomOptions`/`ComputedOptions` and the `ComputeDiff` `lastComputedEpoch` parameter doc are corrected to match (for a computed it is `lastCheckedEpoch`, not the last change). SPEC rules H2, H3, HB1 and HB2 updated.

The `HistoryBuffer` class doc now states the contiguity invariant `getChangesSince` relies on, and the `pushEntry` doc describes the new `undefined` handling; other comments are left as they were.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the three new/changed tests fail on `main` and pass with this change

### Release notes

- Fix computeds read inside an atom's `computeDiff` never seeing that change
- Fix an explicit `null` diff passed to `atom.set()` or returned from `withDiff()` clearing history

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +45 / -21 |
| Tests | +35 / -3 |
| Documentation | +4 / -4 |

