### PR TITLE
fix(select): restore the full prior selection when scribble brushing is cancelled

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -13,22 +13,15 @@ export class ScribbleBrushing extends StateNode {
 	static override id = 'scribble_brushing'
 	static override trackPerformance = true
 
-	hits = new Set<TLShapeId>()
-
-	size = 0
-
 	scribbleId = 'id'
 
 	initialSelectedShapeIds = new Set<TLShapeId>()
 	newlySelectedShapeIds = new Set<TLShapeId>()
 
 	override onEnter() {
-		this.initialSelectedShapeIds = new Set<TLShapeId>(
-			this.editor.inputs.getShiftKey() ? this.editor.getSelectedShapeIds() : []
-		)
+		// Kept for cancel; whether shift adds it to the result is decided on each update
+		this.initialSelectedShapeIds = new Set<TLShapeId>(this.editor.getSelectedShapeIds())
 		this.newlySelectedShapeIds = new Set<TLShapeId>()
-		this.size = 0
-		this.hits.clear()
 
 		const scribbleItem = this.editor.scribbles.addScribble({
 			color: 'selection-stroke',


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where cancelling a scribble (alt-drag) selection cleared the previous selection instead of restoring it.

### Before

`ScribbleBrushing.onEnter` recorded `initialSelectedShapeIds` only when shift was held, and `cancel()` restores that set — so for a plain alt-drag it restored nothing.

### After

The pre-interaction selection is always recorded on enter; whether shift adds it to the result is still decided on each update. The unused `hits` and `size` fields are removed.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape, then alt-drag a scribble over other shapes (without shift).
2. Press Escape before releasing; the original shape should be selected again.

- [ ] Unit tests — no new tests; the selection suites pass

### Release notes

- Fix cancelling a scribble selection clearing the previous selection instead of restoring it.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -9    |
