### PR TITLE
fix(select): always leave pointing_arrow_label on pointer up

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -134,13 +134,16 @@ export class PointingArrowLabel extends StateNode {
 
 	override onPointerUp() {
 		const shape = this.editor.getShape<TLArrowShape>(this.shapeId)
-		if (!shape) return
 
-		if (this.didDrag || !this.wasAlreadySelected) {
-			this.complete()
-		} else if (this.editor.canEditShape(shape)) {
+		// Clicking the label of an already-selected arrow starts editing it; every other
+		// outcome (drag, fresh selection, deleted or uneditable arrow) must leave this state,
+		// which has no pointer down handler to recover from.
+		if (shape && !this.didDrag && this.wasAlreadySelected && this.editor.canEditShape(shape)) {
 			startEditingShapeWithRichText(this.editor, shape.id)
+			return
 		}
+
+		this.complete()
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -603,6 +603,55 @@ describe('PointingLabel', () => {
 		)
 	})
 
+	it('returns to idle on pointer up when the arrow was deleted', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.select(shape.id)
+		editor.pointerDown(150, 100, { target: 'shape', shape })
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+		editor.deleteShapes([ids.arrow1])
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('returns to idle on pointer up when the arrow cannot be edited', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.select(shape.id)
+		editor.updateInstanceState({ isReadonly: true })
+		editor.setCurrentTool('hand').setCurrentTool('select')
+		editor.pointerDown(150, 100, { target: 'shape', shape })
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('Doesnt go into pointing_arrow_label mode if not selecting the arrow shape', () => {
 		editor.createShapes([
 			{


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the select tool got stuck in `select.pointing_arrow_label` and swallowed every later click until Escape was pressed.

### Before

`PointingArrowLabel.onPointerUp` returned early when the arrow had been deleted, and when the arrow was already selected, not dragged and not editable (read-only editor, or a locked arrow with `selectLockedShapes`). The state has no pointer-down handler, so nothing could recover from it.

### After

Only the one intended outcome — clicking the label of an already-selected, editable arrow — starts editing; every other outcome completes back to idle.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. In a read-only editor, select an arrow with a label, press on the label, nudge past the drag threshold, and release; the next click on the canvas should work normally.

- [x] Unit tests — the new tests (2) fail on `main` and pass with this change

### Release notes

- Fix the select tool getting stuck after pressing an arrow label in a read-only editor or on a deleted arrow.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -4 |
| Tests     | +49 / -0 |
