### PR TITLE
fix(eraser): rebuild the erasing list from the live set each update

### DIFF
--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -9,8 +9,6 @@ export class Erasing extends StateNode {
 	private markId = ''
 	private excludedShapeIds = new Set<TLShapeId>()
 
-	_erasingShapeIds: TLShapeId[] = []
-
 	override onEnter(info: TLPointerEventInfo) {
 		this.markId = this.editor.markHistoryStoppingPoint('erase scribble begin')
 		this.info = info
@@ -34,14 +32,13 @@ export class Erasing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
-		this._erasingShapeIds = this.editor
-			.getShapesAtPoint(originPagePoint)
-			.filter((s) => !this.excludedShapeIds.has(s.id))
-			.map((s) => s.id)
-
-		this.editor.setErasingShapes([
-			...new Set([...this.editor.getErasingShapeIds(), ...this._erasingShapeIds]),
-		])
+		// Keep what the pointing state marked (it hit-tests with a margin) plus whatever is under the origin
+		const hitsAtOrigin = this.editor.getShapesAtPoint(originPagePoint).map((s) => s.id)
+		this.editor.setErasingShapes(
+			[...new Set([...this.editor.getErasingShapeIds(), ...hitsAtOrigin])].filter(
+				(id) => !this.excludedShapeIds.has(id)
+			)
+		)
 
 		const scribble = this.editor.scribbles.addScribble({
 			color: 'muted-1',
@@ -95,10 +92,7 @@ export class Erasing extends StateNode {
 		const candidateIds = editor.getShapeIdsInsideBounds(lineBounds)
 
 		// Early return if no candidates - avoid expensive getCurrentPageRenderingShapesSorted()
-		if (candidateIds.size === 0) {
-			editor.setErasingShapes(Array.from(erasing))
-			return
-		}
+		if (candidateIds.size === 0) return
 
 		const allShapes = editor.getCurrentPageRenderingShapesSorted()
 		const currentPageShapes = allShapes.filter((shape) => candidateIds.has(shape.id))
@@ -143,21 +137,18 @@ export class Erasing extends StateNode {
 					erasing.add(outermost.id)
 				}
 			}
-
-			this._erasingShapeIds = [...erasing]
 		}
 
 		// Remove the hit shapes, except if they're in the list of excluded shapes
 		// (these excluded shapes will be any frames or groups the pointer was inside of
 		// when the user started erasing)
-		this.editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
+		this.editor.setErasingShapes([...erasing].filter((id) => !excludedShapeIds.has(id)))
 	}
 
 	complete(info?: TLPointerEventInfo) {
 		const { editor } = this
 		editor.deleteShapes(editor.getCurrentPageState().erasingShapeIds)
 		this.parent.transition('idle', info)
-		this._erasingShapeIds = []
 	}
 
 	cancel() {

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId } from '@tldraw/editor'
+import { IndexKey, createShapeId } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { createDrawSegments } from '../lib/utils/test-helpers'
 import { TestEditor } from './TestEditor'
@@ -285,6 +285,47 @@ describe('When clicking', () => {
 		expect(editor.getErasingShapeIds()).toEqual([])
 		expect(editor.getShape(ids.box1)).toBeDefined()
 		expect(shapesAfterCount).toBe(shapesBeforeCount)
+	})
+})
+
+describe('When the drag starts over shapes that were hit with a margin', () => {
+	it('keeps a shape the pointing state marked when the first drag step only crosses other shapes', () => {
+		const lineId = createShapeId('line')
+		const groupA = createShapeId('groupA')
+		const groupB = createShapeId('groupB')
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{
+				id: lineId,
+				type: 'line',
+				x: 100,
+				y: 100,
+				props: {
+					points: {
+						a1: { id: 'a1', index: 'a1' as IndexKey, x: 0, y: 0 },
+						a2: { id: 'a2', index: 'a2' as IndexKey, x: 100, y: 0 },
+					},
+				},
+			},
+			{ id: groupA, type: 'geo', x: 0, y: 0, props: { w: 10, h: 10 } },
+			{ id: groupB, type: 'geo', x: 400, y: 400, props: { w: 10, h: 10 } },
+		])
+		// A group whose bounds cover the area makes the first erasing update see a candidate
+		// (the group) without hit-testing anything else.
+		editor.groupShapes([groupA, groupB])
+
+		editor.setCurrentTool('eraser')
+		editor.pointerDown(150, 102) // 2px from the line, inside the hit-test margin
+		editor.expectToBeIn('eraser.pointing')
+		expect(editor.getErasingShapeIds()).toEqual([lineId])
+
+		editor.pointerMove(150, 105)
+		editor.pointerMove(150, 108)
+		editor.expectToBeIn('eraser.erasing')
+		expect(editor.getErasingShapeIds()).toEqual([lineId])
+
+		editor.pointerUp()
+		expect(editor.getShape(lineId)).toBeUndefined()
 	})
 })
 


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where the eraser dropped a shape it had highlighted on pointer down if the first drag step only crossed other shapes.

### Before

`Erasing` kept a private `_erasingShapeIds` copy that the first drag step rebuilt from exact hits only; the pointing state hit-tests with a margin and had already marked the shape, so it was silently dropped from the erase.

### After

The erasing set is computed from the editor's current `erasingShapeIds` plus the shapes hit by each scribble segment; the no-candidates early return no longer rewrites the set.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. With the eraser, press down just outside a shape (within the hit margin) so it highlights, then drag across a different shape.
2. Release; both shapes should be erased.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix the eraser dropping a shape it had highlighted on pointer down when the first drag step only crossed other shapes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -18   |
| Tests     | +42 / -1   |
