### PR TITLE
refactor(select): remove dead state and duplicated helpers from select tool states

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -21,9 +21,7 @@ export class DragAndDropManager {
 	}
 
 	shapesToActuallyMove: TLShape[] = []
-	draggedOverShapeIds = new Set<TLShapeId>()
 
-	initialGroupIds = new Map<TLShapeId, TLShapeId>()
 	initialParentIds = new Map<TLShapeId, TLParentId>()
 	initialIndices = new Map<TLShapeId, IndexKey>()
 
@@ -69,17 +67,12 @@ export class DragAndDropManager {
 				this.initialParentIds.set(shape.id, parent.id)
 			}
 			this.initialIndices.set(shape.id, shape.index)
-
-			const group = editor.findShapeAncestor(shape, (s) => editor.isShapeOfType(s, 'group'))
-			if (group) {
-				this.initialGroupIds.set(shape.id, group.id)
-			}
 		}
 
-		const allShapes = editor.getCurrentPageShapesSorted()
+		const zIndexById = new Map(editor.getCurrentPageShapesSorted().map((s, i) => [s.id, i]))
 		this.shapesToActuallyMove = Array.from(shapesToActuallyMove)
 			.filter((s) => !s.isLocked)
-			.sort((a, b) => allShapes.indexOf(a) - allShapes.indexOf(b))
+			.sort((a, b) => zIndexById.get(a.id)! - zIndexById.get(b.id)!)
 
 		this.initialDraggingOverShape = editor.getDraggingOverShape(point, this.shapesToActuallyMove)
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -19,16 +19,15 @@ export class Brushing extends StateNode {
 	static override id = 'brushing'
 	static override trackPerformance = true
 
-	info = {} as TLPointerEventInfo & { target: 'canvas' }
-
 	initialSelectedShapeIds: TLShapeId[] = []
 	excludedShapeIds = new Set<TLShapeId>()
 	isWrapMode = false
 
 	viewportDidChange = false
+	// No-op until onEnter installs the reactor, so onExit can always call it
 	cleanupViewportChangeReactor() {
 		void null
-	} // cleanup function for the viewport reactor
+	}
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
 		const { editor } = this
@@ -64,7 +63,6 @@ export class Brushing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
-		this.info = info
 		this.initialSelectedShapeIds = editor.getSelectedShapeIds().slice()
 		this.hitTestShapes()
 		isInitialCheck = false

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -75,7 +75,7 @@ export class EditingShape extends StateNode {
 		}
 
 		// Check if dragging from editing shape with blurred input
-		if (this.didPointerDownOnEditingShape && this.editor.inputs.isDragging) {
+		if (this.didPointerDownOnEditingShape && this.editor.inputs.getIsDragging()) {
 			if (this.editor.getIsReadonly()) return
 
 			const editingShape = this.editor.getEditingShape()
@@ -132,7 +132,7 @@ export class EditingShape extends StateNode {
 				}
 
 				// for shapes with labels, check to see if the click was inside of the shape's label
-				const geometry = this.editor.getShapeUtil(selectingShape).getGeometry(selectingShape)
+				const geometry = this.editor.getShapeGeometry(selectingShape)
 				const textLabels = getTextLabels(geometry)
 				const textLabel = textLabels.length === 1 ? textLabels[0] : undefined
 				// N.B. One nuance here is that we want empty text fields to be removed from the canvas when the user clicks away from them.

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -15,7 +15,6 @@ import {
 	toRichText,
 	unsafe__withoutCapture,
 } from '@tldraw/editor'
-import { isOverArrowLabel } from '../../../shapes/arrow/arrowLabel'
 import { getHitShapeOnCanvasPointerDown } from '../../selection-logic/getHitShapeOnCanvasPointerDown'
 import { updateHoveredOverlayId } from '../../selection-logic/updateHoveredOverlayId'
 import {
@@ -146,22 +145,8 @@ export class Idle extends StateNode {
 					}
 				} else {
 					switch (overlayType) {
-						case 'rotate_handle': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
-						case 'mobile_rotate': {
-							this.onPointerDown({
-								...info,
-								target: 'selection',
-								handle: overlay.props.handle as any,
-							})
-							break
-						}
+						case 'rotate_handle':
+						case 'mobile_rotate':
 						case 'resize_handle': {
 							this.onPointerDown({
 								...info,
@@ -543,9 +528,7 @@ export class Idle extends StateNode {
 
 				if (
 					!selectedShapeIds.includes(targetShape.id) &&
-					!this.editor.findShapeAncestor(targetShape, (shape) =>
-						selectedShapeIds.includes(shape.id)
-					)
+					!this.editor.isAncestorSelected(targetShape)
 				) {
 					this.editor.markHistoryStoppingPoint('selecting shape')
 					this.editor.setSelectedShapes([targetShape.id])
@@ -712,12 +695,6 @@ export class Idle extends StateNode {
 			editor.setEditingShape(shape)
 		}
 		this.parent.transition('editing_shape', info)
-	}
-
-	isOverArrowLabelTest(shape: TLShape | undefined) {
-		if (!shape) return false
-
-		return isOverArrowLabel(this.editor, shape)
 	}
 
 	handleDoubleClickOnCanvas(info: TLClickEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingSelection.ts
@@ -4,14 +4,6 @@ import { selectOnCanvasPointerUp } from '../../selection-logic/selectOnCanvasPoi
 export class PointingSelection extends StateNode {
 	static override id = 'pointing_selection'
 
-	info = {} as TLPointerEventInfo & {
-		target: 'selection'
-	}
-
-	override onEnter(info: TLPointerEventInfo & { target: 'selection' }) {
-		this.info = info
-	}
-
 	override onPointerUp(info: TLPointerEventInfo) {
 		selectOnCanvasPointerUp(this.editor, info)
 		this.parent.transition('idle', info)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -82,33 +82,29 @@ export class PointingShape extends StateNode {
 			return
 		}
 
-		const selectingShape = hitShape
-			? this.editor.getOutermostSelectableShape(hitShape)
-			: this.hitShapeForPointerUp
+		const selectingShape = this.editor.getOutermostSelectableShape(hitShape)
 
-		if (selectingShape) {
-			// If the selecting shape has a click handler, call it instead of selecting the shape
-			const util = this.editor.getShapeUtil(selectingShape)
-			if (util.onClick) {
-				const change = util.onClick?.(selectingShape)
-				if (change) {
-					this.editor.markHistoryStoppingPoint('shape on click')
-					this.editor.updateShapes([change])
-					this.parent.transition('idle', info)
-					return
-				}
-			}
-
-			if (selectingShape.id === focusedGroupId) {
-				if (selectedShapeIds.length > 0) {
-					this.editor.markHistoryStoppingPoint('clearing shape ids')
-					this.editor.setSelectedShapes([])
-				} else {
-					this.editor.popFocusedGroupId()
-				}
+		// If the selecting shape has a click handler, call it instead of selecting the shape
+		const util = this.editor.getShapeUtil(selectingShape)
+		if (util.onClick) {
+			const change = util.onClick?.(selectingShape)
+			if (change) {
+				this.editor.markHistoryStoppingPoint('shape on click')
+				this.editor.updateShapes([change])
 				this.parent.transition('idle', info)
 				return
 			}
+		}
+
+		if (selectingShape.id === focusedGroupId) {
+			if (selectedShapeIds.length > 0) {
+				this.editor.markHistoryStoppingPoint('clearing shape ids')
+				this.editor.setSelectedShapes([])
+			} else {
+				this.editor.popFocusedGroupId()
+			}
+			this.parent.transition('idle', info)
+			return
 		}
 
 		if (!this.didSelectOnEnter) {
@@ -137,7 +133,7 @@ export class PointingShape extends StateNode {
 
 						// if the shape has a text label, and we're inside of the label, then we want to begin editing the label.
 						if (selectedShapeIds.length === 1) {
-							const geometry = this.editor.getShapeUtil(selectingShape).getGeometry(selectingShape)
+							const geometry = this.editor.getShapeGeometry(selectingShape)
 							const textLabels = getTextLabels(geometry)
 							const textLabel = textLabels.length === 1 ? textLabels[0] : undefined
 							// N.B. we're only interested if there is exactly one text label. We don't handle the

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -2,8 +2,6 @@ import {
 	Box,
 	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,6 +17,7 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -321,8 +320,6 @@ export class Resizing extends StateNode {
 		// calculate the scale by measuring the current distance between the drag handle and the scale origin
 		// and dividing by the original distance between the drag handle and the scale origin
 
-		// bug: for edges, the page point doesn't matter, the
-
 		const distanceFromScaleOriginNow = Vec.Sub(currentPagePoint, scaleOriginPage).rot(
 			-selectionRotation
 		)
@@ -496,8 +493,6 @@ export class Resizing extends StateNode {
 		this.editor.setHintingShapes(hintingShapeIds)
 	}
 
-	// ---
-
 	private updateCursor({
 		dragHandle,
 		isFlippedX,
@@ -670,23 +665,3 @@ export class Resizing extends StateNode {
 }
 
 type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
-}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -47,14 +47,13 @@ export class Rotating extends StateNode {
 		}
 		this.snapshot = snapshot
 
-		// Trigger a pointer move
 		const newSelectionRotation = this._getRotationFromPointerPosition({
 			snapToNearestDegree: false,
 		})
 
 		applyRotationToSnapshotShapes({
 			editor: this.editor,
-			delta: this._getRotationFromPointerPosition({ snapToNearestDegree: false }),
+			delta: newSelectionRotation,
 			snapshot: this.snapshot,
 			stage: 'start',
 		})
@@ -96,8 +95,6 @@ export class Rotating extends StateNode {
 	override onCancel() {
 		this.cancel()
 	}
-
-	// ---
 
 	private update() {
 		const newSelectionRotation = this._getRotationFromPointerPosition({

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -341,12 +341,10 @@ export class Translating extends StateNode {
 			editor,
 			snapshot: { shapeSnapshots },
 		} = this
-		const movingShapes: TLShape[] = []
 
 		shapeSnapshots.forEach((shapeSnapshot) => {
 			const shape = editor.getShape(shapeSnapshot.shape.id)
 			if (!shape) return
-			movingShapes.push(shape)
 
 			const parentTransform = isPageId(shape.parentId)
 				? null


### PR DESCRIPTION
**Risk: medium · Importance: low**

This PR improves the select tool's child states so that the behavior fixes split out of #10161 land on code without dead state or duplicated helpers. No behavior change.

### Before

`DragAndDropManager.initialGroupIds` / `draggedOverShapeIds`, `Brushing.info`, `PointingSelection.info`, `Idle.isOverArrowLabelTest` and the `movingShapes` array in `Translating.reset` were written and never read. `Resizing` carried its own copy of `rotateSelectionHandle` while everything else used the `@tldraw/editor` export. `Rotating` computed the initial rotation twice. `Idle` had three identical overlay `case`s and an inline `findShapeAncestor(..., selected)` where `isAncestorSelected` exists. `PointingShape.onPointerUp` branched on a `hitShape` that is always defined (`getShapeAtPoint(...) ?? this.hitShape`). `DragAndDropManager` sorted with `indexOf` in the comparator.

### After

All of the above removed or replaced: the shared helpers are used, the unreachable branch is flattened, the sort uses an id→index map, `getShapeUtil(s).getGeometry(s)` becomes the cached `editor.getShapeGeometry(s)`, and `inputs.isDragging` becomes `inputs.getIsDragging()`.

Split out of #10161.

### Change type

- [x] `improvement`

### Test plan

- [ ] Unit tests — no new tests; the full `packages/tldraw` suite (2187 tests) pass

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +32 / -106 |
