### PR TITLE
fix(select): handle cancel in pointing_canvas

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -45,6 +45,10 @@ export class PointingCanvas extends StateNode {
 		this.complete()
 	}
 
+	override onCancel() {
+		this.parent.transition('idle')
+	}
+
 	override onInterrupt() {
 		this.parent.transition('idle')
 	}

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -47,6 +47,13 @@ describe('TLSelectTool.Idle', () => {
 		editor.expectToBeIn('select.pointing_canvas')
 	})
 
+	it('Returns to idle when a canvas press is cancelled', () => {
+		editor.pointerDown(10, 10, { target: 'canvas' })
+		editor.expectToBeIn('select.pointing_canvas')
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('Nudges selected shapes on arrow key down', () => {
 		const shape = editor.getShape(ids.box1)!
 		editor.select(shape.id)


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where Escape was ignored while the pointer was down on empty canvas with the select tool.

### Before

`PointingCanvas` handled `onInterrupt` by returning to idle but had no `onCancel`, so a cancel while pressing on the canvas left the state in `pointing_canvas` until pointer up.

### After

`PointingCanvas.onCancel` returns to idle, the same as every other select-tool press.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Pointer down on empty canvas and press Escape before releasing: the select tool is back in idle.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix Escape being ignored while pressing on the canvas with the select tool.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -0    |
| Tests     | +7 / -0    |
