### PR TITLE
fix(select): start editing editable shapes without rich text instead of throwing

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
@@ -138,6 +138,17 @@ describe('When in the idle state', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
+	it('Starts editing an editable shape without rich text on "Enter" instead of throwing', () => {
+		editor.createShape({ type: 'frame', x: 0, y: 0, props: { w: 100, h: 100 } })
+		const frame = editor.getLastCreatedShape()
+		editor.select(frame)
+		editor.setCurrentTool('geo')
+
+		expect(() => editor.keyPress('Enter')).not.toThrow()
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getEditingShapeId()).toBe(frame.id)
+	})
+
 	it('Does not enter edit shape state on "Enter" key up when multiple geo shapes are selected', () => {
 		editor.setCurrentTool('geo')
 		editor.pointerDown(50, 50)

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -15,11 +15,12 @@ export function hasRichText(
 	return 'richText' in shape.props && richTextValidator.isValid(shape.props.richText)
 }
 /**
- * Start editing a shape that has rich text, such as text, note, geo, or arrow shapes.
- * This will enter the editing state for the shape and optionally select all the text.
+ * Start editing a shape. Shapes with rich text, such as text, note, geo, or arrow shapes, can
+ * optionally have all of their text selected; other editable shapes (such as frames) simply enter
+ * the editing state.
  *
  * @param editor - The editor instance.
- * @param shapeOrId - The shape to start editing. This shape must have a richText property with a TLRichText value.
+ * @param shapeOrId - The shape to start editing.
  * @param options - Options: selectAll or info (TLEventInfo)
  *
  * @public
@@ -34,9 +35,6 @@ export function startEditingShapeWithRichText(
 
 	if (!editor.canEditShape(shape)) return
 
-	if (!hasRichText(shape)) {
-		throw new Error('Shape does not have rich text')
-	}
 	// Finish this shape and start editing the next one
 	editor.setEditingShape(shape)
 	editor.setCurrentTool('select.editing_shape', {
@@ -44,7 +42,7 @@ export function startEditingShapeWithRichText(
 		target: 'shape',
 		shape: shape,
 	})
-	if (options.selectAll) {
+	if (options.selectAll && hasRichText(shape)) {
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where pressing Enter in the geo, arrow, or text tool with a frame (or video) selected crashed the editor.

### Before

Those tools call `startEditingShapeWithRichText` on Enter with whatever is selected, and it threw `Shape does not have rich text` after only a `canEditShape` guard; the error propagated out of the key handler to the crash screen.

### After

It enters the editing state for any shape `canEditShape` accepts and only emits `select-all-text` when the shape has rich text. The `@public` signature is unchanged; the doc comment no longer claims a rich-text requirement.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a frame, switch to the geo tool, press Enter: the frame enters editing (its name field), no crash.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix pressing Enter in the geo, arrow, or text tool with a frame selected crashing the editor.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -7    |
| Tests     | +11 / -0   |
