### PR TITLE
fix(select): don't select a locked group by clicking its child

### DIFF
--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -16,7 +16,8 @@ export function selectOnCanvasPointerUp(
 		hitLabels: true,
 		hitLocked: selectLockedShapes,
 		renderingOnly: true,
-		filter: (shape) => selectLockedShapes || !shape.isLocked,
+		// A child of a locked group would otherwise resolve to the locked group and select it
+		filter: (shape) => selectLockedShapes || !editor.isShapeOrAncestorLocked(shape),
 	})
 
 	// Note at the start: if we select a shape that is inside of a group,

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -47,6 +47,21 @@ describe('TLSelectTool.Idle', () => {
 		editor.expectToBeIn('select.pointing_canvas')
 	})
 
+	it('Does not select a locked group by clicking one of its children', () => {
+		const a = createShapeId('a')
+		const b = createShapeId('b')
+		const groupId = createShapeId('group')
+		editor.createShapes([
+			{ id: a, type: 'geo', x: 300, y: 300, props: { w: 100, h: 100, fill: 'solid' } },
+			{ id: b, type: 'geo', x: 500, y: 300, props: { w: 100, h: 100, fill: 'solid' } },
+		])
+		editor.groupShapes([a, b], { groupId })
+		editor.updateShape({ id: groupId, type: 'group', isLocked: true })
+		editor.selectNone()
+		editor.pointerDown(350, 350).pointerUp(350, 350)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
 	it('Nudges selected shapes on arrow key down', () => {
 		const shape = editor.getShape(ids.box1)!
 		editor.select(shape.id)


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where clicking a child of a locked group selected the locked group.

### Before

`selectOnCanvasPointerUp`'s hit-test filter only rejected shapes that were themselves locked, so an unlocked child of a locked group passed, resolved to its outermost selectable ancestor — the locked group — and selected it, even though clicking the group's own bounds does nothing.

### After

The filter rejects shapes with a locked ancestor (`isShapeOrAncestorLocked`).

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Group two shapes, lock the group, deselect.
2. Click one of the children: nothing is selected.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix clicking a child of a locked group selecting the locked group.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -1    |
| Tests     | +15 / -0   |
