### PR TITLE
fix(embeds): anchor hostname matching so lookalike hosts are not trusted

### DIFF
--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -137,6 +137,15 @@ const MATCH_URL_TEST_URLS: (MatchUrlTestNoMatchDef | MatchUrlTestMatchDef)[] = [
 		url: 'https://lite.tldraw.com/something',
 		match: false,
 	},
+	// hostname patterns are anchored: a lookalike host must not inherit the tldraw sandbox
+	{
+		url: 'https://tldraw.com.evil.io/r/choochoo',
+		match: false,
+	},
+	{
+		url: 'https://nottldraw.com/r/choochoo',
+		match: false,
+	},
 	// codesandbox
 	{
 		url: 'https://codesandbox.io/s/breathing-dots-checkpoint-7-nor86',

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -41,7 +41,10 @@ const globlikeRegExp = (input: string) => {
 
 const checkHostnames = (hostnames: readonly string[], targetHostname: string) => {
 	return !!hostnames.find((hostname) => {
-		const re = new RegExp(globlikeRegExp(hostname))
+		// The host must be the pattern or a subdomain of it. Unanchored, `tldraw.com` would
+		// also match `tldraw.com.evil.io`, which would then inherit that definition's relaxed
+		// iframe sandbox permissions.
+		const re = new RegExp(`^(?:.+\\.)?${globlikeRegExp(hostname)}$`)
 		return targetHostname.match(re)
 	})
 }


### PR DESCRIPTION
**Risk: low · Importance: urgent**

This PR fixes a bug where a lookalike host such as `tldraw.com.evil.io` matched the `tldraw` embed definition and was rendered with that definition's relaxed iframe permissions.

### Before

`checkHostnames` built an unanchored `RegExp` from each hostname pattern, so `tldraw.com` matched anywhere inside the target host. A pasted URL on an attacker-controlled host that merely contained a trusted hostname inherited the trusted definition's `overridePermissions` (for example `allow-top-navigation`).

### After

Patterns are anchored as `^(?:.+\.)?<pattern>$`, so a host must be the pattern or a subdomain of it. `lite.tldraw.com` still matches; `tldraw.com.evil.io` and `nottldraw.com` do not. Two no-match cases are added to the embed tests.

### Implementation notes

Wildcard patterns (`google.*`) still expand `*` to `.+` so `google.co.uk` keeps matching, which means `docs.google.com.evil.io` still matches `docs.google.*`. Tightening that needs a TLD-aware pattern and is left for a follow-up.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new lookalike-host cases fail on `main` and pass with this change

### Release notes

- Fix embed hostname matching so lookalike hosts no longer get a trusted definition's iframe permissions

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |
| Tests     | +9 / -0    |