### PR TITLE
fix(tools): pressing Enter to edit a frame, video or embed no longer crashes the geo, arrow and text tools

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
@@ -1,5 +1,5 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo, TLShapeId } from '@tldraw/editor'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 import { ArrowShapeUtil } from '../ArrowShapeUtil'
 import { clearArrowTargetState, updateArrowTargetState } from '../arrowTargetState'
 
@@ -42,9 +42,8 @@ export class Idle extends StateNode {
 		this.update()
 		if (info.key === 'Enter') {
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
-			if (this.editor.canEditShape(onlySelectedShape)) {
-				startEditingShapeWithRichText(this.editor, onlySelectedShape, { selectAll: true })
-			}
+			if (!this.editor.canEditShape(onlySelectedShape)) return
+			startEditingShape(this.editor, onlySelectedShape, { selectAll: true })
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Idle.ts
@@ -1,5 +1,5 @@
 import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -16,9 +16,8 @@ export class Idle extends StateNode {
 		const { editor } = this
 		if (info.key === 'Enter') {
 			const onlySelectedShape = editor.getOnlySelectedShape()
-			if (editor.canEditShape(onlySelectedShape)) {
-				startEditingShapeWithRichText(editor, onlySelectedShape, { selectAll: true })
-			}
+			if (!editor.canEditShape(onlySelectedShape)) return
+			startEditingShape(editor, onlySelectedShape, { selectAll: true })
 		}
 	}
 

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Idle.ts
@@ -3,7 +3,7 @@ import {
 	cancelUpdateHoveredShapeId,
 	updateHoveredShapeId,
 } from '../../../tools/selection-logic/updateHoveredShapeId'
-import { startEditingShapeWithRichText } from '../../../tools/SelectTool/selectHelpers'
+import { startEditingShape } from '../../../tools/SelectTool/selectHelpers'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -34,7 +34,7 @@ export class Idle extends StateNode {
 			const onlySelectedShape = this.editor.getOnlySelectedShape()
 			if (!this.editor.canEditShape(onlySelectedShape)) return
 			this.editor.setCurrentTool('select')
-			startEditingShapeWithRichText(this.editor, onlySelectedShape.id, { info })
+			startEditingShape(this.editor, onlySelectedShape, { info })
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -48,3 +48,24 @@ export function startEditingShapeWithRichText(
 		editor.emit('select-all-text', { shapeId: shape.id })
 	}
 }
+
+/**
+ * Start editing any editable shape. Shapes with rich text go through
+ * `startEditingShapeWithRichText`; editable shapes without it (frame, video, embed) would
+ * make that helper throw, so they enter the editing state directly.
+ *
+ * @internal
+ */
+export function startEditingShape(
+	editor: Editor,
+	shape: TLShape,
+	options: { selectAll?: boolean; info?: TLEventInfo } = {}
+) {
+	if (!editor.canEditShape(shape)) return
+	if (hasRichText(shape)) {
+		startEditingShapeWithRichText(editor, shape, options)
+		return
+	}
+	editor.setEditingShape(shape)
+	editor.setCurrentTool('select.editing_shape', { ...options.info, target: 'shape', shape })
+}


### PR DESCRIPTION
**Risk: low · Importance: high**

This PR fixes a bug where pressing Enter with a frame, video or embed selected while the geo, arrow or text tool was active crashed the editor.

### Before

The three tools' `Idle` states called `startEditingShapeWithRichText` after `canEditShape()`, but that helper throws `'Shape does not have rich text'` for editable shapes without a `richText` prop. The throw happened inside the event batch and took the editor to the crash screen.

### After

A shared `startEditingShape` helper in `selectHelpers.ts` routes shapes with rich text through `startEditingShapeWithRichText` and enters `select.editing_shape` directly for the rest, mirroring what the select tool already does. The three `Idle` states call it.

### Implementation notes

The helper is `@internal`; the select tool's own `Idle.startEditingShape` keeps its separate implementation because it also transitions its parent state.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame, select it, press `G`, press Enter — the frame label enters editing, no crash.
2. Repeat with `A` and `T`.

- [ ] Unit tests

### Release notes

- Fix a crash when pressing Enter with a frame, video or embed selected while the geo, arrow or text tool is active

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +29 / -10  |