### PR TITLE
fix(shapes): fix a batch of shape util and tool state bugs

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -577,25 +577,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
         y: number;
     };
     // (undocumented)
-    onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape): {
-        id: TLShapeId_2;
-        index: IndexKey;
-        isLocked: boolean;
-        meta: JsonObject;
-        opacity: TLOpacityType;
-        parentId: TLParentId;
-        props: {
-            assetId: null | TLAssetId;
-            h: number;
-            url: string;
-            w: number;
-        };
-        rotation: number;
-        type: "bookmark";
-        typeName: 'shape';
-        x: number;
-        y: number;
-    } | undefined;
+    onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape): TLBookmarkShape | undefined;
     // (undocumented)
     options: BookmarkShapeOptions;
     // (undocumented)
@@ -2042,6 +2024,8 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
             w: number;
         };
         type: "frame";
+        x: number;
+        y: number;
     } | undefined;
     // (undocumented)
     options: FrameShapeOptions;

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -8,6 +8,7 @@ import {
 	Geometry2d,
 	Group2d,
 	IndexKey,
+	Mat,
 	PI2,
 	Polyline2d,
 	Rectangle2d,
@@ -596,7 +597,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		// When we start translating shapes, record where their bindings were in page space so we
 		// can maintain them as we translate the arrow
 		shapeAtTranslationStart.set(shape, {
-			pagePosition: shapePageTransform.applyToPoint(shape),
+			pagePosition: Mat.applyToPoint(this.editor.getShapeParentTransform(shape), shape),
 			terminalBindings: mapObjectMapValues(terminalsInArrowSpace, (terminalName, point) => {
 				const binding = bindings[terminalName]
 				if (!binding) return null
@@ -644,16 +645,19 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const atTranslationStart = shapeAtTranslationStart.get(initialShape)
 		if (!atTranslationStart) return
 
-		const shapePageTransform = this.editor.getShapePageTransform(shape.id)!
+		// How far the arrow's origin has moved in page space. `shape.x/y` are in the parent's
+		// space and may not be in the store yet (one-off moves like nudge/align/distribute pass a
+		// working copy), so map them through the parent transform. Applying the arrow's own page
+		// transform to them instead folds the arrow's rotation into the delta.
 		const pageDelta = Vec.Sub(
-			shapePageTransform.applyToPoint(shape),
+			Mat.applyToPoint(this.editor.getShapeParentTransform(shape), shape),
 			atTranslationStart.pagePosition
 		)
 
 		for (const terminalBinding of Object.values(atTranslationStart.terminalBindings)) {
 			if (!terminalBinding) continue
 
-			const newPagePoint = Vec.Add(terminalBinding.pagePosition, Vec.Mul(pageDelta, 0.5))
+			const newPagePoint = Vec.Add(terminalBinding.pagePosition, pageDelta)
 			const newTarget = this.editor.getShapeAtPoint(newPagePoint, {
 				hitInside: true,
 				hitFrameInside: true,
@@ -689,8 +693,11 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 	override onResize(shape: TLArrowShape, info: TLResizeInfo<TLArrowShape>) {
 		const { scaleX, scaleY } = info
 
-		const bindings = this._resizeInitialBindings.get(shape, () =>
-			getArrowBindings(this.editor, shape)
+		// Key on `info.initialShape`: the editor passes a fresh `{ ...initialShape, x, y }` as
+		// `shape` on every frame, so keying on it would re-read the already-mirrored bindings
+		// from the store and flip the anchors back and forth while dragging past zero.
+		const bindings = this._resizeInitialBindings.get(info.initialShape, () =>
+			getArrowBindings(this.editor, info.initialShape)
 		)
 		const terminals = getArrowTerminalsInArrowSpace(this.editor, shape, bindings)
 

--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -182,7 +182,7 @@ export function getCurvedArrowInfo(
 				const strokeOffset =
 					arrowSW / 2 +
 					('size' in startShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
+						? (theme.strokeWidth * (STROKE_SIZES[startShapeInfo.shape.props.size] ?? 0)) / 2
 						: 0)
 				offsetA = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale
@@ -265,7 +265,7 @@ export function getCurvedArrowInfo(
 				const strokeOffset =
 					arrowSW / 2 +
 					('size' in endShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
+						? (theme.strokeWidth * (STROKE_SIZES[endShapeInfo.shape.props.size] ?? 0)) / 2
 						: 0)
 				offsetB = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale

--- a/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
@@ -142,12 +142,14 @@ export function getElbowArrowInfo(
 	}
 
 	// We expand the bounds of the terminals so we can route arrows around them without the arrows
-	// being too close to the shapes.
+	// being too close to the shapes. Always a separate Box from `bounds`: ElbowArrowWorkingInfo
+	// transforms `original` and `expanded` in place, so sharing one object would transform a point
+	// terminal twice (a no-op for flips, a 180° turn for rotations) and corrupt the route.
 	const expandedA = aTerminal.isPoint
-		? aTerminal.bounds
+		? aTerminal.bounds.clone()
 		: aTerminal.bounds.clone().expandBy(options.expandElbowLegLength)
 	const expandedB = bTerminal.isPoint
-		? bTerminal.bounds
+		? bTerminal.bounds.clone()
 		: bTerminal.bounds.clone().expandBy(options.expandElbowLegLength)
 
 	const common: ElbowArrowBox = {
@@ -304,7 +306,6 @@ export function getElbowArrowInfo(
  * Take the route from `getElbowArrowInfo` (which represents the visible body of the arrow) and
  * convert it into a path we can use to show that paths to the handles, which may extend further
  * into the target shape geometries.
- * @returns
  */
 export function getRouteHandlePath(info: ElbowArrowInfo, route: ElbowArrowRoute): ElbowArrowRoute {
 	const startTarget = info.swapOrder ? info.B.target : info.A.target

--- a/packages/tldraw/src/lib/shapes/arrow/getArrowInfo.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/getArrowInfo.ts
@@ -18,8 +18,9 @@ const arrowInfoCache = createComputedCache<Editor, TLArrowInfo, TLArrowShape>(
 	(editor: Editor, shape: TLArrowShape): TLArrowInfo => {
 		const bindings = getArrowBindings(editor, shape)
 		const util = editor.getShapeUtil(shape)
+		// A replacement arrow util may not carry display values; fall back to the theme width.
 		const sw =
-			'getDisplayValues' in util.options
+			'getDefaultDisplayValues' in util.options && 'getCustomDisplayValues' in util.options
 				? (getDisplayValues(util as any, shape) as { strokeWidth: number }).strokeWidth
 				: editor.getCurrentTheme().strokeWidth * STROKE_SIZES[shape.props.size]
 

--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -108,9 +108,11 @@ export function getStraightArrowInfo(
 	) {
 		if (endShapeInfo.didIntersect && !startShapeInfo.didIntersect) {
 			// ...and if only the end shape intersected, then make it
-			// a short arrow ending at the end shape intersection.
+			// a short arrow ending at the end shape intersection. The start
+			// sits MIN_ARROW_LENGTH before it along the arrow's direction;
+			// adding would put it past the intersection, inside the end shape.
 			if (startShapeInfo.isClosed) {
-				a.setTo(b.clone().add(uAB.clone().mul(MIN_ARROW_LENGTH * shape.props.scale)))
+				a.setTo(b.clone().sub(uAB.clone().mul(MIN_ARROW_LENGTH * shape.props.scale)))
 			}
 		} else if (!endShapeInfo.didIntersect) {
 			// ...and if only the end shape intersected, or if neither
@@ -139,7 +141,7 @@ export function getStraightArrowInfo(
 			strokeOffsetA =
 				arrowSW / 2 +
 				('size' in startShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
+					? (theme.strokeWidth * (STROKE_SIZES[startShapeInfo.shape.props.size] ?? 0)) / 2
 					: 0)
 			offsetA = (BOUND_ARROW_OFFSET + strokeOffsetA) * shape.props.scale
 			minLength += strokeOffsetA * shape.props.scale
@@ -156,7 +158,7 @@ export function getStraightArrowInfo(
 			strokeOffsetB =
 				arrowSW / 2 +
 				('size' in endShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
+					? (theme.strokeWidth * (STROKE_SIZES[endShapeInfo.shape.props.size] ?? 0)) / 2
 					: 0)
 			offsetB = (BOUND_ARROW_OFFSET + strokeOffsetB) * shape.props.scale
 			minLength += strokeOffsetB * shape.props.scale

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
@@ -1,5 +1,5 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo, TLShapeId } from '@tldraw/editor'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 import { ArrowShapeUtil } from '../ArrowShapeUtil'
 import { clearArrowTargetState, updateArrowTargetState } from '../arrowTargetState'
 
@@ -29,8 +29,17 @@ export class Idle extends StateNode {
 
 	override onExit() {
 		clearArrowTargetState(this.editor)
+		this.resetPrecise()
+	}
+
+	// Precise mode is earned by hovering one target; it must not carry over to the next
+	// target or to the next arrow.
+	private resetPrecise() {
+		this.isPrecise = false
+		this.preciseTargetId = null
 		if (this.isPreciseTimerId !== null) {
 			clearTimeout(this.isPreciseTimerId)
+			this.isPreciseTimerId = null
 		}
 	}
 
@@ -42,9 +51,8 @@ export class Idle extends StateNode {
 		this.update()
 		if (info.key === 'Enter') {
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
-			if (this.editor.canEditShape(onlySelectedShape)) {
-				startEditingShapeWithRichText(this.editor, onlySelectedShape, { selectAll: true })
-			}
+			if (!this.editor.canEditShape(onlySelectedShape)) return
+			startEditingShape(this.editor, onlySelectedShape, { selectAll: true })
 		}
 	}
 
@@ -61,21 +69,14 @@ export class Idle extends StateNode {
 		})
 
 		if (targetState && targetState.target.id !== this.preciseTargetId) {
-			if (this.isPreciseTimerId !== null) {
-				clearTimeout(this.isPreciseTimerId)
-			}
-
+			this.resetPrecise()
 			this.preciseTargetId = targetState.target.id
 			this.isPreciseTimerId = this.editor.timers.setTimeout(() => {
 				this.isPrecise = true
 				this.update()
 			}, arrowUtil.options.hoverPreciseTimeout)
 		} else if (!targetState && this.preciseTargetId) {
-			this.isPrecise = false
-			this.preciseTargetId = null
-			if (this.isPreciseTimerId !== null) {
-				clearTimeout(this.isPreciseTimerId)
-			}
+			this.resetPrecise()
 		}
 	}
 }

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -117,19 +117,19 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 	}
 
 	override onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape) {
+		let next = shape
 		if (prev.props.url !== shape.props.url) {
 			if (!T.linkUrl.isValid(shape.props.url)) {
 				return { ...shape, props: { ...shape.props, url: prev.props.url } }
-			} else {
-				updateBookmarkAssetOnUrlChange(this.editor, shape)
 			}
+			next = updateBookmarkAssetOnUrlChange(this.editor, shape)
 		}
 
-		if (prev.props.assetId !== shape.props.assetId) {
-			return setBookmarkHeight(this.editor, shape)
+		if (prev.props.assetId !== next.props.assetId) {
+			return setBookmarkHeight(this.editor, next)
 		}
 
-		return undefined
+		return next === shape ? undefined : next
 	}
 	override getInterpolatedProps(
 		startShape: TLBookmarkShape,

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -51,38 +51,31 @@ export function getHumanReadableAddress(url: string) {
 	}
 }
 
-export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
+/**
+ * Resolve the asset for a bookmark whose url just changed: the existing asset for the new url
+ * if there is one, otherwise `null` while a new one is fetched in the background.
+ *
+ * Returns the shape to store rather than writing it. This runs inside `onBeforeUpdate`, where
+ * a nested `updateShapes` is overwritten by the outer put and the old asset would stick.
+ */
+export function updateBookmarkAssetOnUrlChange(
+	editor: Editor,
+	shape: TLBookmarkShape
+): TLBookmarkShape {
 	const { url } = shape.props
 
 	// Derive the asset id from the URL
 	const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
 
 	if (editor.getAsset(assetId)) {
-		// Existing asset for this URL?
-		if (shape.props.assetId !== assetId) {
-			editor.updateShapes([
-				{
-					id: shape.id,
-					type: shape.type,
-					props: { assetId },
-				},
-			])
-		}
-	} else {
-		// No asset for this URL?
-
-		// First, clear out the existing asset reference
-		editor.updateShapes([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { assetId: null },
-			},
-		])
-
-		// Then try to asyncronously create a new one
-		createBookmarkAssetOnUrlChange(editor, shape)
+		if (shape.props.assetId === assetId) return shape
+		return { ...shape, props: { ...shape.props, assetId } }
 	}
+
+	// No asset for this URL yet: drop the stale reference and fetch one asynchronously
+	createBookmarkAssetOnUrlChange(editor, shape)
+	if (shape.props.assetId === null) return shape
+	return { ...shape, props: { ...shape.props, assetId: null } }
 }
 
 /**
@@ -138,10 +131,7 @@ async function _createBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmark
 	}
 
 	editor.run(() => {
-		// Create the new asset
 		editor.createAssets([asset])
-
-		// And update the shape
 		editor.updateShapes([
 			{
 				id: shape.id,

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -119,6 +119,12 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 
 		const sw = (getDisplayValues(this, shape).strokeWidth + 1) * shape.props.scale
 
+		// No points yet (the default props have no segments): a dot at the origin, so geometry
+		// lookups don't throw on a shape created from its defaults.
+		if (points.length === 0) {
+			return new Circle2d({ x: -sw, y: -sw, radius: sw, isFilled: true })
+		}
+
 		// A dot
 		if (shape.props.segments.length === 1) {
 			const box = Box.FromPoints(points)
@@ -202,7 +208,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 		const solidStrokePath =
 			strokePoints.length > 1
 				? getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed)
-				: getDot(allPointsFromSegments[0], sw)
+				: getDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, sw)
 
 		return new Path2D(solidStrokePath)
 	}
@@ -367,7 +373,7 @@ function DrawShapeSvg({
 	const fill = isDot || shape.props.isClosed ? shape.props.fill : 'none'
 
 	const solidStrokePath = isDot
-		? getDot(allPointsFromSegments[0], 0)
+		? getDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, 0)
 		: getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed && fill !== 'none')
 
 	return (

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -132,8 +132,18 @@ export class Drawing extends StateNode {
 					break
 				}
 				case 'starting_straight': {
-					this.pagePointWhereNextSegmentChanged = null
-					this.segmentMode = 'free'
+					// 'starting_straight' is entered from 'free' and from 'starting_free'. In the
+					// latter case the last segment is still the straight one we were leaving, so
+					// going to 'free' here would append free points to a straight segment and the
+					// stroke would stop updating; go back to 'starting_free' instead.
+					const shape =
+						this.initialShape && this.editor.getShape<DrawableShape>(this.initialShape.id)
+					if (shape && last(shape.props.segments)?.type === 'straight') {
+						this.segmentMode = 'starting_free'
+					} else {
+						this.pagePointWhereNextSegmentChanged = null
+						this.segmentMode = 'free'
+					}
 					break
 				}
 			}
@@ -233,7 +243,13 @@ export class Drawing extends StateNode {
 		if (this.initialShape) {
 			const shape = this.editor.getShape<DrawableShape>(this.initialShape.id)
 
-			if (shape && this.segmentMode === 'straight') {
+			// The previous shape may be on another page now (page switched with the tool
+			// still active); don't extend a shape the user can't see.
+			if (
+				shape &&
+				this.segmentMode === 'straight' &&
+				this.editor.getCurrentPageShapeIds().has(shape.id)
+			) {
 				// Connect dots
 
 				this.didJustShiftClickToExtendPreviousShapeLine = true
@@ -347,8 +363,10 @@ export class Drawing extends StateNode {
 					throw Error('We should have a point where the segment changed')
 				}
 
+				// page-space distance against a screen-space threshold, so scale by the zoom
+				const zoom = this.editor.getZoomLevel()
 				const hasMovedFarEnough =
-					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
+					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) * zoom * zoom >
 					this.editor.options.dragDistanceSquared
 
 				// Find the distance from where the pointer was when shift was released and
@@ -384,20 +402,23 @@ export class Drawing extends StateNode {
 
 						this.pagePointWhereCurrentSegmentChanged = Mat.applyToPoint(transform, prevLastPoint)
 					} else {
+						this.currentLineLength += Vec.Dist(newLastPoint, newPoint)
+
 						newSegment = this.makeSegment('straight', [newLastPoint, newPoint])
 					}
 
+					const nextSegments = [...segments, newSegment]
 					const shapePartial: TLShapePartial<DrawableShape> = {
 						id,
 						type: this.shapeType,
 						props: {
-							segments: [...segments, newSegment],
+							segments: nextSegments,
 						},
 					}
 
 					if (this.canClose()) {
 						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-							segments,
+							nextSegments,
 							size,
 							scale
 						)
@@ -414,8 +435,10 @@ export class Drawing extends StateNode {
 					throw Error('We should have a point where the segment changed')
 				}
 
+				// page-space distance against a screen-space threshold, so scale by the zoom
+				const zoom = this.editor.getZoomLevel()
 				const hasMovedFarEnough =
-					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
+					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) * zoom * zoom >
 					this.editor.options.dragDistanceSquared
 
 				// Find the distance from where the pointer was when shift was released and
@@ -595,21 +618,17 @@ export class Drawing extends StateNode {
 				// then the user just did a click-and-immediately-press-shift to create a new straight line
 				// without continuing the previous line. In this case, we want to remove the previous segment.
 
+				// A straight segment is just [first, last]; swap its previous length for the new one
+				// (adding the whole length on every move would let tiny strokes close as if long).
+				const firstPoint = b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!
+				const prevLastPoint = b64Vecs.decodeLastPoint(newSegment.path, newSegment.dim)!
 				this.currentLineLength +=
-					newSegments.length && b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)
-						? Vec.Dist(
-								b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!,
-								Vec.From(newPoint)
-							)
-						: 0
+					Vec.Dist(firstPoint, Vec.From(newPoint)) - Vec.Dist(firstPoint, prevLastPoint)
 
 				newSegments[newSegments.length - 1] = {
 					...newSegment,
 					type: 'straight',
-					path: b64Vecs.encodePoints(
-						[b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!, Vec.From(newPoint)],
-						newSegment.dim
-					),
+					path: b64Vecs.encodePoints([firstPoint, Vec.From(newPoint)], newSegment.dim),
 				}
 
 				const shapePartial: TLShapePartial<DrawableShape> = {
@@ -622,7 +641,7 @@ export class Drawing extends StateNode {
 
 				if (this.canClose()) {
 					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-						segments,
+						newSegments,
 						size,
 						scale
 					)
@@ -693,7 +712,7 @@ export class Drawing extends StateNode {
 					const currentPagePoint = inputs.getCurrentPagePoint()
 
 					// Reset cache for the new shape's segment
-					const initialPoint = new Vec(0, 0, this.isPenOrStylus ? +(z! * 1.25).toFixed() : 0.5)
+					const initialPoint = new Vec(0, 0, this.isPenOrStylus ? +(z! * 1.25).toFixed(2) : 0.5)
 					this.currentSegmentPoints = [initialPoint]
 
 					this.editor.createShape({

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -12,6 +12,7 @@ import {
 	TLFrameShapeProps,
 	TLShapePartial,
 	TLShapeUtilConstructor,
+	Vec,
 	clamp,
 	compact,
 	frameShapeMigrations,
@@ -390,9 +391,15 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 			this.editor.updateShapes(changes)
 		})
 
+		// The children were shifted by (dx, dy) in frame space; move the frame the opposite way
+		// (in its parent's space) so they keep their canvas positions, as fitFrameToContent does.
+		const diff = new Vec(isHorizontalEdge ? dx : 0, isVerticalEdge ? dy : 0).rot(shape.rotation)
+
 		return {
 			id: shape.id,
 			type: shape.type,
+			x: shape.x - diff.x,
+			y: shape.y - diff.y,
 			props: {
 				w: isHorizontalEdge ? w : shape.props.w,
 				h: isVerticalEdge ? h : shape.props.h,

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -32,12 +32,6 @@ const measurementWeakmap = new WeakMap()
 
 /**
  * Get the frame heading info (size and text) for a frame shape.
- *
- * @param editor The editor instance.
- * @param shape The frame shape.
- * @param opts The text measurement options.
- *
- * @returns The frame heading's size (as a Box) and JSX text spans.
  */
 export function getFrameHeadingSize(
 	editor: Editor,

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -559,6 +559,9 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 
 		const scaledW = unscaledW * shape.props.scale
 		const scaledH = unscaledH * shape.props.scale
+		// the offset is in the shape's (scaled) units, so the label over-shrink must be scaled too
+		const scaledOverShrinkX = overShrinkX * shape.props.scale
+		const scaledOverShrinkY = overShrinkY * shape.props.scale
 
 		const offset = new Vec(0, 0)
 
@@ -569,7 +572,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		if (handle === 'left' || handle === 'top_left' || handle === 'bottom_left') {
-			offset.x += scaleX < 0 ? overShrinkX : -overShrinkX
+			offset.x += scaleX < 0 ? scaledOverShrinkX : -scaledOverShrinkX
 		}
 
 		// y offsets
@@ -579,7 +582,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		if (handle === 'top' || handle === 'top_left' || handle === 'top_right') {
-			offset.y += scaleY < 0 ? overShrinkY : -overShrinkY
+			offset.y += scaleY < 0 ? scaledOverShrinkY : -scaledOverShrinkY
 		}
 
 		const { x, y } = offset.rot(shape.rotation).add(newPoint)

--- a/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
+++ b/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
@@ -447,7 +447,9 @@ function getXBoxPath(
 			geometry: { isInternal: true, isFilled: false },
 		})
 		.lineTo(clamp(w - sw * inset, 0, w), clamp(h - sw * inset, 0, h))
-		.moveTo(clamp(w - sw * inset, 0, w), clamp(sw * inset, 0, h))
+		.moveTo(clamp(w - sw * inset, 0, w), clamp(sw * inset, 0, h), {
+			geometry: { isInternal: true, isFilled: false },
+		})
 		.lineTo(clamp(sw * inset, 0, w), clamp(h - sw * inset, 0, h))
 
 	return path
@@ -514,8 +516,6 @@ function getStarPath(w: number, h: number, isFilled: boolean) {
 		{ geometry: { isFilled } }
 	).close()
 }
-
-/* ---------------------- Cloud --------------------- */
 
 function getOvalPerimeter(h: number, w: number) {
 	if (h > w) return (PI * (w / 2) + (h - w)) * 2

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -1,5 +1,5 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -16,9 +16,8 @@ export class Idle extends StateNode {
 		const { editor } = this
 		if (info.key === 'Enter') {
 			const onlySelectedShape = editor.getOnlySelectedShape()
-			if (editor.canEditShape(onlySelectedShape)) {
-				startEditingShapeWithRichText(editor, onlySelectedShape, { selectAll: true })
-			}
+			if (!editor.canEditShape(onlySelectedShape)) return
+			startEditingShape(editor, onlySelectedShape, { selectAll: true })
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -104,7 +104,8 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	getGeometry(shape: TLHighlightShape) {
 		const dv = getDisplayValues(this, shape)
 		const strokeWidth = dv.strokeWidth * shape.props.scale
-		if (getIsDot(shape)) {
+		// No segments yet (the default props): treat it as a dot so geometry lookups don't throw.
+		if (getIsDot(shape) || shape.props.segments.length === 0) {
 			return new Circle2d({
 				x: -strokeWidth / 2,
 				y: -strokeWidth / 2,
@@ -178,7 +179,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 
 		let strokePath
 		if (strokePoints.length < 2) {
-			strokePath = getIndicatorDot(allPointsFromSegments[0], sw)
+			strokePath = getIndicatorDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, sw)
 		} else {
 			strokePath = getSvgPathFromStrokePoints(strokePoints, false)
 		}
@@ -241,7 +242,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	): TLHighlightShapeProps {
 		return {
 			...(t > 0.5 ? endShape.props : startShape.props),
-			...endShape.props,
 			segments: interpolateSegments(startShape.props.segments, endShape.props.segments, t),
 			scale: lerp(startShape.props.scale, endShape.props.scale, t),
 		}
@@ -330,7 +330,7 @@ function HighlightRenderer({
 	const solidStrokePath =
 		strokePoints.length > 1
 			? getSvgPathFromStrokePoints(strokePoints, false)
-			: getShapeDot(allPointsFromSegments[0])
+			: getShapeDot(allPointsFromSegments[0] ?? { x: 0, y: 0 })
 
 	return (
 		<path

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -231,26 +231,34 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 		const { w } = getUncroppedSize(shape.props, props.crop)
 
-		const src = await imageSvgExportCache.get(asset, async () => {
-			let src = await ctx.resolveAssetUrl(asset.id, w)
-			if (!src) return null
-			if (
-				src.startsWith('blob:') ||
-				src.startsWith('http') ||
-				src.startsWith('/') ||
-				src.startsWith('./')
-			) {
-				// If it's a remote image, we need to fetch it and convert it to a data URI
-				src = (await getDataURIFromURL(src)) || ''
-			}
+		const src = await imageSvgExportCache
+			.get(asset, async () => {
+				let src = await ctx.resolveAssetUrl(asset.id, w)
+				if (!src) return null
+				if (
+					src.startsWith('blob:') ||
+					src.startsWith('http') ||
+					src.startsWith('/') ||
+					src.startsWith('./')
+				) {
+					// If it's a remote image, we need to fetch it and convert it to a data URI
+					src = (await getDataURIFromURL(src)) || ''
+				}
 
-			// If it's animated then we need to get the first frame
-			if (getIsAnimated(this.editor, asset.id)) {
-				const { promise } = getFirstFrameOfAnimatedImage(src)
-				src = await promise
-			}
-			return src
-		})
+				// If it's animated then we need to get the first frame
+				if (getIsAnimated(this.editor, asset.id)) {
+					const { promise } = getFirstFrameOfAnimatedImage(src)
+					src = await promise
+				}
+				return src
+			})
+			.catch(() => {
+				// Don't memoize a failure (e.g. a CORS-blocked fetch): the next export should retry
+				// instead of failing forever for this asset. Skip the image rather than failing the
+				// whole export, as the unresolvable-url path above does.
+				imageSvgExportCache.items.delete(asset)
+				return null
+			})
 
 		if (!src) return null
 
@@ -342,10 +350,15 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 		if (url && isAnimated) {
 			const { promise, cancel } = getFirstFrameOfAnimatedImage(url)
 
-			promise.then((dataUrl) => {
-				setStaticFrameSrc(dataUrl)
-				setLoadedUrl(url)
-			})
+			promise.then(
+				(dataUrl) => {
+					setStaticFrameSrc(dataUrl)
+					setLoadedUrl(url)
+				},
+				() => {
+					// couldn't decode a first frame; keep showing the animated source
+				}
+			)
 
 			return () => {
 				cancel()
@@ -610,7 +623,9 @@ function SvgImage({ shape, src }: { shape: TLImageShape; src: string }) {
 function getFirstFrameOfAnimatedImage(url: string) {
 	let cancelled = false
 
-	const promise = new Promise<string>((resolve) => {
+	// Must settle on failure too: an image that never loads would otherwise leave the
+	// export awaiting this promise forever.
+	const promise = new Promise<string>((resolve, reject) => {
 		const image = Image()
 		image.onload = () => {
 			if (cancelled) return
@@ -620,11 +635,15 @@ function getFirstFrameOfAnimatedImage(url: string) {
 			canvas.height = image.height
 
 			const ctx = canvas.getContext('2d')
-			if (!ctx) return
+			if (!ctx) {
+				reject(new Error('Could not get a 2d canvas context'))
+				return
+			}
 
 			ctx.drawImage(image, 0, 0)
 			resolve(canvas.toDataURL())
 		}
+		image.onerror = () => reject(new Error(`Could not load image: ${url}`))
 		image.crossOrigin = 'anonymous'
 		image.src = url
 	})

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -134,8 +134,6 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 		})
 	}
 
-	//   Events
-
 	override onResize(shape: TLLineShape, info: TLResizeInfo<TLLineShape>) {
 		const { scaleX, scaleY } = info
 
@@ -167,13 +165,23 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 			return point.x === firstPoint.x && point.y === firstPoint.y
 		})
 		if (allSame) {
+			// Copy rather than mutate: createShapes spreads the partial's props shallowly, so
+			// `points` is the caller's object — on duplicate, the frozen source record's.
 			const lastKey = pointKeys[pointKeys.length - 1]
-			points[lastKey] = {
-				...points[lastKey],
-				x: points[lastKey].x + 0.1,
-				y: points[lastKey].y + 0.1,
+			return {
+				...next,
+				props: {
+					...next.props,
+					points: {
+						...points,
+						[lastKey]: {
+							...points[lastKey],
+							x: points[lastKey].x + 0.1,
+							y: points[lastKey].y + 0.1,
+						},
+					},
+				},
 			}
-			return next
 		}
 		return
 	}
@@ -305,16 +313,19 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				index = getIndexAbove(index)
 			}
 		} else if (endPoints.length > startPoints.length) {
-			// we'll need to converge points
+			// we'll need to converge points. The start points become the output's points, so they
+			// need fresh indices too: extra points cloned from the last start point would otherwise
+			// share its index and be dropped by linePointsToArray until the animation ends.
 			for (let i = 0; i < endPoints.length; i++) {
 				pointsToUseEnd[i] = { ...endPoints[i] }
 				if (startPoints[i] === undefined) {
 					pointsToUseStart[i] = {
 						...startPoints[startPoints.length - 1],
 						id: index,
+						index,
 					}
 				} else {
-					pointsToUseStart[i] = { ...startPoints[i], id: index }
+					pointsToUseStart[i] = { ...startPoints[i], id: index, index }
 				}
 				index = getIndexAbove(index)
 			}
@@ -358,6 +369,12 @@ const pathCache = new WeakCache<TLLineShape, PathBuilder>()
 function getPathForLineShape(shape: TLLineShape): PathBuilder {
 	return pathCache.get(shape, () => {
 		const points = linePointsToArray(shape).map(Vec.From)
+
+		// A line needs two points to have a path. onBeforeCreate lets 0/1-point lines through
+		// (they can also arrive via updateShape or a file), and without this every geometry
+		// lookup on the page would throw — getShapeAtPoint included.
+		if (points.length === 0) points.push(new Vec(0, 0))
+		if (points.length === 1) points.push(points[0].clone().addXY(0.1, 0.1))
 
 		switch (shape.props.spline) {
 			case 'cubic': {

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -1,5 +1,4 @@
 import {
-	Mat,
 	StateNode,
 	TLLineShape,
 	TLShapeId,
@@ -28,10 +27,11 @@ export class Pointing extends StateNode {
 
 		this.markId = undefined
 
-		// Previously created line shape that we might be extending
+		// Previously created line shape that we might be extending (it may have been left
+		// on another page if the page was switched with the tool still active)
 		const shape = info.shapeId && this.editor.getShape<TLLineShape>(info.shapeId)
 
-		if (shape && inputs.getShiftKey()) {
+		if (shape && inputs.getShiftKey() && this.editor.getCurrentPageShapeIds().has(shape.id)) {
 			// Extending a previous shape
 			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${shape.id}`)
 			this.shape = shape
@@ -43,12 +43,10 @@ export class Pointing extends StateNode {
 			const endHandle = vertexHandles[vertexHandles.length - 1]
 			const prevEndHandle = vertexHandles[vertexHandles.length - 2]
 
-			const shapePagePoint = Mat.applyToPoint(
-				this.editor.getShapeParentTransform(this.shape)!,
-				new Vec(this.shape.x, this.shape.y)
-			)
 			// nudge the point slightly to avoid zero-length lines
-			const nudgedPoint = Vec.Sub(currentPagePoint, shapePagePoint).addXY(0.1, 0.1)
+			const nudgedPoint = this.editor
+				.getPointInShapeSpace(this.shape, currentPagePoint)
+				.addXY(0.1, 0.1)
 			const nextPoint = maybeSnapToGrid(nudgedPoint, this.editor)
 			const points = structuredClone(this.shape.props.points)
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -308,13 +308,16 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					style: 'normal',
 				})
 
-		if (shape.props.textLastEditedBy && !isEmptyRichText(shape.props.richText)) {
-			return [...fonts, DefaultFontFaces.tldraw_sans.normal.normal]
-		}
 		const themeFaces = getThemeFontFaces(this.editor.getCurrentTheme(), shape.props.font)
-		if (themeFaces) return [...themeFaces, ...fonts]
+		const textFaces = themeFaces ? [...themeFaces, ...fonts] : fonts
 
-		return fonts.length ? fonts : EMPTY_ARRAY
+		// The attribution line renders in the default sans face regardless of the note's font.
+		// Theme faces come first so an attributed note keeps its custom font (export included).
+		if (shape.props.textLastEditedBy && !isEmptyRichText(shape.props.richText)) {
+			return [...textFaces, DefaultFontFaces.tldraw_sans.normal.normal]
+		}
+
+		return textFaces.length ? textFaces : EMPTY_ARRAY
 	}
 
 	component(shape: TLNoteShape) {

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -135,7 +135,8 @@ export function getAvailableNoteAdjacentPositions(
 				getNoteAdjacentPositions(editor, {
 					pagePoint: transform.point(),
 					pageRotation: rotation,
-					growY: shape.props.growY,
+					// page units, like the base positions (see PointingHandle)
+					growY: shape.props.growY * shape.props.scale,
 					extraHeight,
 					scale,
 					noteWidth,
@@ -191,8 +192,11 @@ export function getNoteShapeForAdjacentPosition(
 	// Start from the top of the stack, and work our way down
 	const allShapesOnPage = editor.getCurrentPageShapesSorted()
 
+	// Squared, in page units, to compare against Dist2 below. A neighbour that has grown
+	// (growY) sits further from the ideal slot centre, so the radius is a full note plus margin.
 	const minDistance =
-		(Math.max(noteWidth, noteHeight) + editor.options.adjacentShapeMargin ** 2) ** shape.props.scale
+		((Math.max(noteWidth, noteHeight) + editor.options.adjacentShapeMargin) * shape.props.scale) **
+		2
 
 	for (let i = allShapesOnPage.length - 1; i >= 0; i--) {
 		const otherNote = allShapesOnPage[i]
@@ -260,11 +264,18 @@ export function getNoteShapeForAdjacentPosition(
 		nextNote = editor.getShape(id)!
 	}
 
-	editor.zoomToSelectionIfOffscreen(16, {
-		animation: {
-			duration: editor.options.animationMediumMs,
-		},
-		inset: 0,
-	})
+	// When dragging a clone handle the caller is about to move the note under the pointer,
+	// so don't animate the camera towards the adjacent slot
+	if (!forceNew) {
+		// Select the next note first: the zoom targets the selection, and until now that was
+		// still the note we came from (which is on screen), so the new note never scrolled into view.
+		editor.select(nextNote.id)
+		editor.zoomToSelectionIfOffscreen(16, {
+			animation: {
+				duration: editor.options.animationMediumMs,
+			},
+			inset: 0,
+		})
+	}
 	return nextNote
 }

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -182,10 +182,12 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 
 	editor.select(id)
 	const bounds = editor.getShapeGeometry(shape).bounds
-	const newPoint = maybeSnapToGrid(
-		new Vec(shape.x - bounds.width / 2, shape.y - bounds.height / 2),
-		editor
-	)
+	// shape.x/y are in the parent's space (createShape may have parented the note into a
+	// rotated frame), so the half-size offset has to be rotated into that space too
+	const delta = new Vec(bounds.width / 2, bounds.height / 2)
+	const parentTransform = editor.getShapeParentTransform(shape)
+	if (parentTransform) delta.rot(-parentTransform.rotation())
+	const newPoint = maybeSnapToGrid(new Vec(shape.x - delta.x, shape.y - delta.y), editor)
 
 	// Center the text around the created point
 	editor.updateShapes([

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -71,7 +71,6 @@ export function getUncroppedSize(
 	return { w, h }
 }
 
-// Utility function to get crop dimensions
 function getCropDimensions(crop: TLShapeCrop) {
 	return {
 		width: crop.bottomRight.x - crop.topLeft.x,
@@ -79,7 +78,6 @@ function getCropDimensions(crop: TLShapeCrop) {
 	}
 }
 
-// Utility function to get crop center
 function getCropCenter(crop: TLShapeCrop) {
 	const { width, height } = getCropDimensions(crop)
 	return {
@@ -88,7 +86,6 @@ function getCropCenter(crop: TLShapeCrop) {
 	}
 }
 
-// Utility function to create crop with specified dimensions centered on given point
 function createCropAroundCenter(
 	centerX: number,
 	centerY: number,
@@ -442,7 +439,18 @@ interface CropChange {
 	y: number
 }
 
-// Base function for calculating crop changes
+/**
+ * Top-left position that keeps the image's visual centre where it is after its display size
+ * changes. The half-size delta is in the shape's own space, so it has to be rotated by the
+ * shape's rotation; a plain `center - newSize / 2` only holds for unrotated images.
+ */
+function getPositionKeepingCenter(imageShape: TLImageShape, newW: number, newH: number) {
+	const delta = new Vec((imageShape.props.w - newW) / 2, (imageShape.props.h - newH) / 2).rot(
+		imageShape.rotation
+	)
+	return { x: imageShape.x + delta.x, y: imageShape.y + delta.y }
+}
+
 function calculateCropChange(
 	imageShape: TLImageShape,
 	newCropWidth: number,
@@ -452,10 +460,6 @@ function calculateCropChange(
 ): CropChange {
 	const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
 	const currentCrop = imageShape.props.crop || getDefaultCrop()
-
-	// Calculate image and crop centers
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
 
 	let cropCenterX, cropCenterY
 	if (centerOnCurrentCrop) {
@@ -467,7 +471,6 @@ function calculateCropChange(
 		cropCenterY = 0.5
 	}
 
-	// Create new crop
 	const newCrop = createCropAroundCenter(
 		cropCenterX,
 		cropCenterY,
@@ -484,8 +487,7 @@ function calculateCropChange(
 		crop: newCrop,
 		w: croppedW,
 		h: croppedH,
-		x: imageCenterX - croppedW / 2,
-		y: imageCenterY - croppedH / 2,
+		...getPositionKeepingCenter(imageShape, croppedW, croppedH),
 	}
 }
 
@@ -526,10 +528,9 @@ export function getCroppedImageDataWhenZooming(
 	result.h *= scaleFactor
 
 	// Recenter
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
-	result.x = imageCenterX - result.w / 2
-	result.y = imageCenterY - result.h / 2
+	const { x, y } = getPositionKeepingCenter(imageShape, result.w, result.h)
+	result.x = x
+	result.y = y
 
 	return result
 }
@@ -551,7 +552,13 @@ export function getCroppedImageDataForReplacedImage(
 	let crop = defaultCrop
 	let newDisplayW = origDisplayW
 	let newDisplayH = origDisplayH
-	const isOriginalCrop = isEqual(imageShape.props.crop, defaultCrop)
+	// Compare the bounds, not the whole object: an explicit `isCircle: false` must still count
+	// as the original crop.
+	const isOriginalCrop =
+		!!imageShape.props.crop &&
+		isEqual(imageShape.props.crop.topLeft, defaultCrop.topLeft) &&
+		isEqual(imageShape.props.crop.bottomRight, defaultCrop.bottomRight) &&
+		!imageShape.props.crop.isCircle
 
 	if (isOriginalCrop) {
 		newDisplayW = origDisplayW
@@ -603,19 +610,11 @@ export function getCroppedImageDataForReplacedImage(
 		)
 	}
 
-	// Position so visual center stays put
-	const pageCenterX = imageShape.x + origDisplayW / 2
-	const pageCenterY = imageShape.y + origDisplayH / 2
-
-	const newX = pageCenterX - newDisplayW / 2
-	const newY = pageCenterY - newDisplayH / 2
-
 	return {
 		crop,
 		w: newDisplayW,
 		h: newDisplayH,
-		x: newX,
-		y: newY,
+		...getPositionKeepingCenter(imageShape, newDisplayW, newDisplayH),
 	}
 }
 
@@ -629,15 +628,12 @@ export function getCroppedImageDataForAspectRatio(
 	// If original aspect ratio is requested, use default crop
 	if (aspectRatioOption === 'original') {
 		const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
-		const imageCenterX = imageShape.x + imageShape.props.w / 2
-		const imageCenterY = imageShape.y + imageShape.props.h / 2
 
 		return {
 			crop: getDefaultCrop(),
 			w,
 			h,
-			x: imageCenterX - w / 2,
-			y: imageCenterY - h / 2,
+			...getPositionKeepingCenter(imageShape, w, h),
 		}
 	}
 
@@ -753,18 +749,10 @@ export function getCroppedImageDataForAspectRatio(
 	const newW = baseW * currentScale
 	const newH = baseH * currentScale
 
-	// Calculate the new top-left position (x, y) for the shape
-	// to keep the visual center of the cropped area fixed on the page.
-	const currentCenterXPage = imageShape.x + imageShape.props.w / 2
-	const currentCenterYPage = imageShape.y + imageShape.props.h / 2
-	const newX = currentCenterXPage - newW / 2
-	const newY = currentCenterYPage - newH / 2
-
 	return {
 		crop: newCrop,
 		w: newW,
 		h: newH,
-		x: newX,
-		y: newY,
+		...getPositionKeepingCenter(imageShape, newW, newH),
 	}
 }

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -55,7 +55,6 @@ export function useEditablePlainText(
 		}
 	}, [editor, isEditing])
 
-	// When the user presses ctrl / meta enter, complete the editing state.
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
 			if (editor.getEditingShapeId() !== shapeId) return
@@ -72,7 +71,6 @@ export function useEditablePlainText(
 		[editor, shapeId]
 	)
 
-	// When the text changes, update the text value.
 	const handleChange = useCallback(
 		({ plaintext }: { plaintext: string }) => {
 			if (editor.getEditingShapeId() !== shapeId) return

--- a/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
@@ -29,7 +29,6 @@ export function useEditableRichText(
 		}
 	}, [editor, isEditing])
 
-	// When the user presses ctrl / meta enter, complete the editing state.
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
 			if (editor.getEditingShapeId() !== shapeId) return
@@ -38,7 +37,6 @@ export function useEditableRichText(
 		[editor, shapeId]
 	)
 
-	// When the text changes, update the text value.
 	const handleChange = useCallback(
 		({ richText }: { richText: TLRichText }) => {
 			if (editor.getEditingShapeId() !== shapeId) return

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -78,7 +78,17 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 			shouldRunImmediately.current = true
 		}
 
-		if (!assetId) return
+		if (!assetId) {
+			// The asset was removed from the shape: drop the previous asset/url rather than
+			// keep rendering it
+			if (assetIdChanged) {
+				// Forget the old url too, or re-attaching the same asset is treated as "same url"
+				// in resolve() and the image stays blank
+				previousUrl.current = null
+				setResult((prev) => ({ ...prev, asset: null, url: null }))
+			}
+			return
+		}
 
 		let isCancelled = false
 		let cancelDebounceFn: (() => void) | undefined

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -271,7 +271,6 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 	const { $from, $to } = state.selection
 	const isShift = event.shiftKey
 
-	// Create a new transaction
 	let tr = state.tr
 
 	// Iterate over each line in the selection in reverse so that the positions
@@ -285,7 +284,6 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		const lineEnd = line.end
 		const lineText = state.doc.textBetween(lineStart, lineEnd, '\n')
 
-		// Check if the current line or any of its parent nodes are part of a list
 		let isInList = false
 		state.doc.nodesBetween(lineStart, lineEnd, (node) => {
 			if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
@@ -299,10 +297,8 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		// sinkListItem and liftListItem from @tiptap/pm/schema-list
 		if (!isInList) {
 			if (!isShift) {
-				// Insert a tab character at the start of the line
 				tr = tr.insertText('\t', lineStart + 1)
 			} else {
-				// Remove a tab character from the start of the line
 				if (lineText.startsWith('\t')) {
 					tr = tr.delete(lineStart + 1, lineStart + 2)
 				}

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -3,7 +3,7 @@ import {
 	cancelUpdateHoveredShapeId,
 	updateHoveredShapeId,
 } from '../../../tools/selection-logic/updateHoveredShapeId'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -34,7 +34,7 @@ export class Idle extends StateNode {
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			if (!this.editor.canEditShape(onlySelectedShape)) return
 			this.editor.setCurrentTool('select')
-			startEditingShapeWithRichText(this.editor, onlySelectedShape.id, { info })
+			startEditingShape(this.editor, onlySelectedShape, { info })
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -21,6 +21,9 @@ export class Pointing extends StateNode {
 	enterTime = 0
 	override onEnter(): void {
 		this.enterTime = Date.now()
+		// Only the drag-to-create path sets a mark. Without this reset, a later cancel
+		// would bail to a mark left over from a previous text shape and undo unrelated work.
+		this.markId = ''
 	}
 
 	override onExit() {

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -116,12 +116,18 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const asset = this.editor.getAsset<TLAsset>(props.assetId)
 		if (!asset) return null
 
-		const src = await videoSvgExportCache.get(asset, async () => {
-			const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
-			if (!assetUrl) return null
-			const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
-			return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
-		})
+		const src = await videoSvgExportCache
+			.get(asset, async () => {
+				const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
+				if (!assetUrl) return null
+				const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
+				return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
+			})
+			.catch((error) => {
+				// Don't memoize a failure: the next export should retry for this asset.
+				videoSvgExportCache.items.delete(asset)
+				throw error
+			})
 
 		if (!src) return null
 

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -48,3 +48,24 @@ export function startEditingShapeWithRichText(
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
 }
+
+/**
+ * Start editing any editable shape. Shapes with rich text go through
+ * `startEditingShapeWithRichText`; editable shapes without it (frame, video, embed) would
+ * make that helper throw, so they enter the editing state directly.
+ *
+ * @internal
+ */
+export function startEditingShape(
+	editor: Editor,
+	shape: TLShape,
+	options: { selectAll?: boolean; info?: TLEventInfo } = {}
+) {
+	if (!editor.canEditShape(shape)) return
+	if (hasRichText(shape)) {
+		startEditingShapeWithRichText(editor, shape, options)
+		return
+	}
+	editor.setEditingShape(shape)
+	editor.setCurrentTool('select.editing_shape', { ...options.info, target: 'shape', shape })
+}

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -137,6 +137,15 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		url: 'https://lite.tldraw.com/something',
 		match: false,
 	},
+	// hostname patterns are anchored: a lookalike host must not inherit the tldraw sandbox
+	{
+		url: 'https://tldraw.com.evil.io/r/choochoo',
+		match: false,
+	},
+	{
+		url: 'https://nottldraw.com/r/choochoo',
+		match: false,
+	},
 	// codesandbox
 	{
 		url: 'https://codesandbox.io/s/breathing-dots-checkpoint-7-nor86',

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -41,7 +41,10 @@ const globlikeRegExp = (input: string) => {
 
 const checkHostnames = (hostnames: readonly string[], targetHostname: string) => {
 	return !!hostnames.find((hostname) => {
-		const re = new RegExp(globlikeRegExp(hostname))
+		// The host must be the pattern or a subdomain of it. Unanchored, `tldraw.com` would
+		// also match `tldraw.com.evil.io`, which would then inherit that definition's relaxed
+		// iframe sandbox permissions.
+		const re = new RegExp(`^(?:.+\\.)?${globlikeRegExp(hostname)}$`)
 		return targetHostname.match(re)
 	})
 }


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a batch of bugs in the default shape utils and shape tool states found by a review pass over `packages/tldraw/src/lib/shapes`. Each fix is small and independent; they are grouped here because they came out of one pass. Relates to #10071, which touches many of the same files and will need a rebase on whichever side lands second.

### Before

The notable ones, by symptom:

- **Enter on a frame/video/embed with the geo, arrow or text tool active crashed the editor.** The tool `Idle` states called `startEditingShapeWithRichText` after `canEditShape` without checking `hasRichText`, and the helper throws for shapes without rich text.
- **Escape/interrupt while pointing with the text tool undid unrelated work.** `text/toolStates/Pointing` never reset `markId` on enter, so `bailToMark` used a stale mark from an earlier drag-created text shape.
- **Lookalike hosts got trusted embed permissions.** `checkHostnames` built an unanchored regex, so `tldraw.com.evil.io` matched the `tldraw` definition and inherited its relaxed iframe sandbox.
- **Resizing a box with a bound arrow selected flip-flopped the arrow's anchors.** `ArrowShapeUtil.onResize` cached the initial bindings keyed on the `shape` argument, which `Editor.resizeShape` recreates every frame, so the mirrored bindings were re-read and re-mirrored per pointer move.
- **Dragging a rotated bound arrow, or nudge/align/distribute on one, moved the bound terminals by the wrong delta.** `onTranslate` ran the arrow's own x/y through its page transform (folding in rotation) and then halved it.
- **Cmd+Enter on a note sometimes created a new note on top of an existing neighbour.** `getNoteShapeForAdjacentPosition` compared a squared distance against `(max(w,h) + margin ** 2) ** scale`, a ~24px radius, so a neighbour with `growY` wasn't recognised.
- **Double-clicking a frame edge jumped the frame's content across the canvas.** `onDoubleClickEdge` shifted the children and shrank the frame but never moved the frame's own x/y.
- **Changing a bookmark's url kept the old preview.** `onBeforeUpdate` resolved the new asset with a nested `updateShapes` and returned the unchanged record, so the outer put overwrote the asset write.
- **Arrows between overlapping shapes collapsed to a stub.** `straight-arrow.ts` added `MIN_ARROW_LENGTH` along the arrow direction instead of subtracting it in the "only the end shape intersected" branch.
- **Geo shapes with `scale != 1` drifted at the fixed edge when resized past the label minimum.** `onResize` added the unscaled label over-shrink to a scaled offset.
- **Elbow arrows with a free point terminal routed through the bound shape in some layouts.** Point terminals used the same `Box` for `original` and `expanded`, and `ElbowArrowWorkingInfo` transforms both in place, so the box was transformed twice.
- **A line with 0/1 points, or a draw/highlight shape created from its default props, broke hit testing for the whole page.** Their geometry constructors threw on too few points.
- **One failed animated-image export broke every later export of that asset.** The export cache memoised a promise that `getFirstFrameOfAnimatedImage` never settled on error.
- **`getCustomDisplayValues` stroke width was ignored for arrow geometry.** `getArrowInfo` checked for a `getDisplayValues` option key that doesn't exist.
- **Changing a rotated image's aspect ratio or zoom jumped it on the canvas.** The crop helpers recomputed `x/y` as `centre - newSize/2` without rotating the half-size delta.

### After

Each of those paths does what its name says: the three tool `Idle` states share a `startEditingShape` helper that falls back to `setEditingShape` for editable shapes without rich text; `markId` is reset on enter; hostname patterns are anchored as `^(?:.+\.)?pattern$` (subdomains still match); the arrow resize cache is keyed on `info.initialShape` and the translate delta comes from the parent transform; the note radius is `((max(w,h) + margin) * scale) ** 2`; the frame moves by the rotated `(dx, dy)`; `updateBookmarkAssetOnUrlChange` returns the record for `onBeforeUpdate` to return; the straight-arrow sign is fixed; the geo over-shrink is scaled; point terminals get a cloned `Box`; degenerate line/draw/highlight shapes render as a dot; export caches evict on rejection and `getFirstFrameOfAnimatedImage` rejects on `onerror`; `getArrowInfo` reads the real option keys; and the crop helpers go through a rotation-aware `getPositionKeepingCenter`.

Smaller fixes in the same pass: note created inside a rotated frame is centred correctly; line/draw shift-extend ignores a previous shape left on another page; `Drawing.ts` shift-keyup from `starting_free` no longer freezes the stroke, straight-mode length accounting, `isClosed` computed from the new segments, zoom-scaled segment threshold; arrow tool `isPrecise` resets on target change; `STROKE_SIZES[size] ?? 0` for custom `size` values; `LineShapeUtil.onBeforeCreate` no longer mutates the caller's (possibly frozen) points; `getInterpolatedProps` gives cloned line points unique indices; attributed notes keep their theme font faces; `useImageOrVideoAsset` clears its result when `assetId` goes null. Plus comment cleanups per the repo conventions.

### Implementation notes

- `startEditingShape` is `@internal` in `selectHelpers.ts`; the select tool's own `Idle.startEditingShape` is left alone because it also transitions the parent state.
- Embed hostname wildcards (`google.*`) still expand to `.+` so `google.co.uk` keeps matching; that means `docs.google.com.evil.io` still matches `docs.google.*`. Tightening that needs a TLD-aware pattern and is left for a follow-up.
- Known and deliberately not touched: the image toolbar passes `MAX_ZOOM` where `getCroppedImageDataWhenZooming` expects a 0–1 fraction (`ui/`), `FrameLabelInput` calling `useBreakpoint()` outside `<TldrawUi>`, and geo `toSvg` scale mismatches at `scale != 1`.

### Change type

- [x] `bugfix`

### Test plan

1. Select a frame, press `G`, press `Enter` — no crash, frame label enters editing.
2. Draw a box and an arrow bound to it; select both and drag a resize handle past the opposite edge — arrow stays attached at the mirrored anchor.
3. Paste `https://tldraw.com.evil.io/r/x` — it should not become a tldraw embed.
4. Rotate an image, change its aspect ratio from the image toolbar — the image stays in place.
5. Double-click a frame edge with content inside — the content stays where it was on the canvas.

- [x] Unit tests — the embed lookalike-host cases fail on `main`; the existing `packages/tldraw` suite passes.

### Release notes

- Fix crash when pressing Enter on a frame, video or embed with the geo, arrow or text tool active
- Fix text tool cancel undoing unrelated work after an earlier drag-created text shape
- Fix embed hostname matching so lookalike hosts don't get a trusted definition's iframe permissions
- Fix arrow bindings flip-flopping while resizing a bound shape, and wrong terminal movement when translating rotated arrows
- Fix Cmd+Enter on a note creating a duplicate on top of an existing neighbour
- Fix frame double-click-edge moving the frame's content
- Fix bookmark keeping its old preview after a url change
- Fix straight arrows between overlapping shapes collapsing to a stub
- Fix rotated images jumping when changing aspect ratio or zoom
- Fix geometry errors for lines and draw shapes with too few points
- Fix animated-image export failures poisoning later exports of the same asset

### Code changes

| Section   | LOC change  |
| --------- | ----------- |
| Core code | +324 / -237 |
| Tests     | +9 / -0     |