### PR TITLE
fix(select): cancelling a note clone-handle drag removes the new note and stays in select

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -173,6 +173,23 @@ it('Selects an adjacent note when clicking the clone handle', () => {
 	editor.expectToBeIn('select.editing_shape')
 })
 
+it('Removes the new note and stays in the select tool when a clone handle drag is cancelled', () => {
+	editor.createShape({ type: 'note', x: 1000, y: 1000 })
+	const shape = editor.getLastCreatedShape()!
+	editor.select(shape.id)
+	const handle = editor.getShapeHandles(shape.id)![0]
+
+	editor.pointerDown(handle.x, handle.y, { target: 'handle', shape, handle })
+	editor.pointerMove(handle.x + 30, handle.y + 30)
+	editor.expectToBeIn('select.translating')
+	expect(editor.getCurrentPageShapes()).toHaveLength(2)
+
+	editor.cancel()
+	editor.expectToBeIn('select.idle')
+	expect(editor.getCurrentPageShapes()).toHaveLength(1)
+	expect(editor.getSelectedShapeIds()).toEqual([shape.id])
+})
+
 it('Creates an adjacent note when dragging the clone handle', () => {
 	editor.createShape({
 		type: 'note',

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -121,6 +121,8 @@ export class PointingHandle extends StateNode {
 			const noteUtil = editor.getShapeUtil(shape) as NoteShapeUtil
 			const dv = getDisplayValues(noteUtil, shape)
 
+			// Cancelling the drag bails to this mark, which removes the note created below
+			const creatingMarkId = editor.markHistoryStoppingPoint('creating note from handle')
 			const nextNote = getNoteForAdjacentPosition(editor, shape, handle, true)
 			if (nextNote) {
 				// Center the shape on the current pointer
@@ -142,8 +144,8 @@ export class PointingHandle extends StateNode {
 						...this.info,
 						target: 'shape',
 						shape: editor.getShape(nextNote),
-						onInteractionEnd: 'note',
 						isCreating: true,
+						creatingMarkId,
 						onCreate: () => {
 							// When we're done, start editing it
 							startEditingShapeWithRichText(editor, nextNote, { selectAll: true })


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where cancelling a note clone-handle drag left the new note behind and switched the user into the note tool.

### Before

`PointingHandle` created the adjacent note and handed off to `select.translating` with `onInteractionEnd: 'note'` and no `creatingMarkId`, so Escape had no mark to bail to and ended by switching tools.

### After

History is marked before the note is created and passed as `creatingMarkId`, and the `onInteractionEnd` hand-off is dropped; cancel removes the note and returns to `select.idle` with the original note still selected.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a note and drag one of its clone handles.
2. Press Escape mid-drag: the new note disappears, the original stays selected, and the select tool is still active.
3. Complete the drag normally: the new note is created and enters editing as before.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix cancelling a note clone-handle drag leaving the new note behind and switching to the note tool.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |
| Tests     | +17 / -0   |
