### PR TITLE
fix(select): return to the locked text tool from editing_shape without re-routing the state chart

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -4,6 +4,7 @@ import {
 	TLCancelEventInfo,
 	TLCompleteEventInfo,
 	tlenv,
+	TLEventInfo,
 	TLPointerEventInfo,
 	TLShape,
 } from '@tldraw/editor'
@@ -50,14 +51,21 @@ export class EditingShape extends StateNode {
 	}
 
 	override onExit() {
-		const hadEditingShape = !!this.editor.getEditingShapeId()
 		this.editor.setEditingShape(null)
-
 		cancelUpdateHoveredShapeId(this.editor)
-
-		if (this.info.isCreatingTextWhileToolLocked && hadEditingShape) {
+		if (this.info.isCreatingTextWhileToolLocked) {
 			this.parent.setCurrentToolIdMask(undefined)
+		}
+	}
+
+	// Switching tools from onExit would re-route the state chart in the middle of the transition
+	// that is exiting this state (the select tool's idle gets entered under an inactive select
+	// tool and clobbers the text tool's cursor), so the tool-lock return happens here instead.
+	private leave(info: TLEventInfo) {
+		if (this.info.isCreatingTextWhileToolLocked) {
 			this.editor.setCurrentTool('text', {})
+		} else {
+			this.parent.transition('idle', info)
 		}
 	}
 
@@ -181,7 +189,7 @@ export class EditingShape extends StateNode {
 		}
 
 		// still here? Cancel editing and transition back to select idle
-		this.parent.transition('idle', info)
+		this.leave(info)
 		// then feed the pointer down event back into the state chart as if it happened in that state
 		this.editor.root.handleEvent(info)
 	}
@@ -230,11 +238,11 @@ export class EditingShape extends StateNode {
 
 	override onComplete(info: TLCompleteEventInfo) {
 		this.editor.getContainer().focus()
-		this.parent.transition('idle', info)
+		this.leave(info)
 	}
 
 	override onCancel(info: TLCancelEventInfo) {
 		this.editor.getContainer().focus()
-		this.parent.transition('idle', info)
+		this.leave(info)
 	}
 }

--- a/packages/tldraw/src/test/strange-tools.test.ts
+++ b/packages/tldraw/src/test/strange-tools.test.ts
@@ -1,3 +1,4 @@
+import { toRichText } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -48,6 +49,23 @@ describe('interaction between the select tool and the editing state', () => {
 			.pointerDown()
 			.pointerUp()
 			.expectToBeIn('select.idle')
+	})
+
+	it('returns to the text tool with its own cursor when a tool-locked edit is finished', () => {
+		editor
+			.updateInstanceState({ isToolLocked: true })
+			.setCurrentTool('text')
+			.pointerMove(100, 100)
+			.pointerDown()
+			.pointerUp()
+			.expectToBeIn('select.editing_shape')
+		const id = editor.getEditingShapeId()!
+		editor.updateShape({ id, type: 'text', props: { richText: toRichText('hello') } })
+
+		editor.cancel().expectToBeIn('text.idle')
+		expect(editor.getInstanceState().cursor.type).toBe('cross')
+		// The select tool's idle must not have been entered underneath the text tool
+		expect(editor.getStateDescendant('select.idle')!.getIsActive()).toBe(false)
 	})
 
 	it('leaves editing when clicking the select tool while tool locked', () => {


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where finishing a text edit with the text tool locked left a select-tool child state active and the wrong cursor.

### Before

`EditingShape.onExit` called `setCurrentTool('text')`, re-routing the state chart in the middle of the transition that was already exiting the state: the select tool's `idle` was entered under a now-inactive select tool, which stayed active and clobbered the text tool's cursor.

### After

The tool-lock return moves into a `leave()` helper called from the complete, cancel, and pointer-down paths; `onExit` only tears down editing state and the mask.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Lock the text tool (double-click it or use the lock button), click to create a text shape, type, then press Escape or Enter.
2. The editor should be back in the text tool with the text cursor, and no select-tool child state should be active.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix the cursor and state chart after finishing a text edit with the text tool locked.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +15 / -7   |
| Tests     | +18 / -0   |
