### PR TITLE
docs(agents): slim comment guidance and scope it to new or changed code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,36 +195,17 @@ Dependencies:
 
 ## Comments
 
-A comment earns its place by saying something the code cannot: why this way, what breaks otherwise, which bug it guards. Everything else is noise a reader wades through to reach the code — and enough of it teaches people to skip comments entirely, including the load-bearing ones.
+A comment earns its place by saying something the code cannot: why this way, what breaks otherwise, which bug it guards. The litmus: a good comment names a failure mode, not a mechanism.
 
-Delete on sight:
+Scope: these rules apply to comments you write — new code, and lines you are already changing. Do not sweep existing comments while fixing a bug or refactoring; that buries a small change in a large diff. Leave an existing comment alone unless your change makes it inaccurate, you are rewriting the lines it is attached to, or the user asked for a cleanup. If you notice comments worth cleaning up, mention it or do it in a separate PR.
 
-- **Restatement.** `/** Get the toolbar element */` above `getToolbar()`. The name already said it.
-- **Narration.** `// Check if the shape is already selected` above the line that checks. `// Delete the shapes` above `editor.deleteShapes()`.
-- **Section banners.** `// ===== Locators =====`, `// --- internals ---`. A file that needs signposting needs splitting. Judge the label like any other comment once the rule is off it — `// Bug 3: arrow binding survives rotation` above `test('bug 3: arrow binding survives rotation')` is restatement wearing decoration.
-- **`@param` / `@returns` that restate the signature.** The types carry it. Keep the tag only for what the type can't say — units, a caller precondition, `0 = first button`.
-- **Rationale copy-pasted across sibling call sites.** State it once where the shared thing lives and point at it. Three copies become three subtly different claims, and then nobody knows which is current.
-- **Call-site lists.** `Used by: SelectTool, DrawTool, EraserTool…`. Find-references gives this for free and it rots on the next caller.
+When writing comments:
 
-Trim, rather than delete, when the reason is real but overlong. The test is whether a reviewer reads it or skips past it to get at the code: **once a comment is longer than the code it explains, it has stopped working.** A twenty-line rationale block is usually three good lines plus seventeen restating them — keep the three. One orienting header per file is fine; one per method is not.
-
-**Narrative belongs in a doc; the comment keeps the local fact and points at it.** Ask: does this knowledge span more than one file, and would you read it _before_ starting rather than while typing? Then it is narrative — put it in the project's doc (a `README.md` beside the code, a `SPEC.md`, an article in `apps/docs/content/`) and leave a header of a few lines carrying what this file's own reader needs, plus the reference. A guard comment fails that test and must stay at the line: it is read _during_ an edit, by the person about to delete the thing it guards, and nobody consults a doc before deleting a line.
-
-The pointer is the deliverable, not the leftover — extraction without one is deletion with extra steps. And extract, never copy: a duplicated narrative is the thing that rots, because each copy drifts into a slightly different claim and the stalest one is indistinguishable from the current one.
-
-**The litmus, in one line: a good comment names a failure mode, not a mechanism.** The mechanism is on screen. What is not on screen is what goes wrong without it — "otherwise the binding updates before the shape has its new page transform". Write the "otherwise" and the mechanism explains itself. Expect length, not category, to be the usual defect: most blocks worth editing already name a real force, and then say it three more times.
-
-What earns real length, and should not be trimmed for being long:
-
-- **A diagram.** Twenty lines of box-drawing beat any prose about geometry.
-- **An enumerated set of cases** the code must not break — the list is the specification.
-- **Provenance.** An issue number, "we tried X and it did Y", "modified from the upstream version to…".
-
-Keep, always: the non-obvious invariant, the bug or issue number, the constant nobody should tune blindly.
-
-**Application code is not library code.** In `packages/*`, doc comments on the `@public` surface are a deliverable — they become the API reference on tldraw.dev and land in `api-report.md`, and density there is expected. In `apps/*` and `templates/*` almost nothing is a published surface, so comment lines are explanation prose and cost reading time. App code carrying library-grade comment density, with no `@public` surface to justify it, is over-commented by definition.
-
-Applies to code you write **and** code you touch. Prior art: [#9824](https://github.com/tldraw/tldraw/pull/9824).
+- Don't restate the code (`/** Get the toolbar */` above `getToolbar()`), narrate it (`// Delete the shapes` above `editor.deleteShapes()`), add section banners, list call sites, or write `@param`/`@returns` that only repeat the signature.
+- State a rationale once where the shared thing lives; don't copy it across sibling call sites.
+- Keep comments shorter than the code they explain. Narrative that spans files belongs in a doc (`README.md`, `SPEC.md`, `apps/docs/content/`) with a short pointer from the code.
+- Always keep: non-obvious invariants, issue numbers and provenance, constants nobody should tune blindly, diagrams, and enumerated cases the code must not break.
+- In `packages/*`, doc comments on the `@public` surface become the API reference; density there is expected. In `apps/*` and `templates/*`, keep comments sparse.
 
 ## Writing style
 


### PR DESCRIPTION
**Risk: low · Importance: low**

In order to stop bug fixes and refactors turning into comment-cleanup sweeps, this PR rewrites the comments section of \`AGENTS.md\`. Agents were reading "applies to code you touch" as a license to strip or rewrite every comment in a file they edited, burying small changes in large diffs. The section now states that the rules apply to new or changed code only, and that existing comments stay unless the change makes them inaccurate, the lines they sit on are being rewritten, or the user asked for a cleanup. It also cuts the section from ~35 lines to 15 while keeping the same rules.

### Change type

- [x] \`other\`

### Test plan

- [ ] Unit tests
- [ ] End to end tests