### PR TITLE
perf(state): allocate less per signal and per flush

### DIFF
--- a/packages/state/SPEC.md
+++ b/packages/state/SPEC.md
@@ -158,6 +158,7 @@ Sections marked **internal** describe supporting machinery (`ArraySet`, `History
 - **AS1** `add` returns true and inserts when the element is absent; returns false and does nothing when present. `remove` returns true and deletes when present; returns false otherwise.
 - **AS2** `visit` and `[Symbol.iterator]` yield each element exactly once; `has`, `size`, and `isEmpty` are consistent with the elements yielded.
 - **AS3** The implementation stores up to `ARRAY_SIZE_THRESHOLD` (8) elements in an array, promoting to a `Set` on overflow. Behavior is identical in both modes and across the promotion boundary, including after interleaved adds, removes, and clears.
+- **AS4** A fresh ArraySet allocates no backing storage until the first `add`. Every query on it (`has`, `size`, `isEmpty`, `visit`, iteration) answers as empty, and `remove` and `clear` are no-ops that leave it usable.
 
 ## 17. HistoryBuffer — internal (HB)
 

--- a/packages/state/src/lib/ArraySet.ts
+++ b/packages/state/src/lib/ArraySet.ts
@@ -1,88 +1,46 @@
 /**
- * The maximum number of items that can be stored in an ArraySet in array mode before switching to Set mode.
+ * The number of items an ArraySet holds in array mode before switching to a Set.
  *
- * @public
- * @example
- * ```ts
- * import { ARRAY_SIZE_THRESHOLD } from '@tldraw/state'
- *
- * console.log(ARRAY_SIZE_THRESHOLD) // 8
- * ```
+ * @internal
  */
 export const ARRAY_SIZE_THRESHOLD = 8
 
 /**
  * An ArraySet operates as an array until it reaches a certain size, after which a Set is used
  * instead. In either case, the same methods are used to get, set, remove, and visit the items.
+ *
+ * The backing array is allocated on the first `add`: most signals never get a child, and an
+ * empty ArraySet is created for every atom and effect, and two for every computed.
  * @internal
  */
 export class ArraySet<T> {
 	private arraySize = 0
 
-	private array: (T | undefined)[] | null = Array(ARRAY_SIZE_THRESHOLD)
+	// Slots [0, arraySize) hold the items; slots beyond are undefined. `add`/`has` scan the whole
+	// array with indexOf, which is why `clear` and `remove` must blank vacated slots.
+	private array: (T | undefined)[] | null = null
 
 	private set: Set<T> | null = null
 
 	/**
 	 * Get whether this ArraySet has any elements.
-	 *
-	 * @returns True if this ArraySet has any elements, false otherwise.
 	 */
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get isEmpty() {
-		if (this.array) {
-			return this.arraySize === 0
-		}
-
 		if (this.set) {
 			return this.set.size === 0
 		}
 
-		throw new Error('no set or array')
+		return this.arraySize === 0
 	}
 
 	/**
 	 * Add an element to the ArraySet if it is not already present.
 	 *
-	 * @param elem - The element to add to the set
 	 * @returns `true` if the element was added, `false` if it was already present
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 *
-	 * console.log(arraySet.add('hello')) // true
-	 * console.log(arraySet.add('hello')) // false (already exists)
-	 * ```
 	 */
 	add(elem: T) {
-		if (this.array) {
-			const idx = this.array.indexOf(elem)
-
-			// Return false if the element is already in the array.
-			if (idx !== -1) {
-				return false
-			}
-
-			if (this.arraySize < ARRAY_SIZE_THRESHOLD) {
-				// If the array is below the size threshold, push items into the array.
-
-				// Insert the element into the array's next available slot.
-				this.array[this.arraySize] = elem
-				this.arraySize++
-
-				return true
-			} else {
-				// If the array is full, convert it to a set and remove the array.
-				this.set = new Set(this.array as any)
-				this.array = null
-				this.set.add(elem)
-
-				return true
-			}
-		}
-
 		if (this.set) {
-			// Return false if the element is already in the set.
 			if (this.set.has(elem)) {
 				return false
 			}
@@ -91,191 +49,121 @@ export class ArraySet<T> {
 			return true
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			this.array = Array(ARRAY_SIZE_THRESHOLD)
+		} else if (this.array.indexOf(elem) !== -1) {
+			return false
+		}
+
+		if (this.arraySize < ARRAY_SIZE_THRESHOLD) {
+			this.array[this.arraySize] = elem
+			this.arraySize++
+
+			return true
+		}
+
+		// The array is full: promote to a set.
+		this.set = new Set(this.array as T[])
+		this.array = null
+		this.set.add(elem)
+
+		return true
 	}
 
 	/**
 	 * Remove an element from the ArraySet if it is present.
 	 *
-	 * @param elem - The element to remove from the set
 	 * @returns `true` if the element was removed, `false` if it was not present
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 *
-	 * console.log(arraySet.remove('hello')) // true
-	 * console.log(arraySet.remove('hello')) // false (not present)
-	 * ```
 	 */
 	remove(elem: T) {
-		if (this.array) {
-			const idx = this.array.indexOf(elem)
-
-			// If the item is not in the array, return false.
-			if (idx === -1) {
-				return false
-			}
-
-			this.array[idx] = undefined
-			this.arraySize--
-
-			if (idx !== this.arraySize) {
-				// If the item is not the last item in the array, move the last item into the
-				// removed item's slot.
-				this.array[idx] = this.array[this.arraySize]
-				this.array[this.arraySize] = undefined
-			}
-
-			return true
-		}
-
 		if (this.set) {
-			// If the item is not in the set, return false.
-			if (!this.set.has(elem)) {
-				return false
-			}
-
-			this.set.delete(elem)
-
-			return true
+			return this.set.delete(elem)
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			return false
+		}
+
+		const idx = this.array.indexOf(elem)
+
+		if (idx === -1) {
+			return false
+		}
+
+		this.arraySize--
+
+		// Move the last item into the vacated slot so the items stay dense.
+		this.array[idx] = this.array[this.arraySize]
+		this.array[this.arraySize] = undefined
+
+		return true
 	}
 
 	/**
 	 * Execute a callback function for each element in the ArraySet.
-	 *
-	 * @param visitor - A function to call for each element in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 * arraySet.add('world')
-	 *
-	 * arraySet.visit((item) => {
-	 *   console.log(item) // 'hello', 'world'
-	 * })
-	 * ```
 	 */
 	visit(visitor: (item: T) => void) {
-		if (this.array) {
-			for (let i = 0; i < this.arraySize; i++) {
-				const elem = this.array[i]
-
-				if (typeof elem !== 'undefined') {
-					visitor(elem)
-				}
-			}
-
-			return
-		}
-
 		if (this.set) {
 			this.set.forEach(visitor)
 
 			return
 		}
 
-		throw new Error('no set or array')
+		if (!this.array) {
+			return
+		}
+
+		for (let i = 0; i < this.arraySize; i++) {
+			visitor(this.array[i]!)
+		}
 	}
 
 	/**
 	 * Make the ArraySet iterable, allowing it to be used in for...of loops and with spread syntax.
-	 *
-	 * @returns An iterator that yields each element in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<number>()
-	 * arraySet.add(1)
-	 * arraySet.add(2)
-	 *
-	 * for (const item of arraySet) {
-	 *   console.log(item) // 1, 2
-	 * }
-	 *
-	 * const items = [...arraySet] // [1, 2]
-	 * ```
 	 */
 	*[Symbol.iterator]() {
-		if (this.array) {
-			for (let i = 0; i < this.arraySize; i++) {
-				const elem = this.array[i]
-
-				if (typeof elem !== 'undefined') {
-					yield elem
-				}
-			}
-		} else if (this.set) {
+		if (this.set) {
 			yield* this.set
-		} else {
-			throw new Error('no set or array')
+		} else if (this.array) {
+			for (let i = 0; i < this.arraySize; i++) {
+				yield this.array[i]!
+			}
 		}
 	}
 
 	/**
 	 * Check whether an element is present in the ArraySet.
-	 *
-	 * @param elem - The element to check for
-	 * @returns `true` if the element is present, `false` otherwise
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 *
-	 * console.log(arraySet.has('hello')) // true
-	 * console.log(arraySet.has('world')) // false
-	 * ```
 	 */
 	has(elem: T) {
-		if (this.array) {
-			return this.array.indexOf(elem) !== -1
-		} else {
-			return this.set!.has(elem)
+		if (this.set) {
+			return this.set.has(elem)
 		}
+
+		return this.array ? this.array.indexOf(elem) !== -1 : false
 	}
 
 	/**
 	 * Remove all elements from the ArraySet.
-	 *
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * arraySet.add('hello')
-	 * arraySet.add('world')
-	 *
-	 * arraySet.clear()
-	 * console.log(arraySet.size()) // 0
-	 * ```
 	 */
 	clear() {
 		if (this.set) {
 			this.set.clear()
-		} else {
+		} else if (this.array) {
+			// Blank the used slots in place rather than allocating a new array: this runs on every
+			// computed derive and effect run.
+			this.array.fill(undefined, 0, this.arraySize)
 			this.arraySize = 0
-			this.array = []
 		}
 	}
 
 	/**
 	 * Get the number of elements in the ArraySet.
-	 *
-	 * @returns The number of elements in the set
-	 * @example
-	 * ```ts
-	 * const arraySet = new ArraySet<string>()
-	 * console.log(arraySet.size()) // 0
-	 *
-	 * arraySet.add('hello')
-	 * console.log(arraySet.size()) // 1
-	 * ```
 	 */
 	size() {
 		if (this.set) {
 			return this.set.size
-		} else {
-			return this.arraySize
 		}
+
+		return this.arraySize
 	}
 }

--- a/packages/state/src/lib/ArraySet.ts
+++ b/packages/state/src/lib/ArraySet.ts
@@ -1,6 +1,6 @@
 /**
  * The number of items an ArraySet holds in array mode before switching to a Set.
- *
+ * Exported only for tests.
  * @internal
  */
 export const ARRAY_SIZE_THRESHOLD = 8
@@ -9,18 +9,21 @@ export const ARRAY_SIZE_THRESHOLD = 8
  * An ArraySet operates as an array until it reaches a certain size, after which a Set is used
  * instead. In either case, the same methods are used to get, set, remove, and visit the items.
  *
- * The backing array is allocated on the first `add`: most signals never get a child, and an
- * empty ArraySet is created for every atom and effect, and two for every computed.
+ * `set` and `array` are never both non-null. `set` being null means array mode, but the array
+ * itself is only allocated on the first `add` (most signals never get a child, and an empty
+ * ArraySet is created for every atom and effect, and two for every computed), so array-mode code
+ * must handle `array === null`; `arraySize` is 0 in that state. Once promoted to a set, an
+ * ArraySet never goes back.
  * @internal
  */
 export class ArraySet<T> {
-	private arraySize = 0
+	private set: Set<T> | null = null
 
 	// Slots [0, arraySize) hold the items; slots beyond are undefined. `add`/`has` scan the whole
 	// array with indexOf, which is why `clear` and `remove` must blank vacated slots.
 	private array: (T | undefined)[] | null = null
 
-	private set: Set<T> | null = null
+	private arraySize = 0
 
 	/**
 	 * Get whether this ArraySet has any elements.
@@ -64,8 +67,9 @@ export class ArraySet<T> {
 
 		// The array is full: promote to a set.
 		this.set = new Set(this.array as T[])
-		this.array = null
 		this.set.add(elem)
+		this.array = null
+		this.arraySize = 0
 
 		return true
 	}

--- a/packages/state/src/lib/__tests__/ArraySet.test.ts
+++ b/packages/state/src/lib/__tests__/ArraySet.test.ts
@@ -91,6 +91,24 @@ describe(ArraySet, () => {
 		expect(as.add(1)).toBe(true)
 	})
 
+	it('[AS4] a fresh ArraySet answers every query as empty and survives remove and clear', () => {
+		const as = new ArraySet<number>()
+
+		expect(as.has(1)).toBe(false)
+		expect(as.size()).toBe(0)
+		expect(as.isEmpty).toBe(true)
+		expect([...as]).toEqual([])
+		expect(get(as)).toEqual(new Set())
+
+		expect(as.remove(1)).toBe(false)
+		as.clear()
+
+		expect(as.isEmpty).toBe(true)
+		expect(as.add(1)).toBe(true)
+		expect(as.has(1)).toBe(true)
+		expect(as.size()).toBe(1)
+	})
+
 	it('works with small numbers of things', () => {
 		const as = new ArraySet<number>()
 
@@ -172,25 +190,33 @@ function runTest(seed: number) {
 	const s = new Set<number>()
 	const r = rng(seed)
 
-	const nums = new Array(ARRAY_SIZE_THRESHOLD * 2).fill(0).map(() => Math.floor(r() * 100))
+	// Enough candidates, and enough bias toward adds, that the set fills past the promotion
+	// threshold rather than hovering below it in array mode forever.
+	const nums = new Array(ARRAY_SIZE_THRESHOLD * 4).fill(0).map(() => Math.floor(r() * 100))
 
 	for (let i = 0; i < 1000; i++) {
 		const num = nums[Math.floor(r() * nums.length)]
 
 		const choice = r()
-		if (choice < 0.45) {
-			as.add(num)
-			s.add(num)
-		} else if (choice < 0.9) {
-			as.remove(num)
-			s.delete(num)
-		} else {
-			as.clear()
-			s.clear()
-		}
-
 		try {
+			if (choice < 0.55) {
+				expect(as.add(num)).toBe(!s.has(num))
+				s.add(num)
+			} else if (choice < 0.95) {
+				expect(as.remove(num)).toBe(s.has(num))
+				s.delete(num)
+			} else {
+				as.clear()
+				s.clear()
+			}
+
 			expect(get(as)).toEqual(s)
+			expect(new Set([...as])).toEqual(s)
+			expect(as.size()).toBe(s.size)
+			expect(as.isEmpty).toBe(s.size === 0)
+			for (const n of nums) {
+				expect(as.has(n)).toBe(s.has(n))
+			}
 		} catch (e) {
 			console.error('Failed on iteration', i, 'with seed', seed)
 			throw e
@@ -198,7 +224,7 @@ function runTest(seed: number) {
 	}
 }
 
-describe('fuzzing this thing (if this fails tell david)', () => {
+describe('fuzzing against a reference Set', () => {
 	new Array(10).fill(0).forEach(() => {
 		const seed = Math.floor(Math.random() * 1000000)
 		it(`fuzz with seed ${seed}`, () => {

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -44,9 +44,17 @@ class Transaction {
 			flushChanges(this.initialAtomValues.keys())
 		} else {
 			// For transactions with parents, add the transaction's initial values to the parent's.
+			// A parent that has recorded nothing yet adopts the map outright: this transaction is
+			// finished with it, and the common nested case is a single inner transaction doing all
+			// the writes.
+			const parentValues = this.parent!.initialAtomValues
+			if (parentValues.size === 0) {
+				this.parent!.initialAtomValues = this.initialAtomValues
+				return
+			}
 			this.initialAtomValues.forEach((value, atom) => {
-				if (!this.parent!.initialAtomValues.has(atom)) {
-					this.parent!.initialAtomValues.set(atom, value)
+				if (!parentValues.has(atom)) {
+					parentValues.set(atom, value)
 				}
 			})
 		}
@@ -115,7 +123,9 @@ export function getIsReacting() {
 	return inst.globalIsReacting
 }
 
-// Reusable state for traverse to avoid closure allocation
+// The set `traverseChild` collects reactors into. Module-level rather than a closure so that a
+// flush over thousands of atoms doesn't allocate a visitor per atom; traversal never runs user
+// code, so nothing can re-enter and swap it mid-walk.
 let traverseReactors: Set<Reactor>
 
 function traverseChild(child: Child) {
@@ -130,11 +140,6 @@ function traverseChild(child: Child) {
 	} else {
 		;(child as any as Signal<any>).children.visit(traverseChild)
 	}
-}
-
-function traverse(reactors: Set<Reactor>, child: Child) {
-	traverseReactors = reactors
-	traverseChild(child)
 }
 
 /**
@@ -154,11 +159,10 @@ function flushChanges(atoms: Iterable<_Atom>) {
 		inst.globalIsReacting = true
 		inst.reactionEpoch = inst.globalEpoch
 
-		// Collect all of the visited reactors.
 		const reactors = new Set<Reactor>()
-
+		traverseReactors = reactors
 		for (const atom of atoms) {
-			atom.children.visit((child) => traverse(reactors, child))
+			atom.children.visit(traverseChild)
 		}
 
 		// Run each reactor.
@@ -214,8 +218,8 @@ export function atomDidChange(atom: _Atom, previousValue: any) {
 }
 
 function traverseAtomForCleanup(atom: _Atom) {
-	const rs = (inst.cleanupReactors ??= new Set())
-	atom.children.visit((child) => traverse(rs, child))
+	traverseReactors = inst.cleanupReactors ??= new Set()
+	atom.children.visit(traverseChild)
 }
 
 /**


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR reduces allocations on the `@tldraw/state` paths that scale with the number of records: signal construction and change flushes.

### Before

- Every `ArraySet` allocated its backing `Array(8)` in the constructor. Every atom and effect creates one and every computed creates two, and most signals never get a child, so ~100 B per signal sat unused. `ArraySet.clear()` allocated a fresh array on every derive and effect run.
- `flushChanges` and `traverseAtomForCleanup` allocated a visitor closure per changed atom (`(child) => traverse(reactors, child)`), so a 5000-atom transaction allocated 5000 of them.
- A nested transaction committing into a parent copied its `initialAtomValues` into the parent's map entry by entry, even when the parent's map was empty.

### After

- `ArraySet` allocates the array on the first `add`, and `clear()` blanks the slots in place.
- `flushChanges` and `traverseAtomForCleanup` set the module-level `traverseReactors` once and pass `traverseChild` directly. Traversal never runs user code, so nothing can re-enter and swap the set mid-walk.
- A parent that has recorded nothing yet adopts the child's map outright; the child is finished with it.

No behavior change; the existing suite covers all three paths. Split out of #10144, where the benchmark numbers for the combined changes are reported.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests

### Release notes

- Reduce per-signal memory and per-flush allocations in `@tldraw/state`

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +78 / -186 |
