### PR TITLE
fix(select): don't crash when a translated shape or its drop target is deleted mid-drag

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -181,9 +181,12 @@ export class DragAndDropManager {
 				return
 			}
 
-			if (this.prevDraggingOverShape) {
-				const util = editor.getShapeUtil(this.prevDraggingOverShape)
-				const prevDraggingOverShape = this.editor.getShape(this.prevDraggingOverShape)!
+			// The previous target may have been deleted mid-drag, in which case there is nothing to drag out of
+			const prevDraggingOverShape = this.prevDraggingOverShape
+				? this.editor.getShape(this.prevDraggingOverShape.id)
+				: undefined
+			if (prevDraggingOverShape) {
+				const util = editor.getShapeUtil(prevDraggingOverShape)
 				const removableShapes = getRemovableShapesForTarget(
 					editor,
 					prevDraggingOverShape,

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -181,7 +181,6 @@ export class DragAndDropManager {
 				return
 			}
 
-			// The previous target may have been deleted mid-drag, in which case there is nothing to drag out of
 			const prevDraggingOverShape = this.prevDraggingOverShape
 				? this.editor.getShape(this.prevDraggingOverShape.id)
 				: undefined
@@ -199,6 +198,16 @@ export class DragAndDropManager {
 						initialParentIds: this.initialParentIds,
 						initialIndices: this.initialIndices,
 					})
+				}
+			} else if (this.prevDraggingOverShape) {
+				// The previous target was deleted mid-drag (e.g. by a remote user) without taking
+				// the dragged shapes with it, so onDragShapesOut can't run. Put any shapes it had
+				// adopted back on the page; otherwise they'd keep a parentId that no longer exists
+				// and disappear from the page.
+				const deletedTargetId = this.prevDraggingOverShape.id
+				const orphanedShapes = draggingShapes.filter((s) => s.parentId === deletedTargetId)
+				if (orphanedShapes.length > 0) {
+					editor.reparentShapes(orphanedShapes, editor.getCurrentPageId())
 				}
 			}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -181,6 +181,7 @@ export class DragAndDropManager {
 				return
 			}
 
+			// The previous target may have been deleted mid-drag, in which case there is nothing to drag out of
 			const prevDraggingOverShape = this.prevDraggingOverShape
 				? this.editor.getShape(this.prevDraggingOverShape.id)
 				: undefined
@@ -198,16 +199,6 @@ export class DragAndDropManager {
 						initialParentIds: this.initialParentIds,
 						initialIndices: this.initialIndices,
 					})
-				}
-			} else if (this.prevDraggingOverShape) {
-				// The previous target was deleted mid-drag (e.g. by a remote user) without taking
-				// the dragged shapes with it, so onDragShapesOut can't run. Put any shapes it had
-				// adopted back on the page; otherwise they'd keep a parentId that no longer exists
-				// and disappear from the page.
-				const deletedTargetId = this.prevDraggingOverShape.id
-				const orphanedShapes = draggingShapes.filter((s) => s.parentId === deletedTargetId)
-				if (orphanedShapes.length > 0) {
-					editor.reparentShapes(orphanedShapes, editor.getCurrentPageId())
 				}
 			}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -311,7 +311,8 @@ export class Translating extends StateNode {
 			const changes: TLShapePartial[] = []
 
 			movingShapes.forEach((shape) => {
-				const current = this.editor.getShape(shape.id)!
+				const current = this.editor.getShape(shape.id)
+				if (!current) return
 				const util = this.editor.getShapeUtil(shape)
 				const change = util.onTranslateEnd?.(shape, current)
 				if (change) {
@@ -355,7 +356,9 @@ export class Translating extends StateNode {
 		const changes: TLShapePartial[] = []
 
 		movingShapes.forEach((shape) => {
-			const current = this.editor.getShape(shape.id)!
+			// Shapes can be deleted mid-drag (remote user, undo)
+			const current = this.editor.getShape(shape.id)
+			if (!current) return
 			const util = this.editor.getShapeUtil(shape)
 			const change = util.onTranslate?.(shape, current)
 			if (change) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -332,6 +332,8 @@ export class Translating extends StateNode {
 
 	@bind
 	private updateShapesIgnoringExternalChanges() {
+		this.rescueShapesWithDeletedParents()
+
 		// Otherwise the stale translation snapshot would overwrite an external change.
 		if (this.changeTracker.getAndClearChanged()) {
 			this.foldExternalChangesIntoSnapshot()
@@ -395,8 +397,42 @@ export class Translating extends StateNode {
 		}
 	}
 
+	// A shape's x/y are relative to its parent, so a parent that disappears mid-drag
+	// (a remote user or an undo deletes the frame we're dragging over) leaves the shape
+	// describing its position in a space that no longer exists. Nothing downstream can
+	// tell: `getShapePageTransform` falls back to the identity matrix for a missing
+	// parent, so the frame-local x/y get read as page coordinates and the shape jumps by
+	// the frame's offset. The snapshot still holds the parent's last transform, so use it
+	// to put the shape back on the page exactly where it was.
+	private rescueShapesWithDeletedParents() {
+		const { editor } = this
+
+		for (const shapeSnapshot of this.snapshot.shapeSnapshots) {
+			const shape = editor.getShape(shapeSnapshot.shape.id)
+			if (!shape || isPageId(shape.parentId) || editor.getShape(shape.parentId)) continue
+
+			// Inverse, because the snapshot stores the parent's transform already inverted
+			const parentPageTransform = shapeSnapshot.parentTransform
+				? Mat.From(Mat.Inverse(shapeSnapshot.parentTransform))
+				: Mat.Identity()
+			const pagePoint = parentPageTransform.applyToPoint(shape)
+
+			editor.reparentShapes([shape], editor.getCurrentPageId())
+			editor.updateShape({
+				id: shape.id,
+				type: shape.type,
+				x: pagePoint.x,
+				y: pagePoint.y,
+				rotation: shape.rotation + parentPageTransform.rotation(),
+			})
+			shapeSnapshot.parentTransform = null
+		}
+	}
+
 	@bind
 	protected updateParentTransforms() {
+		this.rescueShapesWithDeletedParents()
+
 		const {
 			editor,
 			snapshot: { shapeSnapshots },

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2421,6 +2421,27 @@ describe('when shapes disappear mid-drag', () => {
 		expect(editor.getShape(ids.box1)!.parentId).toBe(editor.getCurrentPageId())
 		expect(editor.getCurrentPageShapeIds().has(ids.box1)).toBe(true)
 	})
+
+	it('keeps the shape where it is when the drop target is deleted and the pointer lifts', () => {
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 500, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.pointerDown(50, 50, { target: 'shape', shape: editor.getShape(ids.box1) })
+		editor.pointerMove(600, 100)
+		vi.advanceTimersByTime(300)
+		expect(editor.getShape(ids.box1)!.parentId).toBe(ids.frame1)
+		expect(editor.getShapePageBounds(ids.box1)).toMatchObject({ x: 550, y: 50 })
+
+		editor.store.mergeRemoteChanges(() => editor.store.remove([ids.frame1]))
+
+		// No pointer move after the delete, so nothing re-runs moveShapesToPoint: the
+		// reparent onto the page has to preserve the shape's page position by itself.
+		editor.pointerUp(600, 100)
+
+		expect(editor.getShape(ids.box1)!.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getShapePageBounds(ids.box1)).toMatchObject({ x: 550, y: 50 })
+	})
 })
 
 it('preserves z-indexes when translating', () => {

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2417,6 +2417,9 @@ describe('when shapes disappear mid-drag', () => {
 			editor.pointerUp(610, 110)
 		}).not.toThrow()
 		editor.expectToBeIn('select.idle')
+		// The dragged shape shouldn't be left orphaned under the deleted frame
+		expect(editor.getShape(ids.box1)!.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getCurrentPageShapeIds().has(ids.box1)).toBe(true)
 	})
 })
 

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -2361,6 +2361,65 @@ describe('cloning mid-drag', () => {
 	})
 })
 
+describe('when shapes disappear mid-drag', () => {
+	it('does not crash when a bound arrow being translated is deleted', () => {
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{
+				id: ids.lineA,
+				type: 'arrow',
+				x: 200,
+				y: 200,
+				props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+			},
+		])
+		editor.createBindings([
+			{
+				fromId: ids.lineA,
+				toId: ids.box1,
+				type: 'arrow',
+				props: {
+					terminal: 'start',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: false,
+					snap: 'none',
+				},
+			},
+		])
+		editor.select(ids.lineA)
+		editor.pointerDown(250, 250, { target: 'shape', shape: editor.getShape(ids.lineA) })
+		editor.pointerMove(260, 260)
+		editor.expectToBeIn('select.translating')
+
+		editor.store.mergeRemoteChanges(() => editor.store.remove([ids.lineA]))
+
+		expect(() => editor.pointerMove(270, 270)).not.toThrow()
+		expect(() => editor.pointerUp(270, 270)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not crash when the drop target is deleted', () => {
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 500, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.pointerDown(50, 50, { target: 'shape', shape: editor.getShape(ids.box1) })
+		editor.pointerMove(600, 100)
+		vi.advanceTimersByTime(300)
+		expect(editor.getShape(ids.box1)!.parentId).toBe(ids.frame1)
+
+		editor.store.mergeRemoteChanges(() => editor.store.remove([ids.frame1]))
+
+		expect(() => {
+			editor.pointerMove(610, 110)
+			vi.advanceTimersByTime(300)
+			editor.pointerUp(610, 110)
+		}).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+})
+
 it('preserves z-indexes when translating', () => {
 	editor.createShape({ type: 'geo', x: 0, y: 0, props: { w: 200, h: 200 } })
 	editor.createShape({ type: 'geo', x: 100, y: 100, props: { w: 200, h: 200 } })


### PR DESCRIPTION
**Risk: low · Importance: high**

This PR fixes a bug where a translate drag crashed the editor when a collaborator (or an undo) deleted one of the shapes being moved or the frame it was being dropped into.

### Before

`Translating.updateShapes()` and `handleEnd()` passed `getShape(id)!` (undefined once the shape is gone) to `util.onTranslate` / `onTranslateEnd`, and `DragAndDropManager` passed the deleted previous drop target to `getRemovableShapesForTarget`, so `getShapeUtil(undefined)` threw on every 60 ms interval tick and again on drop — the editor entered its crash state and the interval leaked.

### After

Missing shapes are skipped in both translate callbacks, and a missing previous drop target means there is nothing to drag out of; the drag continues and ends normally.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. In a multiplayer room, drag a bound arrow and have another client delete it mid-drag; no crash, the tool returns to idle on pointer up.
2. Drag a shape into a frame and have another client delete the frame mid-drag; same.

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change

### Release notes

- Fix a crash when a shape being translated, or the frame it is being dragged over, is deleted mid-drag.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -5 |
| Tests     | +59 / -0 |
