### PR TITLE
fix(notes): scroll a newly created adjacent note into view

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -260,11 +260,18 @@ export function getNoteShapeForAdjacentPosition(
 		nextNote = editor.getShape(id)!
 	}
 
-	editor.zoomToSelectionIfOffscreen(16, {
-		animation: {
-			duration: editor.options.animationMediumMs,
-		},
-		inset: 0,
-	})
+	// When dragging a clone handle the caller is about to move the note under the pointer,
+	// so don't animate the camera towards the adjacent slot
+	if (!forceNew) {
+		// Select the next note first: the zoom targets the selection, and until now that was
+		// still the note we came from (which is on screen), so the new note never scrolled into view.
+		editor.select(nextNote.id)
+		editor.zoomToSelectionIfOffscreen(16, {
+			animation: {
+				duration: editor.options.animationMediumMs,
+			},
+			inset: 0,
+		})
+	}
 	return nextNote
 }


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where creating an adjacent note with Cmd+Enter or Tab near the edge of the viewport never scrolled the new note into view.

### Before

`getNoteShapeForAdjacentPosition` called `zoomToSelectionIfOffscreen` before the caller selected the new note, so the selection was still the source note — which is on screen — and the zoom was a no-op.

### After

The helper selects the next note before zooming. The select+zoom is skipped on the clone-handle drag path (`forceNew`), where the caller immediately moves the note under the pointer and a camera animation towards the adjacent slot would fight the drag.

### Change type

- [x] `bugfix`

### Test plan

1. Create a note near the bottom of the viewport.
2. Press Cmd+Enter. The viewport scrolls so the new note is visible.
3. Drag a note's clone handle — no camera jump.

- [ ] Unit tests

### Release notes

- Fix a new adjacent note (Cmd+Enter / Tab) not scrolling into view when created offscreen

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -6   |