### PR TITLE
fix(select): bail to idle when the pointed shape is deleted before the drag starts

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -47,6 +47,14 @@ export class DraggingHandle extends StateNode {
 
 	override onEnter(info: DraggingHandleInfo) {
 		const { shape, isCreating, creatingMarkId, handle } = info
+
+		// The shape can be deleted (remotely, by undo) between pointer down and the drag
+		const handles = this.editor.getShapeHandles(shape)
+		if (!handles) {
+			this.parent.transition('idle')
+			return
+		}
+
 		this.info = info
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -78,15 +86,15 @@ export class DraggingHandle extends StateNode {
 
 		this.editor.setCursor({ type: isCreating ? 'cross' : 'grabbing', rotation: 0 })
 
-		const handles = this.editor.getShapeHandles(shape)!.sort(sortByIndex)
-		const index = handles.findIndex((h) => h.id === info.handle.id)
+		const sortedHandles = handles.slice().sort(sortByIndex)
+		const index = sortedHandles.findIndex((h) => h.id === info.handle.id)
 
 		// Find the adjacent handle
 		this.initialAdjacentHandle = null
 
 		// First, check if the handle specifies a custom reference handle
 		if (info.handle.snapReferenceHandleId) {
-			const customHandle = handles.find((h) => h.id === info.handle.snapReferenceHandleId)
+			const customHandle = sortedHandles.find((h) => h.id === info.handle.snapReferenceHandleId)
 			if (customHandle) {
 				this.initialAdjacentHandle = customHandle
 			}
@@ -95,8 +103,8 @@ export class DraggingHandle extends StateNode {
 		// If no custom reference handle, use default behavior
 		if (!this.initialAdjacentHandle) {
 			// Start from the handle and work forward
-			for (let i = index + 1; i < handles.length; i++) {
-				const handle = handles[i]
+			for (let i = index + 1; i < sortedHandles.length; i++) {
+				const handle = sortedHandles[i]
 				if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
 					this.initialAdjacentHandle = handle
 					break
@@ -105,8 +113,8 @@ export class DraggingHandle extends StateNode {
 
 			// If still no handle, start from the end and work backward
 			if (!this.initialAdjacentHandle) {
-				for (let i = handles.length - 1; i >= 0; i--) {
-					const handle = handles[i]
+				for (let i = sortedHandles.length - 1; i >= 0; i--) {
+					const handle = sortedHandles[i]
 					if (handle.type === 'vertex' && handle.id !== 'middle' && handle.id !== info.handle.id) {
 						this.initialAdjacentHandle = handle
 						break

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -86,6 +86,7 @@ export class DraggingHandle extends StateNode {
 
 		this.editor.setCursor({ type: isCreating ? 'cross' : 'grabbing', rotation: 0 })
 
+		// getShapeHandles is cached; don't sort it in place
 		const sortedHandles = handles.slice().sort(sortByIndex)
 		const index = sortedHandles.findIndex((h) => h.id === info.handle.id)
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -67,6 +67,13 @@ export class PointingHandle extends StateNode {
 	override onPointerUp() {
 		const { shape, handle } = this.info
 
+		// The shape may have been deleted since pointer down (remote user, undo); the note
+		// branch below would clone a new note from the dead record
+		if (!this.editor.getShape(shape.id)) {
+			this.parent.transition('idle')
+			return
+		}
+
 		if (this.isDoubleClick) {
 			this.parent.transition('idle')
 			this.parent.getCurrent()?.handleEvent({
@@ -122,6 +129,11 @@ export class PointingHandle extends StateNode {
 		const { editor } = this
 		if (editor.getIsReadonly()) return
 		const { shape, handle } = this.info
+
+		if (!editor.getShape(shape.id)) {
+			this.parent.transition('idle')
+			return
+		}
 
 		if (editor.isShapeOfType(shape, 'note')) {
 			const noteUtil = editor.getShapeUtil(shape) as NoteShapeUtil

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -227,6 +227,12 @@ export class PointingShape extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
+			// The pointed shape may have been deleted since pointer down (remote user, undo)
+			if (!this.editor.getShape(this.hitShape.id)) {
+				this.parent.transition('idle', info)
+				return
+			}
+
 			if (isOverArrowLabel(this.editor, this.hitShape)) {
 				// We're moving the label on a shape.
 				this.parent.transition('pointing_arrow_label', { ...info, shape: this.hitShape })
@@ -251,8 +257,13 @@ export class PointingShape extends StateNode {
 		// If we didn't select the shape on enter (e.g. because it has an onClick handler),
 		// and there's no current selection, select it now before transitioning to translating.
 		if (!this.didSelectOnEnter && !this.editor.getSelectedShapeIds().length) {
+			const shapeToSelect = this.editor.getShape(this.hitShapeForPointerUp.id)
+			if (!shapeToSelect) {
+				this.parent.transition('idle', info)
+				return
+			}
 			this.editor.markHistoryStoppingPoint('selecting shape')
-			this.editor.setSelectedShapes([this.hitShapeForPointerUp.id])
+			this.editor.setSelectedShapes([shapeToSelect.id])
 		}
 
 		// Re-focus the editor, just in case the text label of the shape has stolen focus

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -227,15 +227,10 @@ export class PointingShape extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
-			// Brushing doesn't touch the shape, so it can go ahead even if the shape is gone
-			if (this.didCtrlOnEnter) {
-				this.parent.transition('brushing', info)
-				return
-			}
-
-			// The pointed shape may have been deleted since pointer down (remote user, undo)
+			// The pointed shape may have been deleted since pointer down (remote user, undo).
+			// Brushing never reads it, so a ctrl-drag can still go ahead.
 			if (!this.editor.getShape(this.hitShape.id)) {
-				this.parent.transition('idle', info)
+				this.parent.transition(this.didCtrlOnEnter ? 'brushing' : 'idle', info)
 				return
 			}
 
@@ -245,7 +240,11 @@ export class PointingShape extends StateNode {
 				return
 			}
 
-			this.startTranslating(info)
+			if (this.didCtrlOnEnter) {
+				this.parent.transition('brushing', info)
+			} else {
+				this.startTranslating(info)
+			}
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -227,6 +227,12 @@ export class PointingShape extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
+			// Brushing doesn't touch the shape, so it can go ahead even if the shape is gone
+			if (this.didCtrlOnEnter) {
+				this.parent.transition('brushing', info)
+				return
+			}
+
 			// The pointed shape may have been deleted since pointer down (remote user, undo)
 			if (!this.editor.getShape(this.hitShape.id)) {
 				this.parent.transition('idle', info)
@@ -239,11 +245,7 @@ export class PointingShape extends StateNode {
 				return
 			}
 
-			if (this.didCtrlOnEnter) {
-				this.parent.transition('brushing', info)
-			} else {
-				this.startTranslating(info)
-			}
+			this.startTranslating(info)
 		}
 	}
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -224,6 +224,38 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 		expect(() => editor.pointerUp(shape.x + 10, shape.y + 10)).not.toThrow()
 		editor.expectToBeIn('select.idle')
 	})
+
+	it('does not crash when dragging after a labelled arrow is deleted', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: { richText: toRichText('label'), start: { x: 0, y: 0 }, end: { x: 200, y: 0 } },
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.pointerDown(200, 100, { target: 'shape', shape })
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.arrow1])
+
+		expect(() => editor.pointerMove(220, 120)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not select a deleted shape when the drag starts', () => {
+		editor.select(ids.box1)
+		const shape = editor.getShape(ids.box1)!
+		editor.pointerDown(150, 150, { target: 'shape', shape })
+
+		editor.deleteShapes([ids.box1])
+
+		editor.pointerMove(200, 200)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.expectToBeIn('select.idle')
+	})
 })
 
 describe('TLSelectTool.Translating', () => {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -245,7 +245,7 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 		editor.expectToBeIn('select.idle')
 	})
 
-	it('does not select a deleted shape when the drag starts', () => {
+	it('returns to idle without reselecting a deleted shape on pointer move', () => {
 		editor.select(ids.box1)
 		const shape = editor.getShape(ids.box1)!
 		editor.pointerDown(150, 150, { target: 'shape', shape })
@@ -254,6 +254,48 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 
 		editor.pointerMove(200, 200)
 		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not reselect a deleted shape when a long press starts translating', () => {
+		editor.select(ids.box1)
+		const shape = editor.getShape(ids.box1)!
+		editor.pointerDown(150, 150, { target: 'shape', shape })
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.box1])
+		editor.expectToBeIn('select.pointing_shape')
+
+		vi.advanceTimersByTime(editor.options.longPressDurationMs + 100)
+		editor.forceTick()
+
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.expectToBeIn('select.idle')
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+})
+
+describe('TLSelectTool.PointingHandle when the shape is deleted before dragging', () => {
+	it('returns to idle without crashing when the pointed arrow is deleted', () => {
+		editor.createShape({ id: ids.arrow1, type: 'arrow', x: 100, y: 100 })
+		const shape = editor.getShape(ids.arrow1)!
+		const handle = editor.getShapeHandles(shape)!.find((handle) => handle.id === 'end')!
+		editor.select(shape.id).pointerDown(shape.x + handle.x, shape.y + handle.y, {
+			target: 'handle',
+			shape,
+			handle,
+		})
+		editor.expectToBeIn('select.pointing_handle')
+
+		editor.deleteShapes([shape.id])
+		editor.expectToBeIn('select.pointing_handle')
+
+		expect(() => editor.pointerMove(shape.x + handle.x + 50, shape.y + handle.y + 50)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(editor.getInstanceState().cursor.type).toBe('default')
+		editor.pointerUp()
 		editor.expectToBeIn('select.idle')
 	})
 })

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -274,6 +274,17 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 		editor.pointerUp()
 		editor.expectToBeIn('select.idle')
 	})
+
+	it('still brushes on ctrl-drag when the pointed shape is deleted', () => {
+		const shape = editor.getShape(ids.box1)!
+		editor.pointerDown(150, 150, { target: 'shape', shape, accelKey: true })
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.box1])
+
+		editor.pointerMove(200, 200, { accelKey: true })
+		editor.expectToBeIn('select.brushing')
+	})
 })
 
 describe('TLSelectTool.PointingHandle when the shape is deleted before dragging', () => {
@@ -297,6 +308,40 @@ describe('TLSelectTool.PointingHandle when the shape is deleted before dragging'
 		expect(editor.getInstanceState().cursor.type).toBe('default')
 		editor.pointerUp()
 		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not clone a deleted note when its clone handle is dragged', () => {
+		const noteId = createShapeId('note1')
+		editor.createShapes([{ id: noteId, type: 'note', x: 100, y: 100 }])
+		editor.select(noteId)
+		const shape = editor.getShape(noteId)!
+		const handle = editor.getShapeHandles(shape)!.find((h) => h.id === 'right')!
+		editor.pointerDown(300, 200, { target: 'handle', shape, handle })
+		editor.expectToBeIn('select.pointing_handle')
+
+		editor.deleteShapes([noteId])
+
+		editor.pointerMove(350, 200)
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCurrentPageShapes().filter((s) => s.type === 'note')).toHaveLength(0)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
+	it('does not clone a deleted note when its clone handle is clicked', () => {
+		const noteId = createShapeId('note1')
+		editor.createShapes([{ id: noteId, type: 'note', x: 100, y: 100 }])
+		editor.select(noteId)
+		const shape = editor.getShape(noteId)!
+		const handle = editor.getShapeHandles(shape)!.find((h) => h.id === 'right')!
+		editor.pointerDown(300, 200, { target: 'handle', shape, handle })
+		editor.expectToBeIn('select.pointing_handle')
+
+		editor.deleteShapes([noteId])
+
+		editor.pointerUp(300, 200)
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCurrentPageShapes().filter((s) => s.type === 'note')).toHaveLength(0)
+		expect(editor.getEditingShapeId()).toBeNull()
 	})
 })
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -275,6 +275,22 @@ describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () =>
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('still moves the label on ctrl-drag over a live arrow label', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: { richText: toRichText('label'), start: { x: 0, y: 0 }, end: { x: 200, y: 0 } },
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.pointerDown(200, 100, { target: 'shape', shape, accelKey: true })
+		editor.pointerMove(220, 120, { accelKey: true })
+		editor.expectToBeIn('select.pointing_arrow_label')
+	})
+
 	it('still brushes on ctrl-drag when the pointed shape is deleted', () => {
 		const shape = editor.getShape(ids.box1)!
 		editor.pointerDown(150, 150, { target: 'shape', shape, accelKey: true })


### PR DESCRIPTION
**Risk: low · Importance: high**

This PR fixes a bug where deleting a shape (by a collaborator, or by undo) between pointer down and the drag threshold crashed the editor and left the select tool stuck in the pointing state.

### Before

`PointingShape.onPointerMove` passed a deleted shape to arrow-label geometry, and `DraggingHandle.onEnter` tried to sort its missing handles; both paths crashed. A long press could also make `startTranslating` reselect the deleted shape ID. The equivalent crop-handle crash was fixed separately in #10370.

### After

Each of those paths checks that the shape still exists and transitions to idle when it does not. `PointingHandle`'s note branch (clone handle drag or click) gets the same guard, since it returned before `DraggingHandle` and would otherwise clone a fresh note from the deleted record. Ctrl-drag still brushes when the shape is gone, since brushing never reads it; on a live shape the order is unchanged, so ctrl-drag on an arrow label still moves the label. `DraggingHandle` also stops sorting the memoized `getShapeHandles` array in place.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. In a multiplayer room, press on a labelled arrow (or an arrow end handle, or a sticky note clone handle) and have another client delete the shape before you move; the tool returns to idle without a crash screen.

- [x] Unit tests — all four regression tests fail on `main` and pass with this change, covering labelled-arrow dragging, pointer-move selection, long-press selection, and arrow-handle dragging

### Release notes

- Fix a crash when a shape is deleted between pointing at it and starting to drag it, or its handle.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +27 / -8 |
| Tests     | +74 / -0 |