### PR TITLE
fix(state): don't throw from localStorageAtom outside the browser

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -150,6 +150,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **LS3** The atom's value is written to localStorage as JSON on creation and after every change.
 - **LS4** A `storage` event for the same key updates the atom with the parsed new value; a `storage` event with `newValue: null` resets the atom to `initialValue`; an unparseable `newValue` and events for other keys are ignored.
 - **LS5** `cleanup()` stops localStorage writes and storage-event handling. The atom itself keeps working as a plain atom. Atom `options` (equality, history) pass through per A/H rules.
+- **LS6** Without a `window` (Node, SSR) `localStorageAtom` does not throw: it behaves as a plain atom with `initialValue` and `cleanup()` is a no-op.
 
 ## 16. ArraySet — internal (AS)
 

--- a/packages/state/src/lib/__tests__/localStorageAtom.test.ts
+++ b/packages/state/src/lib/__tests__/localStorageAtom.test.ts
@@ -260,4 +260,19 @@ describe('localStorageAtom', () => {
 			cleanup2()
 		})
 	})
+
+	describe('outside the browser', () => {
+		it('[LS6] does not throw without a window and returns a working atom', () => {
+			vi.stubGlobal('window', undefined)
+			try {
+				const [atom, cleanup] = localStorageAtom('test-key', 'initial-value')
+				expect(atom.get()).toBe('initial-value')
+				atom.set('next')
+				expect(atom.get()).toBe('next')
+				expect(() => cleanup()).not.toThrow()
+			} finally {
+				vi.unstubAllGlobals()
+			}
+		})
+	})
 })

--- a/packages/state/src/lib/localStorageAtom.ts
+++ b/packages/state/src/lib/localStorageAtom.ts
@@ -82,6 +82,7 @@ export function localStorageAtom<Value, Diff = unknown>(
 		window.addEventListener('storage', handleStorageEvent)
 	}
 
+	// Combined cleanup function
 	const cleanup = () => {
 		reactCleanup()
 		if (canListen) {

--- a/packages/state/src/lib/localStorageAtom.ts
+++ b/packages/state/src/lib/localStorageAtom.ts
@@ -75,12 +75,18 @@ export function localStorageAtom<Value, Diff = unknown>(
 		}
 	}
 
-	window.addEventListener('storage', handleStorageEvent)
+	// The storage helpers above tolerate environments without localStorage (Node, SSR); do the
+	// same here rather than throwing on `window`.
+	const canListen = typeof window !== 'undefined'
+	if (canListen) {
+		window.addEventListener('storage', handleStorageEvent)
+	}
 
-	// Combined cleanup function
 	const cleanup = () => {
 		reactCleanup()
-		window.removeEventListener('storage', handleStorageEvent)
+		if (canListen) {
+			window.removeEventListener('storage', handleStorageEvent)
+		}
 	}
 
 	return [outAtom, cleanup]


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `localStorageAtom` threw `ReferenceError: window is not defined` in Node and SSR environments.

### Before

The `getFromLocalStorage`/`setInLocalStorage` helpers it uses deliberately tolerate environments without `localStorage`, but `localStorageAtom` then called `window.addEventListener('storage', …)` unguarded — after already creating the atom and its persisting effect, so nothing was returned for cleanup either.

### After

The `storage` listener is only added (and removed) when `window` exists; otherwise the atom behaves as a plain atom with `initialValue` and `cleanup()` is a no-op. SPEC rule LS6 added.

Split out of #10144.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix `localStorageAtom` throwing outside the browser

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +9 / -3 |
| Tests | +15 / -0 |
| Documentation | +1 / -0 |
