### PR TITLE
fix(select): treat near-right-angle page rotations as right angles for bounds snapping

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -1,6 +1,5 @@
 import {
 	Box,
-	HALF_PI,
 	SelectionHandle,
 	ShapeWithCrop,
 	StateNode,
@@ -11,6 +10,7 @@ import {
 	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getCropBox, getDefaultCrop, getUncroppedSize } from '../../../../../shapes/shared/crop'
+import { isRightAngleRotation } from '../../../selectHelpers'
 import { CursorTypeMap } from '../../PointingResizeHandle'
 
 type Snapshot = ReturnType<Cropping['createSnapshot']>
@@ -110,7 +110,7 @@ export class Cropping extends StateNode {
 		editor.snaps.clearIndicators()
 		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 		let didSnap = false
-		if (shouldSnap && initialSelectionPageBounds && selectionRotation % HALF_PI === 0) {
+		if (shouldSnap && initialSelectionPageBounds && isRightAngleRotation(selectionRotation)) {
 			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
 				initialSelectionPageBounds,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -1,6 +1,5 @@
 import {
 	Box,
-	HALF_PI,
 	Mat,
 	PI,
 	PI2,
@@ -22,6 +21,7 @@ import {
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
+import { isRightAngleRotation } from '../selectHelpers'
 
 export type ResizingInfo = TLPointerEventInfo & {
 	target: 'selection'
@@ -298,7 +298,7 @@ export class Resizing extends StateNode {
 
 		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 
-		if (shouldSnap && selectionRotation % HALF_PI === 0) {
+		if (shouldSnap && isRightAngleRotation(selectionRotation)) {
 			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
 				initialSelectionPageBounds: initialSelectionPageBounds,

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -1,11 +1,13 @@
 import {
 	Editor,
 	ExtractShapeByProps,
+	HALF_PI,
 	richTextValidator,
 	TLEventInfo,
 	TLRichText,
 	TLShape,
 	TLShapeId,
+	approximately,
 } from '@tldraw/editor'
 
 /** @internal */
@@ -47,4 +49,16 @@ export function startEditingShapeWithRichText(
 	if (options.selectAll) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
+}
+
+/**
+ * Whether a rotation is a multiple of 90 degrees. An exact `rotation % HALF_PI === 0` misses
+ * page rotations accumulated through rotated parents, which land a few ulps off and silently
+ * disable right-angle-only behavior such as bounds snapping.
+ *
+ * @internal
+ */
+export function isRightAngleRotation(rotation: number) {
+	const turns = rotation / HALF_PI
+	return approximately(turns, Math.round(turns))
 }


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where bounds snapping did not engage while resizing or cropping a shape whose page rotation is a right angle only through its rotated parents.

### Before

`Resizing` and `Cropping` gated snapping on `selectionRotation % HALF_PI === 0`. A page rotation accumulated through rotated frames or groups lands a few ulps off an exact multiple of π/2, so the check silently failed for visually axis-aligned shapes.

### After

Both use a tolerant `isRightAngleRotation` helper in `selectHelpers`.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Put a shape in a frame rotated 90° (or nest two frames rotated 45° each) and enable snap mode.
2. Resize the shape near another shape's edge: snap indicators appear and the edge snaps.
3. Same while cropping an image in that frame.

- [ ] Unit tests — no new tests; the resizing, cropping, and snapping suites pass

### Release notes

- Fix bounds snapping not engaging while resizing or cropping shapes inside rotated frames or groups.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -4   |
