### PR TITLE
fix(tools): harden select tool states against deleted shapes and fix crop, clone, and handle bugs

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11619,9 +11619,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'keyboard': {
-				// please, please
-				if (info.key === 'ShiftRight') info.key = 'ShiftLeft'
-				if (info.key === 'AltRight') info.key = 'AltLeft'
+				// Browsers report `key: 'Shift'` for both shifts; only `code` tells them apart, and
+				// `inputs.keys` stores codes, so normalize codes or right-hand modifiers go unseen.
+				if (info.code === 'ShiftRight') info.code = 'ShiftLeft'
+				if (info.code === 'AltRight') info.code = 'AltLeft'
 				if (info.code === 'ControlRight') info.code = 'ControlLeft'
 				if (info.code === 'MetaRight') info.code = 'MetaLeft'
 

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
@@ -138,6 +138,17 @@ describe('When in the idle state', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
+	it('Starts editing an editable shape without rich text on "Enter" instead of throwing', () => {
+		editor.createShape({ type: 'frame', x: 0, y: 0, props: { w: 100, h: 100 } })
+		const frame = editor.getLastCreatedShape()
+		editor.select(frame)
+		editor.setCurrentTool('geo')
+
+		expect(() => editor.keyPress('Enter')).not.toThrow()
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getEditingShapeId()).toBe(frame.id)
+	})
+
 	it('Does not enter edit shape state on "Enter" key up when multiple geo shapes are selected', () => {
 		editor.setCurrentTool('geo')
 		editor.pointerDown(50, 50)

--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -173,6 +173,23 @@ it('Selects an adjacent note when clicking the clone handle', () => {
 	editor.expectToBeIn('select.editing_shape')
 })
 
+it('Removes the new note and stays in the select tool when a clone handle drag is cancelled', () => {
+	editor.createShape({ type: 'note', x: 1000, y: 1000 })
+	const shape = editor.getLastCreatedShape()!
+	editor.select(shape.id)
+	const handle = editor.getShapeHandles(shape.id)![0]
+
+	editor.pointerDown(handle.x, handle.y, { target: 'handle', shape, handle })
+	editor.pointerMove(handle.x + 30, handle.y + 30)
+	editor.expectToBeIn('select.translating')
+	expect(editor.getCurrentPageShapes()).toHaveLength(2)
+
+	editor.cancel()
+	editor.expectToBeIn('select.idle')
+	expect(editor.getCurrentPageShapes()).toHaveLength(1)
+	expect(editor.getSelectedShapeIds()).toEqual([shape.id])
+})
+
 it('Creates an adjacent note when dragging the clone handle', () => {
 	editor.createShape({
 		type: 'note',

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -9,8 +9,6 @@ export class Erasing extends StateNode {
 	private markId = ''
 	private excludedShapeIds = new Set<TLShapeId>()
 
-	_erasingShapeIds: TLShapeId[] = []
-
 	override onEnter(info: TLPointerEventInfo) {
 		this.markId = this.editor.markHistoryStoppingPoint('erase scribble begin')
 		this.info = info
@@ -34,14 +32,13 @@ export class Erasing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
-		this._erasingShapeIds = this.editor
-			.getShapesAtPoint(originPagePoint)
-			.filter((s) => !this.excludedShapeIds.has(s.id))
-			.map((s) => s.id)
-
-		this.editor.setErasingShapes([
-			...new Set([...this.editor.getErasingShapeIds(), ...this._erasingShapeIds]),
-		])
+		// Keep what the pointing state marked (it hit-tests with a margin) plus whatever is under the origin
+		const hitsAtOrigin = this.editor.getShapesAtPoint(originPagePoint).map((s) => s.id)
+		this.editor.setErasingShapes(
+			[...new Set([...this.editor.getErasingShapeIds(), ...hitsAtOrigin])].filter(
+				(id) => !this.excludedShapeIds.has(id)
+			)
+		)
 
 		const scribble = this.editor.scribbles.addScribble({
 			color: 'muted-1',
@@ -95,10 +92,7 @@ export class Erasing extends StateNode {
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
 		// Early return if no candidates - avoid expensive getCurrentPageRenderingShapesSorted()
-		if (candidateIds.size === 0) {
-			editor.setErasingShapes(Array.from(erasing))
-			return
-		}
+		if (candidateIds.size === 0) return
 
 		const allShapes = editor.getCurrentPageRenderingShapesSorted()
 		const currentPageShapes = allShapes.filter((shape) => candidateIds.has(shape.id))
@@ -143,21 +137,18 @@ export class Erasing extends StateNode {
 					erasing.add(outermost.id)
 				}
 			}
-
-			this._erasingShapeIds = [...erasing]
 		}
 
 		// Remove the hit shapes, except if they're in the list of excluded shapes
 		// (these excluded shapes will be any frames or groups the pointer was inside of
 		// when the user started erasing)
-		this.editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
+		this.editor.setErasingShapes([...erasing].filter((id) => !excludedShapeIds.has(id)))
 	}
 
 	complete(info?: TLPointerEventInfo) {
 		const { editor } = this
 		editor.deleteShapes(editor.getCurrentPageState().erasingShapeIds)
 		this.parent.transition('idle', info)
-		this._erasingShapeIds = []
 	}
 
 	cancel() {

--- a/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/OneFingerZooming.ts
@@ -47,6 +47,16 @@ export class OneFingerZooming extends StateNode {
 		this.complete()
 	}
 
+	override onPointerDown() {
+		// A second touch resets the input origin to the new pointer, so continuing
+		// the zoom would jump the camera. Yield before the pinch begins.
+		this.parent.transition('idle')
+	}
+
+	override onComplete() {
+		this.parent.transition('idle')
+	}
+
 	override onCancel() {
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -21,9 +21,7 @@ export class DragAndDropManager {
 	}
 
 	shapesToActuallyMove: TLShape[] = []
-	draggedOverShapeIds = new Set<TLShapeId>()
 
-	initialGroupIds = new Map<TLShapeId, TLShapeId>()
 	initialParentIds = new Map<TLShapeId, TLParentId>()
 	initialIndices = new Map<TLShapeId, IndexKey>()
 
@@ -69,17 +67,12 @@ export class DragAndDropManager {
 				this.initialParentIds.set(shape.id, parent.id)
 			}
 			this.initialIndices.set(shape.id, shape.index)
-
-			const group = editor.findShapeAncestor(shape, (s) => editor.isShapeOfType(s, 'group'))
-			if (group) {
-				this.initialGroupIds.set(shape.id, group.id)
-			}
 		}
 
-		const allShapes = editor.getCurrentPageShapesSorted()
+		const zIndexById = new Map(editor.getCurrentPageShapesSorted().map((s, i) => [s.id, i]))
 		this.shapesToActuallyMove = Array.from(shapesToActuallyMove)
 			.filter((s) => !s.isLocked)
-			.sort((a, b) => allShapes.indexOf(a) - allShapes.indexOf(b))
+			.sort((a, b) => zIndexById.get(a.id)! - zIndexById.get(b.id)!)
 
 		this.initialDraggingOverShape = editor.getDraggingOverShape(point, this.shapesToActuallyMove)
 
@@ -181,9 +174,12 @@ export class DragAndDropManager {
 				return
 			}
 
-			if (this.prevDraggingOverShape) {
-				const util = editor.getShapeUtil(this.prevDraggingOverShape)
-				const prevDraggingOverShape = this.editor.getShape(this.prevDraggingOverShape)!
+			// The previous target may have been deleted mid-drag, in which case there is nothing to drag out of
+			const prevDraggingOverShape = this.prevDraggingOverShape
+				? this.editor.getShape(this.prevDraggingOverShape.id)
+				: undefined
+			if (prevDraggingOverShape) {
+				const util = editor.getShapeUtil(prevDraggingOverShape)
 				const removableShapes = getRemovableShapesForTarget(
 					editor,
 					prevDraggingOverShape,

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -84,5 +84,9 @@ export class SelectTool extends StateNode {
 		if (this.editor.getCurrentPageState().editingShapeId) {
 			this.editor.setEditingShape(null)
 		}
+		// Leaving crop mode for another tool would otherwise keep the image in its cropping state
+		if (this.editor.getCroppingShapeId()) {
+			this.editor.setCroppingShape(null)
+		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -19,16 +19,15 @@ export class Brushing extends StateNode {
 	static override id = 'brushing'
 	static override trackPerformance = true
 
-	info = {} as TLPointerEventInfo & { target: 'canvas' }
-
 	initialSelectedShapeIds: TLShapeId[] = []
 	excludedShapeIds = new Set<TLShapeId>()
 	isWrapMode = false
 
 	viewportDidChange = false
+	// No-op until onEnter installs the reactor, so onExit can always call it
 	cleanupViewportChangeReactor() {
 		void null
-	} // cleanup function for the viewport reactor
+	}
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
 		const { editor } = this
@@ -64,7 +63,6 @@ export class Brushing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
-		this.info = info
 		this.initialSelectedShapeIds = editor.getSelectedShapeIds().slice()
 		this.hitTestShapes()
 		isInitialCheck = false
@@ -122,13 +120,13 @@ export class Brushing extends StateNode {
 		const originPagePoint = editor.inputs.getOriginPagePoint()
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
 		const shiftKey = editor.inputs.getShiftKey()
-		const ctrlKey = editor.inputs.getCtrlKey()
+		const accelKey = editor.inputs.getAccelKey()
 
 		// We'll be collecting shape ids of selected shapes; if we're holding shift key, we start from our initial shapes
 		const results = new Set(shiftKey ? this.initialSelectedShapeIds : [])
 
 		// In wrap mode, we need to completely enclose a shape to select it
-		const isWrapping = isWrapMode ? !ctrlKey : ctrlKey
+		const isWrapping = isWrapMode ? !accelKey : accelKey
 
 		// Set the brush to contain the current and origin points
 		const brush = Box.FromPoints([originPagePoint, currentPagePoint])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -15,22 +15,21 @@ export class Crop extends StateNode {
 	markId = ''
 
 	override onEnter() {
-		this.didExit = false
 		this.markId = this.editor.markHistoryStoppingPoint('crop')
 	}
-	didExit = false
+
 	override onExit() {
-		if (!this.didExit) {
-			this.didExit = true
-			if (this.editor.getMarkIdMatching(this.markId) === this.markId) {
-				this.editor.squashToMark(this.markId)
-			}
+		// Bailing pops the mark, so there is nothing to squash after a cancel
+		if (this.editor.getMarkIdMatching(this.markId) === this.markId) {
+			this.editor.squashToMark(this.markId)
 		}
 	}
+
 	override onCancel() {
-		if (!this.didExit) {
-			this.didExit = true
-			this.editor.bailToMark(this.markId)
-		}
+		// Parents see events before children. A cancel during a child interaction belongs to that
+		// child, which bails its own mark and stays in crop mode; only a cancel from idle ends the
+		// session and reverts it.
+		if (this.getCurrent()?.id !== 'idle') return
+		this.editor.bailToMark(this.markId)
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -1,6 +1,5 @@
 import {
 	Box,
-	HALF_PI,
 	SelectionHandle,
 	ShapeWithCrop,
 	StateNode,
@@ -11,9 +10,10 @@ import {
 	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getCropBox, getDefaultCrop, getUncroppedSize } from '../../../../../shapes/shared/crop'
+import { isRightAngleRotation } from '../../../selectHelpers'
 import { CursorTypeMap } from '../../PointingResizeHandle'
 
-type Snapshot = ReturnType<Cropping['createSnapshot']>
+type Snapshot = NonNullable<ReturnType<Cropping['createSnapshot']>>
 
 export class Cropping extends StateNode {
 	static override id = 'cropping'
@@ -40,8 +40,15 @@ export class Cropping extends StateNode {
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
+		// The shape can be deleted (remotely, by undo) between pointer down and the drag
+		const snapshot = this.createSnapshot()
+		if (!snapshot) {
+			this.editor.setCroppingShape(null)
+			this.editor.setCurrentTool('select.idle')
+			return
+		}
 		this.markId = this.editor.markHistoryStoppingPoint('cropping')
-		this.snapshot = this.createSnapshot()
+		this.snapshot = snapshot
 		this.updateShapes()
 	}
 
@@ -110,7 +117,7 @@ export class Cropping extends StateNode {
 		editor.snaps.clearIndicators()
 		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 		let didSnap = false
-		if (shouldSnap && initialSelectionPageBounds && selectionRotation % HALF_PI === 0) {
+		if (shouldSnap && initialSelectionPageBounds && isRightAngleRotation(selectionRotation)) {
 			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
 				initialSelectionPageBounds,
@@ -122,7 +129,9 @@ export class Cropping extends StateNode {
 			didSnap = true
 		}
 
-		const change = currentPagePoint.clone().sub(originPagePoint).rot(-shape.rotation)
+		// The crop lives in the shape's own space, so the page-space drag comes off by the shape's
+		// page rotation; its local rotation alone is wrong inside a rotated frame or group
+		const change = currentPagePoint.clone().sub(originPagePoint).rot(-selectionRotation)
 
 		const crop = shape.props.crop ?? getDefaultCrop()
 		const uncroppedSize = getUncroppedSize(shape.props, crop)
@@ -232,7 +241,8 @@ export class Cropping extends StateNode {
 
 		const shape = this.editor.getOnlySelectedShape() as ShapeWithCrop
 
-		const selectionBounds = this.editor.getSelectionRotatedPageBounds()!
+		const selectionBounds = this.editor.getSelectionRotatedPageBounds()
+		if (!shape || !selectionBounds) return null
 
 		const dragHandlePoint = Vec.RotWith(
 			selectionBounds.getHandlePoint(this.info.handle!),

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
@@ -3,6 +3,12 @@ import { StateNode, TLClickEventInfo, TLPointerEventInfo } from '@tldraw/editor'
 export class PointingCrop extends StateNode {
 	static override id = 'pointing_crop'
 
+	private pendingDoubleClick: TLClickEventInfo | null = null
+
+	override onEnter() {
+		this.pendingDoubleClick = null
+	}
+
 	override onCancel() {
 		this.editor.setCurrentTool('select.crop.idle', {})
 	}
@@ -17,9 +23,15 @@ export class PointingCrop extends StateNode {
 	}
 
 	override onPointerUp(info: TLPointerEventInfo) {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.editor.setCurrentTool('select.crop.idle', info)
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -30,8 +42,7 @@ export class PointingCrop extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	startDragging(info: TLPointerEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
@@ -11,9 +11,11 @@ export class PointingCropHandle extends StateNode {
 	static override id = 'pointing_crop_handle'
 
 	private info = {} as TLPointingCropHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	override onEnter(info: TLPointingCropHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -49,6 +51,12 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
+
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {
@@ -62,6 +70,7 @@ export class PointingCropHandle extends StateNode {
 		this.editor.setCurrentTool('select.idle')
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -72,8 +81,7 @@ export class PointingCropHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/crop_helpers.ts
@@ -24,7 +24,8 @@ export function getTranslateCroppedImageChange(editor: Editor, shape: ShapeWithC
 		delta.y = 0
 	}
 
-	delta.rot(-shape.rotation)
+	// The crop lives in the shape's own space; use the page rotation, which includes rotated parents
+	delta.rot(-editor.getShapePageTransform(shape.id).rotation())
 
 	const { w, h } = getUncroppedSize(shape.props, oldCrop)
 	const xCropSize = oldCrop.bottomRight.x - oldCrop.topLeft.x

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -42,12 +42,19 @@ export class DraggingHandle extends StateNode {
 	info!: DraggingHandleInfo
 
 	isPrecise = false
-	isPreciseId: TLShapeId | null = null
-	pointingId: TLShapeId | null = null
 
 	override onEnter(info: DraggingHandleInfo) {
 		const { shape, isCreating, creatingMarkId, handle } = info
+
+		// The shape can be deleted (remotely, by undo) between pointer down and the drag
+		const handles = this.editor.getShapeHandles(shape)
+		if (!handles) {
+			this.parent.transition('idle')
+			return
+		}
+
 		this.info = info
+		this.isPrecise = false
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -78,15 +85,15 @@ export class DraggingHandle extends StateNode {
 
 		this.editor.setCursor({ type: isCreating ? 'cross' : 'grabbing', rotation: 0 })
 
-		const handles = this.editor.getShapeHandles(shape)!.sort(sortByIndex)
-		const index = handles.findIndex((h) => h.id === info.handle.id)
+		const sortedHandles = handles.slice().sort(sortByIndex)
+		const index = sortedHandles.findIndex((h) => h.id === info.handle.id)
 
 		// Find the adjacent handle
 		this.initialAdjacentHandle = null
 
 		// First, check if the handle specifies a custom reference handle
 		if (info.handle.snapReferenceHandleId) {
-			const customHandle = handles.find((h) => h.id === info.handle.snapReferenceHandleId)
+			const customHandle = sortedHandles.find((h) => h.id === info.handle.snapReferenceHandleId)
 			if (customHandle) {
 				this.initialAdjacentHandle = customHandle
 			}
@@ -95,8 +102,8 @@ export class DraggingHandle extends StateNode {
 		// If no custom reference handle, use default behavior
 		if (!this.initialAdjacentHandle) {
 			// Start from the handle and work forward
-			for (let i = index + 1; i < handles.length; i++) {
-				const handle = handles[i]
+			for (let i = index + 1; i < sortedHandles.length; i++) {
+				const handle = sortedHandles[i]
 				if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
 					this.initialAdjacentHandle = handle
 					break
@@ -105,8 +112,8 @@ export class DraggingHandle extends StateNode {
 
 			// If still no handle, start from the end and work backward
 			if (!this.initialAdjacentHandle) {
-				for (let i = handles.length - 1; i >= 0; i--) {
-					const handle = handles[i]
+				for (let i = sortedHandles.length - 1; i >= 0; i--) {
+					const handle = sortedHandles[i]
 					if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
 						this.initialAdjacentHandle = handle
 						break
@@ -115,22 +122,16 @@ export class DraggingHandle extends StateNode {
 			}
 		}
 
-		// <!-- Only relevant to arrows
 		if (this.editor.isShapeOfType(shape, 'arrow')) {
 			const initialBinding = getArrowBindings(this.editor, shape)[info.handle.id as 'start' | 'end']
 
-			this.isPrecise = false
-
 			if (initialBinding) {
 				this.isPrecise = initialBinding.props.isPrecise
-				if (this.isPrecise) {
-					this.isPreciseId = initialBinding.toId
-				} else {
+				if (!this.isPrecise) {
 					this.resetExactTimeout()
 				}
 			}
 		}
-		// -->
 
 		// Call onHandleDragStart callback
 		const handleDragInfo = {
@@ -150,10 +151,8 @@ export class DraggingHandle extends StateNode {
 		this.editor.select(this.shapeId)
 	}
 
-	// Only relevant to arrows
 	private exactTimeout = -1
 
-	// Only relevant to arrows
 	private resetExactTimeout() {
 		const arrowUtil = this.editor.getShapeUtil<ArrowShapeUtil>('arrow')
 		const timeoutValue = arrowUtil.options.pointingPreciseTimeout
@@ -165,14 +164,12 @@ export class DraggingHandle extends StateNode {
 		this.exactTimeout = this.editor.timers.setTimeout(() => {
 			if (this.getIsActive() && !this.isPrecise) {
 				this.isPrecise = true
-				this.isPreciseId = this.pointingId
 				this.update()
 			}
 			this.exactTimeout = -1
 		}, timeoutValue)
 	}
 
-	// Only relevant to arrows
 	private clearExactTimeout() {
 		if (this.exactTimeout !== -1) {
 			clearTimeout(this.exactTimeout)
@@ -207,6 +204,8 @@ export class DraggingHandle extends StateNode {
 
 	override onExit() {
 		this.parent.setCurrentToolIdMask(undefined)
+		// Otherwise a timer armed by this drag can flip the next drag to precise
+		this.clearExactTimeout()
 		clearArrowTargetState(this.editor)
 		this.editor.snaps.clearIndicators()
 
@@ -288,7 +287,7 @@ export class DraggingHandle extends StateNode {
 		const { snaps } = editor
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
 		const shiftKey = editor.inputs.getShiftKey()
-		const ctrlKey = editor.inputs.getCtrlKey()
+		const accelKey = editor.inputs.getAccelKey()
 		const altKey = editor.inputs.getAltKey()
 		const pointerVelocity = editor.inputs.getPointerVelocity()
 
@@ -331,15 +330,14 @@ export class DraggingHandle extends StateNode {
 			canSnap = initialHandle.canSnap || initialHandle.snapType !== undefined
 		}
 
-		if (canSnap && (isSnapMode ? !ctrlKey : ctrlKey)) {
+		if (canSnap && (isSnapMode ? !accelKey : accelKey)) {
 			// We're snapping
-			const pageTransform = editor.getShapePageTransform(shape.id)
-			if (!pageTransform) throw Error('Expected a page transform')
-
 			const snap = snaps.handles.snapHandle({ currentShapeId: shapeId, handle: nextHandle })
 
 			if (snap) {
-				snap.nudge.rot(-editor.getShapeParentTransform(shape)!.rotation())
+				// The nudge is in page space and `point` is in the shape's own space, so the shape's
+				// full page rotation (not just its parent's) has to come off
+				snap.nudge.rot(-editor.getShapePageTransform(shape.id).rotation())
 				point.add(snap.nudge)
 				nextHandle = { ...initialHandle, x: point.x, y: point.y }
 			}
@@ -354,22 +352,17 @@ export class DraggingHandle extends StateNode {
 
 		const next: TLShapePartial<any> = { id: shape.id, type: shape.type, ...changes }
 
-		// Arrows
 		if (initialHandle.type === 'vertex' && this.editor.isShapeOfType(shape, 'arrow')) {
 			const bindingAfter = getArrowBindings(editor, shape)[initialHandle.id as 'start' | 'end']
 
 			if (bindingAfter) {
 				if (initialBinding?.toId !== bindingAfter.toId) {
-					this.pointingId = bindingAfter.toId
 					this.isPrecise = pointerVelocity.len() < 0.5 || altKey
-					this.isPreciseId = this.isPrecise ? bindingAfter.toId : null
 					this.resetExactTimeout()
 				}
 			} else {
 				if (initialBinding) {
-					this.pointingId = null
 					this.isPrecise = false
-					this.isPreciseId = null
 					this.resetExactTimeout()
 				}
 			}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -4,6 +4,7 @@ import {
 	TLCancelEventInfo,
 	TLCompleteEventInfo,
 	tlenv,
+	TLEventInfo,
 	TLPointerEventInfo,
 	TLShape,
 } from '@tldraw/editor'
@@ -50,14 +51,21 @@ export class EditingShape extends StateNode {
 	}
 
 	override onExit() {
-		const hadEditingShape = !!this.editor.getEditingShapeId()
 		this.editor.setEditingShape(null)
-
 		cancelUpdateHoveredShapeId(this.editor)
-
-		if (this.info.isCreatingTextWhileToolLocked && hadEditingShape) {
+		if (this.info.isCreatingTextWhileToolLocked) {
 			this.parent.setCurrentToolIdMask(undefined)
+		}
+	}
+
+	// Switching tools from onExit would re-route the state chart in the middle of the transition
+	// that is exiting this state (the select tool's idle gets entered under an inactive select
+	// tool and clobbers the text tool's cursor), so the tool-lock return happens here instead.
+	private leave(info: TLEventInfo) {
+		if (this.info.isCreatingTextWhileToolLocked) {
 			this.editor.setCurrentTool('text', {})
+		} else {
+			this.parent.transition('idle', info)
 		}
 	}
 
@@ -75,7 +83,7 @@ export class EditingShape extends StateNode {
 		}
 
 		// Check if dragging from editing shape with blurred input
-		if (this.didPointerDownOnEditingShape && this.editor.inputs.isDragging) {
+		if (this.didPointerDownOnEditingShape && this.editor.inputs.getIsDragging()) {
 			if (this.editor.getIsReadonly()) return
 
 			const editingShape = this.editor.getEditingShape()
@@ -132,7 +140,7 @@ export class EditingShape extends StateNode {
 				}
 
 				// for shapes with labels, check to see if the click was inside of the shape's label
-				const geometry = this.editor.getShapeUtil(selectingShape).getGeometry(selectingShape)
+				const geometry = this.editor.getShapeGeometry(selectingShape)
 				const textLabels = getTextLabels(geometry)
 				const textLabel = textLabels.length === 1 ? textLabels[0] : undefined
 				// N.B. One nuance here is that we want empty text fields to be removed from the canvas when the user clicks away from them.
@@ -181,7 +189,7 @@ export class EditingShape extends StateNode {
 		}
 
 		// still here? Cancel editing and transition back to select idle
-		this.parent.transition('idle', info)
+		this.leave(info)
 		// then feed the pointer down event back into the state chart as if it happened in that state
 		this.editor.root.handleEvent(info)
 	}
@@ -230,11 +238,11 @@ export class EditingShape extends StateNode {
 
 	override onComplete(info: TLCompleteEventInfo) {
 		this.editor.getContainer().focus()
-		this.parent.transition('idle', info)
+		this.leave(info)
 	}
 
 	override onCancel(info: TLCancelEventInfo) {
 		this.editor.getContainer().focus()
-		this.parent.transition('idle', info)
+		this.leave(info)
 	}
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -1,5 +1,4 @@
 import {
-	Editor,
 	StateNode,
 	TLAdjacentDirection,
 	TLClickEventInfo,
@@ -7,22 +6,23 @@ import {
 	TLPointerEventInfo,
 	TLShape,
 	Vec,
-	VecLike,
 	createShapeId,
 	debugFlags,
 	kickoutOccludedShapes,
-	pointInPolygon,
 	toRichText,
 	unsafe__withoutCapture,
 } from '@tldraw/editor'
-import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { updateHoveredOverlayId } from '../../selection-logic/updateHoveredOverlayId'
 import {
 	cancelUpdateHoveredShapeId,
 	updateHoveredShapeId,
 } from '../../selection-logic/updateHoveredShapeId'
-import { hasRichText, startEditingShapeWithRichText } from '../selectHelpers'
+import {
+	hasRichText,
+	isPointInRotatedSelectionBounds,
+	startEditingShapeWithRichText,
+} from '../selectHelpers'
 
 const SKIPPED_KEYS_FOR_AUTO_EDITING = [
 	'Delete',
@@ -146,22 +146,8 @@ export class Idle extends StateNode {
 					}
 				} else {
 					switch (overlayType) {
-						case 'rotate_handle': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
-						case 'mobile_rotate': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
+						case 'rotate_handle':
+						case 'mobile_rotate':
 						case 'resize_handle': {
 							this.onPointerDown({
 								...info,
@@ -321,6 +307,8 @@ export class Idle extends StateNode {
 							this.editor.getShapeAtPoint(currentPagePoint, {
 								margin: this.editor.getHitTestMargin(),
 								hitInside: false,
+								hitLocked: this.editor.options.selectLockedShapes,
+								renderingOnly: true,
 							}))
 
 				if (hitShape) {
@@ -373,21 +361,22 @@ export class Idle extends StateNode {
 						break
 					}
 
-					// Test edges for an onDoubleClickEdge handler
-					if (isEdge) {
-						const change = util.onDoubleClickEdge?.(onlySelectedShape, info)
+					// Mark before calling the handler: it may write to the store itself (e.g. a frame
+					// reflowing its children), and those writes belong to this undo group
+					if (isEdge && util.onDoubleClickEdge) {
+						this.editor.markHistoryStoppingPoint('double click edge')
+						const change = util.onDoubleClickEdge(onlySelectedShape, info)
 						if (change) {
-							this.editor.markHistoryStoppingPoint('double click edge')
 							this.editor.updateShapes([change])
 							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
 							return
 						}
 					}
 
-					if (isCorner) {
-						const change = util.onDoubleClickCorner?.(onlySelectedShape, info)
+					if (isCorner && util.onDoubleClickCorner) {
+						this.editor.markHistoryStoppingPoint('double click corner')
+						const change = util.onDoubleClickCorner(onlySelectedShape, info)
 						if (change) {
-							this.editor.markHistoryStoppingPoint('double click corner')
 							this.editor.updateShapes([change])
 							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
 							return
@@ -433,12 +422,12 @@ export class Idle extends StateNode {
 
 				const util = this.editor.getShapeUtil(shape)
 
-				// Allow playing videos and embeds
-				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
+				// Shapes that opt into read-only editing (embeds, custom utils) still get their double click
+				if (this.editor.getIsReadonly() && !util.canEditInReadonly(shape)) break
 
 				if (util.onDoubleClick) {
-					// Call the shape's double click handler
-					const change = util.onDoubleClick?.(shape)
+					this.editor.markHistoryStoppingPoint('double click shape')
+					const change = util.onDoubleClick(shape)
 					if (change) {
 						this.editor.updateShapes([change])
 						return
@@ -469,6 +458,7 @@ export class Idle extends StateNode {
 				const { shape, handle } = info
 
 				const util = this.editor.getShapeUtil(shape)
+				this.editor.markHistoryStoppingPoint('double click handle')
 				const changes = util.onDoubleClickHandle?.(shape, handle)
 
 				if (changes) {
@@ -543,9 +533,7 @@ export class Idle extends StateNode {
 
 				if (
 					!selectedShapeIds.includes(targetShape.id) &&
-					!this.editor.findShapeAncestor(targetShape, (shape) =>
-						selectedShapeIds.includes(shape.id)
-					)
+					!this.editor.isAncestorSelected(targetShape)
 				) {
 					this.editor.markHistoryStoppingPoint('selecting shape')
 					this.editor.setSelectedShapes([targetShape.id])
@@ -570,29 +558,7 @@ export class Idle extends StateNode {
 	override onKeyDown(info: TLKeyboardEventInfo) {
 		this.selectedShapesOnKeyDown = this.editor.getSelectedShapes()
 
-		switch (info.code) {
-			case 'ArrowLeft':
-			case 'ArrowRight':
-			case 'ArrowUp':
-			case 'ArrowDown': {
-				if (info.accelKey) {
-					if (info.shiftKey) {
-						if (info.code === 'ArrowDown') {
-							this.editor.selectFirstChildShape()
-						} else if (info.code === 'ArrowUp') {
-							this.editor.selectParentShape()
-						}
-					} else {
-						this.editor.selectAdjacentShape(
-							info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
-						)
-					}
-					return
-				}
-				this.nudgeSelectedShapes(false)
-				return
-			}
-		}
+		if (this.handleArrowKey(info, false)) return
 
 		if (debugFlags['editOnType'].get()) {
 			// This feature flag lets us start editing a note shape's label when a key is pressed.
@@ -624,28 +590,42 @@ export class Idle extends StateNode {
 	}
 
 	override onKeyRepeat(info: TLKeyboardEventInfo) {
+		if (this.handleArrowKey(info, true)) return
+
+		if (info.code === 'Tab') {
+			const selectedShapes = this.editor.getSelectedShapes()
+			if (selectedShapes.length && !info.altKey) {
+				this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
+			}
+		}
+	}
+
+	// Shared by key down and key repeat so a held combination keeps doing what the first press did
+	private handleArrowKey(info: TLKeyboardEventInfo, ephemeral: boolean): boolean {
 		switch (info.code) {
 			case 'ArrowLeft':
 			case 'ArrowRight':
 			case 'ArrowUp':
 			case 'ArrowDown': {
 				if (info.accelKey) {
-					this.editor.selectAdjacentShape(
-						info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
-					)
-					return
+					if (info.shiftKey) {
+						if (info.code === 'ArrowDown') {
+							this.editor.selectFirstChildShape()
+						} else if (info.code === 'ArrowUp') {
+							this.editor.selectParentShape()
+						}
+					} else {
+						this.editor.selectAdjacentShape(
+							info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
+						)
+					}
+					return true
 				}
-				this.nudgeSelectedShapes(true)
-				break
-			}
-			case 'Tab': {
-				const selectedShapes = this.editor.getSelectedShapes()
-				if (selectedShapes.length && !info.altKey) {
-					this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
-				}
-				break
+				this.nudgeSelectedShapes(ephemeral)
+				return true
 			}
 		}
+		return false
 	}
 
 	override onKeyUp(info: TLKeyboardEventInfo) {
@@ -712,12 +692,6 @@ export class Idle extends StateNode {
 			editor.setEditingShape(shape)
 		}
 		this.parent.transition('editing_shape', info)
-	}
-
-	isOverArrowLabelTest(shape: TLShape | undefined) {
-		if (!shape) return false
-
-		return isOverArrowLabel(this.editor, shape)
 	}
 
 	handleDoubleClickOnCanvas(info: TLClickEventInfo) {
@@ -799,16 +773,3 @@ export class Idle extends StateNode {
 export const MAJOR_NUDGE_FACTOR = 10
 export const MINOR_NUDGE_FACTOR = 1
 export const GRID_INCREMENT = 5
-
-function isPointInRotatedSelectionBounds(editor: Editor, point: VecLike) {
-	const selectionBounds = editor.getSelectionRotatedPageBounds()
-	if (!selectionBounds) return false
-
-	const selectionRotation = editor.getSelectionRotation()
-	if (!selectionRotation) return selectionBounds.containsPoint(point)
-
-	return pointInPolygon(
-		point,
-		selectionBounds.corners.map((c) => Vec.RotWith(c, selectionBounds.point, selectionRotation))
-	)
-}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -134,13 +134,16 @@ export class PointingArrowLabel extends StateNode {
 
 	override onPointerUp() {
 		const shape = this.editor.getShape<TLArrowShape>(this.shapeId)
-		if (!shape) return
 
-		if (this.didDrag || !this.wasAlreadySelected) {
-			this.complete()
-		} else if (this.editor.canEditShape(shape)) {
+		// Clicking the label of an already-selected arrow starts editing it; every other
+		// outcome (drag, fresh selection, deleted or uneditable arrow) must leave this state,
+		// which has no pointer down handler to recover from.
+		if (shape && !this.didDrag && this.wasAlreadySelected && this.editor.canEditShape(shape)) {
 			startEditingShapeWithRichText(this.editor, shape.id)
+			return
 		}
+
+		this.complete()
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -45,6 +45,10 @@ export class PointingCanvas extends StateNode {
 		this.complete()
 	}
 
+	override onCancel() {
+		this.parent.transition('idle')
+	}
+
 	override onInterrupt() {
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -7,7 +7,10 @@ import {
 	TLPointerEventInfo,
 	Vec,
 } from '@tldraw/editor'
-import { updateArrowTargetState } from '../../../shapes/arrow/arrowTargetState'
+import {
+	clearArrowTargetState,
+	updateArrowTargetState,
+} from '../../../shapes/arrow/arrowTargetState'
 import { getArrowBindings } from '../../../shapes/arrow/shared'
 import {
 	getNoteAdjacentPositions,
@@ -55,6 +58,8 @@ export class PointingHandle extends StateNode {
 
 	override onExit() {
 		this.editor.setHintingShapes([])
+		// onEnter shows the arrow's binding target; a click without a drag would leave it showing
+		clearArrowTargetState(this.editor)
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 	}
 
@@ -121,6 +126,8 @@ export class PointingHandle extends StateNode {
 			const noteUtil = editor.getShapeUtil(shape) as NoteShapeUtil
 			const dv = getDisplayValues(noteUtil, shape)
 
+			// Cancelling the drag bails to this mark, which removes the note created below
+			const creatingMarkId = editor.markHistoryStoppingPoint('creating note from handle')
 			const nextNote = getNoteForAdjacentPosition(editor, shape, handle, true)
 			if (nextNote) {
 				// Center the shape on the current pointer
@@ -142,8 +149,8 @@ export class PointingHandle extends StateNode {
 						...this.info,
 						target: 'shape',
 						shape: editor.getShape(nextNote),
-						onInteractionEnd: 'note',
 						isCreating: true,
+						creatingMarkId,
 						onCreate: () => {
 							// When we're done, start editing it
 							startEditingShapeWithRichText(editor, nextNote, { selectAll: true })

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -30,6 +30,7 @@ export class PointingResizeHandle extends StateNode {
 	static override id = 'pointing_resize_handle'
 
 	private info = {} as PointingResizeHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	private updateCursor() {
 		const cursorType = CursorTypeMap[this.info.handle!]
@@ -41,6 +42,7 @@ export class PointingResizeHandle extends StateNode {
 
 	override onEnter(info: PointingResizeHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -67,9 +69,17 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.complete()
 	}
 
+	// A double click's 'down' phase arrives while the second press is still held. Acting on it
+	// immediately would steal a press that is about to become a drag (#9499), so it is deferred
+	// to pointer up.
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -80,8 +90,7 @@ export class PointingResizeHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -9,6 +9,7 @@ export class PointingRotateHandle extends StateNode {
 	static override id = 'pointing_rotate_handle'
 
 	private info = {} as PointingRotateHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	private updateCursor() {
 		this.editor.setCursor({
@@ -19,6 +20,7 @@ export class PointingRotateHandle extends StateNode {
 
 	override onEnter(info: PointingRotateHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -46,9 +48,15 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.complete()
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -59,8 +67,7 @@ export class PointingRotateHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
@@ -4,14 +4,6 @@ import { selectOnCanvasPointerUp } from '../../selection-logic/selectOnCanvasPoi
 export class PointingSelection extends StateNode {
 	static override id = 'pointing_selection'
 
-	info = {} as TLPointerEventInfo & {
-		target: 'selection'
-	}
-
-	override onEnter(info: TLPointerEventInfo & { target: 'selection' }) {
-		this.info = info
-	}
-
 	override onPointerUp(info: TLPointerEventInfo) {
 		selectOnCanvasPointerUp(this.editor, info)
 		this.parent.transition('idle', info)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -1,6 +1,7 @@
 import { StateNode, TLClickEventInfo, TLPointerEventInfo, TLShape } from '@tldraw/editor'
 import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getTextLabels } from '../../../utils/shapes/shapes'
+import { isPointInRotatedSelectionBounds } from '../selectHelpers'
 
 export class PointingShape extends StateNode {
 	static override id = 'pointing_shape'
@@ -14,7 +15,6 @@ export class PointingShape extends StateNode {
 
 	override onEnter(info: TLPointerEventInfo & { target: 'shape' }) {
 		const selectedShapeIds = this.editor.getSelectedShapeIds()
-		const selectionBounds = this.editor.getSelectionRotatedPageBounds()
 		const focusedGroupId = this.editor.getFocusedGroupId()
 		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 		const { shiftKey, altKey, accelKey } = info
@@ -23,9 +23,6 @@ export class PointingShape extends StateNode {
 		this.isDoubleClick = false
 		this.didCtrlOnEnter = accelKey
 		const outermostSelectingShape = this.editor.getOutermostSelectableShape(info.shape)
-		const selectedAncestor = this.editor.findShapeAncestor(outermostSelectingShape, (parent) =>
-			selectedShapeIds.includes(parent.id)
-		)
 
 		if (
 			this.didCtrlOnEnter ||
@@ -36,9 +33,10 @@ export class PointingShape extends StateNode {
 			// ...or if the shape is within the selection
 			selectedShapeIds.includes(outermostSelectingShape.id) ||
 			// ...or if an ancestor of the shape is selected
-			selectedAncestor ||
-			// ...or if the current point is NOT within the selection bounds
-			(selectedShapeIds.length > 1 && selectionBounds?.containsPoint(currentPagePoint))
+			this.editor.isAncestorSelected(outermostSelectingShape) ||
+			// ...or if the point is inside a multi-shape selection, so a drag moves the whole selection
+			(selectedShapeIds.length > 1 &&
+				isPointInRotatedSelectionBounds(this.editor, currentPagePoint))
 		) {
 			// We won't select the shape on enter, though we might select it on pointer up!
 			this.didSelectOnEnter = false
@@ -71,6 +69,7 @@ export class PointingShape extends StateNode {
 			this.editor.getShapeAtPoint(currentPagePoint, {
 				margin: this.editor.getHitTestMargin(),
 				hitInside: true,
+				hitLocked: this.editor.options.selectLockedShapes,
 				renderingOnly: true,
 			}) ?? this.hitShape
 
@@ -82,33 +81,29 @@ export class PointingShape extends StateNode {
 			return
 		}
 
-		const selectingShape = hitShape
-			? this.editor.getOutermostSelectableShape(hitShape)
-			: this.hitShapeForPointerUp
+		const selectingShape = this.editor.getOutermostSelectableShape(hitShape)
 
-		if (selectingShape) {
-			// If the selecting shape has a click handler, call it instead of selecting the shape
-			const util = this.editor.getShapeUtil(selectingShape)
-			if (util.onClick) {
-				const change = util.onClick?.(selectingShape)
-				if (change) {
-					this.editor.markHistoryStoppingPoint('shape on click')
-					this.editor.updateShapes([change])
-					this.parent.transition('idle', info)
-					return
-				}
-			}
-
-			if (selectingShape.id === focusedGroupId) {
-				if (selectedShapeIds.length > 0) {
-					this.editor.markHistoryStoppingPoint('clearing shape ids')
-					this.editor.setSelectedShapes([])
-				} else {
-					this.editor.popFocusedGroupId()
-				}
+		// If the selecting shape has a click handler, call it instead of selecting the shape
+		const util = this.editor.getShapeUtil(selectingShape)
+		if (util.onClick) {
+			const change = util.onClick?.(selectingShape)
+			if (change) {
+				this.editor.markHistoryStoppingPoint('shape on click')
+				this.editor.updateShapes([change])
 				this.parent.transition('idle', info)
 				return
 			}
+		}
+
+		if (selectingShape.id === focusedGroupId) {
+			if (selectedShapeIds.length > 0) {
+				this.editor.markHistoryStoppingPoint('clearing shape ids')
+				this.editor.setSelectedShapes([])
+			} else {
+				this.editor.popFocusedGroupId()
+			}
+			this.parent.transition('idle', info)
+			return
 		}
 
 		if (!this.didSelectOnEnter) {
@@ -137,7 +132,7 @@ export class PointingShape extends StateNode {
 
 						// if the shape has a text label, and we're inside of the label, then we want to begin editing the label.
 						if (selectedShapeIds.length === 1) {
-							const geometry = this.editor.getShapeUtil(selectingShape).getGeometry(selectingShape)
+							const geometry = this.editor.getShapeGeometry(selectingShape)
 							const textLabels = getTextLabels(geometry)
 							const textLabel = textLabels.length === 1 ? textLabels[0] : undefined
 							// N.B. we're only interested if there is exactly one text label. We don't handle the
@@ -224,6 +219,12 @@ export class PointingShape extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
+			// The pointed shape may have been deleted since pointer down (remote user, undo)
+			if (!this.editor.getShape(this.hitShape.id)) {
+				this.parent.transition('idle', info)
+				return
+			}
+
 			if (isOverArrowLabel(this.editor, this.hitShape)) {
 				// We're moving the label on a shape.
 				this.parent.transition('pointing_arrow_label', { ...info, shape: this.hitShape })
@@ -248,8 +249,13 @@ export class PointingShape extends StateNode {
 		// If we didn't select the shape on enter (e.g. because it has an onClick handler),
 		// and there's no current selection, select it now before transitioning to translating.
 		if (!this.didSelectOnEnter && !this.editor.getSelectedShapeIds().length) {
+			const shapeToSelect = this.editor.getShape(this.hitShapeForPointerUp.id)
+			if (!shapeToSelect) {
+				this.parent.transition('idle', info)
+				return
+			}
 			this.editor.markHistoryStoppingPoint('selecting shape')
-			this.editor.setSelectedShapes([this.hitShapeForPointerUp.id])
+			this.editor.setSelectedShapes([shapeToSelect.id])
 		}
 
 		// Re-focus the editor, just in case the text label of the shape has stolen focus

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -1,9 +1,6 @@
 import {
 	Box,
-	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,9 +16,11 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
+import { isRightAngleRotation } from '../selectHelpers'
 
 export type ResizingInfo = TLPointerEventInfo & {
 	target: 'selection'
@@ -56,22 +55,21 @@ export class Resizing extends StateNode {
 
 		this.info = info
 		this.didHoldCommand = false
+		this.markId = ''
 
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
 		this.creationCursorOffset = creationCursorOffset
 
-		try {
-			// On rare and mysterious occasions, the user can enter the resizing state with no shapes selected
-			this.snapshot = this._createSnapshot()
-		} catch (e) {
-			console.error(e)
-			this.cancel()
+		// The selection can be empty here, e.g. when the pointed shape was deleted remotely between
+		// pointer down and the drag. Nothing has been marked or changed yet, so just leave.
+		const snapshot = this._createSnapshot()
+		if (!snapshot) {
+			this.parent.transition('idle')
 			return
 		}
-
-		this.markId = ''
+		this.snapshot = snapshot
 
 		if (isCreating) {
 			if (creatingMarkId) {
@@ -202,7 +200,8 @@ export class Resizing extends StateNode {
 		const changes: TLShapePartial[] = []
 
 		shapeSnapshots.forEach(({ shape }) => {
-			const current = this.editor.getShape(shape.id)!
+			const current = this.editor.getShape(shape.id)
+			if (!current) return
 			const util = this.editor.getShapeUtil(shape)
 			const change = util.onResizeEnd?.(shape, current)
 			if (change) {
@@ -298,7 +297,7 @@ export class Resizing extends StateNode {
 
 		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 
-		if (shouldSnap && selectionRotation % HALF_PI === 0) {
+		if (shouldSnap && isRightAngleRotation(selectionRotation)) {
 			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
 				initialSelectionPageBounds: initialSelectionPageBounds,
@@ -320,8 +319,6 @@ export class Resizing extends StateNode {
 
 		// calculate the scale by measuring the current distance between the drag handle and the scale origin
 		// and dividing by the original distance between the drag handle and the scale origin
-
-		// bug: for edges, the page point doesn't matter, the
 
 		const distanceFromScaleOriginNow = Vec.Sub(currentPagePoint, scaleOriginPage).rot(
 			-selectionRotation
@@ -428,8 +425,9 @@ export class Resizing extends StateNode {
 
 			for (const { id, children } of frames) {
 				if (!children.length) continue
-				const initial = shapeSnapshots.get(id)!.shape
-				const current = this.editor.getShape(id)!
+				// A frame-like shape that can't resize is never snapshotted
+				const initial = shapeSnapshots.get(id)?.shape
+				const current = this.editor.getShape(id)
 				if (!(initial && current)) continue
 
 				const dx = current.x - initial.x
@@ -496,8 +494,6 @@ export class Resizing extends StateNode {
 		this.editor.setHintingShapes(hintingShapeIds)
 	}
 
-	// ---
-
 	private updateCursor({
 		dragHandle,
 		isFlippedX,
@@ -545,6 +541,9 @@ export class Resizing extends StateNode {
 		if (this.info.isCreating && this.editor.getHintingShapeIds().length > 0) {
 			this.editor.setHintingShapes([])
 		}
+		// Don't keep the last resize's shapes, transforms and callbacks alive until the next one
+		this.snapshot = {} as any as Snapshot
+		this.info = {} as ResizingInfo
 	}
 
 	private _createSnapshot() {
@@ -554,7 +553,7 @@ export class Resizing extends StateNode {
 		const originPagePoint = editor.inputs.getOriginPagePoint()
 
 		const selectionBounds = editor.getSelectionRotatedPageBounds()
-		if (!selectionBounds) throw Error('Resizing but nothing is selected')
+		if (!selectionBounds) return null
 
 		const dragHandlePoint = Vec.RotWith(
 			selectionBounds.getHandlePoint(this.info.handle!),
@@ -669,24 +668,4 @@ export class Resizing extends StateNode {
 	}
 }
 
-type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
-}
+type Snapshot = NonNullable<ReturnType<Resizing['_createSnapshot']>>

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -47,14 +47,13 @@ export class Rotating extends StateNode {
 		}
 		this.snapshot = snapshot
 
-		// Trigger a pointer move
 		const newSelectionRotation = this._getRotationFromPointerPosition({
 			snapToNearestDegree: false,
 		})
 
 		applyRotationToSnapshotShapes({
 			editor: this.editor,
-			delta: this._getRotationFromPointerPosition({ snapToNearestDegree: false }),
+			delta: newSelectionRotation,
 			snapshot: this.snapshot,
 			stage: 'start',
 		})
@@ -96,8 +95,6 @@ export class Rotating extends StateNode {
 	override onCancel() {
 		this.cancel()
 	}
-
-	// ---
 
 	private update() {
 		const newSelectionRotation = this._getRotationFromPointerPosition({

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -13,22 +13,15 @@ export class ScribbleBrushing extends StateNode {
 	static override id = 'scribble_brushing'
 	static override trackPerformance = true
 
-	hits = new Set<TLShapeId>()
-
-	size = 0
-
 	scribbleId = 'id'
 
 	initialSelectedShapeIds = new Set<TLShapeId>()
 	newlySelectedShapeIds = new Set<TLShapeId>()
 
 	override onEnter() {
-		this.initialSelectedShapeIds = new Set<TLShapeId>(
-			this.editor.inputs.getShiftKey() ? this.editor.getSelectedShapeIds() : []
-		)
+		// Kept for cancel; whether shift adds it to the result is decided on each update
+		this.initialSelectedShapeIds = new Set<TLShapeId>(this.editor.getSelectedShapeIds())
 		this.newlySelectedShapeIds = new Set<TLShapeId>()
-		this.size = 0
-		this.hits.clear()
 
 		const scribbleItem = this.editor.scribbles.addScribble({
 			color: 'selection-stroke',

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -46,14 +46,12 @@ export class Translating extends StateNode {
 
 	isCloning = false
 	isCreating = false
-	onCreate(_shape: TLShape | null): void {
-		return
-	}
+	onCreate?: (shape: TLShape | null) => void
 
 	dragAndDropManager = new DragAndDropManager(this.editor)
 
 	override onEnter(info: TranslatingInfo) {
-		const { isCreating = false, creatingMarkId, onCreate = () => void null } = info
+		const { isCreating = false, creatingMarkId, onCreate } = info
 
 		if (!this.editor.getSelectedShapeIds()?.length) {
 			this.parent.transition('idle')
@@ -170,6 +168,9 @@ export class Translating extends StateNode {
 		this.editor.duplicateShapes(Array.from(this.editor.getSelectedShapeIds()))
 
 		this.snapshot = getTranslatingSnapshot(this.editor)
+		// The manager ignores startDraggingShapes while it is running, so it has to be
+		// cleared or it keeps reparenting the originals instead of the clones
+		this.dragAndDropManager.clear()
 		this.handleStart()
 		this.updateShapes()
 	}
@@ -179,6 +180,8 @@ export class Translating extends StateNode {
 		this.snapshot = this.selectionSnapshot
 		this.reset()
 		this.markId = this.editor.markHistoryStoppingPoint('translate')
+		// Same as in startCloning: the manager is still tracking the (now deleted) clones
+		this.dragAndDropManager.clear()
 		this.updateShapes()
 	}
 
@@ -208,11 +211,13 @@ export class Translating extends StateNode {
 			}
 		}
 
-		if (this.isCreating) {
-			this.onCreate?.(this.editor.getOnlySelectedShape())
-		} else {
-			this.parent.transition('idle')
+		// A creating tool that passes no onCreate still needs the interaction to end
+		if (this.isCreating && this.onCreate) {
+			this.onCreate(this.editor.getOnlySelectedShape())
+			return
 		}
+
+		this.parent.transition('idle')
 	}
 
 	private cancel() {
@@ -289,7 +294,9 @@ export class Translating extends StateNode {
 		const changes: TLShapePartial[] = []
 
 		movingShapes.forEach((shape) => {
-			const current = this.editor.getShape(shape.id)!
+			// Shapes can be deleted mid-drag (remote user, undo)
+			const current = this.editor.getShape(shape.id)
+			if (!current) return
 			const util = this.editor.getShapeUtil(shape)
 			const change = util.onTranslateEnd?.(shape, current)
 			if (change) {
@@ -322,7 +329,8 @@ export class Translating extends StateNode {
 		const changes: TLShapePartial[] = []
 
 		movingShapes.forEach((shape) => {
-			const current = this.editor.getShape(shape.id)!
+			const current = this.editor.getShape(shape.id)
+			if (!current) return
 			const util = this.editor.getShapeUtil(shape)
 			const change = util.onTranslate?.(shape, current)
 			if (change) {
@@ -341,12 +349,10 @@ export class Translating extends StateNode {
 			editor,
 			snapshot: { shapeSnapshots },
 		} = this
-		const movingShapes: TLShape[] = []
 
 		shapeSnapshots.forEach((shapeSnapshot) => {
 			const shape = editor.getShape(shapeSnapshot.shape.id)
 			if (!shape) return
-			movingShapes.push(shape)
 
 			const parentTransform = isPageId(shape.parentId)
 				? null

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -1,11 +1,16 @@
 import {
 	Editor,
 	ExtractShapeByProps,
+	HALF_PI,
 	richTextValidator,
 	TLEventInfo,
 	TLRichText,
 	TLShape,
 	TLShapeId,
+	Vec,
+	VecLike,
+	approximately,
+	pointInPolygon,
 } from '@tldraw/editor'
 
 /** @internal */
@@ -15,11 +20,12 @@ export function hasRichText(
 	return 'richText' in shape.props && richTextValidator.isValid(shape.props.richText)
 }
 /**
- * Start editing a shape that has rich text, such as text, note, geo, or arrow shapes.
- * This will enter the editing state for the shape and optionally select all the text.
+ * Start editing a shape. Shapes with rich text, such as text, note, geo, or arrow shapes, can
+ * optionally have all of their text selected; other editable shapes (such as frames) simply enter
+ * the editing state.
  *
  * @param editor - The editor instance.
- * @param shapeOrId - The shape to start editing. This shape must have a richText property with a TLRichText value.
+ * @param shapeOrId - The shape to start editing.
  * @param options - Options: selectAll or info (TLEventInfo)
  *
  * @public
@@ -34,9 +40,6 @@ export function startEditingShapeWithRichText(
 
 	if (!editor.canEditShape(shape)) return
 
-	if (!hasRichText(shape)) {
-		throw new Error('Shape does not have rich text')
-	}
 	// Finish this shape and start editing the next one
 	editor.setEditingShape(shape)
 	editor.setCurrentTool('select.editing_shape', {
@@ -44,7 +47,39 @@ export function startEditingShapeWithRichText(
 		target: 'shape',
 		shape: shape,
 	})
-	if (options.selectAll) {
+	if (options.selectAll && hasRichText(shape)) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
+}
+
+/**
+ * Whether a page point is inside the selection's rotated bounding box. The box returned by
+ * `getSelectionRotatedPageBounds` is expressed in the rotated frame, so a plain `containsPoint`
+ * on it is only meaningful when the selection rotation is zero.
+ *
+ * @internal
+ */
+export function isPointInRotatedSelectionBounds(editor: Editor, point: VecLike) {
+	const selectionBounds = editor.getSelectionRotatedPageBounds()
+	if (!selectionBounds) return false
+
+	const selectionRotation = editor.getSelectionRotation()
+	if (!selectionRotation) return selectionBounds.containsPoint(point)
+
+	return pointInPolygon(
+		point,
+		selectionBounds.corners.map((c) => Vec.RotWith(c, selectionBounds.point, selectionRotation))
+	)
+}
+
+/**
+ * Whether a rotation is a multiple of 90 degrees. An exact `rotation % HALF_PI === 0` misses
+ * page rotations accumulated through rotated parents, which land a few ulps off and silently
+ * disable right-angle-only behavior such as bounds snapping.
+ *
+ * @internal
+ */
+export function isRightAngleRotation(rotation: number) {
+	const turns = rotation / HALF_PI
+	return approximately(turns, Math.round(turns))
 }

--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -22,14 +22,15 @@ export class ZoomTool extends StateNode {
 
 	override onEnter(info: TLPointerEventInfo & { onInteractionEnd: string }) {
 		this.info = info
-		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask
+		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask.
+		// getCurrentToolId reads the mask from the current tool, i.e. this node, not the root.
 		const toolId = info.onInteractionEnd?.split('.')[0]
-		this.parent.setCurrentToolIdMask(toolId)
+		this.setCurrentToolIdMask(toolId)
 		this.updateCursor()
 	}
 
 	override onExit() {
-		this.parent.setCurrentToolIdMask(undefined)
+		this.setCurrentToolIdMask(undefined)
 		this.editor.updateInstanceState({ zoomBrush: null, cursor: { type: 'default', rotation: 0 } })
 	}
 

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -16,7 +16,8 @@ export function selectOnCanvasPointerUp(
 		hitLabels: true,
 		hitLocked: selectLockedShapes,
 		renderingOnly: true,
-		filter: (shape) => selectLockedShapes || !shape.isLocked,
+		// A child of a locked group would otherwise resolve to the locked group and select it
+		filter: (shape) => selectLockedShapes || !editor.isShapeOrAncestorLocked(shape),
 	})
 
 	// Note at the start: if we select a shape that is inside of a group,

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId } from '@tldraw/editor'
+import { IndexKey, createShapeId } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { createDrawSegments } from '../lib/utils/test-helpers'
 import { TestEditor } from './TestEditor'
@@ -285,6 +285,47 @@ describe('When clicking', () => {
 		expect(editor.getErasingShapeIds()).toEqual([])
 		expect(editor.getShape(ids.box1)).toBeDefined()
 		expect(shapesAfterCount).toBe(shapesBeforeCount)
+	})
+})
+
+describe('When the drag starts over shapes that were hit with a margin', () => {
+	it('keeps a shape the pointing state marked when the first drag step only crosses other shapes', () => {
+		const lineId = createShapeId('line')
+		const groupA = createShapeId('groupA')
+		const groupB = createShapeId('groupB')
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{
+				id: lineId,
+				type: 'line',
+				x: 100,
+				y: 100,
+				props: {
+					points: {
+						a1: { id: 'a1', index: 'a1' as IndexKey, x: 0, y: 0 },
+						a2: { id: 'a2', index: 'a2' as IndexKey, x: 100, y: 0 },
+					},
+				},
+			},
+			{ id: groupA, type: 'geo', x: 0, y: 0, props: { w: 10, h: 10 } },
+			{ id: groupB, type: 'geo', x: 400, y: 400, props: { w: 10, h: 10 } },
+		])
+		// A group whose bounds cover the area makes the first erasing update see a candidate
+		// (the group) without hit-testing anything else.
+		editor.groupShapes([groupA, groupB])
+
+		editor.setCurrentTool('eraser')
+		editor.pointerDown(150, 102) // 2px from the line, inside the hit-test margin
+		editor.expectToBeIn('eraser.pointing')
+		expect(editor.getErasingShapeIds()).toEqual([lineId])
+
+		editor.pointerMove(150, 105)
+		editor.pointerMove(150, 108)
+		editor.expectToBeIn('eraser.erasing')
+		expect(editor.getErasingShapeIds()).toEqual([lineId])
+
+		editor.pointerUp()
+		expect(editor.getShape(lineId)).toBeUndefined()
 	})
 })
 

--- a/packages/tldraw/src/test/HandTool.test.ts
+++ b/packages/tldraw/src/test/HandTool.test.ts
@@ -39,6 +39,27 @@ describe(HandTool, () => {
 		expect(editor.getCamera().z).toBeGreaterThan(before)
 	})
 
+	it('Ends one-finger zoom when a second touch starts, instead of jumping the zoom', () => {
+		editor.setCurrentTool('hand')
+		editor.updateInstanceState({ isCoarsePointer: true })
+
+		editor.pointerDown(100, 100).pointerUp(100, 100)
+		editor.pointerDown(100, 100)
+		vi.advanceTimersByTime(editor.options.multiClickDurationMs)
+		editor.expectToBeIn('hand.one_finger_zooming')
+
+		editor.pointerMove(100, 120)
+		const zoomBeforeSecondTouch = editor.getCamera().z
+		expect(zoomBeforeSecondTouch).toBeGreaterThan(1)
+
+		// A second finger lands far away and moves; the pan/zoom must yield rather than
+		// treat the new pointer as a continuation of the first one.
+		editor.pointerDown(300, 400, { pointerId: 2 })
+		editor.expectToBeIn('hand.idle')
+		editor.pointerMove(300, 420, { pointerId: 2 })
+		expect(editor.getCamera().z).toBe(zoomBeforeSecondTouch)
+	})
+
 	it('Zooms in (not one-finger zoom) when a coarse pointer double-taps and releases', () => {
 		editor.setCurrentTool('hand')
 		editor.updateInstanceState({ isCoarsePointer: true })

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -47,6 +47,28 @@ describe('TLSelectTool.Idle', () => {
 		editor.expectToBeIn('select.pointing_canvas')
 	})
 
+	it('Returns to idle when a canvas press is cancelled', () => {
+		editor.pointerDown(10, 10, { target: 'canvas' })
+		editor.expectToBeIn('select.pointing_canvas')
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('Does not select a locked group by clicking one of its children', () => {
+		const a = createShapeId('a')
+		const b = createShapeId('b')
+		const groupId = createShapeId('group')
+		editor.createShapes([
+			{ id: a, type: 'geo', x: 300, y: 300, props: { w: 100, h: 100, fill: 'solid' } },
+			{ id: b, type: 'geo', x: 500, y: 300, props: { w: 100, h: 100, fill: 'solid' } },
+		])
+		editor.groupShapes([a, b], { groupId })
+		editor.updateShape({ id: groupId, type: 'group', isLocked: true })
+		editor.selectNone()
+		editor.pointerDown(350, 350).pointerUp(350, 350)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
 	it('Nudges selected shapes on arrow key down', () => {
 		const shape = editor.getShape(ids.box1)!
 		editor.select(shape.id)
@@ -55,6 +77,24 @@ describe('TLSelectTool.Idle', () => {
 		const nudgedShape = editor.getShape(shape.id)
 		expect(nudgedShape).toBeDefined()
 		expect(nudgedShape?.x).toBe(101)
+	})
+
+	it('Major-nudges with either shift key held', () => {
+		editor.select(ids.box1)
+		const keyboard = {
+			type: 'keyboard' as const,
+			shiftKey: true,
+			ctrlKey: false,
+			altKey: false,
+			metaKey: false,
+			accelKey: false,
+		}
+		// Browsers send key 'Shift' for both shifts; only the code differs.
+		editor.dispatch({ ...keyboard, name: 'key_down', key: 'Shift', code: 'ShiftRight' })
+		editor.dispatch({ ...keyboard, name: 'key_down', key: 'ArrowRight', code: 'ArrowRight' })
+		editor.dispatch({ ...keyboard, name: 'key_up', key: 'ArrowRight', code: 'ArrowRight' })
+		editor.dispatch({ ...keyboard, name: 'key_up', key: 'Shift', code: 'ShiftRight' })
+		expect(editor.getShape(ids.box1)!.x).toBe(110)
 	})
 })
 
@@ -157,6 +197,79 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 
 		expect(() => editor.pointerUp(shape.x + 10, shape.y + 10)).not.toThrow()
 		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not crash when dragging after a labelled arrow is deleted', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: { richText: toRichText('label'), start: { x: 0, y: 0 }, end: { x: 200, y: 0 } },
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.pointerDown(200, 100, { target: 'shape', shape })
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.arrow1])
+
+		expect(() => editor.pointerMove(220, 120)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not select a deleted shape when the drag starts', () => {
+		editor.select(ids.box1)
+		const shape = editor.getShape(ids.box1)!
+		editor.pointerDown(150, 150, { target: 'shape', shape })
+
+		editor.deleteShapes([ids.box1])
+
+		editor.pointerMove(200, 200)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.expectToBeIn('select.idle')
+	})
+})
+
+describe('TLSelectTool.PointingShape with selectLockedShapes', () => {
+	it('keeps a selected locked shape selected when clicking it over another shape', () => {
+		editor.dispose()
+		editor = new TestEditor({ options: { selectLockedShapes: true } })
+		const behind = createShapeId('behind')
+		const locked = createShapeId('locked')
+		editor.createShapes([
+			{ id: behind, type: 'geo', x: 0, y: 0, props: { w: 300, h: 300, fill: 'solid' } },
+			{
+				id: locked,
+				type: 'geo',
+				x: 100,
+				y: 100,
+				props: { w: 100, h: 100, fill: 'solid' },
+				isLocked: true,
+			},
+		])
+		editor.select(locked)
+		editor.pointerDown(150, 150).pointerUp(150, 150)
+		expect(editor.getSelectedShapeIds()).toEqual([locked])
+	})
+})
+
+describe('TLSelectTool.PointingShape with a rotated multi-selection', () => {
+	it('defers selection when pointing inside the rotated selection bounds', () => {
+		const a = createShapeId('a')
+		const b = createShapeId('b')
+		const c = createShapeId('c')
+		editor.deleteShapes([ids.box1]).createShapes([
+			{ id: a, type: 'geo', x: 0, y: 0, rotation: Math.PI / 2, props: { w: 100, h: 100 } },
+			{ id: b, type: 'geo', x: 300, y: 0, rotation: Math.PI / 2, props: { w: 100, h: 100 } },
+			// between a and b, inside the selection's rotated bounds (page x -100..300, y 0..100)
+			{ id: c, type: 'geo', x: 120, y: 20, props: { w: 50, h: 50, fill: 'solid' } },
+		])
+		editor.select(a, b)
+		editor.pointerDown(145, 45, { target: 'shape', shape: editor.getShape(c)! })
+		expect(editor.getSelectedShapeIds()).toEqual([a, b])
+		editor.pointerUp(145, 45)
 	})
 })
 
@@ -501,6 +614,55 @@ describe('PointingLabel', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('returns to idle on pointer up when the arrow was deleted', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.select(shape.id)
+		editor.pointerDown(150, 100, { target: 'shape', shape })
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+		editor.deleteShapes([ids.arrow1])
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('returns to idle on pointer up when the arrow cannot be edited', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.select(shape.id)
+		editor.updateInstanceState({ isReadonly: true })
+		editor.setCurrentTool('hand').setCurrentTool('select')
+		editor.pointerDown(150, 100, { target: 'shape', shape })
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('Doesnt go into pointing_arrow_label mode if not selecting the arrow shape', () => {
 		editor.createShapes([
 			{
@@ -600,6 +762,29 @@ describe('When undo/redo restores an invalid editing shape', () => {
 //     .expectToBeIn('select.editing_shape')
 // })
 
+describe('When double clicking a frame edge', () => {
+	it('keeps the reflow the handler did and the resize in one undo group', () => {
+		const frameId = createShapeId('frame')
+		const childId = createShapeId('child')
+		editor.createShapes<TLFrameShape>([
+			{ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } },
+		])
+		editor.createShapes([
+			{ id: childId, type: 'geo', parentId: frameId, x: 100, y: 100, props: { w: 50, h: 50 } },
+		])
+		editor.select(frameId)
+		editor.doubleClick(400, 200, { target: 'selection', handle: 'right' })
+		const frameAfter = editor.getShape<TLFrameShape>(frameId)!
+		const childAfter = editor.getShape(childId)!
+		expect(frameAfter.props.w).not.toBe(400)
+		expect(childAfter.x).not.toBe(100)
+
+		editor.undo()
+		expect(editor.getShape<TLFrameShape>(frameId)!.props.w).toBe(400)
+		expect(editor.getShape(childId)!.x).toBe(100)
+	})
+})
+
 describe('When double clicking the selection edge', () => {
 	it('Begins editing the text if handler returns no change', () => {
 		const id = createShapeId()
@@ -669,6 +854,66 @@ describe('When double clicking the selection edge', () => {
 
 		expect(editor.getEditingShapeId()).toBe(id)
 		expect(editor.getInstanceState().cursor.type).toBe('default')
+	})
+})
+
+describe('When a second press on a resize handle arrives as a double click', () => {
+	// The click manager reports a second press inside the double-click window as a pointer down
+	// followed by a double_click 'down'. The double click must not steal a press that becomes a
+	// drag (#9499 fixed the same thing for shape handles).
+	function pressAgain(handle: 'bottom_right' | 'bottom_right_rotate') {
+		editor.pointerDown(200, 200, { target: 'selection', handle })
+		editor.dispatch({
+			type: 'click',
+			name: 'double_click',
+			phase: 'down',
+			point: { x: 200, y: 200 },
+			pointerId: 1,
+			button: 0,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+			target: 'selection',
+			handle,
+		})
+	}
+
+	it('still resizes when the second press becomes a drag', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right')
+		editor.expectToBeIn('select.pointing_resize_handle')
+		editor.pointerMove(250, 250)
+		editor.expectToBeIn('select.resizing')
+		editor.pointerUp(250, 250)
+		expect(editor.getShape(ids.box1)!.props).toMatchObject({ w: 150, h: 150 })
+	})
+
+	it('still rotates when the second press on a rotate handle becomes a drag', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right_rotate' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right_rotate')
+		editor.expectToBeIn('select.pointing_rotate_handle')
+		editor.pointerMove(250, 100)
+		editor.expectToBeIn('select.rotating')
+	})
+
+	it('acts on the double click on pointer up when the second press is released in place', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right')
+		editor.expectToBeIn('select.pointing_resize_handle')
+		editor.pointerUp(200, 200)
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getEditingShapeId()).toBe(ids.box1)
 	})
 })
 

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -21,6 +21,15 @@ describe('TLSelectTool.Zooming', () => {
 			.createShapes([{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
 	})
 
+	it('Reports the originating tool as the current tool id while zooming', () => {
+		editor.setCurrentTool('draw')
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'draw.idle' })
+		editor.expectToBeIn('zoom.idle')
+		expect(editor.getCurrentToolId()).toBe('draw')
+		editor.setCurrentTool('select')
+		expect(editor.getCurrentToolId()).toBe('select')
+	})
+
 	it('Correctly zooms in when clicking', () => {
 		editor.setCurrentTool('zoom', { onInteractionEnd: 'select' })
 		expect(editor.getZoomLevel()).toBe(1)

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1240,3 +1240,142 @@ describe('When cropping with modifiers and snapping...', () => {
 		expect(editor.snaps.getIndicators().length).toBe(0)
 	})
 })
+
+describe('Cropping an image inside a rotated parent', () => {
+	it('moves the crop along the dragged edge even when the page rotation comes from a frame', () => {
+		const frameId = createShapeId('frame')
+		const imageId = createShapeId('image')
+		editor.createShapes([
+			{
+				id: frameId,
+				type: 'frame',
+				x: 500,
+				y: 100,
+				rotation: Math.PI / 2,
+				props: { w: 400, h: 400 },
+			},
+			{
+				id: imageId,
+				type: 'image',
+				parentId: frameId,
+				x: 50,
+				y: 50,
+				props: { ...imageProps, w: 200, h: 100 },
+			},
+		])
+		editor.select(imageId)
+		editor.setCurrentTool('select.crop.idle')
+		editor.expectToBeIn('select.crop.idle')
+
+		// The image's right edge is vertical in its own space but horizontal on screen; drag it
+		// inward along its on-screen normal.
+		const handle = editor.getSelectionHandlePagePoint('right')
+		editor.pointerDown(handle.x, handle.y, { target: 'selection', handle: 'right' })
+		editor.pointerMove(handle.x, handle.y - 50)
+		editor.expectToBeIn('select.crop.cropping')
+		editor.pointerUp()
+
+		const image = editor.getShape<TLImageShape>(imageId)!
+		expect(image.props.w).toBe(150)
+		expect(image.props.crop).toMatchObject({
+			topLeft: { x: 0, y: 0 },
+			bottomRight: { x: 0.75, y: 1 },
+		})
+	})
+})
+
+describe('Cancelling while cropping', () => {
+	it('escape during a crop drag only reverts that drag and keeps the session cancellable', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		// First drag commits
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 590)
+		editor.pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		const afterFirst = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(afterFirst).not.toMatchObject(before)
+
+		// Escape mid-drag reverts only the second drag
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.expectToBeIn('select.crop.cropping')
+		editor.cancel()
+		editor.expectToBeIn('select.crop.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(afterFirst)
+
+		// Escape from idle still reverts the whole session
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+
+	it('squashes the session into one undo even after a cancelled drag', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.cancel()
+		editor.expectToBeIn('select.crop.idle')
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 590)
+		editor.pointerUp()
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.pointerUp()
+		editor.keyDown('Enter').keyUp('Enter')
+		editor.expectToBeIn('select.idle')
+
+		editor.undo()
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+})
+
+describe('Leaving crop mode by switching tools', () => {
+	it('clears the cropping shape', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.setCurrentTool('hand')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.setCurrentTool('select')
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+	})
+})
+
+describe('When a second press on a crop handle arrives as a double click', () => {
+	it('still crops when the press becomes a drag instead of resetting the crop', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' }).pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.dispatch({
+			type: 'click',
+			name: 'double_click',
+			phase: 'down',
+			point: { x: 500, y: 600 },
+			pointerId: 1,
+			button: 0,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+			target: 'selection',
+			handle: 'bottom',
+		})
+		editor.expectToBeIn('select.crop.pointing_crop_handle')
+		editor.pointerMove(510, 590)
+		editor.expectToBeIn('select.crop.cropping')
+		editor.pointerUp()
+
+		const after = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(after).not.toMatchObject(before)
+		expect(after.bottomRight.y).toBeLessThan(before.bottomRight.y)
+	})
+})

--- a/packages/tldraw/src/test/customSnapping.test.tsx
+++ b/packages/tldraw/src/test/customSnapping.test.tsx
@@ -321,6 +321,38 @@ describe('custom handle snapping', () => {
 			expect(editor.snaps.getIndicators()).toHaveLength(0)
 			expect(handlePosition()).toMatchObject({ x: 251, y: 251 })
 		})
+
+		test('lands on the snap target when the dragged shape is rotated', () => {
+			// Rotating the line around its start puts its end handle at page (0, 100); the snap
+			// nudge is in page space and must come off by the shape's own rotation.
+			editor.updateShape<TLLineShape>({
+				id: ids.line,
+				type: 'line',
+				rotation: Math.PI / 2,
+				props: {
+					points: {
+						a1: { id: 'a1', index: 'a1' as IndexKey, x: 0, y: 0 },
+						a2: { id: 'a2', index: 'a2' as IndexKey, x: 100, y: 0 },
+					},
+				},
+			})
+			editor.updateShape({ id: ids.test2, type: TEST2_TYPE, x: 10, y: 110 })
+			const line = editor.select(ids.line).getOnlySelectedShape()! as TLLineShape
+			const endHandle = editor.getShapeHandles(line)!.at(-1)!
+			const endHandlePagePoint = editor.getShapePageTransform(line).applyToPoint(endHandle)
+			editor.pointerDown(endHandlePagePoint.x, endHandlePagePoint.y, {
+				target: 'handle',
+				shape: line,
+				handle: endHandle,
+			})
+			editor.pointerMove(7, 109, undefined, { ctrlKey: true })
+			expect(editor.snaps.getIndicators()).toHaveLength(1)
+			const shape = editor.getShape<TLLineShape>(ids.line)!
+			const handle = editor.getShapeHandles(shape)!.at(-1)!
+			const pagePoint = editor.getShapePageTransform(shape).applyToPoint(handle)
+			expect(pagePoint.x).toBeCloseTo(10)
+			expect(pagePoint.y).toBeCloseTo(110)
+		})
 	})
 
 	describe('with empty handleSnapGeometry.outline', () => {

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -4086,3 +4086,31 @@ describe('cancelling a resize operation', () => {
 		expect(editor.getShape(shape.id)).toBeUndefined()
 	})
 })
+
+describe('entering the resizing state with nothing selected', () => {
+	it('returns to idle without touching earlier history', () => {
+		// A completed resize leaves a mark behind; a later failed entry must not bail to it
+		editor.select(ids.boxA)
+		editor.pointerDownOnHandle('bottom_right')
+		editor.pointerMoveBy(50, 50)
+		editor.pointerUp()
+		expect(editor.getShape<TLGeoShape>(ids.boxA)!.props).toMatchObject({ w: 150, h: 150 })
+		editor.updateShape({ id: ids.boxA, type: 'geo', x: 500 })
+		editor.selectNone()
+
+		// e.g. the pointed shape was deleted remotely between pointer down and the drag
+		expect(() =>
+			editor.setCurrentTool('select.resizing', { target: 'selection', handle: 'bottom_right' })
+		).not.toThrow()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLGeoShape>(ids.boxA)).toMatchObject({ x: 500, props: { w: 150 } })
+	})
+
+	it('does not crash on the first ever entry', () => {
+		editor.selectNone()
+		expect(() =>
+			editor.setCurrentTool('select.resizing', { target: 'selection', handle: 'bottom_right' })
+		).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+})

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -1,3 +1,4 @@
+import { toRichText } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -48,6 +49,23 @@ describe('interaction between the select tool and the editing state', () => {
 			.pointerDown()
 			.pointerUp()
 			.expectToBeIn('select.idle')
+	})
+
+	it('returns to the text tool with its own cursor when a tool-locked edit is finished', () => {
+		editor
+			.updateInstanceState({ isToolLocked: true })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+		const id = editor.getEditingShapeId()!
+		editor.updateShape({ id, type: 'text', props: { richText: toRichText('hello') } })
+
+		editor.cancel().expectToBeIn('text.idle')
+		expect(editor.getInstanceState().cursor.type).toBe('cross')
+		// The select tool's idle must not have been entered underneath the text tool
+		expect(editor.getStateDescendant('select.idle')!.getIsActive()).toBe(false)
 	})
 
 	it('leaves editing when clicking the select tool while tool locked', () => {

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2305,6 +2305,133 @@ describe('cancelling a translate operation', () => {
 	})
 })
 
+describe('cloning mid-drag', () => {
+	it('reparents the clone, not the original, when alt is pressed during the drag', () => {
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 500, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.pointerDown(50, 50, { target: 'shape', shape: editor.getShape(ids.box1) })
+		editor.pointerMove(60, 60)
+		editor.expectToBeIn('select.translating')
+		editor.keyDown('Alt')
+		editor.pointerMove(600, 100)
+		vi.advanceTimersByTime(300)
+		editor.pointerUp(600, 100)
+
+		const original = editor.getShape(ids.box1)!
+		expect(original.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getShapePageBounds(original)).toMatchObject({ x: 0, y: 0 })
+
+		const clone = editor.getCurrentPageShapes().find((s) => s.type === 'geo' && s.id !== ids.box1)!
+		expect(clone.parentId).toBe(ids.frame1)
+	})
+
+	it('reparents the original when alt is released during the drag', () => {
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 500, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.keyDown('Alt')
+		editor.pointerDown(50, 50, { target: 'shape', shape: editor.getShape(ids.box1) })
+		editor.pointerMove(60, 60)
+		editor.expectToBeIn('select.translating')
+		editor.keyUp('Alt')
+		vi.advanceTimersByTime(250) // the alt key is released on a timer
+		editor.pointerMove(600, 100)
+		vi.advanceTimersByTime(300)
+		editor.pointerUp(600, 100)
+
+		expect(editor.getCurrentPageShapes().filter((s) => s.type === 'geo')).toHaveLength(1)
+		expect(editor.getShape(ids.box1)!.parentId).toBe(ids.frame1)
+	})
+})
+
+describe('when shapes disappear mid-drag', () => {
+	it('does not crash when a bound arrow being translated is deleted', () => {
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{
+				id: ids.lineA,
+				type: 'arrow',
+				x: 200,
+				y: 200,
+				props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+			},
+		])
+		editor.createBindings([
+			{
+				fromId: ids.lineA,
+				toId: ids.box1,
+				type: 'arrow',
+				props: {
+					terminal: 'start',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: false,
+					snap: 'none',
+				},
+			},
+		])
+		editor.select(ids.lineA)
+		editor.pointerDown(250, 250, { target: 'shape', shape: editor.getShape(ids.lineA) })
+		editor.pointerMove(260, 260)
+		editor.expectToBeIn('select.translating')
+
+		editor.store.mergeRemoteChanges(() => editor.store.remove([ids.lineA]))
+
+		expect(() => editor.pointerMove(270, 270)).not.toThrow()
+		expect(() => editor.pointerUp(270, 270)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not crash when the drop target is deleted', () => {
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 500, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.pointerDown(50, 50, { target: 'shape', shape: editor.getShape(ids.box1) })
+		editor.pointerMove(600, 100)
+		vi.advanceTimersByTime(300)
+		expect(editor.getShape(ids.box1)!.parentId).toBe(ids.frame1)
+
+		editor.store.mergeRemoteChanges(() => editor.store.remove([ids.frame1]))
+
+		expect(() => {
+			editor.pointerMove(610, 110)
+			vi.advanceTimersByTime(300)
+			editor.pointerUp(610, 110)
+		}).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+})
+
+it('returns to idle after a creating translate with no onCreate', () => {
+	editor.createShape({ type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	const shape = editor.getLastCreatedShape()
+	editor.select(shape)
+	editor.pointerMove(50, 50)
+	editor.setCurrentTool('select.translating', {
+		type: 'pointer',
+		button: 0,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		isPen: false,
+		name: 'pointer_move',
+		point: { x: 50, y: 50 },
+		pointerId: 0,
+		shape,
+		shiftKey: false,
+		target: 'shape',
+		isCreating: true,
+	} satisfies TranslatingInfo)
+	editor.pointerMove(100, 100)
+	editor.pointerUp(100, 100)
+	editor.expectToBeIn('select.idle')
+})
+
 it('preserves z-indexes when translating', () => {
 	editor.createShape({ type: 'geo', x: 0, y: 0, props: { w: 200, h: 200 } })
 	editor.createShape({ type: 'geo', x: 100, y: 100, props: { w: 200, h: 200 } })


### PR DESCRIPTION
**Risk: high · Importance: high**

**Umbrella PR** — this diff has been split into 30 per-topic PRs, listed below. Review those instead; this one stays open only as a reference until they land.

- #10163 fix(select): only bail the whole crop session on a cancel from crop idle
- #10164 fix(select): clear the precise-binding timer when a handle drag ends
- #10165 fix(select): leave the resizing state cleanly when the selection is gone
- #10166 fix(select): honor selectLockedShapes on pointer up and rotated bounds on pointer down
- #10167 fix(select): clear the cropping shape when leaving the select tool
- #10168 fix(select): rotate handle snap nudges by the shape's page rotation
- #10169 fix(select): mark history before shape double-click handlers run
- #10170 fix(select): crop in the shape's page rotation inside rotated frames and groups
- #10171 fix(select): don't crash when a translated shape or its drop target is deleted mid-drag
- #10172 fix(select): use the accel key to toggle handle snapping and brush wrap mode
- #10173 fix(select): gate read-only double clicks on canEditInReadonly
- #10174 fix(select): return to the locked text tool from editing_shape without re-routing the state chart
- #10175 fix(select): handle cancel in pointing_canvas
- #10176 fix(select): defer handle double clicks to pointer up so a second press can still drag
- #10178 fix(hand): end one-finger zoom when a second touch starts
- #10179 fix(select): bail to idle when the pointed shape is deleted before the drag starts
- #10180 fix(select): don't select a locked group by clicking its child
- #10181 fix(select): treat near-right-angle page rotations as right angles for bounds snapping
- #10182 fix(eraser): rebuild the erasing list from the live set each update
- #10183 fix(select): always leave pointing_arrow_label on pointer up
- #10184 fix(select): route repeated arrow keys the same way as the first press
- #10185 fix(zoom): report the originating tool as the current tool id while zooming
- #10186 fix(select): reparent the clones, not the originals, when alt is toggled mid-drag
- #10187 fix(select): cancelling a note clone-handle drag removes the new note and stays in select
- #10188 fix(select): start editing editable shapes without rich text instead of throwing
- #10189 fix(select): restore the full prior selection when scribble brushing is cancelled
- #10190 fix(select): end a creating translate that passes no onCreate
- #10191 fix(select): clear the arrow binding hint when pointing_handle exits without a drag
- #10192 fix(editor): normalize right-hand shift and alt by key code
- #10193 refactor(select): remove dead state and duplicated helpers from select tool states

---
In order to stop the select tool from crashing or getting stuck when a shape disappears mid-interaction (a collaborator deletes it, or an undo lands between pointer down and the drag), and to fix a batch of long-standing interaction bugs found in a review sweep of `packages/tldraw/src/lib/tools`, this PR hardens the select tool's child states and fixes the behavior bugs the sweep turned up. Each fix comes with a regression test that fails on `main`.

**Deleted-shape crashes and stuck states.** `Resizing`, `Translating`, `DragAndDropManager`, `PointingShape`, `PointingArrowLabel`, `DraggingHandle` and `Cropping` all held a `getShape(id)!` or a shape cached at pointer down and assumed it still existed. Now they bail to idle (or skip the missing shape) instead of throwing into the editor's crash state. The worst case was `Resizing._createSnapshot`'s catch calling `cancel()` against the *previous* resize's mark, which silently bailed to an old history mark and lost work.

**Behavior fixes.**

- Alt-cloning mid-drag: `DragAndDropManager` kept tracking the original shapes, so dropping a clone into a frame reparented the original instead.
- Crop: a cancelled second drag reverted earlier crops too, later Escapes stopped reverting, and `croppingShapeId` was never cleared on tool switch (un-cropped the image on the next double-click). Crop drags and nudges inside a rotated frame/group used the shape's local rotation instead of its page rotation.
- Double-click on resize/rotate/crop handles consumed a second press-and-drag as a double click (same bug as #9499, which only covered `PointingHandle`); the double click is now deferred to pointer up.
- `selectLockedShapes`: the pointer-up hit test skipped a selected locked shape and picked the shape behind it.
- Note clone handles: Escape left the new note behind and switched to the note tool.
- Snapping a handle on a rotated shape missed its target (nudge rotated by parent rotation only); `DraggingHandle`/`Brushing` now use the accel key for snap/wrap toggles like translate/resize/crop.
- Enter in the geo/arrow/text tool with a frame or video selected threw "Shape does not have rich text".
- `EditingShape`'s tool-lock return to the text tool ran from `onExit` and re-routed the state chart mid-transition (select idle active under an inactive select tool, wrong cursor).
- `OneFingerZooming` yields on a second touch instead of jumping the camera; `Erasing` rebuilds its list from the live set; history marks are created before `onDoubleClickEdge/Corner/Handle` run so a frame reflow + resize is one undo group; `ScribbleBrushing.cancel` restores the full prior selection; a locked group is no longer selectable via its child; `ZoomTool` masks its own node so `getCurrentToolId()` reports the originating tool.
- One line in `packages/editor` `Editor.ts`: right-Shift/Alt were normalized by `key` (never `ShiftRight`), so right-Shift didn't major-nudge.

Small cleanups along the way: dead fields removed (`DragAndDropManager.initialGroupIds/draggedOverShapeIds`, `Brushing.info`, `PointingSelection.info`, `ScribbleBrushing.hits/size`), a local `rotateSelectionHandle` copy replaced by the `@tldraw/editor` export, and `isPointInRotatedSelectionBounds` / `isRightAngleRotation` shared from `selectHelpers`.

Overlaps files with #9215 and #9493, which change `Translating`/`Idle` for different reasons; no conflicting intent.

### Change type

- [x] `bugfix`

### Test plan

1. In a multiplayer room, start resizing/translating/dragging a handle of a shape and delete it from another client; the tool returns to idle without a crash screen.
2. Drag a shape, press Alt mid-drag, drop the clone into a frame; the clone (not the original) is reparented.
3. Crop an image, commit one drag, start a second and press Escape; only the second drag is reverted. Switch tools and double-click the image edge; it does not un-crop.
4. Click a resize handle twice quickly and drag on the second press; the shape resizes.

- [x] Unit tests

### Release notes

- Fix select tool crashes and stuck states when a shape is deleted during a resize, translate, crop, or handle drag.
- Fix Alt-clone mid-drag reparenting the original shape instead of the clone.
- Fix crop cancel reverting earlier crops, crop handles inside rotated frames, and stale crop state after switching tools.
- Fix double-click on resize, rotate, and crop handles swallowing a second press-and-drag.
- Fix `selectLockedShapes` pointer-up hit test, note clone-handle cancel, snapping handles on rotated shapes, and right-Shift nudges.

### Code changes

| Section   | LOC change  |
| --------- | ----------- |
| Core code | +349 / -318 |
| Tests     | +689 / -1   |
