### PR TITLE
fix(editor): normalize right-hand shift and alt by key code

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11619,9 +11619,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'keyboard': {
-				// please, please
-				if (info.key === 'ShiftRight') info.key = 'ShiftLeft'
-				if (info.key === 'AltRight') info.key = 'AltLeft'
+				// Browsers report `key: 'Shift'` for both shifts; only `code` tells them apart, and
+				// `inputs.keys` stores codes, so normalize codes or right-hand modifiers go unseen.
+				if (info.code === 'ShiftRight') info.code = 'ShiftLeft'
+				if (info.code === 'AltRight') info.code = 'AltLeft'
 				if (info.code === 'ControlRight') info.code = 'ControlLeft'
 				if (info.code === 'MetaRight') info.code = 'MetaLeft'
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -56,6 +56,24 @@ describe('TLSelectTool.Idle', () => {
 		expect(nudgedShape).toBeDefined()
 		expect(nudgedShape?.x).toBe(101)
 	})
+
+	it('Major-nudges with either shift key held', () => {
+		editor.select(ids.box1)
+		const keyboard = {
+			type: 'keyboard' as const,
+			shiftKey: true,
+			ctrlKey: false,
+			altKey: false,
+			metaKey: false,
+			accelKey: false,
+		}
+		// Browsers send key 'Shift' for both shifts; only the code differs.
+		editor.dispatch({ ...keyboard, name: 'key_down', key: 'Shift', code: 'ShiftRight' })
+		editor.dispatch({ ...keyboard, name: 'key_down', key: 'ArrowRight', code: 'ArrowRight' })
+		editor.dispatch({ ...keyboard, name: 'key_up', key: 'ArrowRight', code: 'ArrowRight' })
+		editor.dispatch({ ...keyboard, name: 'key_up', key: 'Shift', code: 'ShiftRight' })
+		expect(editor.getShape(ids.box1)!.x).toBe(110)
+	})
 })
 
 // todo: turn on feature flag for these tests or remove them


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the right-hand Shift and Alt keys were not recognized for modifier shortcuts such as major nudges.

### Before

`Editor`'s keyboard dispatch normalized `ShiftRight` / `AltRight` by `info.key`, but browsers report `key: 'Shift'` for both shifts — only `code` distinguishes them — and `inputs.keys` stores codes, so the check never matched. `ControlRight` / `MetaRight` were already normalized by code.

### After

Shift and Alt are normalized by `info.code` like the others.

Split out of #10161.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape and press right-Shift + ArrowRight.
2. The shape should move by the major nudge amount (10px), the same as with left-Shift.

- [x] Unit tests — the new test fail on `main` and pass with this change

### Release notes

- Fix the right-hand Shift and Alt keys not being recognized for modifier shortcuts such as major nudges.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -3    |
| Tests     | +18 / -0   |
