### PR TITLE
fix(select): route repeated arrow keys the same way as the first press

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -570,29 +570,7 @@ export class Idle extends StateNode {
 	override onKeyDown(info: TLKeyboardEventInfo) {
 		this.selectedShapesOnKeyDown = this.editor.getSelectedShapes()
 
-		switch (info.code) {
-			case 'ArrowLeft':
-			case 'ArrowRight':
-			case 'ArrowUp':
-			case 'ArrowDown': {
-				if (info.accelKey) {
-					if (info.shiftKey) {
-						if (info.code === 'ArrowDown') {
-							this.editor.selectFirstChildShape()
-						} else if (info.code === 'ArrowUp') {
-							this.editor.selectParentShape()
-						}
-					} else {
-						this.editor.selectAdjacentShape(
-							info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
-						)
-					}
-					return
-				}
-				this.nudgeSelectedShapes(false)
-				return
-			}
-		}
+		if (this.handleArrowKey(info, false)) return
 
 		if (debugFlags['editOnType'].get()) {
 			// This feature flag lets us start editing a note shape's label when a key is pressed.
@@ -624,28 +602,42 @@ export class Idle extends StateNode {
 	}
 
 	override onKeyRepeat(info: TLKeyboardEventInfo) {
+		if (this.handleArrowKey(info, true)) return
+
+		if (info.code === 'Tab') {
+			const selectedShapes = this.editor.getSelectedShapes()
+			if (selectedShapes.length && !info.altKey) {
+				this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
+			}
+		}
+	}
+
+	// Shared by key down and key repeat so a held combination keeps doing what the first press did
+	private handleArrowKey(info: TLKeyboardEventInfo, ephemeral: boolean): boolean {
 		switch (info.code) {
 			case 'ArrowLeft':
 			case 'ArrowRight':
 			case 'ArrowUp':
 			case 'ArrowDown': {
 				if (info.accelKey) {
-					this.editor.selectAdjacentShape(
-						info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
-					)
-					return
+					if (info.shiftKey) {
+						if (info.code === 'ArrowDown') {
+							this.editor.selectFirstChildShape()
+						} else if (info.code === 'ArrowUp') {
+							this.editor.selectParentShape()
+						}
+					} else {
+						this.editor.selectAdjacentShape(
+							info.code.replace('Arrow', '').toLowerCase() as TLAdjacentDirection
+						)
+					}
+					return true
 				}
-				this.nudgeSelectedShapes(true)
-				break
-			}
-			case 'Tab': {
-				const selectedShapes = this.editor.getSelectedShapes()
-				if (selectedShapes.length && !info.altKey) {
-					this.editor.selectAdjacentShape(info.shiftKey ? 'prev' : 'next')
-				}
-				break
+				this.nudgeSelectedShapes(ephemeral)
+				return true
 			}
 		}
+		return false
 	}
 
 	override onKeyUp(info: TLKeyboardEventInfo) {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where holding Cmd+Shift+ArrowUp/ArrowDown started by selecting the parent or first child and then, once the key repeated, switched to selecting the adjacent shape instead.

### Before

`Idle.onKeyRepeat` had its own copy of the arrow-key switch that lacked the shift branch `onKeyDown` had.

### After

Both paths route through one `handleArrowKey(info, ephemeral)`; the only difference between them — repeat nudges are ephemeral — is the parameter.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape inside a group, hold Cmd+Shift+ArrowUp: the selection moves to the group and stays there while the key repeats, rather than jumping to a shape above.
2. Hold ArrowRight: the shape keeps nudging as before.

- [ ] Unit tests — no new tests; the select tool and nudge suites pass

### Release notes

- Fix held Cmd+Shift+Arrow key combinations switching from parent/child selection to adjacent selection once the key repeats.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +28 / -36  |
