### PR TITLE
fix(select): defer handle double clicks to pointer up so a second press can still drag

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
@@ -3,6 +3,12 @@ import { StateNode, TLClickEventInfo, TLPointerEventInfo } from '@tldraw/editor'
 export class PointingCrop extends StateNode {
 	static override id = 'pointing_crop'
 
+	private pendingDoubleClick: TLClickEventInfo | null = null
+
+	override onEnter() {
+		this.pendingDoubleClick = null
+	}
+
 	override onCancel() {
 		this.editor.setCurrentTool('select.crop.idle', {})
 	}
@@ -17,9 +23,15 @@ export class PointingCrop extends StateNode {
 	}
 
 	override onPointerUp(info: TLPointerEventInfo) {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.editor.setCurrentTool('select.crop.idle', info)
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -30,8 +42,7 @@ export class PointingCrop extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	startDragging(info: TLPointerEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCropHandle.ts
@@ -11,9 +11,11 @@ export class PointingCropHandle extends StateNode {
 	static override id = 'pointing_crop_handle'
 
 	private info = {} as TLPointingCropHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	override onEnter(info: TLPointingCropHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -49,6 +51,12 @@ export class PointingCropHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
+
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {
 			if (typeof onInteractionEnd === 'string') {
@@ -62,6 +70,7 @@ export class PointingCropHandle extends StateNode {
 		this.editor.setCurrentTool('select.idle')
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -72,8 +81,7 @@ export class PointingCropHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingResizeHandle.ts
@@ -30,6 +30,7 @@ export class PointingResizeHandle extends StateNode {
 	static override id = 'pointing_resize_handle'
 
 	private info = {} as PointingResizeHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	private updateCursor() {
 		const cursorType = CursorTypeMap[this.info.handle!]
@@ -41,6 +42,7 @@ export class PointingResizeHandle extends StateNode {
 
 	override onEnter(info: PointingResizeHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -67,9 +69,17 @@ export class PointingResizeHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.complete()
 	}
 
+	// A double click's 'down' phase arrives while the second press is still held. Acting on it
+	// immediately would steal a press that is about to become a drag (#9499), so it is deferred
+	// to pointer up.
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -80,8 +90,7 @@ export class PointingResizeHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingRotateHandle.ts
@@ -9,6 +9,7 @@ export class PointingRotateHandle extends StateNode {
 	static override id = 'pointing_rotate_handle'
 
 	private info = {} as PointingRotateHandleInfo
+	private pendingDoubleClick: TLClickEventInfo | null = null
 
 	private updateCursor() {
 		this.editor.setCursor({
@@ -19,6 +20,7 @@ export class PointingRotateHandle extends StateNode {
 
 	override onEnter(info: PointingRotateHandleInfo) {
 		this.info = info
+		this.pendingDoubleClick = null
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
 		}
@@ -46,9 +48,15 @@ export class PointingRotateHandle extends StateNode {
 	}
 
 	override onPointerUp() {
+		if (this.pendingDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent(this.pendingDoubleClick)
+			return
+		}
 		this.complete()
 	}
 
+	// See PointingResizeHandle.onDoubleClick
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (
 			this.editor.inputs.getShiftKey() ||
@@ -59,8 +67,7 @@ export class PointingRotateHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.pendingDoubleClick = info
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -672,6 +672,66 @@ describe('When double clicking the selection edge', () => {
 	})
 })
 
+describe('When a second press on a resize handle arrives as a double click', () => {
+	// The click manager reports a second press inside the double-click window as a pointer down
+	// followed by a double_click 'down'. The double click must not steal a press that becomes a
+	// drag (#9499 fixed the same thing for shape handles).
+	function pressAgain(handle: 'bottom_right' | 'bottom_right_rotate') {
+		editor.pointerDown(200, 200, { target: 'selection', handle })
+		editor.dispatch({
+			type: 'click',
+			name: 'double_click',
+			phase: 'down',
+			point: { x: 200, y: 200 },
+			pointerId: 1,
+			button: 0,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+			target: 'selection',
+			handle,
+		})
+	}
+
+	it('still resizes when the second press becomes a drag', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right')
+		editor.expectToBeIn('select.pointing_resize_handle')
+		editor.pointerMove(250, 250)
+		editor.expectToBeIn('select.resizing')
+		editor.pointerUp(250, 250)
+		expect(editor.getShape(ids.box1)!.props).toMatchObject({ w: 150, h: 150 })
+	})
+
+	it('still rotates when the second press on a rotate handle becomes a drag', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right_rotate' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right_rotate')
+		editor.expectToBeIn('select.pointing_rotate_handle')
+		editor.pointerMove(250, 100)
+		editor.expectToBeIn('select.rotating')
+	})
+
+	it('acts on the double click on pointer up when the second press is released in place', () => {
+		editor.select(ids.box1)
+		editor
+			.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right' })
+			.pointerUp(200, 200)
+		pressAgain('bottom_right')
+		editor.expectToBeIn('select.pointing_resize_handle')
+		editor.pointerUp(200, 200)
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getEditingShapeId()).toBe(ids.box1)
+	})
+})
+
 describe('When double clicking a selection handle that registers as a canvas event', () => {
 	let overlayEditor: TestEditor
 	beforeEach(() => {

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1240,3 +1240,37 @@ describe('When cropping with modifiers and snapping...', () => {
 		expect(editor.snaps.getIndicators().length).toBe(0)
 	})
 })
+
+describe('When a second press on a crop handle arrives as a double click', () => {
+	it('still crops when the press becomes a drag instead of resetting the crop', () => {
+		editor.doubleClick(550, 550, ids.imageB).expectToBeIn('select.crop.idle')
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' }).pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		editor.pointerDown(500, 600, { target: 'selection', handle: 'bottom' })
+		editor.dispatch({
+			type: 'click',
+			name: 'double_click',
+			phase: 'down',
+			point: { x: 500, y: 600 },
+			pointerId: 1,
+			button: 0,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+			target: 'selection',
+			handle: 'bottom',
+		})
+		editor.expectToBeIn('select.crop.pointing_crop_handle')
+		editor.pointerMove(510, 590)
+		editor.expectToBeIn('select.crop.cropping')
+		editor.pointerUp()
+
+		const after = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(after).not.toMatchObject(before)
+		expect(after.bottomRight.y).toBeLessThan(before.bottomRight.y)
+	})
+})


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where a quick second press on a resize, rotate, or crop handle was consumed as a double click instead of starting a drag.

### Before

The click manager reports a second press inside the double-click window as a pointer down followed by a `double_click` `down`. `PointingResizeHandle`, `PointingRotateHandle`, `PointingCropHandle` and `PointingCrop` acted on that `down` immediately: clicking a resize handle and pressing it again to drag entered `select.editing_shape` and the shape never resized; on a crop handle `ImageShapeUtil.onDoubleClickEdge` reset the crop and the drag was ignored. #9499 fixed this for `PointingHandle` only.

### After

The four states store the double-click info and act on it at pointer up, so a second press that becomes a drag drags, and one released in place still acts as a double click.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape, click a resize handle, then press it again within the double-click window and drag: the shape resizes.
2. Same on a rotate handle: the shape rotates.
3. In crop mode, same on a crop handle: the crop follows the drag instead of resetting.
4. Press a resize handle twice and release in place: the shape enters editing as before.

- [x] Unit tests — the new tests (4) fail on `main` and pass with this change

### Release notes

- Fix a second quick press on a resize, rotate, or crop handle being consumed as a double click instead of starting a drag.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +43 / -8   |
| Tests     | +94 / -0   |
