### PR TITLE
fix(select): leave the resizing state cleanly when the selection is gone

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -63,22 +63,21 @@ export class Resizing extends StateNode {
 		this.info = info
 		this.didHoldCommand = false
 		this.didFinish = false
+		this.markId = ''
 
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
 		this.creationCursorOffset = creationCursorOffset
 
-		try {
-			// On rare and mysterious occasions, the user can enter the resizing state with no shapes selected
-			this.snapshot = this._createSnapshot()
-		} catch (e) {
-			console.error(e)
-			this.cancel()
+		// The selection can be empty here, e.g. when the pointed shape was deleted remotely between
+		// pointer down and the drag. Nothing has been marked or changed yet, so just leave.
+		const snapshot = this._createSnapshot()
+		if (!snapshot) {
+			this.parent.transition('idle')
 			return
 		}
-
-		this.markId = ''
+		this.snapshot = snapshot
 
 		if (isCreating) {
 			if (creatingMarkId) {
@@ -222,7 +221,8 @@ export class Resizing extends StateNode {
 
 			const changes: TLShapePartial[] = []
 			shapeSnapshots.forEach(({ shape }) => {
-				const current = this.editor.getShape(shape.id)!
+				const current = this.editor.getShape(shape.id)
+				if (!current) return
 				const util = this.editor.getShapeUtil(shape)
 				if (!util.canResize(shape)) return
 				const change = util.onResizeEnd?.(shape, current)
@@ -245,7 +245,13 @@ export class Resizing extends StateNode {
 	private _updateShapes() {
 		// Otherwise the stale resize snapshot would overwrite an external change.
 		if (this.changeTracker.getAndClearChanged()) {
-			this.snapshot = this._createSnapshot(this.editor.inputs.getCurrentPagePoint())
+			const snapshot = this._createSnapshot(this.editor.inputs.getCurrentPagePoint())
+			// The external change may have deleted every shape we were resizing
+			if (!snapshot) {
+				this.parent.transition('idle')
+				return
+			}
+			this.snapshot = snapshot
 			this.changeTracker.setTrackedShapeIds(this.snapshot.shapeSnapshots.keys())
 		}
 
@@ -462,8 +468,9 @@ export class Resizing extends StateNode {
 
 			for (const { id, children } of frames) {
 				if (!children.length) continue
-				const initial = shapeSnapshots.get(id)!.shape
-				const current = this.editor.getShape(id)!
+				// The frame may have been deleted mid-resize
+				const initial = shapeSnapshots.get(id)?.shape
+				const current = this.editor.getShape(id)
 				if (!(initial && current)) continue
 
 				const dx = current.x - initial.x
@@ -586,6 +593,9 @@ export class Resizing extends StateNode {
 		if (this.info.isCreating && !this.didFinish) {
 			this.editor.bailToMark(this.markId)
 		}
+		// Don't keep the last resize's shapes, transforms and callbacks alive until the next one
+		this.snapshot = {} as any as Snapshot
+		this.info = {} as ResizingInfo
 	}
 
 	private _createSnapshot(originPagePoint = this.editor.inputs.getOriginPagePoint()) {
@@ -594,7 +604,7 @@ export class Resizing extends StateNode {
 		const selectionRotation = editor.getSelectionRotation()
 
 		const selectionBounds = editor.getSelectionRotatedPageBounds()
-		if (!selectionBounds) throw Error('Resizing but nothing is selected')
+		if (!selectionBounds) return null
 
 		const dragHandlePoint = Vec.RotWith(
 			selectionBounds.getHandlePoint(this.info.handle!),
@@ -712,4 +722,4 @@ export class Resizing extends StateNode {
 	}
 }
 
-type Snapshot = ReturnType<Resizing['_createSnapshot']>
+type Snapshot = NonNullable<ReturnType<Resizing['_createSnapshot']>>

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -4163,3 +4163,31 @@ describe('When resizing shapes are changed externally mid-resize...', () => {
 		expect(bounds.y).toBeCloseTo(50, 5)
 	})
 })
+
+describe('entering the resizing state with nothing selected', () => {
+	it('returns to idle without touching earlier history', () => {
+		// A completed resize leaves a mark behind; a later failed entry must not bail to it
+		editor.select(ids.boxA)
+		editor.pointerDownOnHandle('bottom_right')
+		editor.pointerMoveBy(50, 50)
+		editor.pointerUp()
+		expect(editor.getShape<TLGeoShape>(ids.boxA)!.props).toMatchObject({ w: 150, h: 150 })
+		editor.updateShape({ id: ids.boxA, type: 'geo', x: 500 })
+		editor.selectNone()
+
+		// e.g. the pointed shape was deleted remotely between pointer down and the drag
+		expect(() =>
+			editor.setCurrentTool('select.resizing', { target: 'selection', handle: 'bottom_right' })
+		).not.toThrow()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLGeoShape>(ids.boxA)).toMatchObject({ x: 500, props: { w: 150 } })
+	})
+
+	it('does not crash on the first ever entry', () => {
+		editor.selectNone()
+		expect(() =>
+			editor.setCurrentTool('select.resizing', { target: 'selection', handle: 'bottom_right' })
+		).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+})


### PR DESCRIPTION
**Risk: low · Importance: high**

This PR fixes a bug where starting a resize with nothing selected (for example, the pointed shape was deleted remotely between pointer down and the drag) crashed the select tool on a fresh editor and, after an earlier resize, silently reverted that resize and everything since.

### Before

`Resizing.onEnter` wrapped `_createSnapshot()` in a try/catch; the snapshot threw on an empty selection and the catch called `cancel()` *before* `markId` and `snapshot` were reset, so `cancel()` ran against the previous resize. On a fresh editor that was a `TypeError` (`reading 'forEach'`) and a tool stuck in `select.resizing`; after a prior resize it was a silent `bailToMark(<old mark>)` with nothing on the redo stack.

### After

`_createSnapshot()` returns `null` when there is no selection and `onEnter` transitions to idle before any mark is created. `handleResizeEnd` and the frame reflow loop skip shapes that no longer exist, and `onExit` drops the snapshot so the last resize's shapes and callbacks are not kept alive until the next one.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. In a multiplayer room, press a resize handle and have another client delete the shape before you drag; the tool returns to idle and earlier edits are untouched.

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change

### Release notes

- Fix the select tool bailing to an old history mark (or crashing) when a resize starts with nothing selected.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +17 / -13 |
| Tests     | +28 / -0 |
