### PR TITLE
docs(state): fix examples and trim comments in @tldraw/state

### DIFF
--- a/packages/state/ARCHITECTURE.md
+++ b/packages/state/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# @tldraw/state Architecture
+# @tldraw/state architecture
 
 This document provides a machine-readable guide to the @tldraw/state package structure, optimized for AI agents and automated tools.
 
-## Package Overview
+## Package overview
 
 **Package Name**: @tldraw/state  
 **Purpose**: Reactive state management library using signals  
@@ -27,17 +27,20 @@ packages/state/
 │       ├── types.ts                # Core type definitions
 │       ├── constants.ts            # System constants
 │       ├── helpers.ts              # Utility functions
-│       ├── isSignal.ts            # Type guards
-│       ├── warnings.ts            # Development warnings
-│       └── __tests__/             # Test files
+│       ├── isSignal.ts             # Type guards
+│       ├── isComputed.ts           # Computed brand check (no import of Computed.ts)
+│       ├── localStorageAtom.ts     # Atom persisted to localStorage
+│       ├── warnings.ts             # Development warnings
+│       └── __tests__/              # Test files
 ├── DOCS.md                        # Human-readable documentation
 ├── README.md                      # Package introduction
-└── ARCHITECTURE.md               # This file
+├── SPEC.md                        # Behavior specification (rule IDs referenced by tests)
+└── ARCHITECTURE.md                # This file
 ```
 
-## Core Modules
+## Core modules
 
-### Primary API Modules
+### Primary API modules
 
 #### `Atom.ts`
 
@@ -57,10 +60,10 @@ packages/state/
 
 - **Exports**: `EffectScheduler`, `react()`, `reactor()`, `EffectSchedulerOptions`, `Reactor`
 - **Purpose**: Side effects and reaction management
-- **Key Classes**: `__EffectScheduler__`, `_Reactor`
+- **Key Classes**: `__EffectScheduler__` (`reactor()` returns a plain object wrapping one)
 - **Dependencies**: ArraySet, capture, helpers, transactions, types
 
-### Supporting Infrastructure
+### Supporting infrastructure
 
 #### `types.ts`
 
@@ -74,13 +77,15 @@ packages/state/
 - **Purpose**: Dependency tracking and debugging
 - **Key Classes**: `CaptureStackFrame`
 - **Role**: Manages parent-child relationships between signals
+- **Dependencies**: helpers, isComputed, types (deliberately not Computed.ts, to avoid a cycle)
 
 #### `transactions.ts`
 
 - **Exports**: `transact()`, `transaction()`, `deferAsyncEffects()`
-- **Purpose**: Batched updates with rollback capability
+- **Purpose**: Batched updates with rollback capability, the global epoch, and the reaction phase (`flushChanges`)
 - **Key Classes**: `Transaction`
 - **Role**: Ensures atomic state updates
+- **Dependencies**: Atom, constants, helpers, types
 
 #### `helpers.ts`
 
@@ -96,10 +101,10 @@ packages/state/
 
 #### `HistoryBuffer.ts`
 
-- **Purpose**: Change tracking for time-travel debugging
-- **Role**: Stores diffs for getDiffSince functionality
+- **Purpose**: Ring buffer of recent diffs
+- **Role**: Stores diffs for `getDiffSince`, so incremental computeds and effects can update from diffs
 
-## Export Mapping
+## Export mapping
 
 ```typescript
 // Core reactive primitives
@@ -109,9 +114,9 @@ react(name, fn, options?) -> () => void
 reactor(name, fn) -> Reactor<T>
 
 // Transaction management
-transact(fn) -> void
-transaction(fn) -> void
-deferAsyncEffects(fn) -> void
+transact(fn) -> T
+transaction(fn) -> T
+deferAsyncEffects(fn) -> Promise<T>
 
 // Debugging and utilities
 unsafe__withoutCapture(fn) -> T
@@ -127,9 +132,12 @@ withDiff(value, diff) -> WithDiff
 UNINITIALIZED -> symbol
 RESET_VALUE -> symbol
 EMPTY_ARRAY -> readonly array
+localStorageAtom(name, initialValue, options?) -> [Atom<T>, cleanup]
+EffectScheduler -> class (low-level effect runner)
+ArraySet -> class (internal)
 ```
 
-## Dependency Graph
+## Dependency graph
 
 ```
 index.ts
@@ -146,6 +154,7 @@ index.ts
 │   ├── capture.ts
 │   ├── constants.ts
 │   ├── helpers.ts
+│   ├── isComputed.ts
 │   ├── transactions.ts
 │   ├── types.ts
 │   └── warnings.ts
@@ -157,114 +166,121 @@ index.ts
 │   ├── transactions.ts
 │   └── types.ts
 ├── capture.ts
-│   ├── Computed.ts
 │   ├── helpers.ts
+│   ├── isComputed.ts
 │   └── types.ts
+├── isSignal.ts
+│   ├── Atom.ts
+│   └── Computed.ts
+├── localStorageAtom.ts
+│   ├── Atom.ts
+│   └── EffectScheduler.ts
 └── transactions.ts
     ├── Atom.ts
-    ├── EffectScheduler.ts
     ├── constants.ts
     ├── helpers.ts
     └── types.ts
 ```
 
-## Key Architectural Patterns
+Atom.ts and transactions.ts import each other; neither uses the other at module-evaluation time, which is what keeps the cycle harmless.
 
-### Signal Interface Pattern
+## Key architectural patterns
+
+### Signal interface pattern
 
 - All reactive values implement `Signal<Value, Diff>` interface
 - Unified API: `get()`, `getDiffSince()`, `__unsafe__getWithoutCapture()`
 - Polymorphic handling of atoms and computed values
 
-### Dependency Tracking Pattern
+### Dependency tracking pattern
 
 - `capture.ts` manages parent-child relationships
 - `Child` interface for dependents, `ArraySet<Child>` for parents
 - Automatic dependency detection via `maybeCaptureParent()`
 
-### Lazy Evaluation Pattern
+### Lazy evaluation pattern
 
 - Computed values only recalculate when dependencies change
 - `lastChangedEpoch` tracking for invalidation
-- `haveParentsChanged()` for efficient dirty checking
+- `haveParentsChanged()` for dirty checking (O(parents)); an actively-listening computed skips it when it has not been traversed by a flush since it was last checked and no transaction is open
 
-### Transaction Pattern
+### Transaction pattern
 
 - Nested transaction support with rollback
 - `initialAtomValues` map for restoration
 - Deferred effect scheduling until commit
 
-### History Tracking Pattern
+### History tracking pattern
 
-- Optional `HistoryBuffer` for change tracking
+- Optional `HistoryBuffer` for diff history
 - `computeDiff` functions for incremental updates
 - `RESET_VALUE` for uncomputable diffs
 
-## Performance Optimizations
+## Performance optimizations
 
-### Memory Management
+### Memory management
 
 - `ArraySet` for efficient parent-child tracking
 - `EMPTY_ARRAY` singleton for empty dependencies
 - Lazy history buffer allocation
 
-### Computation Efficiency
+### Computation efficiency
 
 - Epoch-based invalidation system
 - `unsafe__withoutCapture` for hot paths
 - Singleton pattern for global state
 
-### Effect Scheduling
+### Effect scheduling
 
 - Pluggable `scheduleEffect` for batching
 - `deferAsyncEffects` for transaction control
 - `isActivelyListening` state management
 
-## API Categories by Use Case
+## API categories by use case
 
-### Basic State Management
+### Basic state management
 
 - `atom()` - mutable state
 - `computed()` - derived state
 - `react()` - side effects
 
-### Advanced Control
+### Advanced control
 
 - `reactor()` - controllable reactions
 - `transact()` - batched updates
 - `@computed` - class-based computed properties
 
-### Performance & Debugging
+### Performance & debugging
 
 - `unsafe__withoutCapture()` - performance optimization
 - `whyAmIRunning()` - dependency debugging
-- History tracking options for undo/redo
+- History tracking options for incremental computation
 
-### Type Guards & Utilities
+### Type guards & utilities
 
 - `isSignal()`, `isAtom()`, `isUninitialized()`
 - `UNINITIALIZED`, `RESET_VALUE` constants
 - `withDiff()` for incremental computation
 
-## Integration Points
+## Integration points
 
-### External Dependencies
+### External dependencies
 
 - `@tldraw/utils`: `registerTldrawLibraryVersion()`, `assert()`
 
-### Related Packages
+### Related packages
 
 - `@tldraw/state-react`: React integration layer
 - `@tldraw/store`: Record storage using @tldraw/state
 - `@tldraw/editor`: Canvas editor using reactive state
 
-### Extension Points
+### Extension points
 
 - `AtomOptions.isEqual` - custom equality functions
 - `ComputeDiff` - custom diff computation
 - `EffectSchedulerOptions.scheduleEffect` - custom scheduling
 
-## File Navigation Guide for AI Agents
+## File navigation guide for AI agents
 
 **To understand signals**: Start with `types.ts` → `Atom.ts` → `Computed.ts`  
 **To understand reactivity**: Start with `EffectScheduler.ts` → `capture.ts`  

--- a/packages/state/DOCS.md
+++ b/packages/state/DOCS.md
@@ -1,4 +1,4 @@
-# @tldraw/state Documentation
+# @tldraw/state documentation
 
 ## 1. Introduction
 
@@ -18,7 +18,7 @@ npm install @tldraw/state
 
 @tldraw/state is written in TypeScript and provides excellent type safety out of the box. No additional types package needed.
 
-### Quick Example
+### Quick example
 
 Here's a simple example to show how tldraw state works:
 
@@ -31,7 +31,7 @@ const greeting = computed('greeting', () => `Hello, ${name.get()}!`)
 
 // React to changes
 react('update page title', () => {
-	window.alert(greeting.get())
+	document.title = greeting.get()
 })
 
 // Update the state
@@ -39,7 +39,7 @@ name.set('tldraw state')
 // Page title automatically updates to "Hello, tldraw state!"
 ```
 
-In just a few lines, you've created reactive state that automatically alerts the user when it changes.
+In just a few lines, you've created reactive state that automatically updates the page when it changes.
 
 ## 2. Signals
 
@@ -50,11 +50,11 @@ In @tldraw/state, there are two types of signals:
 - An **Atom** is the basic type of signal that acts as a container for a single value.
 - A **Computed** is a signal that derives its value from several other signals (atoms or other computeds).
 
-### Atoms: The State Containers
+### Atoms: the state containers
 
 Atoms are the foundation of your application's state. They contain "raw" values that the rest of your application will use and react to.
 
-#### Creating Atoms
+#### Creating atoms
 
 You create an atom using the atom function. You must give it a name and an initial value.
 
@@ -67,7 +67,7 @@ const user = atom('user', { name: 'Alice', age: 30 })
 
 > Tip: The name is used for debugging purposes, specifically for the `whyAmIRunning` function described later in these docs.
 
-#### Reading an Atom's Value
+#### Reading an atom's value
 
 To get the current value of an atom, use its `.get()` method.
 
@@ -78,7 +78,7 @@ console.log(user.get().name) // 'Alice'
 
 > Tip: When you call `.get()` inside the function body of computed or a reaction, the library automatically **captures** that signal as a dependency.
 
-#### Updating an Atom's Value
+#### Updating an atom's value
 
 You can change an atom's value in two ways:
 
@@ -98,7 +98,7 @@ console.log(count.get()) // 2
 
 > Tip: If you try to set an atom to a value that is equal to its current value, the update will be skipped, and no reactions will be triggered.
 
-#### Atom Options
+#### Atom options
 
 You can pass an options object as the third argument to atom to customize its behavior.
 
@@ -112,13 +112,13 @@ const activeUser = atom('activeUser', { id: 1, name: 'Bob' }, { isEqual: (a, b) 
 activeUser.set({ id: 1, name: 'Robert' })
 ```
 
-- `historyLength` & `computeDiff`: These options are used for tracking changes over time. See the "History and Diffs" section for more details.
+- `historyLength` & `computeDiff`: These options are used for tracking changes over time. See the "History and diffs" section for more details.
 
-### Computeds: The Derived Values
+### Computeds: the derived values
 
 A Computed is a signal whose value is derived from other signals. You can use computed signals to create complex data models that automatically stay in sync.
 
-#### Creating Computeds
+#### Creating computeds
 
 You create a computed signal using the `computed` function. It takes a name and a function that calculates its value. Inside this function, you can `.get()` the value of other signals.
 
@@ -153,17 +153,17 @@ firstName.set('Sam')
 console.log(greeting.get()) // "Hello, Sam Doe!"
 ```
 
-#### Dependency Capture
+#### Dependency capture
 
 This automatic dependency tracking works through a process called **dependency capture**. When the `fullName` function runs, the library actively "listens" for any calls to `.get()`. Each signal that is "gotten" is automatically registered as a dependency of `fullName`. The list of dependencies is updated every time the function re-runs, so they can even change dynamically.
 
-#### Lazy Evaluation
+#### Lazy evaluation
 
 Computed signals are evaluated **lazily**. The calculation function only runs when you call `.get()` on the computed _and_ one of its captured signal dependencies has changed since the last time it was gotten. If nothing has changed, the computed returns its previous cached value.
 
-#### Using `@computed` as a Decorator
+#### Using `@computed` as a decorator
 
-For classes, you can use the `@computed` decorator to create a computed property from a getter method. This is a clean way to co-locate derived data with its related state.
+For classes, you can use the `@computed` decorator to create a computed property from a method. This is a clean way to co-locate derived data with its related state.
 
 ```ts
 class User {
@@ -191,11 +191,11 @@ const fullNameComputed = getComputedInstance(user, 'getFullName')
 console.log(fullNameComputed.get()) // "John Doe"
 ```
 
-## 3. Reactivity and Side Effects
+## 3. Reactivity and side effects
 
 Reading and deriving state is only half the story. The other half is performing actions, called _side effects_, that run when state changes. Side effects can be used for anything: updating the DOM, logging to the console, making a network request, and so on.
 
-### Simple Reactions with `react`
+### Simple reactions with `react`
 
 The easiest way to create a side effect is with the `react` function. You give it a name and a function to run. The library automatically **captures** which signals the function `.get()`s as dependencies and will re-run it whenever any of them change.
 
@@ -224,7 +224,7 @@ color.set('green')
 
 > Tip: The stop function is perfect for "fire-and-forget" effects, especially within UI components (e.g., in a useEffect hook in React).
 
-### Controlled Reactions with `reactor`
+### Controlled reactions with `reactor`
 
 For more control over the lifecycle of an effect, you can use `reactor`. It's similar to `react` but it doesn't start automatically. Instead, it returns a Reactor object with `.start()` and `.stop()` methods.
 
@@ -253,15 +253,15 @@ name.set('universe')
 
 > Tip: A reactor is useful when you have a long-lived effect that needs to be paused and resumed based on application logic.
 
-## 4. Advanced Topics
+## 4. Advanced topics
 
-### Transactions: Batching State Updates
+### Transactions: batching state updates
 
-When you update multiple atoms that are dependencies of the same reaction, you might cause the reaction to re-run multiple times. transacts solve this by batching all state changes into a single, atomic update, after which reactions will execute.
+When you update multiple atoms that are dependencies of the same reaction, you might cause the reaction to re-run multiple times. Transactions solve this by batching all state changes into a single, atomic update, after which reactions will execute.
 
 #### Using transact()
 
-The `transact` function takes a callback. All state updates inside this callback are queued. Reactions are only triggered _after_ the callback has finished executing successfully.
+The `transact` function takes a callback. All state updates inside this callback are queued. Reactions are only triggered _after_ the callback has finished executing — once, whether the transaction commits or (see below) is rolled back.
 
 ```ts
 const firstName = atom('firstName', 'John')
@@ -283,7 +283,7 @@ transact(() => {
 // Logs: "Hello, Jane Smith!"
 ```
 
-#### Aborting and Rolling Back
+#### Aborting and rolling back
 
 Transactions may be aborted. Aborting a transaction will restore previous values of all signals modified inside of the transaction.
 
@@ -293,7 +293,7 @@ Rollbacks also occur automatically if an error is thrown inside the transaction.
 const name = atom('name', 'Alice')
 
 try {
-	transact((rollback) => {
+	transaction(() => {
 		name.set('Bob')
 		throw new Error('Something went wrong')
 	})
@@ -304,12 +304,12 @@ try {
 console.log(name.get()) // "Alice"
 ```
 
-You can also abort a transaction manually by calling the `rollback` function, which is passed to the transaction callback.
+You can also abort a transaction manually by calling the `rollback` function, which `transaction` (but not `transact`) passes to its callback.
 
 ```ts
 const name = atom('name', 'Alice')
 
-transact((rollback) => {
+transaction((rollback) => {
 	name.set('Bob')
 	rollback() // Discard the change
 })
@@ -317,9 +317,9 @@ transact((rollback) => {
 console.log(name.get()) // "Alice"
 ```
 
-Aborting a transaction will _only_ restore the values of the signals that were modified inside of the transaction. Other types of data or parts of your application will not be affected.
+Aborting a transaction will _only_ restore the values of the signals that were modified inside of the transaction. Other types of data or parts of your application will not be affected. Reactions that depend on those signals still run once after the rollback, observing the restored values.
 
-#### Nested Transactions
+#### Nested transactions
 
 You can call `transact` inside of another transaction. A new transaction will only be created if there is not already one in progress.
 
@@ -343,9 +343,9 @@ console.log(firstName.get()) // "Jane"
 console.log(lastName.get()) // "Doe" // The change was rolled back
 ```
 
-### History and Diffs
+### History and diffs
 
-@tldraw/state can automatically track the history of changes to a signal, which is invaluable for features like undo/redo or creating sync engines.
+@tldraw/state can automatically track the history of changes to a signal, which lets dependents update incrementally instead of recomputing from scratch.
 
 To enable history, you must provide the `historyLength` option when creating an atom or computed.
 
@@ -359,14 +359,12 @@ const count = atom('count', 0, {
 
 The `historyLength` option defines the maximum number of diffs to keep in the history buffer. If you expect the atom to be part of an active effect subscription all the time, and to not change multiple times inside of a single transaction, you can set this to a relatively low number (e.g. 10). Otherwise, set this to a higher number based on your usage pattern and memory constraints.
 
-#### Retrieving Diffs
+#### Retrieving diffs
 
-Once history is enabled, you can use `getDiffSince(epoch)` to get an array of diffs that occurred since a specific point in time.
+Once history is enabled, you can use `getDiffSince(epoch)` to get an array of diffs that occurred since a specific point in time. Every signal exposes `lastChangedEpoch`, the epoch at which it last changed, which is the natural point to measure from.
 
 ```ts
-import { getGlobalEpoch } from '@tldraw/state'
-
-const startEpoch = getGlobalEpoch()
+const startEpoch = count.lastChangedEpoch
 
 count.set(5) // diff is 5
 count.set(12) // diff is 7
@@ -377,35 +375,35 @@ console.log(diffs) // [5, 7]
 
 If the library doesn't have enough history to compute the diffs, it will return the special `RESET_VALUE` symbol. This tells you that you need to re-compute the state from scratch instead of applying patches.
 
-### Computed Options
+### Computed options
 
-Similar to atoms, you can provide a `ComputedOptions` object as the second argument to the `computed` function.
+Similar to atoms, you can provide a `ComputedOptions` object as the third argument to the `computed` function.
 
 ```ts
-const fullName = computed('fullName', () => {
-	return (`${firstName.get()} ${lastName.get()}`, { isEqual: (a, b) => a === b })
+const fullName = computed('fullName', () => `${firstName.get()} ${lastName.get()}`, {
+	isEqual: (a, b) => a === b,
 })
 ```
 
-You also can pass in a `ComputedOptions` when used the `@computed` decorator.
+You also can pass in a `ComputedOptions` when using the `@computed` decorator.
 
 ```ts
 class Counter {
 	max = 100
-	count = atom<number>(0)
+	count = atom('count', 0)
 
 	@computed({ isEqual: (a, b) => a === b })
-	get remaining() {
+	getRemaining() {
 		return this.max - this.count.get()
 	}
 }
 ```
 
-### Incremental Computation
+### Incremental computation
 
 Computed signals can take advantage of diffs to compute a value incrementally.
 
-In addition to the options described for atoms, you can also provide a `computeDiff` function. This function is used to compute the diff between the previous and new values of the computed signal.
+In addition to the options described for atoms, you can also provide a `computeDiff` function. This function is used to compute the diff between the previous and new values of the computed signal. As with atoms, diffs are only recorded when `historyLength` is set.
 
 ```ts
 const count = atom('count', 0)
@@ -414,24 +412,28 @@ const double = computed(
 	(prevValue) => {
 		return count.get() * 2
 	},
-	{ computeDiff: (a, b) => b - a }
+	{ historyLength: 10, computeDiff: (a, b) => b - a }
 )
 ```
 
-You can use the `withDiff` helper to wrap the return value of a computed signal function, indicating that the diff should be used instead of calculating a new one with `AtomOptions.computeDiff`.
+You can use the `withDiff` helper to wrap the return value of a computed signal function, indicating that the diff should be used instead of calculating a new one with `ComputedOptions.computeDiff`.
 
 ```ts
 const count = atom('count', 0)
-const double = computed('double', (prevValue) => {
-	const nextValue = count.get() * 2
-	if (isUninitialized(prevValue)) {
-		return nextValue
-	}
-	return withDiff(nextValue, nextValue - prevValue)
-})
+const double = computed(
+	'double',
+	(prevValue) => {
+		const nextValue = count.get() * 2
+		if (isUninitialized(prevValue)) {
+			return nextValue
+		}
+		return withDiff(nextValue, nextValue - prevValue)
+	},
+	{ historyLength: 10 }
+)
 ```
 
-#### Handling the First Computed Run
+#### Handling the first computed run
 
 Sometimes you need to know if a computed function is running for the very first time. The function is called with the previous value, which will be the special symbol `UNINITIALIZED` on the first run. You can check for this using the `isUninitialized` helper. This is particularly useful for incremental computations.
 
@@ -481,7 +483,7 @@ const stop = react(
 )
 ```
 
-### Performance Optimization
+### Performance optimization
 
 While @tldraw/state is fast by default, there are tools for fine-tuning performance in demanding situations.
 
@@ -505,13 +507,13 @@ react('log important changes', () => {
 frequentlyChangingValue.set(1)
 ```
 
-### Type Guards and Utilities
+### Type guards and utilities
 
 The library exports several type guard functions to help you work with signals in TypeScript.
 
 - `isSignal(value)`: Returns true if the value is an atom or a computed.
 - `isAtom(value)`: Returns true if the value is an atom.
-- `isComputed(value)`: Returns true if the value is a computed.
+- `isUninitialized(value)`: Returns true if the value is the `UNINITIALIZED` symbol passed to a computed function on its first run.
 
 ## 5. Debugging
 
@@ -519,7 +521,7 @@ Because @tldraw/state manages a graph of dependencies, it can sometimes be trick
 
 ### whyAmIRunning()
 
-If you're ever confused about what caused an effect to run, you can call `whyAmIRunning()` at the beginning of its function. It will log a detailed, hierarchical tree to the console, showing you exactly which atom(s) changed and triggered the update.
+If you're ever confused about what caused an effect to run, you can call `whyAmIRunning()` at the beginning of its function. From the next run on, it will log a detailed, hierarchical tree to the console, showing you exactly which atom(s) changed and triggered the update.
 
 ```ts
 import { atom, computed, react, whyAmIRunning } from '@tldraw/state'
@@ -539,8 +541,7 @@ react('log details', () => {
 	console.log(`${greeting.get()} is ${age.get()} years old.`)
 })
 
-// On the first run, it logs:
-// Effect(log details) was executed manually.
+// Nothing is logged on the first run (the run that arms whyAmIRunning).
 
 age.set(43)
 
@@ -552,8 +553,8 @@ name.set('Alice')
 
 // When name is updated, it logs:
 // Effect(log details) is executing because:
-// ↳ Computed(greeting) changed
-// ↳ Atom(name) changed
+//  ↳ Computed(greeting) changed
+//    ↳ Atom(name) changed
 ```
 
 This makes it much easier to trace the flow of data and updates through your application.

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -17,7 +17,7 @@ A `DOCS.md` file is included alongside this README in the published package, wit
 - **Fine-grained reactivity** - Only re-runs computations when their actual dependencies change
 - **High performance** - Lazy evaluation and efficient dependency tracking
 - **Automatic updates** - Derived values and side effects update automatically
-- **Time travel** - Built-in history tracking and transactions with rollback support
+- **Incremental updates** - Built-in diff history and transactions with rollback support
 - **Framework agnostic** - Works with any JavaScript framework or vanilla JS
 - **TypeScript first** - Excellent type safety with full TypeScript support
 
@@ -29,7 +29,7 @@ Perfect for building reactive UIs, real-time collaborative apps, and complex sta
 npm install @tldraw/state
 ```
 
-## Quick Start
+## Quick start
 
 ```ts
 import { atom, computed, react } from '@tldraw/state'
@@ -57,9 +57,9 @@ count.set(42)
 // Logs: "Hello, tldraw! Count: 42"
 ```
 
-## Core Concepts
+## Core concepts
 
-### Atoms - State Containers
+### Atoms - state containers
 
 Atoms hold raw values and are the foundation of your reactive state:
 
@@ -78,7 +78,7 @@ user.update((current) => ({ ...current, age: 31 }))
 theme.set('dark')
 ```
 
-### Computed Values - Automatic Derivation
+### Computed values - automatic derivation
 
 Computed signals derive their values from other signals and update automatically:
 
@@ -98,7 +98,7 @@ firstName.set('Jane')
 console.log(fullName.get()) // "Jane Doe" - automatically updated!
 ```
 
-### Reactions - Side Effects
+### Reactions - side effects
 
 Reactions run side effects when their dependencies change:
 
@@ -120,7 +120,7 @@ selectedId.set('shape-123')
 stop()
 ```
 
-### Transactions - Batched Updates
+### Transactions - batched updates
 
 Batch multiple updates to prevent intermediate reactions:
 
@@ -143,11 +143,11 @@ transact(() => {
 // Logs: "(10, 20)"
 ```
 
-## Advanced Features
+## Advanced features
 
-### History & Time Travel
+### History and diffs
 
-Track changes over time for undo/redo functionality:
+Track changes over time so that dependents can update incrementally instead of recomputing from scratch:
 
 ```ts
 const canvas = atom(
@@ -159,16 +159,17 @@ const canvas = atom(
 	}
 )
 
-// Make changes...
+// Remember where you are...
+const startEpoch = canvas.lastChangedEpoch
+
+// ... make changes ...
 canvas.update((state) => ({ shapes: [...state.shapes, newShape] }))
 
-// Get diffs since a point in time
-const startTime = getGlobalEpoch()
-// ... make more changes ...
-const diffs = canvas.getDiffSince(startTime)
+// ... and get the diffs since then (or RESET_VALUE if the history doesn't reach back that far)
+const diffs = canvas.getDiffSince(startEpoch)
 ```
 
-### Performance Optimization
+### Performance optimization
 
 Use `unsafe__withoutCapture` to read values without creating dependencies:
 
@@ -194,21 +195,18 @@ react('debug-reaction', () => {
 })
 ```
 
-## Integration Examples
+## Integration examples
 
 ### With tldraw SDK
 
 ```ts
-// In a tldraw application
-const editor = useEditor()
-
-// Create reactive state that works with tldraw
+// e.g. in Tldraw's onMount callback, which receives the editor
 const selectedShapes = computed('selectedShapes', () => {
 	return editor.getSelectedShapeIds().map((id) => editor.getShape(id))
 })
 
-// React to selection changes
-react('update-property-panel', () => {
+// React to selection changes; call the returned function to stop
+const stop = react('update-property-panel', () => {
 	const shapes = selectedShapes.get()
 	updatePropertyPanel(shapes)
 })
@@ -223,27 +221,28 @@ npm install @tldraw/state-react
 ```
 
 ```tsx
-import { useAtom, useComputed } from '@tldraw/state-react'
+import { track, useAtom, useComputed } from '@tldraw/state-react'
 
-function Counter() {
-	const [count, setCount] = useAtom(countAtom)
-	const doubled = useComputed(() => count * 2, [count])
+// track() re-renders the component when any signal it reads changes
+const Counter = track(function Counter() {
+	const count = useAtom('count', 0)
+	const doubled = useComputed('doubled', () => count.get() * 2, [count])
 
 	return (
 		<div>
-			<p>Count: {count}</p>
-			<p>Doubled: {doubled}</p>
-			<button onClick={() => setCount(count + 1)}>+</button>
+			<p>Count: {count.get()}</p>
+			<p>Doubled: {doubled.get()}</p>
+			<button onClick={() => count.set(count.get() + 1)}>+</button>
 		</div>
 	)
-}
+})
 ```
 
-## API Reference
+## API reference
 
 For complete API documentation, see [DOCS.md](./DOCS.md).
 
-### Core Functions
+### Core functions
 
 - `atom(name, initialValue, options?)` - Create a reactive state container
 - `computed(name, computeFn, options?)` - Create a derived value
@@ -260,16 +259,16 @@ For complete API documentation, see [DOCS.md](./DOCS.md).
 - `unsafe__withoutCapture(fn)` - Read state without creating dependencies
 - `whyAmIRunning()` - Debug what triggered an update
 - `getComputedInstance(obj, prop)` - Get underlying computed instance
-- `getGlobalEpoch()` - Get current time for history tracking
+- `signal.getDiffSince(epoch)` - Get the diffs recorded since an epoch (see `signal.lastChangedEpoch`)
 
-## Related Packages
+## Related packages
 
 - **[@tldraw/state-react](../state-react)** - React bindings for @tldraw/state
 - **[@tldraw/store](../store)** - Record storage built on @tldraw/state
 - **[@tldraw/editor](../editor)** - The tldraw canvas editor
 - **[@tldraw/tldraw](../tldraw)** - Complete tldraw UI components
 
-## Examples & Patterns
+## Examples & patterns
 
 Looking for more examples? Check out:
 

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -87,34 +87,19 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		this.computeDiff = options.computeDiff
 	}
 
-	/**
-	 * Custom equality function for comparing values, or null to use default equality.
-	 * @internal
-	 */
+	/** @internal */
 	readonly isEqual: null | ((a: any, b: any) => boolean)
 
-	/**
-	 * Optional function to compute diffs between old and new values.
-	 * @internal
-	 */
+	/** @internal */
 	computeDiff?: ComputeDiff<Value, Diff>
 
-	/**
-	 * The global epoch when this atom was last changed.
-	 * @internal
-	 */
+	/** @internal */
 	lastChangedEpoch = getGlobalEpoch()
 
-	/**
-	 * Set of child signals that depend on this atom.
-	 * @internal
-	 */
+	/** @internal */
 	children = new ArraySet<Child>()
 
-	/**
-	 * Optional history buffer for tracking changes over time.
-	 * @internal
-	 */
+	/** @internal */
 	historyBuffer?: HistoryBuffer<Diff>
 
 	/**
@@ -216,7 +201,6 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	getDiffSince(epoch: number): RESET_VALUE | Diff[] {
 		maybeCaptureParent(this)
 
-		// If no changes have occurred since the given epoch, return an empty array.
 		if (epoch >= this.lastChangedEpoch) {
 			return EMPTY_ARRAY
 		}

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -485,7 +485,7 @@ const isComputedMethodKey = '@@__isComputedMethod__@@'
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom(0)
+ *   count = atom('count', 0)
  *
  *   @computed getRemaining() {
  *     return this.max - this.count.get()
@@ -539,7 +539,7 @@ export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom<number>(0)
+ *   count = atom('count', 0)
  *
  *   @computed getRemaining() {
  *     return this.max - this.count.get()
@@ -553,7 +553,7 @@ export function getComputedInstance<Obj extends object, Prop extends keyof Obj>(
  * ```ts
  * class Counter {
  *   max = 100
- *   count = atom<number>(0)
+ *   count = atom('count', 0)
  *
  *   @computed({isEqual: (a, b) => a === b})
  *   getRemaining() {

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -29,12 +29,9 @@ export interface EffectSchedulerOptions {
 	 * 	}
 	 * }
 	 * const stop = react('set page title', () => {
-	 * 	document.title = doc.title,
-	 * }, scheduleEffect)
+	 * 	document.title = doc.title
+	 * }, { scheduleEffect })
 	 * ```
-	 *
-	 * @param execute - A function that will execute the effect.
-	 * @returns void
 	 */
 	// eslint-disable-next-line tldraw/method-signature-style
 	scheduleEffect?: (execute: () => void) => void

--- a/packages/state/src/lib/__tests__/helpers.test.ts
+++ b/packages/state/src/lib/__tests__/helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ArraySet } from '../ArraySet'
 import { atom } from '../Atom'
 import { reactor } from '../EffectScheduler'
-import { attach, detach, equals, hasReactors, haveParentsChanged, singleton } from '../helpers'
+import { attach, detach, equals, haveParentsChanged, singleton } from '../helpers'
 import { Child } from '../types'
 
 // Unit tests for the internal helpers behind SPEC.md rules EQ1/EQ2 (equals),
@@ -132,25 +132,21 @@ describe('helpers', () => {
 		})
 	})
 
-	describe('hasReactors', () => {
-		it('returns false when signal has no actively listening children', () => {
-			const signal = atom('test', 1)
-			expect(hasReactors(signal)).toBe(false)
-		})
-
-		it('integrates correctly with real reactive signals', () => {
+	// CAP7: a signal's children set is non-empty exactly while something downstream is listening
+	describe('children', () => {
+		it('is empty unless something is actively listening', () => {
 			const baseAtom = atom('base', 1)
-			expect(hasReactors(baseAtom)).toBe(false)
+			expect(baseAtom.children.isEmpty).toBe(true)
 
 			const reactorInstance = reactor('test-reactor', () => {
 				baseAtom.get()
 			})
 
 			reactorInstance.start()
-			expect(hasReactors(baseAtom)).toBe(true)
+			expect(baseAtom.children.isEmpty).toBe(false)
 
 			reactorInstance.stop()
-			expect(hasReactors(baseAtom)).toBe(false)
+			expect(baseAtom.children.isEmpty).toBe(true)
 		})
 	})
 })

--- a/packages/state/src/lib/__tests__/history.test.ts
+++ b/packages/state/src/lib/__tests__/history.test.ts
@@ -1,8 +1,9 @@
+import { exhaustiveSwitchError } from '@tldraw/utils'
 import { vi } from 'vitest'
 import { atom } from '../Atom'
 import { Computed, UNINITIALIZED, computed, isUninitialized, withDiff } from '../Computed'
 import { react } from '../EffectScheduler'
-import { EMPTY_ARRAY, assertNever } from '../helpers'
+import { EMPTY_ARRAY } from '../helpers'
 import { getGlobalEpoch, transact, transaction } from '../transactions'
 import { RESET_VALUE, Signal } from '../types'
 
@@ -383,7 +384,7 @@ function getIncrementalRecordMapper<In, Out>(
 					}
 					break
 				default:
-					assertNever(change)
+					exhaustiveSwitchError(change)
 			}
 		}
 

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -24,10 +24,10 @@ const inst = singleton('capture', () => ({ stack: null as null | CaptureStackFra
  * @example
  * ```ts
  * const name = atom('name', 'Sam')
- * const time = atom('time', () => new Date().getTime())
+ * const time = atom('time', Date.now())
  *
  * setInterval(() => {
- *   time.set(new Date().getTime())
+ *   time.set(Date.now())
  * })
  *
  * react('log name changes', () => {
@@ -149,13 +149,9 @@ export function stopCapturingParents() {
  */
 export function maybeCaptureParent(p: Signal<any, any>) {
 	if (inst.stack) {
-		// if the child didn't deref this parent last time it executed, then idx will be -1
-		// if the child did deref this parent last time but in a different order relative to other parents, then idx will be greater than stack.offset
-		// if the child did deref this parent last time in the same order, then idx will be the same as stack.offset
-		// if the child did deref this parent already during this capture session then 0 <= idx < stack.offset
-
-		// `add` returns false when the parent was already captured. In array mode both `has` and
-		// `add` scan with indexOf, so going straight to `add` halves the scans per captured parent.
+		// `add` returns false when the parent was already captured this run. In array mode both
+		// `has` and `add` scan with indexOf, so going straight to `add` halves the scans per
+		// captured parent.
 		if (!inst.stack.child.parentSet.add(p)) {
 			return
 		}
@@ -164,6 +160,9 @@ export function maybeCaptureParent(p: Signal<any, any>) {
 			attach(p, inst.stack.child)
 		}
 
+		// Parents are recorded in deref order. If the slot at this offset held a different parent
+		// last run, that parent may have moved later in the order or been dropped; only
+		// stopCapturingParents can tell, so remember it for then.
 		if (inst.stack.offset < inst.stack.child.parents.length) {
 			const maybeRemovedParent = inst.stack.child.parents[inst.stack.offset]
 			if (maybeRemovedParent !== p) {
@@ -183,7 +182,8 @@ export function maybeCaptureParent(p: Signal<any, any>) {
 
 /**
  * A debugging tool that tells you why a computed signal or effect is running.
- * Call in the body of a computed signal or effect function.
+ * Call in the body of a computed signal or effect function. Nothing is logged for the run that
+ * calls it; from the next run on, each run logs the ancestors that changed.
  *
  * @example
  * ```ts
@@ -195,8 +195,8 @@ export function maybeCaptureParent(p: Signal<any, any>) {
  *
  * name.set('Alice')
  *
- * // 'greeting' is running because:
- * //     'name' changed => 'Alice'
+ * // Effect(greeting) is executing because:
+ * //  ↳ Atom(name) changed
  * ```
  *
  * @public

--- a/packages/state/src/lib/constants.ts
+++ b/packages/state/src/lib/constants.ts
@@ -1,26 +1,7 @@
 /**
- * The initial epoch value used to mark derivations (computed signals and effects) as dirty before their first computation.
+ * Sentinel below any real epoch. Derived signals and effects start with their epochs set to this
+ * so they are dirty until their first run; real epochs start at `GLOBAL_START_EPOCH + 1`.
  *
- * This constant ensures that all computed signals and effects start in a "dirty" state, guaranteeing they will
- * be computed/executed at least once when first accessed or started. The value -1 is used because:
- * - Global epoch starts at 0 (GLOBAL_START_EPOCH + 1)
- * - Any derived signal initialized with GLOBAL_START_EPOCH (-1) will be considered dirty when compared to any positive epoch
- * - This forces initial computation/execution without requiring special initialization logic
- *
- * Used by:
- * - Computed signals to track when they were last changed
- * - Effect schedulers to track when they were last executed
- * - Transaction system for initial global and reaction epoch values
- *
- * @example
- * ```ts
- * // In Computed class constructor
- * lastChangedEpoch = GLOBAL_START_EPOCH // -1, marking as dirty
- *
- * // When global epoch is 5, this computed will be dirty since -1 < 5
- * const needsComputation = this.lastChangedEpoch < globalEpoch
- * ```
- *
- * @public
+ * @internal
  */
 export const GLOBAL_START_EPOCH = -1

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -1,42 +1,23 @@
 import { Child, Signal } from './types'
 
-/**
- * Get whether the given value is a child.
- *
- * @param x The value to check.
- * @returns True if the value is a child, false otherwise.
- * @internal
- */
 function isChild(x: any): x is Child {
 	return x && typeof x === 'object' && 'parents' in x
 }
 
 /**
- * Checks if any of a child's parent signals have changed by comparing their current epochs
- * with the child's cached view of those epochs.
+ * Whether any of the child's parents changed since the child last recorded their epochs. O(parents);
+ * returns at the first changed parent, so parents after it are not brought up to date.
  *
- * This function is used internally to determine if a computed signal or effect needs to
- * be re-evaluated because one of its dependencies has changed.
- *
- * @param child - The child (computed signal or effect) to check for parent changes
- * @returns `true` if any parent signal has changed since the child last observed it, `false` otherwise
- * @example
- * ```ts
- * const childSignal = computed('child', () => parentAtom.get())
- * // Check if the child needs to recompute
- * if (haveParentsChanged(childSignal)) {
- *   // Recompute the child's value
- * }
- * ```
  * @internal
  */
 export function haveParentsChanged(child: Child): boolean {
 	for (let i = 0, n = child.parents.length; i < n; i++) {
-		// Get the parent's value without capturing it.
-		child.parents[i].__unsafe__getWithoutCapture(true)
+		const parent = child.parents[i]
+		// Bring the parent up to date first: a computed parent's `lastChangedEpoch` only moves when
+		// it is re-derived.
+		parent.__unsafe__getWithoutCapture(true)
 
-		// If the parent's epoch does not match the child's view of the parent's epoch, then the parent has changed.
-		if (child.parents[i].lastChangedEpoch !== child.parentEpochs[i]) {
+		if (parent.lastChangedEpoch !== child.parentEpochs[i]) {
 			return true
 		}
 	}
@@ -45,32 +26,17 @@ export function haveParentsChanged(child: Child): boolean {
 }
 
 /**
- * Detaches a child signal from its parent signal, removing the parent-child relationship
- * in the reactive dependency graph. If the parent has no remaining children and is itself
- * a child, it will recursively detach from its own parents.
+ * Removes `child` from `parent.children`. A computed parent that loses its last child stops
+ * listening itself, recursively, so a signal's `children` set is empty whenever nothing downstream
+ * is actively listening.
  *
- * This function is used internally to clean up the dependency graph when signals are no
- * longer needed or when dependencies change.
- *
- * @param parent - The parent signal to detach from
- * @param child - The child signal to detach
- * @example
- * ```ts
- * // When a computed signal's dependencies change
- * const oldParent = atom('old', 1)
- * const child = computed('child', () => oldParent.get())
- * // Later, detach the child from the old parent
- * detach(oldParent, child)
- * ```
  * @internal
  */
 export function detach(parent: Signal<any>, child: Child) {
-	// If the child is not attached to the parent, do nothing.
 	if (!parent.children.remove(child)) {
 		return
 	}
 
-	// If the parent has no more children, then detach the parent from its parents.
 	if (parent.children.isEmpty && isChild(parent)) {
 		for (let i = 0, n = parent.parents.length; i < n; i++) {
 			detach(parent.parents[i], parent)
@@ -79,32 +45,16 @@ export function detach(parent: Signal<any>, child: Child) {
 }
 
 /**
- * Attaches a child signal to its parent signal, establishing a parent-child relationship
- * in the reactive dependency graph. If the parent is itself a child, it will recursively
- * attach to its own parents to maintain the dependency chain.
+ * Adds `child` to `parent.children`. A computed parent that gains its first child starts
+ * listening itself, recursively, so that changes to any ancestor are traversed down to the child.
  *
- * This function is used internally when dependencies are captured during computed signal
- * evaluation or effect execution.
- *
- * @param parent - The parent signal to attach to
- * @param child - The child signal to attach
- * @example
- * ```ts
- * // When a computed signal captures a new dependency
- * const parentAtom = atom('parent', 1)
- * const child = computed('child', () => parentAtom.get())
- * // Internally, attach is called to establish the dependency
- * attach(parentAtom, child)
- * ```
  * @internal
  */
 export function attach(parent: Signal<any>, child: Child) {
-	// If the child is already attached to the parent, do nothing.
 	if (!parent.children.add(child)) {
 		return
 	}
 
-	// If the parent itself is a child, add the parent to the parent's parents.
 	if (isChild(parent)) {
 		for (let i = 0, n = parent.parents.length; i < n; i++) {
 			attach(parent.parents[i], parent)
@@ -113,25 +63,10 @@ export function attach(parent: Signal<any>, child: Child) {
 }
 
 /**
- * Checks if two values are equal using the equality semantics of @tldraw/state.
+ * The default equality used for change detection: `===`, then `Object.is` (so `NaN` equals
+ * `NaN`; `0` and `-0` are already equal by `===`), then the old value's own `.equals(b)` method
+ * if it has one. Only the old value's `equals` is consulted.
  *
- * This function performs equality checks in the following order:
- * 1. Reference equality (`===`)
- * 2. `Object.is()` equality (handles NaN and -0/+0 cases)
- * 3. Custom `.equals()` method when the left-hand value provides one
- *
- * This is used internally to determine if a signal's value has actually changed
- * when setting new values, preventing unnecessary updates and re-computations.
- *
- * @param a - The first value to compare
- * @param b - The second value to compare
- * @returns `true` if the values are considered equal, `false` otherwise
- * @example
- * ```ts
- * equals(1, 1) // true
- * equals(NaN, NaN) // true (unlike === which returns false)
- * equals({ equals: (other: any) => other.id === 1 }, { id: 1 }) // Uses custom equals method
- * ```
  * @internal
  */
 export function equals(a: any, b: any): boolean {
@@ -139,32 +74,6 @@ export function equals(a: any, b: any): boolean {
 		a === b || Object.is(a, b) || Boolean(a && b && typeof a.equals === 'function' && a.equals(b))
 	return shallowEquals
 }
-
-/**
- * A TypeScript utility function for exhaustiveness checking in switch statements and
- * conditional branches. This function should never be called at runtime—it exists
- * purely for compile-time type checking and is `undefined` in emitted JavaScript.
- *
- * @param x - A value that should be of type `never`
- * @throws Always at runtime because the identifier is undefined
- * @example
- * ```ts
- * type Color = 'red' | 'blue'
- *
- * function handleColor(color: Color) {
- *   switch (color) {
- *     case 'red':
- *       return 'Stop'
- *     case 'blue':
- *       return 'Go'
- *     default:
- *       return assertNever(color) // TypeScript error if not all cases handled
- *   }
- * }
- * ```
- * @public
- */
-export declare function assertNever(x: never): never
 
 /**
  * Creates or retrieves a singleton instance using a global symbol registry.
@@ -199,37 +108,3 @@ export function singleton<T>(key: string, init: () => T): T {
  * @public
  */
 export const EMPTY_ARRAY: [] = singleton('empty_array', () => Object.freeze([]) as any)
-
-/**
- * Checks if a signal has any active reactors (effects or computed signals) that are
- * currently listening to it. This determines whether changes to the signal will
- * cause any side effects or recomputations to occur.
- *
- * A signal is considered to have active reactors if any of its child dependencies
- * are actively listening for changes.
- *
- * @param signal - The signal to check for active reactors
- * @returns `true` if the signal has active reactors, `false` otherwise
- * @example
- * ```ts
- * const count = atom('count', 0)
- *
- * console.log(hasReactors(count)) // false - no effects listening
- *
- * const stop = react('logger', () => console.log(count.get()))
- * console.log(hasReactors(count)) // true - effect is listening
- *
- * stop()
- * console.log(hasReactors(count)) // false - effect stopped
- * ```
- * @public
- */
-export function hasReactors(signal: Signal<any>) {
-	for (const child of signal.children) {
-		if (child.isActivelyListening) {
-			return true
-		}
-	}
-
-	return false
-}

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -17,21 +17,11 @@ class Transaction {
 
 	initialAtomValues = new Map<_Atom, any>()
 
-	/**
-	 * Get whether this transaction is a root (no parents).
-	 *
-	 * @public
-	 */
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get isRoot() {
 		return this.parent === null
 	}
 
-	/**
-	 * Commit the transaction's changes.
-	 *
-	 * @public
-	 */
 	commit() {
 		if (inst.globalIsReacting) {
 			// if we're committing during a reaction we actually need to
@@ -60,13 +50,11 @@ class Transaction {
 	abort() {
 		inst.globalEpoch++
 
-		// Reset each of the transaction's atoms to its initial value.
 		this.initialAtomValues.forEach((value, atom) => {
 			atom.set(value)
 			atom.historyBuffer?.clear()
 		})
 
-		// Commit the changes.
 		this.commit()
 	}
 }
@@ -185,14 +173,7 @@ function flushChanges(atoms: Iterable<_Atom>) {
 	}
 }
 
-/**
- * Handle a change to an atom.
- *
- * @param atom The atom that changed.
- * @param previousValue The atom's previous value.
- *
- * @internal
- */
+/** @internal */
 export function atomDidChange(atom: _Atom, previousValue: any) {
 	if (inst.currentTransaction) {
 		// If we are in a transaction, then all we have to do is preserve
@@ -218,12 +199,7 @@ function traverseAtomForCleanup(atom: _Atom) {
 	atom.children.visit((child) => traverse(rs, child))
 }
 
-/**
- * Advances the global epoch counter by one.
- * This is used internally to track when changes occur across the reactive system.
- *
- * @internal
- */
+/** @internal */
 export function advanceGlobalEpoch() {
 	inst.globalEpoch++
 }
@@ -251,7 +227,7 @@ export function advanceGlobalEpoch() {
  * // Logs "Hello, Jane Smith!"
  * ```
  *
- * If the function throws, the transaction is aborted and any signals that were updated during the transaction revert to their state before the transaction began.
+ * If the function throws, the transaction is aborted and any signals that were updated during the transaction revert to their state before the transaction began. An aborted transaction still flushes effects: effects whose parents went through a change-and-restore round trip are checked again and, if a parent's value differs from what they last saw (an atom they read directly always will), run once more with the restored values.
  *
  * @example
  * ```ts
@@ -269,8 +245,9 @@ export function advanceGlobalEpoch() {
  *  throw new Error('oops')
  * })
  *
- * // Does not log
  * // firstName.get() === 'John'
+ * // Logs "Hello, John Doe!" again: effects whose parents were changed and restored still run,
+ * // and observe the restored values.
  * ```
  *
  * A `rollback` callback is passed into the function.
@@ -293,9 +270,9 @@ export function advanceGlobalEpoch() {
  *  rollback()
  * })
  *
- * // Does not log
  * // firstName.get() === 'John'
  * // lastName.get() === 'Doe'
+ * // Logs "Hello, John Doe!" again, as above.
  * ```
  *
  * @param fn - The function to run in a transaction, called with a function to roll back the change.
@@ -305,7 +282,6 @@ export function advanceGlobalEpoch() {
 export function transaction<T>(fn: (rollback: () => void) => T) {
 	const txn = new Transaction(inst.currentTransaction, true)
 
-	// Set the current transaction to the transaction
 	inst.currentTransaction = txn
 
 	try {
@@ -313,10 +289,8 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 		let rollback = false
 
 		try {
-			// Run the function.
 			result = fn(() => (rollback = true))
 		} catch (e) {
-			// Abort the transaction if the function throws.
 			txn.abort()
 			throw e
 		}
@@ -326,7 +300,6 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 		}
 
 		if (rollback) {
-			// If the rollback was triggered, abort the transaction.
 			txn.abort()
 		} else {
 			txn.commit()
@@ -334,7 +307,6 @@ export function transaction<T>(fn: (rollback: () => void) => T) {
 
 		return result
 	} finally {
-		// Set the current transaction to the transaction's parent.
 		inst.currentTransaction = txn.parent
 	}
 }

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -9,12 +9,12 @@ import { ArraySet } from './ArraySet'
  *
  * @example
  * ```ts
- * import { atom, getGlobalEpoch, RESET_VALUE } from '@tldraw/state'
+ * import { atom, RESET_VALUE } from '@tldraw/state'
  *
- * const count = atom('count', 0, { historyLength: 3 })
- * const oldEpoch = getGlobalEpoch()
+ * const count = atom('count', 0, { historyLength: 3, computeDiff: (prev, next) => next - prev })
+ * const oldEpoch = count.lastChangedEpoch
  *
- * // Make many changes that exceed history length
+ * // Make more changes than the history length can hold
  * count.set(1)
  * count.set(2)
  * count.set(3)
@@ -183,8 +183,8 @@ export interface Child {
  * A function type that computes the difference between two values of a signal.
  *
  * This function is used to generate incremental diffs that can be applied to
- * reconstruct state changes over time. It's particularly useful for features
- * like undo/redo, synchronization, and change tracking.
+ * reconstruct state changes over time, so that downstream computeds and effects can
+ * update incrementally instead of recomputing from scratch.
  *
  * The function should analyze the previous and current values and return a
  * diff object that represents the change. If the diff cannot be computed


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR corrects the `@tldraw/state` docs where they contradicted the code and trims comments that restated their code, following the **Comments** section of `AGENTS.md`.

### Before

- README's React example used a nonexistent `useAtom`/`useComputed` from `@tldraw/state`; README, DOCS and `types.ts` imported `getGlobalEpoch`, which is not exported; DOCS listed `isComputed` as exported, used `transact((rollback) => …)`, had a broken `Computed` options example, and claimed `whyAmIRunning` logs on its first run.
- `transaction()` JSDoc said `// Does not log` after a rollback or throw, but effects whose parents went through a change-and-restore round trip do run again (SPEC T6).
- ARCHITECTURE listed a `_Reactor` class, `void` returns, and a wrong dependency graph.
- `EffectSchedulerOptions` example passed `scheduleEffect` bare and had a syntax error; `Computed.ts` examples used `atom<number>(0)`; `capture.ts` had a comment about an `idx` variable that no longer exists and an example storing a function in an atom.
- `assertNever` (`export declare`, emits no JS, unexported; `@tldraw/utils` has `exhaustiveSwitchError`) and `hasReactors` (unexported, unused) were dead; `ARRAY_SIZE_THRESHOLD` and `GLOBAL_START_EPOCH` carried `@public` tags and import examples they cannot honor.
- Narration comments, `@param`/`@returns` restating signatures, a "Used by:" call-site list in `constants.ts`, and multi-line `/** @internal */` blocks that only restated a field name, plus Title Case headings in README, DOCS and ARCHITECTURE.

### After

Every example compiles against the actual exports, the transaction examples say what the effects do on rollback, ARCHITECTURE matches the classes and graph that exist, the dead functions are gone, the two constants are `@internal`, restating comments are cut, and headings are sentence case.

No behavior change. Split out of #10144; the sibling fix PRs touch some of the same files, so whichever lands second rebases.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +52 / -243 |
| Tests | +10 / -13 |
| Documentation | +158 / -142 |
