### PR TITLE
fix(select): clear the cropping shape when leaving the select tool

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -84,5 +84,9 @@ export class SelectTool extends StateNode {
 		if (this.editor.getCurrentPageState().editingShapeId) {
 			this.editor.setEditingShape(null)
 		}
+		// Leaving crop mode for another tool would otherwise keep the image in its cropping state
+		if (this.editor.getCroppingShapeId()) {
+			this.editor.setCroppingShape(null)
+		}
 	}
 }

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1240,3 +1240,15 @@ describe('When cropping with modifiers and snapping...', () => {
 		expect(editor.snaps.getIndicators().length).toBe(0)
 	})
 })
+
+describe('Leaving crop mode by switching tools', () => {
+	it('clears the cropping shape', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.setCurrentTool('hand')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.setCurrentTool('select')
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+	})
+})


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where an image stayed in its cropping state after leaving crop mode by switching tools, so its selection indicator vanished and a later double-click on its edge un-cropped it.

### Before

Neither `Crop.onExit` nor `SelectTool.onExit` cleared `croppingShapeId` (unlike `editingShapeId`). After double-clicking an image to crop, pressing `h`, then `v`, `getCroppingShapeId()` still pointed at the image: `ImageShapeUtil.getIndicatorPath` returned nothing and `onDoubleClickEdge` ran on the next edge double-click.

### After

`SelectTool.onExit` clears the cropping shape alongside the editing shape.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Double-click an image to enter crop mode.
2. Press `h` (hand tool), then `v` (select tool).
3. The image shows its normal selection indicator and double-clicking its edge no longer resets the crop.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix stale crop state after leaving crop mode by switching tools.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -0    |
| Tests     | +12 / -0   |
