### PR TITLE
fix(store): fix transaction rollback leaks, stale queries, undo diff corruption, and other store correctness bugs

### DIFF
--- a/packages/store/DOCS.md
+++ b/packages/store/DOCS.md
@@ -17,9 +17,9 @@ The store provides:
 - **Side effects** - Lifecycle hooks for implementing business logic
 - **Queries** - Reactive indexes and filtering for efficient data access
 
-## 2. Core Concepts
+## 2. Core concepts
 
-### Records: The Foundation
+### Records: the foundation
 
 **Records** are immutable data objects that extend the `BaseRecord` interface. Every record has an `id` and a `typeName` that identifies its type:
 
@@ -34,7 +34,7 @@ interface Book extends BaseRecord<'book', RecordId<Book>> {
 }
 ```
 
-### Record Types: Factories for Records
+### Record types: factories for records
 
 A **RecordType** is a factory that creates and manages records of a specific type. You define how records are created, validated, and what their default properties are:
 
@@ -52,9 +52,9 @@ const Book = createRecordType<Book>('book', {
 
 // Create a new book
 
-## 2. Core Concepts
+## 2. Core concepts
 
-### Records: The Foundation
+### Records: the foundation
 
 **Records** are immutable data objects that extend the `BaseRecord` interface. Every record has an `id` and a `typeName` that identifies its type:
 
@@ -73,7 +73,7 @@ interface Book extends BaseRecord<'book', RecordId<Book>> {
 }
 ```
 
-### Record Types: Factories for Records
+### Record types: factories for records
 
 A **RecordType** is a factory that creates and manages records of a specific type. You define how records are created, validated, and what their default properties are:
 
@@ -100,9 +100,9 @@ const book = Book.create({
 // Results in: { id: 'book:abc123', typeName: 'book', title: '1984', authorId: 'author:xyz789', publishedYear: 2025, inStock: true }
 ```
 
-## 3. Basic Usage
+## 3. Basic usage
 
-### Creating and Storing Records
+### Creating and storing records
 
 You add records to the store using the `put` method:
 
@@ -123,7 +123,7 @@ store.put([orwell, huxley, ...books])
 
 > Tip: The `put` method handles both creating new records and updating existing ones. If a record with the same ID already exists, it will be updated.
 
-### Reading Records
+### Reading records
 
 You can read individual records or access all records of a type:
 
@@ -139,7 +139,7 @@ const allRecords = store.allRecords()
 const hasBook = store.has(books[0].id) // true
 ```
 
-### Updating Records
+### Updating records
 
 Use the `update` method to modify existing records:
 
@@ -153,7 +153,7 @@ store.update(book.id, (currentBook) => ({
 
 The update function receives the current record and returns a new record with your changes applied.
 
-### Removing Records
+### Removing records
 
 Remove records using their IDs:
 
@@ -165,9 +165,9 @@ store.remove([book.id])
 store.remove([book1.id, book2.id, book3.id])
 ```
 
-## 4. Reactive Queries and Indexing
+## 4. Reactive queries and indexing
 
-### Understanding Reactive Indexes
+### Understanding reactive indexes
 
 The store automatically maintains **reactive indexes** that allow efficient querying of your data. These indexes update automatically when records change:
 
@@ -183,7 +183,7 @@ console.log(orwellBooks) // Set<RecordId<Book>>
 
 The index returns a `Map` where keys are property values and values are `Set`s of record IDs that have that property value.
 
-### Reactive Queries with Computed Values
+### Reactive queries with computed values
 
 Combine indexes with computed values to create reactive queries:
 
@@ -210,7 +210,7 @@ const inStockBooksByAuthor = computed('inStockBooksByAuthor', () => {
 console.log(inStockBooksByAuthor.get()) // Map<RecordId<Author>, Book[]>
 ```
 
-### The Store: Your Reactive Database
+### The store: your reactive database
 
 The **Store** is the central container that manages all your records. It provides reactive access to data and automatically tracks changes:
 
@@ -230,9 +230,9 @@ const store = new Store({
 })
 ```
 
-## 3. Basic Usage
+## 3. Basic usage
 
-### Creating and Storing Records
+### Creating and storing records
 
 You add records to the store using the `put` method:
 
@@ -250,7 +250,7 @@ store.put(books)
 
 > Tip: The `put` method handles both creating new records and updating existing ones. If a record with the same ID already exists, it will be updated.
 
-### Reading Records
+### Reading records
 
 You can read individual records or access all records of a type:
 
@@ -266,7 +266,7 @@ const allRecords = store.allRecords()
 const hasBook = store.has(books[0].id) // true
 ```
 
-### Updating Records
+### Updating records
 
 Use the `update` method to modify existing records:
 
@@ -280,7 +280,7 @@ store.update(book.id, (currentBook) => ({
 
 The update function receives the current record and returns a new record with your changes applied.
 
-### Removing Records
+### Removing records
 
 Remove records using their IDs:
 
@@ -292,9 +292,9 @@ store.remove([book.id])
 store.remove([book1.id, book2.id, book3.id])
 ```
 
-## 4. Reactive Queries and Indexing
+## 4. Reactive queries and indexing
 
-### Understanding Reactive Indexes
+### Understanding reactive indexes
 
 The store automatically maintains **reactive indexes** that allow efficient querying of your data. These indexes update automatically when records change:
 
@@ -309,7 +309,7 @@ console.log(orwellBooks) // Set<RecordId<Book>>
 
 The index returns a `Map` where keys are property values and values are `Set`s of record IDs that have that property value.
 
-### Reactive Queries with Computed Values
+### Reactive queries with computed values
 
 Combine indexes with computed values to create reactive queries:
 
@@ -336,7 +336,7 @@ const inStockBooksByAuthor = computed('inStockBooksByAuthor', () => {
 console.log(inStockBooksByAuthor.get()) // Map<string, Book[]>
 ```
 
-### Filtering History for Specific Record Types
+### Filtering history for specific record types
 
 You can create reactive computations that track changes to specific record types:
 
@@ -358,9 +358,9 @@ const dispose = react('book-changes', () => {
 
 > Tip: The `filterHistory` method returns a `Computed` that tracks changes to records of a specific type. Use it with `react()` from `@tldraw/state` to respond to changes.
 
-## 5. Record Scopes and Persistence
+## 5. Record scopes and persistence
 
-### Understanding Record Scopes
+### Understanding record scopes
 
 Records have different **scopes** that determine how they're persisted and synchronized:
 
@@ -382,7 +382,7 @@ const PresenceRecord = createRecordType<PresenceData>('presence', {
 - **`session`** - Per-instance data that might be saved locally
 - **`presence`** - Temporary data that's shared but not saved
 
-### Serialization and Snapshots
+### Serialization and snapshots
 
 You can serialize the store's data for persistence:
 
@@ -400,9 +400,9 @@ store.loadStoreSnapshot(saved)
 
 > Note: The store automatically handles migrations when loading snapshots from older versions of your schema.
 
-## 6. Side Effects and Business Logic
+## 6. Side effects and business logic
 
-### Understanding Side Effects
+### Understanding side effects
 
 **Side effects** are hooks that let you implement business logic in response to record changes. They run automatically when records are created, updated, or deleted:
 
@@ -431,7 +431,7 @@ store.sideEffects.registerAfterDeleteHandler('book', (book, source) => {
 })
 ```
 
-### Change Sources
+### Change sources
 
 Side effects receive a `source` parameter that tells you where the change originated:
 
@@ -447,7 +447,7 @@ store.sideEffects.registerAfterCreateHandler('book', (book, source) => {
 })
 ```
 
-### Before Handlers: Validation and Transformation
+### Before handlers: validation and transformation
 
 **Before handlers** run before changes are applied and can validate or transform the data:
 
@@ -470,9 +470,9 @@ store.sideEffects.registerBeforeCreateHandler('book', (book, source) => {
 })
 ```
 
-## 7. Schema Evolution with Migrations
+## 7. Schema evolution with migrations
 
-### Creating Migration Sequences
+### Creating migration sequences
 
 As your application evolves, you'll need to update your data structure. **Migrations** handle this automatically:
 
@@ -527,7 +527,7 @@ const schema = StoreSchema.create(
 )
 ```
 
-### Migration Safety
+### Migration safety
 
 The store automatically applies migrations when loading data from older versions:
 
@@ -542,13 +542,13 @@ store.loadStoreSnapshot(oldSnapshot)
 
 > Tip: Always test your migrations thoroughly with real data before deploying to production.
 
-## 8. Advanced Topics
+## 8. Advanced topics
 
-### Transactional Operations
+### Transactional operations
 
 The store automatically ensures that related operations happen atomically. When you perform multiple operations in response to user actions or side effects, they are automatically grouped together for consistency and performance.
 
-### Custom Computed Caches
+### Custom computed caches
 
 Create **computed caches** for expensive derivations that should be memoized per record:
 
@@ -564,7 +564,7 @@ const analysis = expensiveBookData.get(book.id)
 
 The cache automatically updates when the underlying record changes and cleans up when records are deleted.
 
-### Extracting Changes
+### Extracting changes
 
 You can capture changes that occur within a function:
 
@@ -585,7 +585,7 @@ This is useful for implementing undo/redo systems or understanding what changed 
 
 The store provides several tools for understanding what's happening in your application.
 
-### Store Listeners
+### Store listeners
 
 Add listeners to react to changes in your store:
 
@@ -608,7 +608,7 @@ const removeDocumentListener = store.listen(
 )
 ```
 
-### Understanding Record Validation
+### Understanding record validation
 
 The store validates all records when they're created or updated. Validation errors provide detailed information:
 
@@ -625,7 +625,7 @@ try {
 
 ## 10. Integration
 
-### Framework Integration
+### Framework integration
 
 The store is framework-agnostic but integrates well with React through `@tldraw/state-react`:
 
@@ -647,7 +647,7 @@ const BookList = track(() => {
 
 The `track` function automatically subscribes the component to relevant store changes.
 
-### Persistence Strategies
+### Persistence strategies
 
 Implement different persistence strategies based on your needs:
 
@@ -685,9 +685,9 @@ store.mergeRemoteChanges(() => {
 
 Changes merged this way are marked with `source: 'remote'` so your side effects can handle them appropriately.
 
-## 11. Performance Considerations
+## 11. Performance considerations
 
-### Memory Management
+### Memory management
 
 The store uses several strategies to maintain good performance:
 
@@ -696,7 +696,7 @@ The store uses several strategies to maintain good performance:
 - **Efficient indexes** - Reactive indexes use incremental updates rather than full rebuilds
 - **Change batching** - Multiple changes are batched together before notifying listeners
 
-### Query Optimization
+### Query optimization
 
 For best performance with large datasets:
 
@@ -712,7 +712,7 @@ const book = store.unsafeGetWithoutCapture(bookId) // No reactive subscription
 const expensiveData = store.createComputedCache('expensive', computeExpensiveData)
 ```
 
-### Side Effect Performance
+### Side effect performance
 
 Keep side effects fast since they run synchronously:
 
@@ -728,9 +728,9 @@ store.sideEffects.registerAfterCreateHandler('book', (book) => {
 })
 ```
 
-## 12. Common Patterns
+## 12. Common patterns
 
-### Repository Pattern
+### Repository pattern
 
 Create typed repositories for cleaner APIs:
 
@@ -754,7 +754,7 @@ class BookRepository {
 }
 ```
 
-### State Machines with Records
+### State machines with records
 
 Use records to represent state machine states:
 
@@ -775,7 +775,7 @@ store.sideEffects.registerAfterChangeHandler('orderState', (prev, next) => {
 })
 ```
 
-### Computed Relationships
+### Computed relationships
 
 Model relationships between records using efficient queries:
 

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -135,7 +135,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 - **QE1** `{ eq: v }` matches by SameValueZero (so `NaN` matches `NaN`); `{ neq: v }` matches values that differ from `v` by SameValueZero; `{ gt: n }` matches only numbers strictly greater than `n` (non-numeric values never match `gt`). A record whose value is `undefined` matches no matcher at all, mirroring the indexes, which only track defined values — so `{ eq: undefined }` matches nothing. A matcher with several operators applies all of them.
 - **QE2** Multiple properties in one expression are ANDed; the result is the intersection of the per-property matches.
-- **QE3** A nested object in the expression matches into the corresponding nested record object, to any depth. If the record's value at that level is missing or not an object, the record does not match. An empty nested object (or an entry that is neither a matcher nor an object) imposes no constraint.
+- **QE3** A nested object in the expression matches into the corresponding nested record object, to any depth. If the record's value at that level is missing or not an object, the record does not match. A nested object that contains no matchers at any depth (or an entry that is neither a matcher nor an object) imposes no constraint, even when the record lacks that nested object.
 - **QE4** The empty expression `{}` matches every record of the type: `objectMatchesQuery({}, r)` is true, `executeQuery(store, type, {})` returns every id of the type, and `ids(type)` contains all ids.
 - **QE5** `executeQuery` (index-based) and `objectMatchesQuery` (predicate) agree: the set of ids returned equals the set of records matching the predicate, including for nested paths and across record types.
 

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -36,9 +36,9 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 4. RecordsDiff (D)
 
 - **D1** `createEmptyRecordsDiff()` returns `{ added: {}, updated: {}, removed: {} }`; `isRecordsDiffEmpty` is true exactly when all three collections are empty.
-- **D2** `reverseRecordsDiff` swaps added and removed and reverses each `[from, to]` pair.
+- **D2** `reverseRecordsDiff` swaps added and removed and reverses each `[from, to]` pair. The result shares no collections or pairs with the input, so squashing into it leaves the input untouched.
 - **D3** `squashRecordDiffs(diffs)` combines sequential diffs into one. Per record id: add then update → add with the final value; add then remove → nothing; update then update → one update from the original `from` to the final `to`; update then remove → remove of the original `from`; remove then add → update from the removed value to the added value, unless the added value is reference-identical to the removed one, in which case nothing.
-- **D4** `squashRecordDiffs` does not mutate its inputs unless `mutateFirstDiff: true`, in which case the first diff is the (mutated) result. `squashRecordDiffsMutable(target, diffs)` applies diffs onto `target` in place with the same semantics.
+- **D4** `squashRecordDiffs` does not mutate its inputs unless `mutateFirstDiff: true`, in which case the first diff is the (mutated) result (an empty diff when there are no diffs); its `[from, to]` pairs are replaced rather than mutated in place. `squashRecordDiffsMutable(target, diffs)` applies diffs onto `target` in place with the same semantics; the target must own its pairs (start from `createEmptyRecordsDiff()`).
 
 ## 5. Store: reading and writing (S)
 
@@ -52,6 +52,8 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **S8** `getStoreSnapshot(scope?)` is `{ store: serialize(scope), schema: schema.serialize() }`.
 - **S9** `loadStoreSnapshot(snapshot)` migrates the snapshot, replaces all current records with the result, and runs the integrity checker — all with side effects disabled (restoring the previous enabled state afterwards). It throws if migration fails, leaving the store unchanged.
 - **S10** `migrateSnapshot(snapshot)` returns the migrated snapshot stamped with the current serialized schema, and throws if migration fails.
+- **S11** Writes do not capture: a reaction or computed that calls `put`/`remove` does not thereby subscribe to the store (neither to `store.history` nor to the record map), so it is not re-run by unrelated store changes.
+- **S12** When the same id appears more than once in one `put`, the history entry records it once: as an update whose `from` is the record as it was before the call, or as a single addition if the call also created it. A record changed and then changed back (by reference) within one call is not recorded at all.
 
 ## 6. Atomic operations and the side-effect flush (AO)
 
@@ -62,11 +64,11 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **AO5** `afterChange` fires only when the before and after records differ by deep equality. (Putting a structurally-equal copy still records a history entry per S3/H1 — only the callback is suppressed.)
 - **AO6** After-handlers run when the outermost atomic's function completes, still inside the transaction. Changes they make trigger another round of after-events, repeating until quiescent. More than 100 rounds throws `Maximum store update depth exceeded`.
 - **AO7** `operationComplete` handlers fire after the after-events of an operation settle; if an `operationComplete` handler makes further changes, the flush (including `operationComplete`) runs again until quiescent.
-- **AO8** `mergeRemoteChanges(fn)` runs `fn` atomically with source `'remote'`; nested calls inside another `mergeRemoteChanges` just run `fn`. After the merge the integrity checker runs. Changes that side-effect handlers make in response to remote changes are attributed to `'user'`.
+- **AO8** `mergeRemoteChanges(fn)` runs `fn` atomically with source `'remote'`; nested calls inside another `mergeRemoteChanges` just run `fn`. After the merge the integrity checker runs. Changes that side-effect handlers — `after*` and `operationComplete` alike — make in response to remote changes are attributed to `'user'`, as are the callback rounds they trigger.
 
 ## 7. Side effect handlers (SE)
 
-- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all.
+- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all. Removing or registering a handler while handlers are being dispatched takes effect from the next dispatch: every handler registered when an event started is still called for it.
 - **SE2** `beforeCreate` runs before validation on create; its return value is what gets validated and stored. Multiple handlers chain, each receiving the previous one's output.
 - **SE3** `beforeChange` runs before validation on update, receiving `(prev, next, source)`; its return value is stored. Returning `prev` blocks the update (with a reference-preserving validator this makes the put a complete no-op per S3).
 - **SE4** `beforeDelete` may return `false` to prevent that record's deletion; other records in the same `remove` call are still deleted.
@@ -79,12 +81,15 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **H2** `listen(fn, filters?)` registers a listener and returns a remover. Listener notification is asynchronous: accumulated entries are flushed on the next frame, not synchronously with the change.
 - **H3** A flush squashes adjacent same-source entries: a listener called after changes `[user, user, remote, user]` receives three entries (`user`, `remote`, `user`), each with the squashed (D3) diff and its source.
 - **H4** `filters.source` (`'user' | 'remote' | 'all'`) drops entries from other sources. `filters.scope` (`'document' | 'session' | 'presence' | 'all'`) filters each entry's diff down to records of that scope; if nothing remains, the listener is not called for that entry.
-- **H5** `listen` flushes pending history first, so a new listener never sees changes made before it subscribed.
+- **H5** `listen` flushes pending history first, so a new listener never sees changes made before it subscribed — including a listener added from inside another listener's callback, which does not receive the flush in progress.
 - **H6** While no listeners are attached, accumulated history is discarded rather than retained.
-- **H7** `extractingChanges(fn)` returns the squashed diff of exactly the changes made during `fn` (listeners still see those changes normally).
+- **H7** `extractingChanges(fn)` returns the squashed diff of exactly the changes made during `fn` (listeners still see those changes normally); changes from a nested transaction that rolled back inside `fn` are excluded.
 - **H8** `addHistoryInterceptor(fn)` calls `fn(entry, source)` synchronously for every change-set as it happens and returns a remover.
 - **H9** `applyDiff(diff)` puts the `added` and `updated` records and removes the `removed` ids. `runCallbacks: false` disables side effects for the application (AO3). Applying a diff and then its `reverseRecordsDiff` (D2) restores the prior state.
-- **H10** `applyDiff` with `ignoreEphemeralKeys: true` ignores changes to keys in the type's `ephemeralKeySet` when applying updates to existing records: non-ephemeral changed keys are merged onto the stored record, and an update touching only ephemeral keys is dropped. Updates for records that don't exist are applied in full, as are records in `added`.
+- **H10** `applyDiff` with `ignoreEphemeralKeys: true` ignores changes to keys in the type's `ephemeralKeySet` when applying updates to existing records: non-ephemeral changed keys are merged onto the stored record (including the removal of a non-ephemeral key that the update leaves out), and an update touching only ephemeral keys is dropped. Updates for records that don't exist are applied in full, as are records in `added`.
+- **H11** Change-sets recorded inside a transaction that later rolls back (a throw, or an explicit rollback) are discarded: listeners never receive them, and a rolled-back nested transaction discards only its own. (History interceptors, being synchronous, have already seen them.)
+- **H12** `dispose()` delivers any pending change-sets to the attached listeners and then cancels the scheduled flush; it does not remove listeners.
+- **H13** A listener that throws does not prevent the other listeners from receiving the same flush; the first error is rethrown once every listener has been called.
 
 ## 9. Validation (V)
 
@@ -101,12 +106,14 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **CC3** `areRecordsEqual` controls which record changes invalidate the cache: when the old and new record are "equal", `derive` does not re-run. `areResultsEqual` controls change propagation: an "equal" result keeps the previous value object.
 - **CC4** The standalone `createComputedCache(name, derive)` works with any `StoreObject` (a store or `{ store }`), keeping a separate cache per context object, and passes the context to `derive`.
 - **CC5** `store.createCache(create)` is the low-level form: `create(id, recordSignal)` returns the signal to cache; `get(id)` on a missing record returns `undefined` without calling `create`.
+- **CC6** `derive`, `areRecordsEqual`, and `areResultsEqual` are never called for a deleted record, and a reader of `get(id)` is re-run when the record is deleted and again if a record with that id is later created — even when `derive` returned the same value before and after.
 
 ## 11. Queries: filtered history (QH)
 
 - **QH1** `store.query.filterHistory(typeName)` returns a computed epoch whose history diffs contain only records of that type; it is cached per type name.
 - **QH2** Within a flush window the diff is squashed per D3 semantics (add+remove cancels, add+update folds into the add, update+update collapses, update+remove removes the oldest `from`).
 - **QH3** Changes to other record types produce no observable change for downstream consumers of the filtered history.
+- **QH4** The filtered history's value strictly increases on every relevant change or reset, so indexes and queries that were read during a transaction that later rolled back are rebuilt rather than left stale.
 
 ## 12. Queries: indexes (QI)
 
@@ -119,17 +126,17 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 13. Queries: ids, records, record, exec (QQ)
 
 - **QQ1** `store.query.ids(typeName, queryCreator?)` returns a computed `Set` of the ids of matching records; with no query it contains all ids of that type. Its history diffs are `CollectionDiff`s.
-- **QQ2** The query expression is itself reactive: `queryCreator` may read signals, and when the expression it returns changes (by deep equality), the query rebuilds and emits a correct diff. An expression that is deep-equal to the previous one causes no rebuild.
+- **QQ2** The query expression is itself reactive: `queryCreator` is called with no arguments and may read signals, and when the expression it returns changes (by deep equality), the query rebuilds and emits a correct diff. An expression that is deep-equal to the previous one causes no rebuild.
 - **QQ3** Changes that do not affect the result (unrelated types, updates that keep a record matching, irrelevant property changes) leave the same `Set` object in place.
 - **QQ4** `records(typeName, queryCreator?)` returns the matching records as an array, with shallow-array equality (same members → no change). `record(typeName, queryCreator?)` returns one matching record or `undefined`.
-- **QQ5** `exec(typeName, query)` runs one non-reactive query and returns matching records; with no matches it returns the shared empty array.
+- **QQ5** `exec(typeName, query)` runs one non-reactive query and returns matching records (all records of the type for `{}`); with no matches it returns the shared empty array.
 
 ## 14. Query execution (QE)
 
-- **QE1** `{ eq: v }` matches strict equality; `{ neq: v }` matches records whose value is defined and differs from `v` — records missing the property do not match, mirroring the indexes, which only track defined values; `{ gt: n }` matches only numbers strictly greater than `n` (non-numeric values never match `gt`).
+- **QE1** `{ eq: v }` matches by SameValueZero (so `NaN` matches `NaN`); `{ neq: v }` matches values that differ from `v` by SameValueZero; `{ gt: n }` matches only numbers strictly greater than `n` (non-numeric values never match `gt`). A record whose value is `undefined` matches no matcher at all, mirroring the indexes, which only track defined values — so `{ eq: undefined }` matches nothing. A matcher with several operators applies all of them.
 - **QE2** Multiple properties in one expression are ANDed; the result is the intersection of the per-property matches.
-- **QE3** A nested object in the expression matches into the corresponding nested record object, to any depth. If the record's value at that level is missing or not an object, the record does not match.
-- **QE4** The empty expression `{}` matches every record of the type: `objectMatchesQuery({}, r)` is true and `ids(type)` contains all ids. (The raw `executeQuery` helper instead returns an empty set for an empty expression; `StoreQueries.ids` special-cases it before calling `executeQuery`.)
+- **QE3** A nested object in the expression matches into the corresponding nested record object, to any depth. If the record's value at that level is missing or not an object, the record does not match. An empty nested object (or an entry that is neither a matcher nor an object) imposes no constraint.
+- **QE4** The empty expression `{}` matches every record of the type: `objectMatchesQuery({}, r)` is true, `executeQuery(store, type, {})` returns every id of the type, and `ids(type)` contains all ids.
 - **QE5** `executeQuery` (index-based) and `objectMatchesQuery` (predicate) agree: the set of ids returned equals the set of records matching the predicate, including for nested paths and across record types.
 
 ## 15. Schema (SC)
@@ -138,7 +145,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **SC2** `serialize()` returns `{ schemaVersion: 2, sequences }` mapping each sequence id to the version of its last migration (0 for an empty sequence).
 - **SC3** `serializeEarliestVersion()` maps every sequence to version 0.
 - **SC4** `getType(typeName)` returns the RecordType and throws for unknown type names.
-- **SC5** `upgradeSchema` converts a v1 serialized schema to v2: `storeVersion` becomes `com.tldraw.store`, each record version becomes `com.tldraw.<typeName>`, and each subtype version becomes `com.tldraw.<typeName>.<subType>`. v2 schemas pass through unchanged; schema versions other than 1 or 2 produce an error result.
+- **SC5** `upgradeSchema` converts a v1 serialized schema to v2: `storeVersion` becomes `com.tldraw.store`, each record version becomes `com.tldraw.<typeName>`, and each subtype version becomes `com.tldraw.<typeName>.<subType>`. v2 schemas pass through unchanged; schema versions other than 1 or 2, and schemas missing their `sequences` (v2) or `recordVersions` (v1) object, produce an error result rather than throwing.
 
 ## 16. Migrations: authoring (M)
 
@@ -151,7 +158,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 17. Migrations: sorting (MS)
 
 - **MS1** `sortMigrations` orders migrations within a sequence by version (`foo/1` before `foo/2`), regardless of input order.
-- **MS2** A migration with `dependsOn` sorts after all of its dependencies, across sequences.
+- **MS2** A migration with `dependsOn` sorts after all of its dependencies, across sequences. A dependency that is also the implicit predecessor in the sequence, or that is listed more than once, is redundant rather than circular.
 - **MS3** Among valid orderings, a migration that others explicitly depend on is scheduled close to (immediately before) its dependents.
 - **MS4** Circular dependencies (direct or via the implicit sequence order) throw.
 
@@ -184,7 +191,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **MA3** Store-scope migrations receive the whole record map and may add, change, and delete records.
 - **MA4** Storage-scope migrations receive a `SynchronousStorage` (get/set/delete/keys/values/entries) and may use it to read and write records directly.
 - **MA5** When migrations are applied, records whose type's scope is not `'document'` are removed from the result (legacy cleanup). A snapshot needing no migrations keeps such records.
-- **MA6** An unknown record type encountered during migration, or a migrator that throws, produces a `migration-error` result.
+- **MA6** An unknown record type encountered during migration, a migrator that throws, or a malformed persisted schema produces a `migration-error` result.
 - **MA7** `migrateStorage(storage)` applies the same process to external storage, writing the current serialized schema via `setSchema` and updating only records that actually changed (deep equality).
 
 ## 21. Integrity (IC)
@@ -198,10 +205,10 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 - **AM1** `get`/`has` are reactive per key: an effect reading a present key re-runs when that key's value changes or the key is deleted, but not when other keys are set, updated, or deleted.
 - **AM2** Reading an absent key subscribes to the map's key set, so the reader re-runs when that key is later added (a reader of an absent key may also re-run when the key set otherwise changes — per-key isolation applies to present keys).
-- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key.
-- **AM4** `delete` returns whether the key existed. `deleteMany(keys)` deletes in one transaction (one reaction for the whole batch), returns the `[key, value]` pairs actually deleted, and ignores missing keys.
+- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key. Any value usable as a `Map` key (including symbols and null-prototype objects) is accepted.
+- **AM4** `delete` returns whether the key existed. `deleteMany(keys)` deletes in one transaction (one reaction for the whole batch), returns the `[key, value]` pairs actually deleted, and ignores missing keys. Like the other mutators, it does not capture the map as a dependency of the calling reaction.
 - **AM5** `clear()` empties the map.
-- **AM6** `entries`, `keys`, `values`, `forEach`, `[Symbol.iterator]`, and `size` see exactly the live entries and are reactive. `forEach` honors `thisArg`.
+- **AM6** `entries`, `keys`, `values`, `forEach`, `[Symbol.iterator]`, and `size` see exactly the live entries and are reactive. `forEach` honors `thisArg`. As with `Map`, an entry deleted during iteration before it is visited is skipped.
 - **AM7** Changes made inside a rolled-back `@tldraw/state` transaction are restored: additions disappear, updates revert, deletions reappear.
 - **AM8** `Object.prototype.toString.call(map)` is `[object AtomMap]`.
 - **AM9** `getOrInsert(key, defaultValue)` and `getOrInsertComputed(key, callback)` return the existing value for a present key, and otherwise insert and return the new value. `callback` runs only when the key is absent.
@@ -225,7 +232,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 26. IncrementalSetConstructor — internal (ISC)
 
 - **ISC1** `get()` returns `undefined` when there are no net changes: nothing done, adding already-present items, removing absent items, or add/remove round trips that cancel out.
-- **ISC2** Otherwise `get()` returns `{ value, diff }`, where `value` is the new set and `diff` is the `CollectionDiff` relative to the original set; the original set is not mutated.
+- **ISC2** Otherwise `get()` returns `{ value, diff }`, where `value` is the new set and `diff` is the `CollectionDiff` relative to the original set, with `added`/`removed` present only when non-empty; the original set is not mutated.
 - **ISC3** Re-adding an item removed earlier in the construction restores it (and removes it from `diff.removed`); removing an item added earlier cancels the add.
 
 ## 27. ImmutableMap — internal (IM)
@@ -234,7 +241,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 - **IM1** `set` and `delete` return a new map and leave the original unchanged.
 - **IM2** `get(k)` returns the value or `undefined`; `get(k, notSetValue)` returns `notSetValue` for missing keys.
-- **IM3** Keys may be objects (hashed by identity): distinct object keys with equal contents are distinct keys. A constructor given duplicate keys keeps the last value.
+- **IM3** Keys may be objects (hashed by identity): distinct object keys with equal contents are distinct keys. Key equality is SameValueZero (`NaN` equals `NaN`, `0` equals `-0`), and string keys named after `Object.prototype` members are ordinary keys. A constructor given duplicate keys keeps the last value.
 - **IM4** `withMutations(fn)` batches many changes into one new map; if `fn` changes nothing, the same instance is returned.
 - **IM5** `deleteAll(keys)` removes all the given keys.
 - **IM6** `entries`/`keys`/`values`/iteration yield every entry exactly once, consistent with `size`.

--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -267,7 +267,7 @@ export function parseMigrationId(id: MigrationId): {
     version: number;
 };
 
-// @public (undocumented)
+// @public
 export type QueryExpression<R extends object> = {
     [k in keyof R & string]?: R[k] extends boolean | null | number | string | undefined ? QueryValueMatcher<R[k]> : R[k] extends object ? QueryExpression<R[k]> : QueryValueMatcher<R[k]>;
 };

--- a/packages/store/src/lib/AtomMap.test.ts
+++ b/packages/store/src/lib/AtomMap.test.ts
@@ -630,3 +630,59 @@ describe('AtomMap', () => {
 		expect(Object.prototype.toString.call(map)).toBe('[object AtomMap]')
 	})
 })
+
+describe('AtomMap: Map parity (AM)', () => {
+	it('[AM6] an entry deleted before iteration reaches it is skipped, like Map', () => {
+		const map = new AtomMap('test', [
+			['a', 1],
+			['b', 2],
+			['c', 3],
+		])
+		const visited: string[] = []
+		for (const [key] of map) {
+			visited.push(key)
+			if (key === visited[0]) {
+				// delete the two keys we have not reached yet
+				for (const other of ['a', 'b', 'c']) if (other !== key) map.delete(other)
+			}
+		}
+		expect(visited).toHaveLength(1)
+		expect(Array.from(map.keys())).toEqual(visited)
+
+		const cleared = new AtomMap('test2', [
+			['a', 1],
+			['b', 2],
+		])
+		const seen: string[] = []
+		for (const key of cleared.keys()) {
+			seen.push(key)
+			cleared.clear()
+		}
+		expect(seen).toHaveLength(1)
+	})
+
+	it('[AM4] deleteMany does not subscribe the calling reaction to the map', () => {
+		const map = new AtomMap('test', [
+			['a', 1],
+			['b', 2],
+		])
+		let runs = 0
+		react('remover', () => {
+			runs++
+			map.deleteMany(['a'])
+		})
+		expect(runs).toBe(1)
+		map.set('zzz', 9)
+		expect(runs).toBe(1)
+	})
+
+	it('[AM3] symbol and null-prototype keys work', () => {
+		const map = new AtomMap<unknown, number>('test')
+		const sym = Symbol('k')
+		const nullProto = Object.create(null)
+		map.set(sym, 1).set(nullProto, 2)
+		expect(map.get(sym)).toBe(1)
+		expect(map.get(nullProto)).toBe(2)
+		expect(() => map.update(Symbol('missing'), (v) => v)).toThrow('not found')
+	})
+})

--- a/packages/store/src/lib/AtomMap.ts
+++ b/packages/store/src/lib/AtomMap.ts
@@ -2,6 +2,12 @@ import { atom, Atom, transact, UNINITIALIZED } from '@tldraw/state'
 import { assert } from '@tldraw/utils'
 import { emptyMap, ImmutableMap } from './ImmutableMap'
 
+// Atom names are debugging aids; `String()` throws for null-prototype objects and template literals
+// throw for symbols, and a Map must accept both as keys.
+function keyToName(key: unknown) {
+	return typeof key === 'object' && key !== null ? '[object]' : String(key)
+}
+
 /**
  * A drop-in replacement for Map that stores values in atoms and can be used in reactive contexts.
  * @public
@@ -32,7 +38,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 		if (entries) {
 			atoms = atoms.withMutations((atoms) => {
 				for (const [k, v] of entries) {
-					atoms.set(k, atom(`${name}:${String(k)}`, v))
+					atoms.set(k, atom(`${name}:${keyToName(k)}`, v))
 				}
 			})
 		}
@@ -158,7 +164,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 			existingAtom.set(value)
 		} else {
 			this.atoms.update((atoms) => {
-				return atoms.set(key, atom(`${this.name}:${String(key)}`, value))
+				return atoms.set(key, atom(`${this.name}:${keyToName(key)}`, value))
 			})
 		}
 		return this
@@ -224,7 +230,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 	update(key: K, updater: (value: V) => V) {
 		const valueAtom = this.atoms.__unsafe__getWithoutCapture().get(key)
 		if (!valueAtom) {
-			throw new Error(`AtomMap: key ${key} not found`)
+			throw new Error(`AtomMap: key ${keyToName(key)} not found`)
 		}
 		const value = valueAtom.__unsafe__getWithoutCapture()
 		assert(value !== UNINITIALIZED)
@@ -275,11 +281,13 @@ export class AtomMap<K, V> implements Map<K, V> {
 	deleteMany(keys: Iterable<K>): [K, V][] {
 		return transact(() => {
 			const deleted: [K, V][] = []
-			const newAtoms = this.atoms.get().withMutations((atoms) => {
+			// Reads here must not capture: a reactor that deletes keys would otherwise subscribe to
+			// the whole key set and to every deleted value atom, as `delete` and `clear` avoid.
+			const newAtoms = this.atoms.__unsafe__getWithoutCapture().withMutations((atoms) => {
 				for (const key of keys) {
 					const valueAtom = atoms.get(key)
 					if (!valueAtom) continue
-					const oldValue = valueAtom.get()
+					const oldValue = valueAtom.__unsafe__getWithoutCapture()
 					assert(oldValue !== UNINITIALIZED)
 
 					deleted.push([key, oldValue])
@@ -334,7 +342,9 @@ export class AtomMap<K, V> implements Map<K, V> {
 	*entries(): Generator<[K, V], undefined, unknown> {
 		for (const [key, valueAtom] of this.atoms.get()) {
 			const value = valueAtom.get()
-			assert(value !== UNINITIALIZED)
+			// The key set is a snapshot taken when iteration started, so a key deleted mid-iteration
+			// still appears in it; skip it, as `Map` skips entries deleted before they are visited.
+			if (value === UNINITIALIZED) continue
 			yield [key, value]
 		}
 	}
@@ -354,7 +364,9 @@ export class AtomMap<K, V> implements Map<K, V> {
 	 * ```
 	 */
 	*keys(): Generator<K, undefined, unknown> {
-		for (const key of this.atoms.get().keys()) {
+		for (const [key, valueAtom] of this.atoms.get()) {
+			// see entries(): skip keys deleted mid-iteration
+			if (valueAtom.__unsafe__getWithoutCapture() === UNINITIALIZED) continue
 			yield key
 		}
 	}
@@ -376,7 +388,8 @@ export class AtomMap<K, V> implements Map<K, V> {
 	*values(): Generator<V, undefined, unknown> {
 		for (const valueAtom of this.atoms.get().values()) {
 			const value = valueAtom.get()
-			assert(value !== UNINITIALIZED)
+			// see entries(): skip keys deleted mid-iteration
+			if (value === UNINITIALIZED) continue
 			yield value
 		}
 	}

--- a/packages/store/src/lib/ImmutableMap.test.ts
+++ b/packages/store/src/lib/ImmutableMap.test.ts
@@ -144,3 +144,36 @@ describe('emptyMap (IM)', () => {
 		expect(empty.get('anything')).toBeUndefined()
 	})
 })
+
+describe('ImmutableMap: key hashing and equality (IM)', () => {
+	it('[IM3] string keys named after Object.prototype members are ordinary keys', () => {
+		const keys = [
+			'a',
+			'b',
+			'c',
+			'd',
+			'e',
+			'f',
+			'g',
+			'h',
+			'constructor',
+			'toString',
+			'__proto__',
+			'hasOwnProperty',
+			'',
+		]
+		let map = new ImmutableMap<string, number>()
+		keys.forEach((key, i) => (map = map.set(key, i)))
+		expect(map.size).toBe(keys.length)
+		keys.forEach((key, i) => expect(map.get(key)).toBe(i))
+		expect(new Set(map.keys())).toEqual(new Set(keys))
+	})
+
+	it('[IM3] key equality is SameValueZero: 0 and -0 are one key, NaN equals NaN', () => {
+		let map = new ImmutableMap<number, string>()
+		map = map.set(0, 'zero').set(NaN, 'nan')
+		expect(map.get(-0)).toBe('zero')
+		expect(map.set(-0, 'neg').size).toBe(2)
+		expect(map.get(NaN)).toBe('nan')
+	})
+})

--- a/packages/store/src/lib/ImmutableMap.ts
+++ b/packages/store/src/lib/ImmutableMap.ts
@@ -74,7 +74,7 @@ function cachedHashString(string: string) {
 		hashed = hashString(string)
 		if (stringHashCacheCount === STRING_HASH_CACHE_SIZE) {
 			stringHashCacheCount = 0
-			stringHashCache = {}
+			stringHashCache = Object.create(null)
 		}
 		stringHashCache[string] = hashed
 		stringHashCacheCount++
@@ -144,7 +144,9 @@ const symbolMap = Object.create(null)
 
 let _objHashUID = 0
 
-let stringHashCache: Record<string, number> = {}
+// Null-prototype so that keys named after `Object.prototype` members ('constructor', 'toString',
+// '__proto__', ...) miss the cache instead of returning the inherited member as their "hash".
+let stringHashCache: Record<string, number> = Object.create(null)
 let stringHashCacheCount = 0
 const STRING_HASH_CACHE_SIZE = 24_000
 
@@ -174,6 +176,12 @@ function SetRef(ref?: Ref): void {
 
 function arrCopy<I>(arr: Array<I>, offset = 0): Array<I> {
 	return arr.slice(offset)
+}
+
+// Key equality is SameValueZero, as in upstream Immutable.js and native `Map`: `NaN` equals `NaN`
+// and `0` equals `-0`.
+function is(a: unknown, b: unknown) {
+	return a === b || (a !== a && b !== b)
 }
 
 class OwnerID {}
@@ -470,7 +478,7 @@ class ArrayMapNode<K, V> {
 	get(_shift: unknown, _keyHash: unknown, key: K, notSetValue?: V) {
 		const entries = this.entries
 		for (let ii = 0, len = entries.length; ii < len; ii++) {
-			if (Object.is(key, entries[ii][0])) {
+			if (is(key, entries[ii][0])) {
 				return entries[ii][1]
 			}
 		}
@@ -492,7 +500,7 @@ class ArrayMapNode<K, V> {
 		let idx = 0
 		const len = entries.length
 		for (; idx < len; idx++) {
-			if (Object.is(key, entries[idx][0])) {
+			if (is(key, entries[idx][0])) {
 				break
 			}
 		}
@@ -710,7 +718,7 @@ class HashCollisionNode<K, V> {
 	get(shift: number, keyHash: number, key: K, notSetValue?: V) {
 		const entries = this.entries
 		for (let ii = 0, len = entries.length; ii < len; ii++) {
-			if (Object.is(key, entries[ii][0])) {
+			if (is(key, entries[ii][0])) {
 				return entries[ii][1]
 			}
 		}
@@ -745,7 +753,7 @@ class HashCollisionNode<K, V> {
 		let idx = 0
 		const len = entries.length
 		for (; idx < len; idx++) {
-			if (Object.is(key, entries[idx][0])) {
+			if (is(key, entries[idx][0])) {
 				break
 			}
 		}
@@ -796,7 +804,7 @@ class ValueNode<K, V> {
 	) {}
 
 	get(shift: number, keyHash: number, key: K, notSetValue?: V) {
-		return Object.is(key, this.entry[0]) ? this.entry[1] : notSetValue
+		return is(key, this.entry[0]) ? this.entry[1] : notSetValue
 	}
 
 	update(
@@ -809,7 +817,7 @@ class ValueNode<K, V> {
 		didAlter?: Ref
 	) {
 		const removed = value === NOT_SET
-		const keyMatch = Object.is(key, this.entry[0])
+		const keyMatch = is(key, this.entry[0])
 		if (keyMatch ? value === this.entry[1] : removed) {
 			return this
 		}

--- a/packages/store/src/lib/IncrementalSetConstructor.test.ts
+++ b/packages/store/src/lib/IncrementalSetConstructor.test.ts
@@ -104,3 +104,13 @@ describe('IncrementalSetConstructor (ISC)', () => {
 		})
 	})
 })
+
+describe('IncrementalSetConstructor: diff shape (ISC)', () => {
+	it('[ISC2] an add/remove round trip does not leave an empty set in the diff', () => {
+		const constructor = new IncrementalSetConstructor(new Set(['a']))
+		constructor.add('b')
+		constructor.remove('b')
+		constructor.remove('a')
+		expect(constructor.get()).toEqual({ value: new Set(), diff: { removed: new Set(['a']) } })
+	})
+})

--- a/packages/store/src/lib/IncrementalSetConstructor.ts
+++ b/packages/store/src/lib/IncrementalSetConstructor.ts
@@ -74,6 +74,10 @@ export class IncrementalSetConstructor<T> {
 		if (numRemoved === 0 && numAdded === 0) {
 			return undefined
 		}
+		// An add/remove round trip leaves an empty set behind; drop it so that consumers can treat
+		// the presence of `added`/`removed` as "there are additions/removals".
+		if (numAdded === 0) delete this.diff!.added
+		if (numRemoved === 0) delete this.diff!.removed
 		return { value: this.nextValue!, diff: this.diff! }
 	}
 

--- a/packages/store/src/lib/RecordsDiff.test.ts
+++ b/packages/store/src/lib/RecordsDiff.test.ts
@@ -148,3 +148,30 @@ describe('squashing diffs (D)', () => {
 		expect(mutableTarget).toEqual(immutableResult)
 	})
 })
+
+describe('diff ownership (D)', () => {
+	it('[D2] reverseRecordsDiff does not share its collections with the input', () => {
+		const input = diff({ 'book:1': book('book:1', 'Added') })
+		const reversed = reverseRecordsDiff(input)
+		squashRecordDiffsMutable(reversed, [diff({ 'book:1': book('book:1', 'Older') })])
+		expect(input).toEqual(diff({ 'book:1': book('book:1', 'Added') }))
+	})
+
+	it('[D4] mutateFirstDiff with no diffs returns an empty diff', () => {
+		expect(squashRecordDiffs([], { mutateFirstDiff: true })).toEqual(createEmptyRecordsDiff())
+	})
+
+	it('[D4] mutateFirstDiff does not mutate the [from, to] tuples of the first diff in place', () => {
+		const v1 = book('book:1', 'v1')
+		const v2 = book('book:1', 'v2')
+		const v3 = book('book:1', 'v3')
+		const tuple: [Book, Book] = [v1, v2]
+		const first = diff({}, { 'book:1': tuple })
+		const result = squashRecordDiffs([first, diff({}, { 'book:1': [v2, v3] })], {
+			mutateFirstDiff: true,
+		})
+		expect(result).toBe(first)
+		expect(result.updated['book:1' as RecordId<Book>]).toEqual([v1, v3])
+		expect(tuple).toEqual([v1, v2])
+	})
+})

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -78,7 +78,13 @@ export function createEmptyRecordsDiff<R extends UnknownRecord>(): RecordsDiff<R
  * @public
  */
 export function reverseRecordsDiff(diff: RecordsDiff<any>) {
-	const result: RecordsDiff<any> = { added: diff.removed, removed: diff.added, updated: {} }
+	// Copy the collections rather than aliasing them: callers squash into the reversed diff
+	// (`squashRecordDiffsMutable`), which would otherwise write through to the input.
+	const result: RecordsDiff<any> = {
+		added: { ...diff.removed },
+		removed: { ...diff.added },
+		updated: {},
+	}
 	for (const [from, to] of objectMapValues(diff.updated)) {
 		result.updated[from.id] = [to, from]
 	}
@@ -162,6 +168,14 @@ export function squashRecordDiffs<T extends UnknownRecord>(
 ): RecordsDiff<T> {
 	if (options?.mutateFirstDiff) {
 		const result = diffs[0]
+		if (!result) return createEmptyRecordsDiff()
+		// The squash mutates the target's `[from, to]` tuples in place, which is only safe when the
+		// target owns them. The first diff's tuples may be shared with other holders, so copy them.
+		for (const _id in result.updated) {
+			const id = _id as IdOf<T>
+			const [from, to] = result.updated[id]
+			result.updated[id] = [from, to]
+		}
 		squashRecordDiffsMutable(result, diffs, 1)
 		return result
 	}
@@ -180,6 +194,10 @@ export function squashRecordDiffs<T extends UnknownRecord>(
  * - Added records: If the record was previously removed, convert to an update; otherwise add it
  * - Updated records: Chain updates together, preserving the original 'from' state
  * - Removed records: If the record was added in this sequence, cancel both operations
+ *
+ * The target's `updated` tuples are mutated in place, so the target must own them: start from
+ * `createEmptyRecordsDiff()` (or a diff built by earlier squashes into it) rather than a diff whose
+ * tuples are shared with another holder.
  *
  * @param target - The diff to modify in-place (will be mutated)
  * @param diffs - Array of diffs to apply to the target

--- a/packages/store/src/lib/Store.test.ts
+++ b/packages/store/src/lib/Store.test.ts
@@ -2,6 +2,7 @@ import { react } from '@tldraw/state'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BaseRecord, RecordId } from './BaseRecord'
 import { createMigrationSequence } from './migrate'
+import { RecordsDiff } from './RecordsDiff'
 import { createRecordType } from './RecordType'
 import { createComputedCache, Store } from './Store'
 import { StoreSchema } from './StoreSchema'
@@ -762,6 +763,164 @@ describe('integrity (IC)', () => {
 		expect(store.isPossiblyCorrupted()).toBe(false)
 		store.markAsPossiblyCorrupted()
 		expect(store.isPossiblyCorrupted()).toBe(true)
+		store.dispose()
+	})
+})
+
+describe('Store: writes from reactions and repeated ids (S)', () => {
+	let store: Store<LibraryType>
+	beforeEach(() => {
+		store = new Store({ props: {}, schema: schema() })
+	})
+	afterEach(() => {
+		store.dispose()
+	})
+
+	it('[S11] a reaction that writes to the store does not re-run for unrelated store changes', () => {
+		const a = Author.create({ name: 'A' })
+		const b = Author.create({ name: 'B' })
+		store.put([a, b])
+		let runs = 0
+		react('writer', () => {
+			runs++
+			if (runs > 20) throw new Error('looping')
+			// a fresh object each run: the validator is not reference-preserving
+			store.put([{ ...a, name: 'A' + runs }])
+		})
+		expect(runs).toBe(1)
+
+		store.put([{ ...b, name: 'B2' }])
+		expect(runs).toBe(1)
+	})
+
+	it('[S11] a reaction that removes records does not re-run for unrelated store changes', () => {
+		const a = Author.create({ name: 'A' })
+		const b = Author.create({ name: 'B' })
+		store.put([a, b])
+		let runs = 0
+		react('remover', () => {
+			runs++
+			store.remove([Author.createId('missing')])
+		})
+		expect(runs).toBe(1)
+
+		store.put([{ ...b, name: 'B2' }])
+		expect(runs).toBe(1)
+	})
+
+	it('[S12] repeated ids in one put record one update whose from is the pre-put record', () => {
+		const author = Author.create({ name: 'Start' })
+		store.put([author])
+		const entries: RecordsDiff<LibraryType>[] = []
+		store.addHistoryInterceptor((entry) => entries.push(entry.changes))
+
+		store.put([
+			{ ...author, name: 'Middle' },
+			{ ...author, name: 'End' },
+		])
+
+		expect(entries).toHaveLength(1)
+		expect(entries[0].updated).toEqual({
+			[author.id]: [author, { ...author, name: 'End' }],
+		})
+	})
+
+	it('[S12] a record created then updated in one put is recorded as a single addition', () => {
+		const author = Author.create({ name: 'Start' })
+		const entries: RecordsDiff<LibraryType>[] = []
+		store.addHistoryInterceptor((entry) => entries.push(entry.changes))
+
+		store.put([author, { ...author, name: 'End' }])
+
+		expect(entries).toHaveLength(1)
+		expect(entries[0]).toEqual({
+			added: { [author.id]: { ...author, name: 'End' } },
+			updated: {},
+			removed: {},
+		})
+	})
+})
+
+describe('computed caches after deletion (CC)', () => {
+	let store: Store<LibraryType>
+	beforeEach(() => {
+		store = new Store({ props: {}, schema: schema() })
+	})
+	afterEach(() => {
+		store.dispose()
+	})
+
+	it('[CC6] derive and areRecordsEqual are never called with a deleted record', () => {
+		const author = Author.create({ name: 'A' })
+		store.put([author])
+		const deriveArgs: unknown[] = []
+		const equalArgs: unknown[] = []
+		const cache = store.createComputedCache(
+			'names',
+			(record: Author) => {
+				deriveArgs.push(record)
+				return record.name
+			},
+			{
+				areRecordsEqual: (a, b) => {
+					equalArgs.push(a, b)
+					return a.name === b.name
+				},
+			}
+		)
+		const seen: (string | undefined)[] = []
+		react('reader', () => seen.push(cache.get(author.id)))
+		expect(seen).toEqual(['A'])
+
+		store.remove([author.id])
+		expect(seen).toEqual(['A', undefined])
+
+		// and the record can come back with the same id
+		store.put([{ ...author, name: 'B' }])
+		expect(seen).toEqual(['A', undefined, 'B'])
+
+		for (const arg of [...deriveArgs, ...equalArgs]) {
+			expect(typeof arg).toBe('object')
+		}
+	})
+})
+
+describe('computed caches after deletion, same-valued derive (CC)', () => {
+	it('[CC6] a reader sees a re-created record even when derive gave the same value before deletion', () => {
+		const store = new Store<LibraryType>({ props: {}, schema: schema() })
+		const author = Author.create({ name: 'Short' })
+		store.put([author])
+		// returns undefined for the live record, which is also what a deleted record yields
+		const cache = store.createComputedCache('long-names', (record: Author) =>
+			record.name.length > 10 ? record.name : undefined
+		)
+		const seen: (string | undefined)[] = []
+		react('reader', () => seen.push(cache.get(author.id)))
+		expect(seen).toEqual([undefined])
+
+		store.remove([author.id])
+		store.put([{ ...author, name: 'A much longer name' }])
+		expect(seen.at(-1)).toBe('A much longer name')
+		store.dispose()
+	})
+})
+
+describe('Store: net no-op puts (S)', () => {
+	it('[S12] a record changed and changed back within one put records nothing', () => {
+		const store = new Store<LibraryType>({ props: {}, schema: schema() })
+		const author = Author.create({ name: 'Start' })
+		store.put([author])
+		const stored = store.get(author.id)!
+		const entries: RecordsDiff<LibraryType>[] = []
+		store.addHistoryInterceptor((entry) => entries.push(entry.changes))
+		const afterChange = vi.fn()
+		store.sideEffects.registerAfterChangeHandler('author', afterChange)
+
+		store.put([{ ...stored, name: 'Middle' }, stored])
+
+		expect(entries).toEqual([])
+		expect(afterChange).not.toHaveBeenCalled()
+		expect(store.get(author.id)).toBe(stored)
 		store.dispose()
 	})
 })

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -529,8 +529,8 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	public _flushHistory() {
 		// If we have accumulated history, flush it and update listeners
 		const version = this.history.__unsafe__getWithoutCapture()
-		if (this.historyAccumulator.hasChanges(version)) {
-			const entries = this.historyAccumulator.flush(version)
+		const entries = this.historyAccumulator.flush(version)
+		if (entries.length > 0) {
 			// Iterate a snapshot: a listener that another listener's callback adds must not receive
 			// the entries that triggered it (H5), and one removed mid-flush stops receiving them.
 			const listeners = Array.from(this.listeners)
@@ -576,8 +576,11 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	dispose() {
 		// Deliver what is still pending first: a change-set made in the same frame as the dispose
 		// would otherwise never reach the listeners (e.g. a sync client) still attached to the store.
-		this._flushHistory()
-		this.cancelHistoryReactor?.()
+		try {
+			this._flushHistory()
+		} finally {
+			this.cancelHistoryReactor?.()
+		}
 	}
 
 	/**
@@ -652,12 +655,6 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			// Iterate through all records, creating, updating or removing as needed
 			let record: R
 
-			// There's a chance that, despite having records, all of the values are
-			// identical to what they were before; and so we'd end up with an "empty"
-			// history entry. Let's keep track of whether we've actually made any
-			// changes (e.g. additions, deletions, or updates that produce a new value).
-			let didChange = false
-
 			const source = this.isMergingRemoteChanges ? 'remote' : 'user'
 
 			for (let i = 0, n = records.length; i < n; i++) {
@@ -682,7 +679,6 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 					record = devFreeze(validated)
 					this.records.set(record.id, record)
 
-					didChange = true
 					if (additions[record.id]) {
 						// the same record was created earlier in this call: fold the update into it
 						additions[record.id] = record
@@ -699,8 +695,6 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 					this.addDiffForAfterEvent(initialValue, record)
 				} else {
 					record = this.sideEffects.handleBeforeCreate(record, source)
-
-					didChange = true
 
 					// If we don't have an atom, create one.
 
@@ -723,8 +717,9 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 				}
 			}
 
-			// If we did change, update the history
-			if (!didChange || (!hasAnyKey(additions) && !hasAnyKey(updates))) return
+			// Validation may have left every record identical to before, in which case there is no
+			// change-set to record.
+			if (!hasAnyKey(additions) && !hasAnyKey(updates)) return
 			this.updateHistory({
 				added: additions,
 				updated: updates,
@@ -1217,12 +1212,10 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			return computed<Result | undefined>(
 				name + ':' + id,
 				() => {
-					// The computed can be re-derived after its record is deleted, e.g. by a reaction
-					// that read it checking whether its parents changed; the atom then holds
-					// UNINITIALIZED rather than a record. Return DELETED_RECORD rather than calling
-					// `derive` with the sentinel or returning undefined: it never equals a real result,
-					// so a reader holding the computed re-runs, looks the id up again (finding nothing
-					// and subscribing to the key set), and so sees the record if it comes back.
+					// The computed can be re-derived after its record is deleted (e.g. by a reaction
+					// checking whether its parents changed), when the atom holds UNINITIALIZED. Return
+					// DELETED_RECORD rather than undefined: it never equals a real result, so a reader
+					// re-runs, looks the id up again, and so sees the record if it comes back.
 					const value = recordSignal.get()
 					if (isUninitialized(value)) return DELETED_RECORD as any
 					return derive(value as Record)
@@ -1466,14 +1459,6 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	clear() {
 		this._history = []
 		this._versions = []
-	}
-
-	/**
-	 * Check if there are any accumulated history entries.
-	 */
-	hasChanges(currentVersion: number) {
-		this.discardFrom(currentVersion + 1)
-		return this._history.length > 0
 	}
 
 	// Drops the entries recorded at or after `version`. Entries are in ascending version order: the

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -1,4 +1,13 @@
-import { Atom, Reactor, Signal, atom, computed, reactor, transact } from '@tldraw/state'
+import {
+	Atom,
+	Reactor,
+	Signal,
+	atom,
+	computed,
+	isUninitialized,
+	reactor,
+	transact,
+} from '@tldraw/state'
 import {
 	WeakCache,
 	assert,
@@ -14,11 +23,15 @@ import {
 import { AtomMap } from './AtomMap'
 import { IdOf, RecordId, UnknownRecord } from './BaseRecord'
 import { devFreeze } from './devFreeze'
-import { isRecordsDiffEmpty, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
+import { hasAnyKey, isRecordsDiffEmpty, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
 import { RecordScope } from './RecordType'
 import { StoreQueries } from './StoreQueries'
 import { SerializedSchema, StoreSchema } from './StoreSchema'
 import { StoreSideEffects } from './StoreSideEffects'
+
+// The value of a cached computed whose record has been deleted (see `createComputedCache`). It never
+// reaches callers: `get` resolves the record's atom first, and there is none for a deleted id.
+const DELETED_RECORD = Symbol('deleted record')
 
 /**
  * Extracts the record type from a record ID type.
@@ -405,13 +418,11 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	private historyReactor: Reactor
 
 	/**
-	 * Function to dispose of any in-flight timeouts.
+	 * Cancels the history flush scheduled for the next frame, if any.
 	 *
 	 * @internal
 	 */
-	private cancelHistoryReactor(): void {
-		/* noop */
-	}
+	private cancelHistoryReactor: null | (() => void) = null
 
 	/**
 	 * The schema that defines the structure and validation rules for records in this store.
@@ -517,18 +528,37 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 
 	public _flushHistory() {
 		// If we have accumulated history, flush it and update listeners
-		if (this.historyAccumulator.hasChanges()) {
-			const entries = this.historyAccumulator.flush()
+		const version = this.history.__unsafe__getWithoutCapture()
+		if (this.historyAccumulator.hasChanges(version)) {
+			const entries = this.historyAccumulator.flush(version)
+			// Iterate a snapshot: a listener that another listener's callback adds must not receive
+			// the entries that triggered it (H5), and one removed mid-flush stops receiving them.
+			const listeners = Array.from(this.listeners)
+			// The entries are already dequeued, so a listener that throws must not stop the others
+			// (e.g. a sync client) from receiving them: deliver to all, then rethrow the first error.
+			const failure = { didThrow: false, error: undefined as unknown }
+			const deliver = (onHistory: StoreListener<R>, entry: HistoryEntry<R>) => {
+				try {
+					onHistory(entry)
+				} catch (error) {
+					if (!failure.didThrow) {
+						failure.didThrow = true
+						failure.error = error
+					}
+				}
+			}
 			for (const { changes, source } of entries) {
 				// Filtered diffs are computed at most once per scope per entry, and shared by every
 				// listener watching that scope.
 				const scopedChanges = new Map<RecordScope, RecordsDiff<R> | null>()
-				for (const { onHistory, filters } of this.listeners) {
+				for (const listener of listeners) {
+					if (!this.listeners.has(listener)) continue
+					const { onHistory, filters } = listener
 					if (filters.source !== 'all' && filters.source !== source) {
 						continue
 					}
 					if (filters.scope === 'all') {
-						onHistory({ changes, source })
+						deliver(onHistory, { changes, source })
 						continue
 					}
 					if (!scopedChanges.has(filters.scope)) {
@@ -536,14 +566,18 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 					}
 					const filtered = scopedChanges.get(filters.scope)
 					if (!filtered) continue
-					onHistory({ changes: filtered, source })
+					deliver(onHistory, { changes: filtered, source })
 				}
 			}
+			if (failure.didThrow) throw failure.error
 		}
 	}
 
 	dispose() {
-		this.cancelHistoryReactor()
+		// Deliver what is still pending first: a change-set made in the same frame as the dispose
+		// would otherwise never reach the listeners (e.g. a sync client) still attached to the store.
+		this._flushHistory()
+		this.cancelHistoryReactor?.()
 	}
 
 	/**
@@ -570,14 +604,22 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * @param changes - The changes to add to the history.
 	 */
 	private updateHistory(changes: RecordsDiff<R>): void {
-		this.historyAccumulator.add({
-			changes,
-			source: this.isMergingRemoteChanges ? 'remote' : 'user',
-		})
+		// Don't capture: a reaction that writes to the store must not become a dependent of the
+		// history atom, or every other store change would re-run it (and it could loop forever).
+		const version = this.history.__unsafe__getWithoutCapture() + 1
+		// Set the atom before recording the entry: interceptors run inside `add`, and a flush they
+		// trigger (e.g. via `listen`) would otherwise discard the entry as not yet committed.
+		this.history.set(version, changes)
+		this.historyAccumulator.add(
+			{
+				changes,
+				source: this.isMergingRemoteChanges ? 'remote' : 'user',
+			},
+			version
+		)
 		if (this.listeners.size === 0) {
 			this.historyAccumulator.clear()
 		}
-		this.history.set(this.history.get() + 1, changes)
 	}
 
 	validate(phase: 'initialize' | 'createRecord' | 'updateRecord' | 'tests') {
@@ -641,7 +683,19 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 					this.records.set(record.id, record)
 
 					didChange = true
-					updates[record.id] = [initialValue, record]
+					if (additions[record.id]) {
+						// the same record was created earlier in this call: fold the update into it
+						additions[record.id] = record
+					} else {
+						// an earlier update to the same record in this call owns the `from`
+						const from = updates[record.id]?.[0] ?? initialValue
+						if (from === record) {
+							// back to where it started within this call: nothing to record
+							delete updates[record.id]
+						} else {
+							updates[record.id] = [from, record]
+						}
+					}
 					this.addDiffForAfterEvent(initialValue, record)
 				} else {
 					record = this.sideEffects.handleBeforeCreate(record, source)
@@ -670,7 +724,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			}
 
 			// If we did change, update the history
-			if (!didChange) return
+			if (!didChange || (!hasAnyKey(additions) && !hasAnyKey(updates))) return
 			this.updateHistory({
 				added: additions,
 				updated: updates,
@@ -1042,11 +1096,22 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * Run `fn` and return a {@link RecordsDiff} of the changes that occurred as a result.
 	 */
 	extractingChanges(fn: () => void): RecordsDiff<R> {
-		const changes: Array<RecordsDiff<R>> = []
-		const dispose = this.historyAccumulator.addInterceptor((entry) => changes.push(entry.changes))
+		const collected: Array<{ version: number; changes: RecordsDiff<R> }> = []
+		const dispose = this.historyAccumulator.addInterceptor((entry, version) => {
+			// a nested transaction that rolled back inside `fn` leaves entries stamped at or past the
+			// next committed version — see HistoryAccumulator
+			while (collected.length && collected[collected.length - 1].version >= version) {
+				collected.pop()
+			}
+			collected.push({ version, changes: entry.changes })
+		})
 		try {
 			transact(fn)
-			return squashRecordDiffs(changes)
+			const current = this.history.__unsafe__getWithoutCapture()
+			while (collected.length && collected[collected.length - 1].version > current) {
+				collected.pop()
+			}
+			return squashRecordDiffs(collected.map((c) => c.changes))
 		} finally {
 			dispose()
 		}
@@ -1065,7 +1130,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			for (const [_from, to] of objectMapValues(diff.updated)) {
 				const type = this.schema.getType(to.typeName)
 				if (ignoreEphemeralKeys && type.ephemeralKeySet.size) {
-					const existing = this.get(to.id)
+					const existing = this.unsafeGetWithoutCapture(to.id)
 					if (!existing) {
 						toPut.push(to)
 						continue
@@ -1078,6 +1143,12 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 
 						if (!changed) changed = { ...existing } as R
 						;(changed as any)[key] = value
+					}
+					// a key the update removed (present before, absent in `to`) is a change too
+					for (const key of Object.keys(existing)) {
+						if (type.ephemeralKeySet.has(key) || Object.hasOwn(to, key)) continue
+						if (!changed) changed = { ...existing } as R
+						delete (changed as any)[key]
 					}
 					if (changed) toPut.push(changed)
 				} else {
@@ -1100,6 +1171,11 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 	 * signal for the underlying record. Return a signal (usually a computed) for the cached value.
 	 * For simple derivations, use {@link Store.createComputedCache}. This function is useful if you
 	 * need more precise control over intermediate values.
+	 *
+	 * After the record is deleted the record signal holds `UNINITIALIZED` rather than a record, and
+	 * a signal that a reader still depends on can be re-derived once more in that state; guard with
+	 * `isUninitialized` when your derivation cannot tolerate it. {@link Store.createComputedCache}
+	 * handles this for you.
 	 */
 	createCache<Result, Record extends R = R>(
 		create: (id: IdOf<Record>, recordSignal: Signal<R>) => Signal<Result>
@@ -1127,18 +1203,35 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 		derive: (record: Record) => Result | undefined,
 		opts?: CreateComputedCacheOpts<Result, Record>
 	): ComputedCache<Result, Record> {
+		const areRecordsEqual = opts?.areRecordsEqual
+		const areResultsEqual = opts?.areResultsEqual
 		return this.createCache((id, record) => {
-			const recordSignal = opts?.areRecordsEqual
-				? computed(`${name}:${id}:isEqual`, () => record.get(), { isEqual: opts.areRecordsEqual })
+			const recordSignal = areRecordsEqual
+				? computed(`${name}:${id}:isEqual`, () => record.get(), {
+						// a deleted record's atom holds UNINITIALIZED, which user code must not see
+						isEqual: (a, b) =>
+							isUninitialized(a) || isUninitialized(b) ? a === b : areRecordsEqual(a, b),
+					})
 				: record
 
 			return computed<Result | undefined>(
 				name + ':' + id,
 				() => {
-					return derive(recordSignal.get() as Record)
+					// The computed can be re-derived after its record is deleted, e.g. by a reaction
+					// that read it checking whether its parents changed; the atom then holds
+					// UNINITIALIZED rather than a record. Return DELETED_RECORD rather than calling
+					// `derive` with the sentinel or returning undefined: it never equals a real result,
+					// so a reader holding the computed re-runs, looks the id up again (finding nothing
+					// and subscribing to the key set), and so sees the record if it comes back.
+					const value = recordSignal.get()
+					if (isUninitialized(value)) return DELETED_RECORD as any
+					return derive(value as Record)
 				},
 				{
-					isEqual: opts?.areResultsEqual,
+					isEqual: areResultsEqual
+						? (a, b) =>
+								a === DELETED_RECORD || b === DELETED_RECORD ? a === b : areResultsEqual(a, b)
+						: undefined,
 				}
 			)
 		})
@@ -1204,11 +1297,10 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 
 			if (!this.pendingAfterEvents) {
 				this.sideEffects.handleOperationComplete(source)
-			} else {
-				// if the side effects triggered by a remote operation resulted in more effects,
-				// those extra effects should not be marked as originating remotely.
-				source = 'user'
 			}
+			// Whatever the after-handlers or the operation-complete handlers changed in response to
+			// a remote operation is not itself remote: later rounds are attributed to 'user'.
+			source = 'user'
 		}
 	}
 	private _isInAtomicOp = false
@@ -1326,13 +1418,18 @@ function squashHistoryEntries<T extends UnknownRecord>(
 class HistoryAccumulator<T extends UnknownRecord> {
 	private _history: HistoryEntry<T>[] = []
 
-	private _interceptors: Set<(entry: HistoryEntry<T>) => void> = new Set()
+	// The `history` atom value each entry was recorded at. A transaction that aborts rolls that atom
+	// back but cannot unwind this array, so an entry stamped at or past the atom's current value
+	// belongs to a rolled-back change-set and must not reach listeners.
+	private _versions: number[] = []
+
+	private _interceptors: Set<(entry: HistoryEntry<T>, version: number) => void> = new Set()
 
 	/**
-	 * Add an interceptor that will be called for each history entry.
-	 * Returns a function to remove the interceptor.
+	 * Add an interceptor that will be called for each history entry, with the version it was
+	 * recorded at (see `add`). Returns a function to remove the interceptor.
 	 */
-	addInterceptor(fn: (entry: HistoryEntry<T>) => void) {
+	addInterceptor(fn: (entry: HistoryEntry<T>, version: number) => void) {
 		this._interceptors.add(fn)
 		return () => {
 			this._interceptors.delete(fn)
@@ -1340,13 +1437,15 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	}
 
 	/**
-	 * Add a history entry to the accumulator.
+	 * Add a history entry recorded at `version` (the `history` atom value it sets).
 	 * Calls all registered interceptors with the entry.
 	 */
-	add(entry: HistoryEntry<T>) {
+	add(entry: HistoryEntry<T>, version: number) {
+		this.discardFrom(version)
 		this._history.push(entry)
+		this._versions.push(version)
 		for (const interceptor of this._interceptors) {
-			interceptor(entry)
+			interceptor(entry, version)
 		}
 	}
 
@@ -1354,9 +1453,10 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 * Flush all accumulated history entries, squashing adjacent entries from the same source.
 	 * Clears the internal history buffer.
 	 */
-	flush() {
+	flush(currentVersion: number) {
+		this.discardFrom(currentVersion + 1)
 		const history = squashHistoryEntries(this._history)
-		this._history = []
+		this.clear()
 		return history
 	}
 
@@ -1365,13 +1465,24 @@ class HistoryAccumulator<T extends UnknownRecord> {
 	 */
 	clear() {
 		this._history = []
+		this._versions = []
 	}
 
 	/**
 	 * Check if there are any accumulated history entries.
 	 */
-	hasChanges() {
+	hasChanges(currentVersion: number) {
+		this.discardFrom(currentVersion + 1)
 		return this._history.length > 0
+	}
+
+	// Drops the entries recorded at or after `version`. Entries are in ascending version order: the
+	// atom increments by one per entry, and a rollback is followed by exactly this discard.
+	private discardFrom(version: number) {
+		while (this._versions.length && this._versions[this._versions.length - 1] >= version) {
+			this._versions.pop()
+			this._history.pop()
+		}
 	}
 }
 

--- a/packages/store/src/lib/StoreListeners.test.ts
+++ b/packages/store/src/lib/StoreListeners.test.ts
@@ -1,4 +1,4 @@
-import { react, RESET_VALUE, transact } from '@tldraw/state'
+import { react, RESET_VALUE, transact, transaction } from '@tldraw/state'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BaseRecord, RecordId } from './BaseRecord'
 import { RecordsDiff, reverseRecordsDiff } from './RecordsDiff'
@@ -458,5 +458,160 @@ describe('applying diffs (H)', () => {
 			expect(result.visitorName).toBe('Janet')
 			expect(result.lastActive).toBe(999)
 		})
+	})
+})
+
+describe('listeners: rollback, re-entrancy, and dispose (H)', () => {
+	it('[H10] ignoreEphemeralKeys also applies the removal of a non-ephemeral key', () => {
+		const visitId = Visit.createId('jane')
+		const visit = Visit.create({ id: visitId, visitorName: 'Jane', lastActive: 100 })
+		store.put([visit])
+
+		const { visitorName: _dropped, ...withoutName } = visit
+		store.applyDiff(
+			{
+				added: {},
+				updated: { [visitId]: [visit, withoutName as Visit] },
+				removed: {},
+			} as RecordsDiff<LibraryType>,
+			{ ignoreEphemeralKeys: true }
+		)
+
+		const result = store.get(visitId) as Visit
+		expect('visitorName' in result).toBe(false)
+		expect(result.lastActive).toBe(100)
+	})
+
+	it('[H11] listeners never see change-sets from a transaction that rolled back', async () => {
+		const listener = vi.fn()
+		store.listen(listener)
+		const author = tolkein()
+
+		expect(() =>
+			store.atomic(() => {
+				store.put([author])
+				throw new Error('abort')
+			})
+		).toThrow('abort')
+		expect(store.get(author.id)).toBeUndefined()
+
+		// a later, committed change flushes whatever the accumulator still holds
+		store.put([Author.create({ name: 'Ursula K. Le Guin' })])
+		await new Promise((resolve) => requestAnimationFrame(resolve))
+
+		const addedIds = listener.mock.calls.flatMap(([entry]) => Object.keys(entry.changes.added))
+		expect(addedIds).not.toContain(author.id)
+		expect(addedIds).toHaveLength(1)
+	})
+
+	it('[H11] a rolled-back nested transaction only discards its own change-sets', async () => {
+		const listener = vi.fn()
+		store.listen(listener)
+		const kept = tolkein()
+		const dropped = Author.create({ name: 'Dropped' })
+
+		transact(() => {
+			store.put([kept])
+			try {
+				transaction(() => {
+					store.put([dropped])
+					throw new Error('inner')
+				})
+			} catch {
+				// the outer transaction commits
+			}
+		})
+		await new Promise((resolve) => requestAnimationFrame(resolve))
+
+		expect(store.get(kept.id)).toBeDefined()
+		expect(store.get(dropped.id)).toBeUndefined()
+		const addedIds = listener.mock.calls.flatMap(([entry]) => Object.keys(entry.changes.added))
+		expect(addedIds).toEqual([kept.id])
+	})
+
+	it('[H5] a listener added by another listener during a flush does not receive that flush', async () => {
+		const late = vi.fn()
+		store.listen(() => {
+			if (late.mock.calls.length === 0 && !(late as any).registered) {
+				;(late as any).registered = true
+				store.listen(late)
+			}
+		})
+
+		store.put([tolkein()])
+		await new Promise((resolve) => requestAnimationFrame(resolve))
+		expect(late).not.toHaveBeenCalled()
+
+		store.put([hobbit()])
+		await new Promise((resolve) => requestAnimationFrame(resolve))
+		expect(late).toHaveBeenCalledTimes(1)
+	})
+
+	it('[H12] dispose delivers pending change-sets to listeners before cancelling the flush', () => {
+		try {
+			// @ts-expect-error - test-only escape hatch
+			globalThis.__FORCE_RAF_IN_TESTS__ = true
+			const listener = vi.fn()
+			store.listen(listener)
+			store.put([tolkein()])
+			expect(listener).not.toHaveBeenCalled()
+
+			store.dispose()
+			expect(listener).toHaveBeenCalledTimes(1)
+		} finally {
+			// @ts-expect-error - test-only escape hatch
+			globalThis.__FORCE_RAF_IN_TESTS__ = false
+		}
+	})
+})
+
+describe('listeners: a throwing listener (H)', () => {
+	it('[H13] a listener that throws does not stop the others from receiving the flush', () => {
+		const received = vi.fn()
+		store.listen(() => {
+			throw new Error('listener failed')
+		})
+		store.listen(received)
+
+		expect(() => store.put([tolkein()])).toThrow('listener failed')
+		expect(received).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('extracting changes across rolled-back nested transactions (H)', () => {
+	it('[H7] extractingChanges excludes changes from a nested transaction that rolled back', () => {
+		const kept = tolkein()
+		const dropped = Author.create({ name: 'Dropped' })
+		const changes = store.extractingChanges(() => {
+			store.put([kept])
+			try {
+				transaction(() => {
+					store.put([dropped])
+					throw new Error('inner')
+				})
+			} catch {
+				// swallowed: the outer work continues
+			}
+		})
+		expect(Object.keys(changes.added)).toEqual([kept.id])
+		expect(store.get(dropped.id)).toBeUndefined()
+	})
+})
+
+describe('listeners added from an interceptor (H)', () => {
+	it('[H8] a flush triggered from inside an interceptor still delivers the entry being recorded', () => {
+		const first = vi.fn()
+		store.listen(first)
+		let added = false
+		store.addHistoryInterceptor(() => {
+			if (added) return
+			added = true
+			// listen() flushes synchronously while the entry is still being recorded
+			store.listen(() => {})
+		})
+
+		store.put([tolkein()])
+		store._flushHistory()
+		expect(first).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/store/src/lib/StoreQueries.test.ts
+++ b/packages/store/src/lib/StoreQueries.test.ts
@@ -801,3 +801,49 @@ describe('integration with reactive state (QI, QQ)', () => {
 		expect(tolkeinBookCount.get()).toBe(2)
 	})
 })
+
+describe('queries across rolled-back transactions (QH, QQ)', () => {
+	it('[QH4] a query read during a transaction that rolls back is correct afterwards', () => {
+		const bookIds = store.query.ids('book')
+		const booksByAuthor = store.query.index('book', 'authorId')
+		expect(bookIds.get().size).toBe(4)
+
+		const phantom = Book.create({ title: 'Phantom', authorId: authors.tolkein.id })
+		expect(() =>
+			store.atomic(() => {
+				store.put([phantom])
+				// a side effect reads the queries mid-operation, so they incorporate the change
+				expect(bookIds.get().has(phantom.id)).toBe(true)
+				expect(booksByAuthor.get().get(authors.tolkein.id)!.has(phantom.id)).toBe(true)
+				throw new Error('abort')
+			})
+		).toThrow('abort')
+		expect(store.get(phantom.id)).toBeUndefined()
+
+		// the same number of changes again, so the history counter comes back round to where the
+		// queries last saw it
+		const real = Book.create({ title: 'Real', authorId: authors.bradbury.id })
+		store.put([real])
+
+		expect(bookIds.get().has(phantom.id)).toBe(false)
+		expect(bookIds.get().has(real.id)).toBe(true)
+		expect(booksByAuthor.get().get(authors.tolkein.id)!.has(phantom.id)).toBe(false)
+		expect(booksByAuthor.get().get(authors.bradbury.id)!.has(real.id)).toBe(true)
+	})
+
+	it('[QQ5] exec with an empty expression returns every record of the type', () => {
+		expect(store.query.exec('book', {})).toHaveLength(4)
+	})
+
+	it('[QQ2] the query creator is called without arguments', () => {
+		const args: unknown[][] = []
+		const ids = store.query.ids('book', (...rest: unknown[]) => {
+			args.push(rest)
+			return {}
+		})
+		ids.get()
+		store.put([Book.create({ title: 'Another', authorId: authors.bradbury.id })])
+		ids.get()
+		for (const call of args) expect(call).toEqual([])
+	})
+})

--- a/packages/store/src/lib/StoreQueries.ts
+++ b/packages/store/src/lib/StoreQueries.ts
@@ -7,12 +7,12 @@ import {
 	RESET_VALUE,
 	withDiff,
 } from '@tldraw/state'
-import { areArraysShallowEqual, isEqual, objectMapValues } from '@tldraw/utils'
+import { areArraysShallowEqual, isEqual } from '@tldraw/utils'
 import { AtomMap } from './AtomMap'
 import { IdOf, UnknownRecord } from './BaseRecord'
 import { executeQuery, objectMatchesQuery, QueryExpression } from './executeQuery'
 import { IncrementalSetConstructor } from './IncrementalSetConstructor'
-import { hasAnyKey, RecordsDiff, squashRecordDiffsMutableByType } from './RecordsDiff'
+import { RecordsDiff, squashRecordDiffsMutableByType } from './RecordsDiff'
 import { diffSets } from './setUtils'
 import { CollectionDiff } from './Store'
 
@@ -161,7 +161,7 @@ export class StoreQueries<R extends UnknownRecord> {
 	 * have been added, updated, or removed.
 	 *
 	 * @param typeName - The type name to filter the history by
-	 * @returns A computed value containing the current epoch and diffs of changes for the specified type
+	 * @returns A computed value containing a change counter and diffs of changes for the specified type
 	 *
 	 * @example
 	 * ```ts
@@ -193,14 +193,20 @@ export class StoreQueries<R extends UnknownRecord> {
 					return this.history.get()
 				}
 
+				// The value tracks the store's history counter, but it must strictly increase on every
+				// reset or relevant change: after a rolled-back transaction the counter can come back
+				// round to `lastValue`, and an unchanged value would hide the reset from downstream
+				// indexes and queries, leaving them stale for good.
+				const next = Math.max(this.history.get(), lastValue + 1)
+
 				const diff = this.history.getDiffSince(lastComputedEpoch)
-				if (diff === RESET_VALUE) return this.history.get()
+				if (diff === RESET_VALUE) return next
 
 				const res = { added: {}, removed: {}, updated: {} } as RecordsDiff<S>
 				const size = squashRecordDiffsMutableByType(res, diff, typeName)
 
 				if (size) {
-					return withDiff(this.history.get(), res)
+					return withDiff(next, res)
 				} else {
 					return lastValue
 				}
@@ -316,25 +322,24 @@ export class StoreQueries<R extends UnknownRecord> {
 
 				const setConstructors = new Map<any, IncrementalSetConstructor<IdOf<S>>>()
 
-				const add = (value: any, id: IdOf<S>) => {
+				const setConstructorFor = (value: any) => {
 					let setConstructor = setConstructors.get(value)
-					if (!setConstructor)
+					if (!setConstructor) {
 						setConstructor = new IncrementalSetConstructor<IdOf<S>>(
 							prevValue.get(value) ?? new Set()
 						)
-					setConstructor.add(id)
-					setConstructors.set(value, setConstructor)
+						setConstructors.set(value, setConstructor)
+					}
+					return setConstructor
 				}
+				const add = (value: any, id: IdOf<S>) => setConstructorFor(value).add(id)
+				const remove = (value: any, id: IdOf<S>) => setConstructorFor(value).remove(id)
 
-				const remove = (value: any, id: IdOf<S>) => {
-					let set = setConstructors.get(value)
-					if (!set) set = new IncrementalSetConstructor<IdOf<S>>(prevValue.get(value) ?? new Set())
-					set.remove(id)
-					setConstructors.set(value, set)
-				}
-
+				// for-in rather than objectMapValues: this runs per frame while dragging, and an
+				// allocation per diff per index adds up (see the note in RecordsDiff.ts)
 				for (const changes of history) {
-					for (const record of objectMapValues(changes.added)) {
+					for (const id in changes.added) {
+						const record = changes.added[id as IdOf<R>]
 						if (record.typeName === typeName) {
 							const value = getPropertyValue(record as S)
 							if (value !== undefined) {
@@ -342,7 +347,8 @@ export class StoreQueries<R extends UnknownRecord> {
 							}
 						}
 					}
-					for (const [from, to] of objectMapValues(changes.updated)) {
+					for (const id in changes.updated) {
+						const [from, to] = changes.updated[id as IdOf<R>]
 						if (to.typeName === typeName) {
 							const prev = getPropertyValue(from as S)
 							const next = getPropertyValue(to as S)
@@ -356,7 +362,8 @@ export class StoreQueries<R extends UnknownRecord> {
 							}
 						}
 					}
-					for (const record of objectMapValues(changes.removed)) {
+					for (const id in changes.removed) {
+						const record = changes.removed[id as IdOf<R>]
 						if (record.typeName === typeName) {
 							const value = getPropertyValue(record as S)
 							if (value !== undefined) {
@@ -510,19 +517,14 @@ export class StoreQueries<R extends UnknownRecord> {
 
 		const typeHistory = this.filterHistory(typeName)
 
-		const fromScratch = () => {
+		const fromScratch = (query: QueryExpression<S>) => {
 			// deref type history early to allow first incremental update to use diffs
 			typeHistory.get()
-			const query: QueryExpression<S> = queryCreator()
-			if (!hasAnyKey(query)) {
-				return this.getAllIdsForType(typeName)
-			}
-
 			return executeQuery(this, typeName, query)
 		}
 
-		const fromScratchWithDiff = (prevValue: Set<IdOf<S>>) => {
-			const nextValue = fromScratch()
+		const fromScratchWithDiff = (prevValue: Set<IdOf<S>>, query: QueryExpression<S>) => {
+			const nextValue = fromScratch(query)
 			const diff = diffSets(prevValue, nextValue)
 			if (diff) {
 				return withDiff(nextValue, diff)
@@ -530,7 +532,10 @@ export class StoreQueries<R extends UnknownRecord> {
 				return prevValue
 			}
 		}
-		const cachedQuery = computed('ids_query:' + name, queryCreator, {
+		// Wrapped rather than passed straight through: a computed's derive function receives
+		// `(previousValue, lastComputedEpoch)`, which a queryCreator with optional parameters
+		// would otherwise misread.
+		const cachedQuery = computed('ids_query:' + name, () => queryCreator(), {
 			isEqual,
 		})
 
@@ -539,31 +544,32 @@ export class StoreQueries<R extends UnknownRecord> {
 			(prevValue, lastComputedEpoch) => {
 				const query = cachedQuery.get()
 				if (isUninitialized(prevValue)) {
-					return fromScratch()
+					return fromScratch(query)
 				}
 
 				// if the query changed since last time this ran then we need to start again
 				if (lastComputedEpoch < cachedQuery.lastChangedEpoch) {
-					return fromScratchWithDiff(prevValue)
+					return fromScratchWithDiff(prevValue, query)
 				}
 
 				// otherwise iterate over the changes from the store and apply them to the previous value if needed
 				const history = typeHistory.getDiffSince(lastComputedEpoch)
 				if (history === RESET_VALUE) {
-					return fromScratchWithDiff(prevValue)
+					return fromScratchWithDiff(prevValue, query)
 				}
 
-				const setConstructor = new IncrementalSetConstructor<IdOf<S>>(
-					prevValue
-				) as IncrementalSetConstructor<IdOf<S>>
+				const setConstructor = new IncrementalSetConstructor<IdOf<S>>(prevValue)
 
+				// for-in rather than objectMapValues: see the index derive above
 				for (const changes of history) {
-					for (const added of objectMapValues(changes.added)) {
+					for (const id in changes.added) {
+						const added = changes.added[id as IdOf<R>]
 						if (added.typeName === typeName && objectMatchesQuery(query, added)) {
 							setConstructor.add(added.id)
 						}
 					}
-					for (const [_, updated] of objectMapValues(changes.updated)) {
+					for (const id in changes.updated) {
+						const updated = changes.updated[id as IdOf<R>][1]
 						if (updated.typeName === typeName) {
 							if (objectMatchesQuery(query, updated)) {
 								setConstructor.add(updated.id)
@@ -572,7 +578,8 @@ export class StoreQueries<R extends UnknownRecord> {
 							}
 						}
 					}
-					for (const removed of objectMapValues(changes.removed)) {
+					for (const id in changes.removed) {
+						const removed = changes.removed[id as IdOf<R>]
 						if (removed.typeName === typeName) {
 							setConstructor.remove(removed.id)
 						}

--- a/packages/store/src/lib/StoreSchema.test.ts
+++ b/packages/store/src/lib/StoreSchema.test.ts
@@ -1062,3 +1062,65 @@ describe('migrateStorage (MA)', () => {
 		expect(result.value[newRecord.id as keyof typeof result.value]).toMatchObject({ name: 'new' })
 	})
 })
+
+describe('malformed persisted schemas (SC, MA)', () => {
+	const schema = StoreSchema.create<Book>(
+		{ book: Book },
+		{
+			migrations: [
+				createMigrationSequence({
+					sequenceId: 'com.tldraw.book',
+					sequence: [{ id: 'com.tldraw.book/1', scope: 'record', up: () => {} }],
+				}),
+			],
+		}
+	)
+
+	it('[SC5] schemas with a missing version or collections produce an error result, not a throw', () => {
+		expect(upgradeSchema({} as any).ok).toBe(false)
+		expect(upgradeSchema({ schemaVersion: 2 } as any).ok).toBe(false)
+		expect(upgradeSchema({ schemaVersion: 1 } as any).ok).toBe(false)
+		expect(upgradeSchema(null as any).ok).toBe(false)
+	})
+
+	it('[MA6] migrateStoreSnapshot reports malformed schemas as a migration error', () => {
+		for (const bad of [{}, { schemaVersion: 2 }, { schemaVersion: 1, recordVersions: null }]) {
+			expect(schema.migrateStoreSnapshot({ store: {}, schema: bad as any })).toEqual({
+				type: 'error',
+				reason: 'migration-error',
+			})
+		}
+	})
+
+	it('[MG3] a persisted sequence named after an Object.prototype member is just unknown', () => {
+		const persisted = { schemaVersion: 2, sequences: { constructor: 1, 'com.tldraw.book': 1 } }
+		expect(schema.getMigrationsSince(persisted as any)).toEqual({ ok: true, value: [] })
+	})
+})
+
+describe('malformed v1 schemas (SC)', () => {
+	it('[SC5] a v1 schema with a malformed record entry produces an error result', () => {
+		expect(
+			upgradeSchema({ schemaVersion: 1, storeVersion: 1, recordVersions: { book: null } } as any).ok
+		).toBe(false)
+		expect(
+			upgradeSchema({
+				schemaVersion: 1,
+				storeVersion: 1,
+				recordVersions: { book: { version: 1, subTypeKey: 'type', subTypeVersions: null } },
+			} as any).ok
+		).toBe(false)
+	})
+})
+
+describe('non-object persisted schemas (MA)', () => {
+	it('[MA6] a missing schema is a migration error, not a throw', () => {
+		const schema = StoreSchema.create<Book>({ book: Book })
+		for (const bad of [undefined, null, 'v2', 3]) {
+			expect(schema.migrateStoreSnapshot({ store: {}, schema: bad as any })).toEqual({
+				type: 'error',
+				reason: 'migration-error',
+			})
+		}
+	})
+})

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -440,8 +440,8 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 	public getMigrationsSince(persistedSchema: SerializedSchema): Result<Migration[], string> {
 		// Every result — success, empty, or error — is cached, so cache once around the whole
 		// computation rather than at each of its exit points.
-		// A persisted schema is untrusted input and may not be an object at all, which a WeakMap
-		// key must be; such a schema is an error result that is cheap enough not to cache.
+		// A non-object schema (see upgradeSchema) cannot be a WeakMap key; its error result is cheap
+		// to recompute.
 		if (!isPlainRecord(persistedSchema)) return this.computeMigrationsSince(persistedSchema)
 
 		const cached = this.migrationCache.get(persistedSchema)

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -123,6 +123,10 @@ export interface SerializedSchemaV2 {
  */
 export type SerializedSchema = SerializedSchemaV1 | SerializedSchemaV2
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 /**
  * Upgrades a serialized schema from version 1 to version 2 format.
  *
@@ -153,8 +157,15 @@ export type SerializedSchema = SerializedSchemaV1 | SerializedSchemaV2
  * @public
  */
 export function upgradeSchema(schema: SerializedSchema): Result<SerializedSchemaV2, string> {
-	if (schema.schemaVersion > 2 || schema.schemaVersion < 1) return Result.err('Bad schema version')
-	if (schema.schemaVersion === 2) return Result.ok(schema as SerializedSchemaV2)
+	// Persisted schemas are untrusted input: check the shape rather than crash on a missing or
+	// malformed `sequences`/`recordVersions` further down.
+	if (!isPlainRecord(schema)) return Result.err('Bad schema')
+	if (schema.schemaVersion === 2) {
+		if (!isPlainRecord(schema.sequences)) return Result.err('Bad schema: missing sequences')
+		return Result.ok(schema)
+	}
+	if (schema.schemaVersion !== 1) return Result.err('Bad schema version')
+	if (!isPlainRecord(schema.recordVersions)) return Result.err('Bad schema: missing recordVersions')
 	const result: SerializedSchemaV2 = {
 		schemaVersion: 2,
 		sequences: {
@@ -163,8 +174,12 @@ export function upgradeSchema(schema: SerializedSchema): Result<SerializedSchema
 	}
 
 	for (const [typeName, recordVersion] of Object.entries(schema.recordVersions)) {
+		if (!isPlainRecord(recordVersion)) return Result.err('Bad schema: malformed recordVersions')
 		result.sequences[`com.tldraw.${typeName}`] = recordVersion.version
 		if ('subTypeKey' in recordVersion) {
+			if (!isPlainRecord(recordVersion.subTypeVersions)) {
+				return Result.err('Bad schema: malformed subTypeVersions')
+			}
 			for (const [subType, version] of Object.entries(recordVersion.subTypeVersions)) {
 				result.sequences[`com.tldraw.${typeName}.${subType}`] = version
 			}
@@ -425,6 +440,10 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 	public getMigrationsSince(persistedSchema: SerializedSchema): Result<Migration[], string> {
 		// Every result — success, empty, or error — is cached, so cache once around the whole
 		// computation rather than at each of its exit points.
+		// A persisted schema is untrusted input and may not be an object at all, which a WeakMap
+		// key must be; such a schema is an error result that is cheap enough not to cache.
+		if (!isPlainRecord(persistedSchema)) return this.computeMigrationsSince(persistedSchema)
+
 		const cached = this.migrationCache.get(persistedSchema)
 		if (cached) {
 			return cached
@@ -442,8 +461,11 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 		const schema = upgradeResult.value
 		const sequenceIdsToInclude = new Set(
-			// start with any shared sequences
-			Object.keys(schema.sequences).filter((sequenceId) => this.migrations[sequenceId])
+			// start with any shared sequences. Own-property lookups: a persisted sequence id like
+			// 'constructor' must not resolve to an Object.prototype member.
+			Object.keys(schema.sequences).filter((sequenceId) =>
+				getOwnProperty(this.migrations, sequenceId)
+			)
 		)
 
 		// also include any sequences that are not in the persisted schema but are marked as postHoc
@@ -548,8 +570,8 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 			migrationsToApply = migrationsToApply.slice().reverse()
 		}
 
-		record = structuredClone(record)
 		try {
+			record = structuredClone(record)
 			for (const migration of migrationsToApply) {
 				if (migration.scope === 'store') throw new Error(/* won't happen, just for TS */)
 				if (migration.scope === 'storage') throw new Error(/* won't happen, just for TS */)
@@ -626,10 +648,15 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 		// Clean up by filtering out any non-document records.
 		// This is mainly legacy support for extremely early days tldraw.
+		// Collect first, then delete, for the same live-iterator reason as the record loop above.
+		const nonDocumentIds: string[] = []
 		for (const [id, state] of storage.entries()) {
 			if (this.getType(state.typeName).scope !== 'document') {
-				storage.delete(id)
+				nonDocumentIds.push(id)
 			}
+		}
+		for (const id of nonDocumentIds) {
+			storage.delete(id)
 		}
 	}
 
@@ -678,14 +705,15 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		if (migrationsToApply.length === 0) {
 			return { type: 'success', value: snapshot.store }
 		}
-		const store = Object.assign(
-			new Map<string, R>(objectMapEntries(snapshot.store).map(devFreeze)),
-			{
-				getSchema: () => snapshot.schema,
-				setSchema: (_: SerializedSchema) => {},
-			}
-		)
 		try {
+			// devFreeze throws for non-plain values, which is a migration failure like any other
+			const store = Object.assign(
+				new Map<string, R>(objectMapEntries(snapshot.store).map(devFreeze)),
+				{
+					getSchema: () => snapshot.schema,
+					setSchema: (_: SerializedSchema) => {},
+				}
+			)
 			this.migrateStorage(store)
 			if (opts?.mutateInputStore) {
 				for (const [id, record] of store.entries()) {

--- a/packages/store/src/lib/StoreSideEffects.test.ts
+++ b/packages/store/src/lib/StoreSideEffects.test.ts
@@ -626,3 +626,61 @@ describe('atomic operations (AO)', () => {
 		])
 	})
 })
+
+describe('handler removal during dispatch and remote attribution (SE, AO)', () => {
+	it('[SE1] a handler that removes itself while running does not stop later handlers from running', () => {
+		const calls: string[] = []
+		const removeA = store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			removeA()
+		})
+		store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A', 'B'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'B', 'B'])
+	})
+
+	it('[SE1] an operationComplete handler that removes itself does not skip the next one', () => {
+		const calls: string[] = []
+		const removeA = store.sideEffects.registerOperationCompleteHandler(() => {
+			calls.push('A')
+			removeA()
+		})
+		store.sideEffects.registerOperationCompleteHandler(() => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A', 'B'])
+	})
+
+	it('[AO8] changes made by operationComplete handlers after a remote operation are attributed to user', () => {
+		store.put([book1, book2])
+		const log: string[] = []
+		store.addHistoryInterceptor((_entry, source) => log.push('history:' + source))
+		store.sideEffects.registerAfterChangeHandler('book', (_prev, _next, source) =>
+			log.push('afterChange:' + source)
+		)
+		let once = true
+		store.sideEffects.registerOperationCompleteHandler((source) => {
+			log.push('operationComplete:' + source)
+			if (once) {
+				once = false
+				store.put([{ ...book2, title: 'renamed' }])
+			}
+		})
+
+		store.mergeRemoteChanges(() => store.remove([book1Id]))
+
+		expect(log).toEqual([
+			'history:remote',
+			'operationComplete:remote',
+			'history:user',
+			'afterChange:user',
+			'operationComplete:user',
+			// the integrity check after the merge is its own (empty) user operation
+			'operationComplete:user',
+		])
+	})
+})

--- a/packages/store/src/lib/StoreSideEffects.ts
+++ b/packages/store/src/lib/StoreSideEffects.ts
@@ -677,7 +677,6 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	}
 }
 
-// A copy of `array` without the first occurrence of `item` (the array itself if it has none).
 function withoutFirst<T>(array: T[], item: T): T[] {
 	const index = array.indexOf(item)
 	if (index < 0) return array

--- a/packages/store/src/lib/StoreSideEffects.ts
+++ b/packages/store/src/lib/StoreSideEffects.ts
@@ -217,6 +217,16 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	private _operationCompleteHandlers: StoreOperationCompleteHandler[] = []
 
 	private _isEnabled = true
+
+	// Handler arrays are replaced, never mutated in place: dispatch iterates the array it looked up,
+	// so a handler that removes itself (or registers another) while running must not shift the
+	// entries out from under that iteration.
+	private addHandler<H>(handlers: { [K in string]?: H[] }, typeName: string, handler: H) {
+		handlers[typeName] = [...(handlers[typeName] ?? []), handler]
+		return () => {
+			handlers[typeName] = withoutFirst(handlers[typeName] ?? [], handler)
+		}
+	}
 	/**
 	 * Checks whether side effects are currently enabled.
 	 * When disabled, all side effect handlers are bypassed.
@@ -478,10 +488,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeCreateHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeCreateHandlers[typeName] as StoreBeforeCreateHandler<any>[]
-		if (!handlers) this._beforeCreateHandlers[typeName] = []
-		this._beforeCreateHandlers[typeName]!.push(handler)
-		return () => remove(this._beforeCreateHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeCreateHandlers, typeName, handler)
 	}
 
 	/**
@@ -510,10 +517,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterCreateHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterCreateHandlers[typeName] as StoreAfterCreateHandler<any>[]
-		if (!handlers) this._afterCreateHandlers[typeName] = []
-		this._afterCreateHandlers[typeName]!.push(handler)
-		return () => remove(this._afterCreateHandlers[typeName]!, handler)
+		return this.addHandler(this._afterCreateHandlers, typeName, handler)
 	}
 
 	/**
@@ -546,10 +550,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeChangeHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeChangeHandlers[typeName] as StoreBeforeChangeHandler<any>[]
-		if (!handlers) this._beforeChangeHandlers[typeName] = []
-		this._beforeChangeHandlers[typeName]!.push(handler)
-		return () => remove(this._beforeChangeHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeChangeHandlers, typeName, handler)
 	}
 
 	/**
@@ -577,10 +578,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterChangeHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterChangeHandlers[typeName] as StoreAfterChangeHandler<any>[]
-		if (!handlers) this._afterChangeHandlers[typeName] = []
-		this._afterChangeHandlers[typeName]!.push(handler as StoreAfterChangeHandler<any>)
-		return () => remove(this._afterChangeHandlers[typeName]!, handler)
+		return this.addHandler(this._afterChangeHandlers, typeName, handler)
 	}
 
 	/**
@@ -610,10 +608,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeDeleteHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeDeleteHandlers[typeName] as StoreBeforeDeleteHandler<any>[]
-		if (!handlers) this._beforeDeleteHandlers[typeName] = []
-		this._beforeDeleteHandlers[typeName]!.push(handler as StoreBeforeDeleteHandler<any>)
-		return () => remove(this._beforeDeleteHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeDeleteHandlers, typeName, handler)
 	}
 
 	/**
@@ -644,10 +639,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterDeleteHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterDeleteHandlers[typeName] as StoreAfterDeleteHandler<any>[]
-		if (!handlers) this._afterDeleteHandlers[typeName] = []
-		this._afterDeleteHandlers[typeName]!.push(handler as StoreAfterDeleteHandler<any>)
-		return () => remove(this._afterDeleteHandlers[typeName]!, handler)
+		return this.addHandler(this._afterDeleteHandlers, typeName, handler)
 	}
 
 	/**
@@ -677,14 +669,17 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	 * @public
 	 */
 	registerOperationCompleteHandler(handler: StoreOperationCompleteHandler) {
-		this._operationCompleteHandlers.push(handler)
-		return () => remove(this._operationCompleteHandlers, handler)
+		// copy on write, see addHandler
+		this._operationCompleteHandlers = [...this._operationCompleteHandlers, handler]
+		return () => {
+			this._operationCompleteHandlers = withoutFirst(this._operationCompleteHandlers, handler)
+		}
 	}
 }
 
-function remove(array: any[], item: any) {
+// A copy of `array` without the first occurrence of `item` (the array itself if it has none).
+function withoutFirst<T>(array: T[], item: T): T[] {
 	const index = array.indexOf(item)
-	if (index >= 0) {
-		array.splice(index, 1)
-	}
+	if (index < 0) return array
+	return [...array.slice(0, index), ...array.slice(index + 1)]
 }

--- a/packages/store/src/lib/executeQuery.test.ts
+++ b/packages/store/src/lib/executeQuery.test.ts
@@ -580,8 +580,8 @@ describe('executeQuery (QE)', () => {
 			const query = {}
 			const result = executeQuery(store.query, 'book', query)
 
-			// Empty query in executeQuery returns empty set (special handling is done in StoreQueries)
-			expect(result).toEqual(new Set())
+			// an empty expression imposes no constraint, matching objectMatchesQuery
+			expect(result).toEqual(new Set(Object.values(books).map((b) => b.id)))
 		})
 
 		it('should handle different record types separately', () => {
@@ -1447,5 +1447,56 @@ describe('reactive nested queries (QE3, QI5, QQ)', () => {
 			// Should now be empty
 			expect(idsQuery.get()).toEqual(new Set())
 		})
+	})
+})
+
+describe('index and predicate agreement (QE)', () => {
+	// Both matching strategies must agree, since a query switches between them (from-scratch uses
+	// the indexes, incremental updates use the predicate).
+	function agree<TypeName extends 'book' | 'author'>(typeName: TypeName, query: any) {
+		const fromIndexes = executeQuery(store.query, typeName, query)
+		const fromPredicate = new Set(
+			store
+				.allRecords()
+				.filter((r) => r.typeName === typeName && objectMatchesQuery(query, r as any))
+				.map((r) => r.id)
+		)
+		expect(fromIndexes).toEqual(fromPredicate)
+		return fromIndexes
+	}
+
+	it('[QE1] eq with undefined matches nothing in both strategies', () => {
+		expect(agree('book', { metadata: { copies: { eq: undefined } } }).size).toBe(0)
+	})
+
+	it('[QE1] eq and neq use SameValueZero, so NaN matches NaN', () => {
+		const odd = Book.create({
+			title: 'NaN',
+			authorId: authors.asimov.id,
+			publishedYear: 2000,
+			inStock: true,
+			rating: NaN,
+		})
+		store.put([odd])
+		expect(agree('book', { rating: { eq: NaN } })).toEqual(new Set([odd.id]))
+		expect(agree('book', { rating: { neq: NaN } }).has(odd.id)).toBe(false)
+	})
+
+	it('[QE1] a matcher with several operators applies all of them', () => {
+		const result = agree('author', { age: { gt: 70, neq: 75 } })
+		expect(result.size).toBeGreaterThan(0)
+		for (const id of result) {
+			const author = store.get(id) as Author
+			expect(author.age).toBeGreaterThan(70)
+			expect(author.age).not.toBe(75)
+		}
+	})
+
+	it('[QE3] an empty nested sub-expression matches every record', () => {
+		expect(agree('book', { metadata: {} }).size).toBe(Object.keys(books).length)
+	})
+
+	it('[QE4] the empty expression matches every record in both strategies', () => {
+		expect(agree('author', {}).size).toBe(Object.keys(authors).length)
 	})
 })

--- a/packages/store/src/lib/executeQuery.test.ts
+++ b/packages/store/src/lib/executeQuery.test.ts
@@ -1496,6 +1496,14 @@ describe('index and predicate agreement (QE)', () => {
 		expect(agree('book', { metadata: {} }).size).toBe(Object.keys(books).length)
 	})
 
+	it('[QE3] a nested sub-expression with no matchers matches records missing that nested object', () => {
+		// authors have no `metadata`, so the predicate must not require it to exist
+		expect(agree('author', { metadata: { copies: {} } }).size).toBe(Object.keys(authors).length)
+		expect(agree('author', { metadata: { extras: { region: {} } } }).size).toBe(
+			Object.keys(authors).length
+		)
+	})
+
 	it('[QE4] the empty expression matches every record in both strategies', () => {
 		expect(agree('author', {}).size).toBe(Object.keys(authors).length)
 	})

--- a/packages/store/src/lib/executeQuery.ts
+++ b/packages/store/src/lib/executeQuery.ts
@@ -1,6 +1,5 @@
 import { objectMapFromEntries, objectMapValues } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
-import { hasAnyKey } from './RecordsDiff'
 import { intersectSets } from './setUtils'
 import { StoreQueries } from './StoreQueries'
 
@@ -82,6 +81,17 @@ function extractMatcherPaths(
 	return paths
 }
 
+// Whether a sub-expression constrains anything at all. `extractMatcherPaths` only ever yields leaf
+// matchers, so a nested object with none (e.g. `{ metadata: { copies: {} } }`) must not make the
+// predicate demand that the record's nested object exists, or the two strategies diverge.
+function hasAnyMatcher(query: object): boolean {
+	for (const value of Object.values(query)) {
+		if (isQueryValueMatcher(value)) return true
+		if (typeof value === 'object' && value !== null && hasAnyMatcher(value)) return true
+	}
+	return false
+}
+
 // SameValueZero, the key equality of the `Map`s backing the indexes: `NaN` matches `NaN`.
 function sameValueZero(a: unknown, b: unknown) {
 	return a === b || (a !== a && b !== b)
@@ -108,8 +118,8 @@ export function objectMatchesQuery<T extends object>(query: QueryExpression<T>, 
 		}
 
 		// A nested query. Mirror `extractMatcherPaths`, for which only matchers constrain anything:
-		// a non-object entry or an empty sub-expression matches every record.
-		if (typeof matcher !== 'object' || matcher === null || !hasAnyKey(matcher)) continue
+		// a non-object entry or a sub-expression with no matchers matches every record.
+		if (typeof matcher !== 'object' || matcher === null || !hasAnyMatcher(matcher)) continue
 		if (typeof value !== 'object' || value === null) return false
 		if (!objectMatchesQuery(matcher as QueryExpression<any>, value as any)) {
 			return false

--- a/packages/store/src/lib/executeQuery.ts
+++ b/packages/store/src/lib/executeQuery.ts
@@ -1,5 +1,6 @@
 import { objectMapFromEntries, objectMapValues } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
+import { hasAnyKey } from './RecordsDiff'
 import { intersectSets } from './setUtils'
 import { StoreQueries } from './StoreQueries'
 
@@ -47,7 +48,6 @@ export type QueryValueMatcher<T> = { eq: T } | { neq: T } | { gt: number }
  *
  * @public
  */
-/** @public */
 export type QueryExpression<R extends object> = {
 	[k in keyof R & string]?: R[k] extends string | number | boolean | null | undefined
 		? QueryValueMatcher<R[k]>
@@ -82,23 +82,34 @@ function extractMatcherPaths(
 	return paths
 }
 
+// SameValueZero, the key equality of the `Map`s backing the indexes: `NaN` matches `NaN`.
+function sameValueZero(a: unknown, b: unknown) {
+	return a === b || (a !== a && b !== b)
+}
+
+// The one place matcher semantics live. `objectMatchesQuery` (the predicate used for incremental
+// updates) and `executeQuery` (the index lookup used from scratch) must agree, and the indexes only
+// track defined values, so an undefined value never matches any matcher.
+function matchesValue(matcher: QueryValueMatcher<any>, value: unknown): boolean {
+	if (value === undefined) return false
+	if ('eq' in matcher && !sameValueZero(value, matcher.eq)) return false
+	if ('neq' in matcher && sameValueZero(value, matcher.neq)) return false
+	if ('gt' in matcher && (typeof value !== 'number' || value <= matcher.gt)) return false
+	return true
+}
+
 export function objectMatchesQuery<T extends object>(query: QueryExpression<T>, object: T) {
 	for (const [key, matcher] of Object.entries(query)) {
 		const value = object[key as keyof T]
 
-		// if you add matching logic here, make sure you also update executeQuery,
-		// where initial data is pulled out of the indexes, since that requires different
-		// matching logic
 		if (isQueryValueMatcher(matcher)) {
-			if ('eq' in matcher && value !== matcher.eq) return false
-			// undefined values must not match neq: the indexes executeQuery reads only
-			// track defined values, and the two matching strategies have to agree
-			if ('neq' in matcher && (value === matcher.neq || value === undefined)) return false
-			if ('gt' in matcher && (typeof value !== 'number' || value <= matcher.gt)) return false
+			if (!matchesValue(matcher, value)) return false
 			continue
 		}
 
-		// It's a nested query
+		// A nested query. Mirror `extractMatcherPaths`, for which only matchers constrain anything:
+		// a non-object entry or an empty sub-expression matches every record.
+		if (typeof matcher !== 'object' || matcher === null || !hasAnyKey(matcher)) continue
 		if (typeof value !== 'object' || value === null) return false
 		if (!objectMatchesQuery(matcher as QueryExpression<any>, value as any)) {
 			return false
@@ -147,6 +158,12 @@ export function executeQuery<R extends UnknownRecord, TypeName extends R['typeNa
 	// Extract all paths with matchers (flattens nested queries)
 	const matcherPaths = extractMatcherPaths(query)
 
+	// No matchers means no constraints, so every record of the type matches — as it does for
+	// `objectMatchesQuery`, for which an empty expression is vacuously true.
+	if (matcherPaths.length === 0) {
+		return store.getAllIdsForType(typeName)
+	}
+
 	// Build a set of matching IDs for each path
 	const matchIds = objectMapFromEntries(
 		matcherPaths.map(({ path }) => [path, new Set<IdOf<S>>()] as const)
@@ -156,24 +173,19 @@ export function executeQuery<R extends UnknownRecord, TypeName extends R['typeNa
 	for (const { path, matcher } of matcherPaths) {
 		const index = store.index(typeName, path as any)
 
-		if ('eq' in matcher) {
+		if ('eq' in matcher && !('neq' in matcher) && !('gt' in matcher)) {
+			// a lone `eq` is a direct index lookup
 			const ids = index.get().get(matcher.eq)
 			if (ids) {
 				for (const id of ids) {
 					matchIds[path].add(id)
 				}
 			}
-		} else if ('neq' in matcher) {
+		} else {
+			// anything else scans the index's values, filtered by the same `matchesValue` the
+			// predicate path uses
 			for (const [value, ids] of index.get()) {
-				if (value !== matcher.neq) {
-					for (const id of ids) {
-						matchIds[path].add(id)
-					}
-				}
-			}
-		} else if ('gt' in matcher) {
-			for (const [value, ids] of index.get()) {
-				if (typeof value === 'number' && value > matcher.gt) {
+				if (matchesValue(matcher, value)) {
 					for (const id of ids) {
 						matchIds[path].add(id)
 					}

--- a/packages/store/src/lib/migrate.test.ts
+++ b/packages/store/src/lib/migrate.test.ts
@@ -375,3 +375,18 @@ describe('sortMigrations (MS)', () => {
 		).toThrowErrorMatchingInlineSnapshot(`[Error: Circular dependency in migrations: bar/1]`)
 	})
 })
+
+describe('sortMigrations: redundant dependencies (MS)', () => {
+	const sort = (migrations: Migration[]) => sortMigrations(migrations).map((mig) => mig.id)
+
+	it('[MS2] an explicit dependency on the implicit predecessor is not a cycle', () => {
+		expect(sort([m('foo/2', { dependsOn: ['foo/1'] }), m('foo/1')])).toEqual(['foo/1', 'foo/2'])
+	})
+
+	it('[MS2] a dependency listed twice counts once', () => {
+		expect(sort([m('bar/1', { dependsOn: ['foo/1', 'foo/1'] }), m('foo/1')])).toEqual([
+			'foo/1',
+			'bar/1',
+		])
+	})
+})

--- a/packages/store/src/lib/migrate.ts
+++ b/packages/store/src/lib/migrate.ts
@@ -360,11 +360,15 @@ export function sortMigrations(migrations: Migration[]): Migration[] {
 		// Explicit dependencies
 		if (m.dependsOn) {
 			for (const depId of m.dependsOn) {
-				if (byId.has(depId)) {
-					dependents.get(depId)!.add(m.id)
-					explicitDeps.get(m.id)!.add(depId)
-					inDegree.set(m.id, inDegree.get(m.id)! + 1)
-				}
+				if (!byId.has(depId)) continue
+				explicitDeps.get(m.id)!.add(depId)
+				// A dependency that is also the implicit predecessor, or that is listed twice, must
+				// only count once: the edge is only ever removed once, so a double-counted in-degree
+				// would leave the migration unprocessed and be reported as a circular dependency.
+				const dependentsOfDep = dependents.get(depId)!
+				if (dependentsOfDep.has(m.id)) continue
+				dependentsOfDep.add(m.id)
+				inDegree.set(m.id, inDegree.get(m.id)! + 1)
 			}
 		}
 	}


### PR DESCRIPTION
**Risk: high · Importance: high**

> **Umbrella PR — superseded by the per-bug splits below.** Kept open as the index and full write-up; close once the splits are in.
>
> History and listeners:
> - #10205 fix(store): drop rolled-back transaction changes from listeners and extractingChanges (supersedes #10100)
> - #10210 fix(store): don't deliver the in-flight flush to a listener added during it
> - #10216 fix(store): keep delivering a flush to other listeners when one throws
> - #10223 fix(store): flush pending changes to listeners on dispose
> - #10229 fix(store): attribute changes made by operationComplete handlers after a remote merge to the user
> - #10236 fix(store): stop store writes subscribing the writing reaction to the store
>
> Writes, diffs, and caches:
> - #10203 fix(store): record one history entry per record when put() sees the same id twice
> - #10207 fix(store): stop reverseRecordsDiff aliasing its input and squashRecordDiffs mutating shared tuples
> - #10215 fix(store): apply the removal of non-ephemeral keys in applyDiff with ignoreEphemeralKeys
> - #10225 fix(store): re-run computed cache readers when a deleted record comes back
> - #10231 fix(store): don't skip the next side-effect handler when one removes itself mid-dispatch
>
> Queries:
> - #10200 fix(store): rebuild indexes and queries after a rolled-back transaction resets the history
> - #10211 fix(store): make executeQuery and objectMatchesQuery agree on matcher semantics and empty expressions
> - #10218 fix(store): call the ids() query creator with no arguments
> - #10221 fix(store): don't emit empty added/removed sets from IncrementalSetConstructor
> - #10228 perf(store): avoid per-diff allocations in the index and ids derive loops
>
> Data structures, migrations, schema, docs:
> - #10202 fix(store): stop ImmutableMap overflowing the stack for keys named after Object.prototype members
> - #10209 fix(store): let AtomMap skip entries deleted mid-iteration and accept symbol and null-prototype keys
> - #10213 fix(store): don't report a duplicate migration dependency as circular
> - #10220 fix(store): return a migration error for malformed persisted schemas instead of throwing
> - #10227 fix(store): collect ids before deleting non-document records in migrateStorage
> - #10232 docs(store): use sentence case for DOCS.md headings

This PR fixes a batch of correctness bugs in `@tldraw/store` found by a deep review of the package: rolled-back transactions leaking to listeners and queries, undo recording states the document never had, reactions that write to the store subscribing to every store change, and a handful of edge cases in `AtomMap`, `ImmutableMap`, migrations, and schema handling. Every fix has a regression test that fails on `main`, and `packages/store/SPEC.md` is updated to match.

Supersedes #10100 (the accumulator rollback fix is the first item below, same approach). Relates to #10159.

### Before

Most of these are quiet: nothing throws, but sync or persistence receives a record the store never kept, a reactive query goes stale, or undo lands on a state that never existed.

**Transactions and history**

- `HistoryAccumulator` was not transaction-aware. `transact(() => { store.put([a]); throw })` rolled back `a` but left `{added: [a]}` queued, so the next flush delivered it to `TLSyncClient` and `TLLocalSyncClient`, which pushed or persisted a record the store did not hold.
- `StoreQueries.filterHistory` returned the raw history counter on `RESET`. After a rollback the counter can come back round to the value the incremental set last saw, so the reset registered no change and `ids()`/`index()` stayed permanently stale (phantom id present, next real id missing).
- `updateHistory` read `history.get()` with capture (and `AtomMap.deleteMany` captured the key set), so a reaction that writes to the store subscribed to every store change and could loop to the reaction depth limit.
- `put()` with the same id twice in one call recorded `updated[id] = [intermediate, final]`, or put the id in both `added` and `updated`. `editor.updateShapes([{id, x}, {id, y}])` therefore recorded a `from` the document never had, and undo restored it.
- `reverseRecordsDiff` aliased the input's `added`/`removed` containers, so `HistoryManager._undo` squashing into the reversed diff wrote through to the diff it had just pushed on the redo stack. `squashRecordDiffs([], {mutateFirstDiff: true})` also returned `undefined`, and `mutateFirstDiff` mutated shared tuples.
- `applyDiff({ignoreEphemeralKeys: true})` (the undo/redo path) merged only keys present in `to`, so a non-ephemeral key the update had removed was silently kept.
- `_flushHistory` iterated the live listener set (a listener added from a callback received the in-flight entries), `dispose()` dropped the pending change-set (an edit in the same frame as `Editor.dispose()` never reached sync/persistence), and a throwing listener starved every later listener.
- `flushAtomicCallbacks` only flipped `source` to `'user'` when after-handlers enqueued more events; events enqueued by `operationComplete` handlers after a remote merge ran as `'remote'`.

**Queries and caches**

- `executeQuery` (index walk) and `objectMatchesQuery` (predicate) disagreed on `{eq: undefined}`, `NaN`, multi-operator matchers, and empty nested sub-expressions, so the same `ids()` gave different answers from scratch and incrementally; `executeQuery({})` returned nothing, so `exec(type, {})` was `[]`.
- `createComputedCache` handed `UNINITIALIZED` to user `derive`/`areRecordsEqual` after the record was deleted, and a reader whose derive had yielded the same value before deletion never re-ran, so it never saw a re-created record with that id.
- Side-effect handler disposers spliced the live handler array during dispatch, so a handler that removed itself (a once-handler) made the next handler skip that event.

**Data structures, migrations, and schema**

- `ImmutableMap`'s string hash cache was a plain `{}`, so keys named after `Object.prototype` members (`'constructor'`, `'toString'`) got a function back as their hash; two such keys in a trie-sized map recursed until stack overflow. It also used `Object.is` instead of SameValueZero.
- `AtomMap` asserted instead of skipping when an entry was deleted mid-iteration (native `Map` skips), and `String(key)` threw for `Symbol` and null-prototype keys.
- `sortMigrations` double-counted the in-degree when `dependsOn` duplicated the implicit predecessor, asserting a false "Circular dependency in migrations".
- Malformed persisted schemas (missing `schemaVersion`/`sequences`, non-object schema, prototype-named sequence ids) threw `TypeError`s from `getMigrationsSince` instead of yielding an error result, bypassing `TLLocalSyncClient`'s error handling; legacy cleanup in `migrateStorage` deleted while iterating live storage.

### After

- Each accumulator entry is tagged with the history version it set; a rollback resets the counter, so later adds and flushes discard entries at or past it. `extractingChanges` excludes rolled-back nested transactions the same way. `filterHistory` returns a strictly increasing value on reset.
- `updateHistory` and `deleteMany` read without capture. `put()` keeps the first `from` per id, folds an update into a same-call addition, and records nothing for A → B → A.
- `reverseRecordsDiff` copies its collections; `squashRecordDiffs` claims tuples before mutating and returns a diff for empty input. `applyDiff` deletes keys absent from `to`.
- `_flushHistory` iterates a snapshot, delivers to every listener and then rethrows the first error; `dispose()` flushes before cancelling the reactor. `flushAtomicCallbacks` attributes every cascade round after the first to `'user'`.
- One shared `matchesValue` (SameValueZero; `undefined` never matches) backs both query paths, and an empty expression matches all records of the type.
- `createComputedCache` uses a never-equal `DELETED_RECORD` sentinel that cannot escape `get()`. Side-effect handler arrays are copy-on-write.
- `ImmutableMap` uses a null-prototype hash cache and SameValueZero; `AtomMap` iteration skips deleted entries and formats any key type. Duplicate migration edges are skipped. `getMigrationsSince` validates the persisted schema shape and returns error results; legacy cleanup collects ids before deleting.

### Implementation notes

- `Store.dispose()` now synchronously delivers pending entries to still-attached listeners. In `Editor.dispose()` the editor's own listeners and the sync/local clients are torn down first, so nothing new fires in practice, but a listener that outlives the editor now gets a final callback.
- `Store.createCache` (low-level) still exposes `UNINITIALIZED` to user signals after deletion; changing that is a type change, so it is documented rather than changed.
- Deliberately left for follow-ups: `put()` inside an enclosing transaction whose caller catches the error (interacts with the in-flight nested-transaction work in `packages/state`); interceptors still see rolled-back entries synchronously (SPEC H11, relied on by `HistoryManager`); the duplicated sections in `packages/store/DOCS.md`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — each new test fails on `main` and passes with this change (`packages/store` 498/498, plus `sync-core`, editor `HistoryManager`, and `tldraw` suites green)

### Release notes

- Fix rolled-back store transactions leaking changes to listeners, reactive queries, and `extractingChanges`
- Fix `put()` recording a wrong undo `from` when the same record appears twice in one call
- Fix `reverseRecordsDiff` aliasing its input and corrupting the redo stack
- Fix undo/redo keeping keys an update had removed
- Fix `executeQuery` and incremental query results disagreeing on `eq: undefined`, `NaN`, and empty expressions
- Fix computed caches never updating when a deleted record is re-created with the same id
- Fix a stack overflow in `AtomMap` for keys named after `Object.prototype` members
- Fix a false "Circular dependency in migrations" when `dependsOn` repeats the implicit predecessor
- Fix malformed persisted schemas throwing instead of returning a migration error

### API changes

- `QueryExpression` now carries its doc comment in the API report (a stray duplicate `@public` tag was hiding it); no signature changes

### Code changes

| Section                  | LOC change |
| ------------------------ | ---------- |
| Core code                | +362 / -178 |
| Tests                    | +675 / -3  |
| Automated files          | +1 / -1    |
| Documentation (SPEC/DOCS) | +77 / -70 |