### PR TITLE
fix(select): gate read-only double clicks on canEditInReadonly

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -433,8 +433,8 @@ export class Idle extends StateNode {
 
 				const util = this.editor.getShapeUtil(shape)
 
-				// Allow playing videos and embeds
-				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
+				// Shapes that opt into read-only editing (embeds, custom utils) still get their double click
+				if (this.editor.getIsReadonly() && !util.canEditInReadonly(shape)) break
 
 				if (util.onDoubleClick) {
 					// Call the shape's double click handler


### PR DESCRIPTION
**Risk: medium · Importance: low**

This PR fixes a bug where double-clicking a custom shape that allows read-only editing did nothing in a read-only editor.

### Before

`Idle.onDoubleClick` gated read-only double clicks on a hard-coded `shape.type !== 'video' && shape.type !== 'embed'`, skipping any shape util that overrides `canEditInReadonly`. The `video` allowance was dead: `VideoShapeUtil` has no double-click handler and does not edit in read-only mode.

### After

The gate is `util.canEditInReadonly(shape)`, the hook `EmbedShapeUtil` already implements and the rest of the select tool consults.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. In a read-only editor, double-click an embed shape: it still starts editing.
2. Register a custom shape util that overrides `canEditInReadonly` to return true and has an `onDoubleClick` handler; in a read-only editor, double-click it: the handler runs.

- [ ] Unit tests — no new tests; the select tool, embed, and video suites pass

### Release notes

- Fix double-clicking a custom shape that allows read-only editing doing nothing in a read-only editor.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -2    |
