### PR TITLE
fix(select): only bail the whole crop session on a cancel from crop idle

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -15,22 +15,21 @@ export class Crop extends StateNode {
 	markId = ''
 
 	override onEnter() {
-		this.didExit = false
 		this.markId = this.editor.markHistoryStoppingPoint('crop')
 	}
-	didExit = false
+
 	override onExit() {
-		if (!this.didExit) {
-			this.didExit = true
-			if (this.editor.getMarkIdMatching(this.markId) === this.markId) {
-				this.editor.squashToMark(this.markId)
-			}
+		// Bailing pops the mark, so there is nothing to squash after a cancel
+		if (this.editor.getMarkIdMatching(this.markId) === this.markId) {
+			this.editor.squashToMark(this.markId)
 		}
 	}
+
 	override onCancel() {
-		if (!this.didExit) {
-			this.didExit = true
-			this.editor.bailToMark(this.markId)
-		}
+		// Parents see events before children. A cancel during a child interaction belongs to that
+		// child, which bails its own mark and stays in crop mode; only a cancel from idle ends the
+		// session and reverts it.
+		if (this.getCurrent()?.id !== 'idle') return
+		this.editor.bailToMark(this.markId)
 	}
 }

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1240,3 +1240,53 @@ describe('When cropping with modifiers and snapping...', () => {
 		expect(editor.snaps.getIndicators().length).toBe(0)
 	})
 })
+
+describe('Cancelling while cropping', () => {
+	it('escape during a crop drag only reverts that drag and keeps the session cancellable', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		// First drag commits
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 590)
+		editor.pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		const afterFirst = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(afterFirst).not.toMatchObject(before)
+
+		// Escape mid-drag reverts only the second drag
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.expectToBeIn('select.crop.cropping')
+		editor.cancel()
+		editor.expectToBeIn('select.crop.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(afterFirst)
+
+		// Escape from idle still reverts the whole session
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+
+	it('squashes the session into one undo even after a cancelled drag', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.cancel()
+		editor.expectToBeIn('select.crop.idle')
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 590)
+		editor.pointerUp()
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.pointerMove(510, 580)
+		editor.pointerUp()
+		editor.keyDown('Enter').keyUp('Enter')
+		editor.expectToBeIn('select.idle')
+
+		editor.undo()
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+})


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where pressing Escape during a crop drag reverted every earlier crop in the session, and later Escapes then stopped reverting anything.

### Before

Parents see events before children, so `Crop.onCancel` ran for a cancel that belonged to a child drag: it bailed the session mark (wiping earlier commits while staying in crop mode) and latched `didExit`, after which later cancels were ignored and `onExit` skipped the squash, leaving one undo entry per drag instead of one.

### After

A cancel during a child interaction belongs to that child, which bails its own mark and stays in crop mode; a cancel from crop idle reverts and ends the session; Enter squashes the session into a single undo entry as before. The `didExit` latch is gone.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Double-click an image to enter crop mode, drag a handle and release, then start a second drag and press Escape: only the second drag is reverted and you are still in crop mode.
2. Press Escape again from crop idle: the whole session reverts.
3. Crop twice and press Enter, then undo once: both crops are undone together.

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change

### Release notes

- Fix Escape during a crop drag reverting earlier crops in the same session and breaking later cancels.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -11  |
| Tests     | +50 / -0   |
