### PR TITLE
fix(notes): scale growY when computing available adjacent positions

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -135,7 +135,8 @@ export function getAvailableNoteAdjacentPositions(
 				getNoteAdjacentPositions(editor, {
 					pagePoint: transform.point(),
 					pageRotation: rotation,
-					growY: shape.props.growY,
+					// page units, like the base positions (see PointingHandle)
+					growY: shape.props.growY * shape.props.scale,
 					extraHeight,
 					scale,
 					noteWidth,


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the adjacent-position snapping for scaled notes used the wrong vertical offset below a grown note.

### Before

`getAvailableNoteAdjacentPositions` passed `shape.props.growY` in shape units into `getNoteAdjacentPositions`, which works in page units (the other caller, `PointingHandle`, already multiplies by `scale`). For a scaled note with `growY`, the "below" slot was placed too close to the note.

### After

`growY` is multiplied by `shape.props.scale`, matching the base positions.

### Change type

- [x] `bugfix`

### Test plan

1. Create a note, scale it up (size), type enough text that it grows.
2. Drag another note near the slot below it — it snaps to a slot that clears the grown note.

- [ ] Unit tests

### Release notes

- Fix adjacent-note snapping under a scaled, grown note

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -1    |