### PR TITLE
fix(notes): use the right radius when looking for an existing adjacent note

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -191,8 +191,11 @@ export function getNoteShapeForAdjacentPosition(
 	// Start from the top of the stack, and work our way down
 	const allShapesOnPage = editor.getCurrentPageShapesSorted()
 
+	// Squared, in page units, to compare against Dist2 below. A neighbour that has grown
+	// (growY) sits further from the ideal slot centre, so the radius is a full note plus margin.
 	const minDistance =
-		(Math.max(noteWidth, noteHeight) + editor.options.adjacentShapeMargin ** 2) ** shape.props.scale
+		((Math.max(noteWidth, noteHeight) + editor.options.adjacentShapeMargin) * shape.props.scale) **
+		2
 
 	for (let i = allShapesOnPage.length - 1; i >= 0; i--) {
 		const otherNote = allShapesOnPage[i]


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where Cmd+Enter (or Tab) on a note created a new note on top of an existing neighbour instead of hopping to it.

### Before

`getNoteShapeForAdjacentPosition` pre-filtered candidate neighbours with `(max(w, h) + margin ** 2) ** scale`, about 600 at scale 1, and compared it against a squared distance — a ~24px radius. A neighbour whose centre sits further from the ideal slot (for example because it has `growY`) was not recognised, so a third note was created exactly on top of it.

### After

The radius is `((max(w, h) + margin) * scale) ** 2`: squared, in page units, and wide enough to cover a full note plus margin.

### Change type

- [x] `bugfix`

### Test plan

1. Create note A. Cmd+Enter to create note B below it and type enough text that B grows.
2. Go back to A and press Cmd+Enter.
3. Focus moves to B; no new note is created on top of it.

- [ ] Unit tests

### Release notes

- Fix Cmd+Enter / Tab on a note creating a duplicate on top of an existing neighbour

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |