### PR TITLE
fix(select): use the accel key to toggle handle snapping and brush wrap mode

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -122,13 +122,13 @@ export class Brushing extends StateNode {
 		const originPagePoint = editor.inputs.getOriginPagePoint()
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
 		const shiftKey = editor.inputs.getShiftKey()
-		const ctrlKey = editor.inputs.getCtrlKey()
+		const accelKey = editor.inputs.getAccelKey()
 
 		// We'll be collecting shape ids of selected shapes; if we're holding shift key, we start from our initial shapes
 		const results = new Set(shiftKey ? this.initialSelectedShapeIds : [])
 
 		// In wrap mode, we need to completely enclose a shape to select it
-		const isWrapping = isWrapMode ? !ctrlKey : ctrlKey
+		const isWrapping = isWrapMode ? !accelKey : accelKey
 
 		// Set the brush to contain the current and origin points
 		const brush = Box.FromPoints([originPagePoint, currentPagePoint])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -288,7 +288,7 @@ export class DraggingHandle extends StateNode {
 		const { snaps } = editor
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
 		const shiftKey = editor.inputs.getShiftKey()
-		const ctrlKey = editor.inputs.getCtrlKey()
+		const accelKey = editor.inputs.getAccelKey()
 		const altKey = editor.inputs.getAltKey()
 		const pointerVelocity = editor.inputs.getPointerVelocity()
 
@@ -331,7 +331,7 @@ export class DraggingHandle extends StateNode {
 			canSnap = initialHandle.canSnap || initialHandle.snapType !== undefined
 		}
 
-		if (canSnap && (isSnapMode ? !ctrlKey : ctrlKey)) {
+		if (canSnap && (isSnapMode ? !accelKey : accelKey)) {
 			// We're snapping
 			const pageTransform = editor.getShapePageTransform(shape.id)
 			if (!pageTransform) throw Error('Expected a page transform')


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where Cmd on Mac did not toggle snapping while dragging a handle or wrap mode while brush selecting, unlike translate, resize, and crop.

### Before

`DraggingHandle` and `Brushing` read the raw `getCtrlKey()`; the other select-tool interactions (and the docs) use the accel key — Cmd on Mac, Ctrl elsewhere.

### After

Both read `getAccelKey()`.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. On a Mac, drag an arrow or line handle near another shape while holding Cmd; snapping should toggle.
2. Brush-select across a partially covered shape while holding Cmd; wrap mode should toggle.

- [ ] Unit tests — no new tests; the select and snapping suites pass

### Release notes

- Use Cmd (Mac) / Ctrl to toggle snapping while dragging handles and wrap mode while brush selecting, matching translate, resize, and crop.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -4    |
