### PR TITLE
fix(arrows): compute the translate delta in the parent space

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -8,6 +8,7 @@ import {
 	Geometry2d,
 	Group2d,
 	IndexKey,
+	Mat,
 	PI2,
 	Polyline2d,
 	Rectangle2d,
@@ -596,7 +597,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		// When we start translating shapes, record where their bindings were in page space so we
 		// can maintain them as we translate the arrow
 		shapeAtTranslationStart.set(shape, {
-			pagePosition: shapePageTransform.applyToPoint(shape),
+			pagePosition: Mat.applyToPoint(this.editor.getShapeParentTransform(shape), shape),
 			terminalBindings: mapObjectMapValues(terminalsInArrowSpace, (terminalName, point) => {
 				const binding = bindings[terminalName]
 				if (!binding) return null
@@ -644,16 +645,19 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		const atTranslationStart = shapeAtTranslationStart.get(initialShape)
 		if (!atTranslationStart) return
 
-		const shapePageTransform = this.editor.getShapePageTransform(shape.id)!
+		// How far the arrow's origin has moved in page space. `shape.x/y` are in the parent's
+		// space and may not be in the store yet (one-off moves like nudge/align/distribute pass a
+		// working copy), so map them through the parent transform. Applying the arrow's own page
+		// transform to them instead folds the arrow's rotation into the delta.
 		const pageDelta = Vec.Sub(
-			shapePageTransform.applyToPoint(shape),
+			Mat.applyToPoint(this.editor.getShapeParentTransform(shape), shape),
 			atTranslationStart.pagePosition
 		)
 
 		for (const terminalBinding of Object.values(atTranslationStart.terminalBindings)) {
 			if (!terminalBinding) continue
 
-			const newPagePoint = Vec.Add(terminalBinding.pagePosition, Vec.Mul(pageDelta, 0.5))
+			const newPagePoint = Vec.Add(terminalBinding.pagePosition, pageDelta)
 			const newTarget = this.editor.getShapeAtPoint(newPagePoint, {
 				hitInside: true,
 				hitFrameInside: true,


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where translating a rotated arrow with bound terminals moved the terminals by the wrong amount, and one-off moves (nudge, align, distribute) moved them by half the distance.

### Before

`ArrowShapeUtil.onTranslate` computed the page delta by applying the arrow's own page transform to `shape.x/y`, which folds the arrow's rotation into the delta, and then multiplied it by `0.5` — a compensation that only happened to be right for unrotated interactive drags. For a one-off move the shape record passed in is a working copy, so the halving gave half the real delta; for a rotated arrow the direction was wrong.

### After

`onTranslateStart` and `onTranslate` map `shape.x/y` through the parent transform (`getShapeParentTransform`) and use the full delta. This works for interactive drags, rotated arrows, and one-off moves alike.

### Change type

- [x] `bugfix`

### Test plan

1. Create a 200×200 box and an arrow bound to it; rotate the arrow 90°.
2. Drag only the arrow sideways. The bound terminal should follow the pointer (and unbind when it leaves the box), not drift diagonally.
3. Select the arrow alone and nudge it with the arrow keys — same expectation.

- [ ] Unit tests

### Release notes

- Fix bound arrow terminals moving by the wrong delta when translating a rotated arrow or nudging an arrow

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -4    |