### PR TITLE
fix(select): mark history before shape double-click handlers run

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -373,21 +373,22 @@ export class Idle extends StateNode {
 						break
 					}
 
-					// Test edges for an onDoubleClickEdge handler
-					if (isEdge) {
-						const change = util.onDoubleClickEdge?.(onlySelectedShape, info)
+					// Mark before calling the handler: it may write to the store itself (e.g. a frame
+					// reflowing its children), and those writes belong to this undo group
+					if (isEdge && util.onDoubleClickEdge) {
+						this.editor.markHistoryStoppingPoint('double click edge')
+						const change = util.onDoubleClickEdge(onlySelectedShape, info)
 						if (change) {
-							this.editor.markHistoryStoppingPoint('double click edge')
 							this.editor.updateShapes([change])
 							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
 							return
 						}
 					}
 
-					if (isCorner) {
-						const change = util.onDoubleClickCorner?.(onlySelectedShape, info)
+					if (isCorner && util.onDoubleClickCorner) {
+						this.editor.markHistoryStoppingPoint('double click corner')
+						const change = util.onDoubleClickCorner(onlySelectedShape, info)
 						if (change) {
-							this.editor.markHistoryStoppingPoint('double click corner')
 							this.editor.updateShapes([change])
 							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
 							return
@@ -437,8 +438,8 @@ export class Idle extends StateNode {
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
 				if (util.onDoubleClick) {
-					// Call the shape's double click handler
-					const change = util.onDoubleClick?.(shape)
+					this.editor.markHistoryStoppingPoint('double click shape')
+					const change = util.onDoubleClick(shape)
 					if (change) {
 						this.editor.updateShapes([change])
 						return
@@ -469,6 +470,7 @@ export class Idle extends StateNode {
 				const { shape, handle } = info
 
 				const util = this.editor.getShapeUtil(shape)
+				this.editor.markHistoryStoppingPoint('double click handle')
 				const changes = util.onDoubleClickHandle?.(shape, handle)
 
 				if (changes) {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -600,6 +600,29 @@ describe('When undo/redo restores an invalid editing shape', () => {
 //     .expectToBeIn('select.editing_shape')
 // })
 
+describe('When double clicking a frame edge', () => {
+	it('keeps the reflow the handler did and the resize in one undo group', () => {
+		const frameId = createShapeId('frame')
+		const childId = createShapeId('child')
+		editor.createShapes<TLFrameShape>([
+			{ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } },
+		])
+		editor.createShapes([
+			{ id: childId, type: 'geo', parentId: frameId, x: 100, y: 100, props: { w: 50, h: 50 } },
+		])
+		editor.select(frameId)
+		editor.doubleClick(400, 200, { target: 'selection', handle: 'right' })
+		const frameAfter = editor.getShape<TLFrameShape>(frameId)!
+		const childAfter = editor.getShape(childId)!
+		expect(frameAfter.props.w).not.toBe(400)
+		expect(childAfter.x).not.toBe(100)
+
+		editor.undo()
+		expect(editor.getShape<TLFrameShape>(frameId)!.props.w).toBe(400)
+		expect(editor.getShape(childId)!.x).toBe(100)
+	})
+})
+
 describe('When double clicking the selection edge', () => {
 	it('Begins editing the text if handler returns no change', () => {
 		const id = createShapeId()


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where undo after double-clicking a shape's edge, corner, or handle left part of the handler's change behind.

### Before

`Idle` created the history mark *after* calling `onDoubleClickEdge` / `onDoubleClickCorner` / `onDoubleClick`. A handler may write to the store itself (the frame util reflows its children on an edge double click), so that write landed in the previous undo group and undo reverted the resize but not the reflow. `onDoubleClickHandle` had no mark at all and merged into whatever came before.

### After

The mark is created before each handler runs, so the handler's own writes and the change it returns are one undo step.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Put a shape inside a frame, select the frame, double-click its right edge so it fits the child.
2. Undo once: both the frame size and the child position revert together.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix undo after double-clicking a shape edge, corner, or handle leaving part of the handler's change behind.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -9   |
| Tests     | +23 / -0   |
