### PR TITLE
fix(zoom): fix toolbar highlighting and a stuck tool when holding Z

### DIFF
--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -23,13 +23,14 @@ export class ZoomTool extends StateNode {
 	override onEnter(info: TLPointerEventInfo & { onInteractionEnd: string }) {
 		this.info = info
 		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask
+		// getCurrentToolId reads the mask off the current tool, so a mask on the parent is never seen
 		const toolId = info.onInteractionEnd?.split('.')[0]
-		this.parent.setCurrentToolIdMask(toolId)
+		this.setCurrentToolIdMask(toolId)
 		this.updateCursor()
 	}
 
 	override onExit() {
-		this.parent.setCurrentToolIdMask(undefined)
+		this.setCurrentToolIdMask(undefined)
 		this.editor.updateInstanceState({ zoomBrush: null, cursor: { type: 'default', rotation: 0 } })
 	}
 

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
@@ -53,11 +53,17 @@ export function useIsToolSelected(tool: TLUiToolItem | undefined) {
 		() => {
 			if (!tool) return false
 			const activeToolId = editor.getCurrentToolId()
-			if (activeToolId === 'geo') {
-				return geo === editor.getSharedStyles().getAsKnownValue(GeoShapeGeoStyle)
-			} else {
-				return activeToolId === tool.id
+			if (geo) {
+				// A tool masking itself as `geo` (the zoom tool does) has no shape type of its own,
+				// so its shared styles come back empty
+				return (
+					activeToolId === 'geo' &&
+					geo ===
+						(editor.getSharedStyles().getAsKnownValue(GeoShapeGeoStyle) ??
+							editor.getStyleForNextShape(GeoShapeGeoStyle))
+				)
 			}
+			return activeToolId === tool.id
 		},
 		[editor, tool?.id, geo]
 	)

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -432,10 +432,11 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (editor.root.getCurrent()?.id === 'zoom') return
 
 					trackEvent('zoom-tool', { source })
-					editor.setCurrentTool('zoom', {
-						onInteractionEnd: path,
-						maskAs: 'zoom',
-					})
+					// The editor ignores keys while a button holds focus, so zoom would never see the
+					// Z key up that exits it. editor.focus() won't help: the button is already inside
+					// the container, so the editor reads as focused.
+					editor.getContainer().focus()
+					editor.setCurrentTool('zoom', { onInteractionEnd: path })
 				},
 			},
 			{

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -21,6 +21,15 @@ describe('TLSelectTool.Zooming', () => {
 			.createShapes([{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
 	})
 
+	it('Reports the originating tool as the current tool id while zooming', () => {
+		editor.setCurrentTool('draw')
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'draw.idle' })
+		editor.expectToBeIn('zoom.idle')
+		expect(editor.getCurrentToolId()).toBe('draw')
+		editor.setCurrentTool('select')
+		expect(editor.getCurrentToolId()).toBe('select')
+	})
+
 	it('Correctly zooms in when clicking', () => {
 		editor.setCurrentTool('zoom', { onInteractionEnd: 'select' })
 		expect(editor.getZoomLevel()).toBe(1)

--- a/packages/tldraw/src/test/toolbar-tool-selection.test.tsx
+++ b/packages/tldraw/src/test/toolbar-tool-selection.test.tsx
@@ -1,0 +1,45 @@
+import { act } from '@testing-library/react'
+import { Editor, GeoShapeGeoStyle } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+let editor: Editor
+
+function pressedToolValues() {
+	const els = document.querySelectorAll(
+		'.tlui-main-toolbar__tools [data-value][aria-pressed="true"]'
+	)
+	return [...els].map((el) => el.getAttribute('data-value')!)
+}
+
+beforeEach(async () => {
+	;({ editor } = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	}))
+})
+
+it('keeps only the originating tool highlighted while the zoom tool masks itself', async () => {
+	await act(async () => {
+		editor.setCurrentTool('draw')
+	})
+	expect(pressedToolValues()).toEqual(['draw'])
+
+	await act(async () => {
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'draw.idle' })
+	})
+	expect(pressedToolValues()).toEqual(['draw'])
+})
+
+it('keeps only the originating geo variant highlighted while the zoom tool masks itself', async () => {
+	await act(async () => {
+		editor.setStyleForNextShapes(GeoShapeGeoStyle, 'ellipse')
+		editor.setCurrentTool('geo')
+	})
+	expect(pressedToolValues()).toEqual(['ellipse'])
+
+	// Tools with no geo variant used to match the zoom tool's empty shared styles and all light up
+	await act(async () => {
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'geo.idle' })
+	})
+	expect(pressedToolValues()).toEqual(['ellipse'])
+})

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import { createShapeId, Editor, TLShapeId } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { Tldraw } from '../../lib/Tldraw'
@@ -164,19 +164,24 @@ async function setupFocusedEditor() {
 	return { editor }
 }
 
-function keydown(editor: Editor, init: KeyboardEventInit) {
-	act(() => {
-		editor
-			.getContainerDocument()
-			.body.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }))
-	})
+// The UI's shortcut listeners sit on the body, the editor's own on the container. Pass a target
+// inside the container to reach both.
+function keydown(editor: Editor, init: KeyboardEventInit, target?: Element) {
+	dispatchKey(editor, 'keydown', init, target)
 }
 
-function keyup(editor: Editor, init: KeyboardEventInit) {
+function keyup(editor: Editor, init: KeyboardEventInit, target?: Element) {
+	dispatchKey(editor, 'keyup', init, target)
+}
+
+function dispatchKey(
+	editor: Editor,
+	type: 'keydown' | 'keyup',
+	init: KeyboardEventInit,
+	target: Element = editor.getContainerDocument().body
+) {
 	act(() => {
-		editor
-			.getContainerDocument()
-			.body.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, ...init }))
+		target.dispatchEvent(new KeyboardEvent(type, { bubbles: true, ...init }))
 	})
 }
 
@@ -262,6 +267,33 @@ describe('keyboard shortcuts with a held key', () => {
 		// trigger redo rather than being blocked by the stale undo registration on `KeyZ`.
 		keydown(editor, { key: 'z', code: 'KeyZ', metaKey: true, shiftKey: true })
 		expect(editor.getCurrentPageShapeIds().has(id)).toBe(true)
+	})
+
+	it('leaves the zoom tool when z is released', async () => {
+		const { editor } = await setupFocusedEditor()
+		editor.setCurrentTool('draw')
+
+		keydown(editor, { key: 'z', code: 'KeyZ' }, editor.getContainer())
+		expect(editor.getPath()).toBe('zoom.idle')
+		keyup(editor, { key: 'z', code: 'KeyZ' }, editor.getContainer())
+		expect(editor.getPath()).toBe('draw.idle')
+	})
+
+	// The shortcut fires whatever holds focus; the editor's key events don't follow it there
+	it('leaves the zoom tool when z is released after a toolbar click', async () => {
+		const { editor } = await setupFocusedEditor()
+		const drawButton = screen.getByTestId('tools.draw')
+		act(() => {
+			drawButton.focus()
+			drawButton.click()
+		})
+		expect(editor.getCurrentToolId()).toBe('draw')
+		expect(editor.getContainerDocument().activeElement).toBe(drawButton)
+
+		keydown(editor, { key: 'z', code: 'KeyZ' }, drawButton)
+		expect(editor.getPath()).toBe('zoom.idle')
+		keyup(editor, { key: 'z', code: 'KeyZ' }, drawButton)
+		expect(editor.getPath()).toBe('draw.idle')
 	})
 })
 


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the toolbar flipped away from the originating tool (for example, draw) while the user held Z to zoom. Fixing that surfaced two more problems with holding Z, both fixed here: every non-geo tool lit up at once when zooming from a shape tool, and the zoom tool got stuck on if Z was pressed straight after a toolbar click.

Split out of #10161.

### Before

**The toolbar flipped away from the originating tool.** `ZoomTool` set its tool-id mask on its parent (the root), but `getCurrentToolId()` reads the mask from the current tool node, so the mask was never consulted.

**Every non-geo tool lit up.** `useIsToolSelected` branched on the active tool id: when it was `geo` it compared the item's geo variant against the shared geo style, otherwise it compared tool ids. Items *without* a geo variant took the first branch too, and their `undefined` matched the shared style's `undefined` whenever no geo value was available — so they all reported as selected. That could never fire before, because `geo` was only ever the active tool id while the geo tool was current, which always yields a geo shared style. Making the mask live opened the hole: `geo` is now the active tool id while `ZoomTool` — which has no shape type, and so no shared styles — is the current tool.

**The zoom tool got stuck on.** It leaves on Z's key up, which reaches it through the editor's container listener. That listener drops every key event while a button holds focus (`areShortcutsDisabled` → `activeElementShouldCaptureKeys`), but the shortcut that *starts* the tool has no such guard. So pressing Z straight after clicking a tool in the toolbar entered the zoom tool and then never heard the key up that leaves it. This one predates the PR — it reproduces on `main` for every tool, not just geo ones — but it's in the same interaction and made the branch look broken.

### After

The mask is set on the `ZoomTool` node itself. `useIsToolSelected` branches on whether the *item* has a geo variant, and falls back to the next shape's geo style when the shared styles are empty, so the originating geo variant stays lit and stays pinned in the main toolbar. The Z shortcut moves focus back to the container before entering the tool.

### Implementation notes

`editor.focus()` doesn't work for the focus fix — it early-returns on `getIsFocused()`, and a toolbar button is inside the container, so the editor already reads as focused. Hence `editor.getContainer().focus()`.

The `??` fallback in `useIsToolSelected` sits inside the `&&` rather than in a `const` above it, so the geo items only subscribe to `getSharedStyles()` while the geo tool is actually active. Reading it up front woke all sixteen of them on every selection change.

Also drops `maskAs: 'zoom'` from the zoom action. Nothing in the repo reads it, and it now asserts the opposite of what the tool does.

Two things deliberately left out, both worth their own issues:

- Making the mask live changes what `getCurrentToolId()` returns for three internal readers that use it as a predicate rather than a UI label — right-click routing to the select tool (`Editor.ts`), the stylus-eraser `_restoreToolId`, and `selectToolActive` in `RichTextLabel`. Splitting the UI label from an internal unmasked accessor would settle that properly.
- The focus mismatch is wider than zoom. Arrow-key nudging is dead the same way after a toolbar click; zoom is just the only case where the missing event leaves you stuck in a modal tool instead of no-opping. `useKeyboardShortcuts` already worked around the same window for the `,` key by a different route.

### Change type

- [x] `bugfix`

### Test plan

1. Select the draw tool, hold Z and drag a zoom brush. The toolbar should keep draw highlighted throughout.
2. Select the rectangle tool, hold Z. Only rectangle should stay highlighted, and it should stay put in the toolbar.
3. Click any tool in the toolbar, then press and release Z **without** clicking the canvas first. You should be back on that tool, not stuck in zoom.

- [x] Unit tests — each new test fails on `main` and passes with this change

### Release notes

- Keep the originating tool highlighted in the toolbar while zooming with Z.
- Fix the zoom tool staying on when Z is pressed straight after clicking a toolbar button.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -10  |
| Tests     | +97 / -11  |
