### PR TITLE
fix(frames): keep children in place when double-clicking a frame edge

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2037,6 +2037,8 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
             w: number;
         };
         type: "frame";
+        x: number;
+        y: number;
     } | undefined;
     // (undocumented)
     options: FrameShapeOptions;

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -12,6 +12,7 @@ import {
 	TLFrameShapeProps,
 	TLShapePartial,
 	TLShapeUtilConstructor,
+	Vec,
 	clamp,
 	compact,
 	frameShapeMigrations,
@@ -390,9 +391,15 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 			this.editor.updateShapes(changes)
 		})
 
+		// The children were shifted by (dx, dy) in frame space; move the frame the opposite way
+		// (in its parent's space) so they keep their canvas positions, as fitFrameToContent does.
+		const diff = new Vec(isHorizontalEdge ? dx : 0, isVerticalEdge ? dy : 0).rot(shape.rotation)
+
 		return {
 			id: shape.id,
 			type: shape.type,
+			x: shape.x - diff.x,
+			y: shape.y - diff.y,
 			props: {
 				w: isHorizontalEdge ? w : shape.props.w,
 				h: isVerticalEdge ? h : shape.props.h,

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1973,3 +1973,48 @@ it('does not get drop children of nested frame if they are occluded from the out
 
 	expect(editor.getShape(rect1)?.parentId).toBe(frame2Id)
 })
+
+describe('When double-clicking a frame edge', () => {
+	it('fits the frame to its content without moving the children', () => {
+		const frameId = createShapeId()
+		const boxId = createShapeId()
+		editor.createShapes([
+			{ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 800, h: 600 } },
+			{ id: boxId, type: 'geo', parentId: frameId, x: 300, y: 200, props: { w: 100, h: 100 } },
+		])
+		editor.select(frameId)
+
+		const boxPageBoundsBefore = editor.getShapePageBounds(boxId)!
+
+		editor.doubleClick(800, 300, { target: 'selection', handle: 'right' })
+
+		// The frame fits the content horizontally (100 wide plus 10 of padding either
+		// side) and moves right to compensate; its height is left alone
+		expect(editor.getShapePageBounds(frameId)).toMatchObject({ x: 290, y: 0, w: 120, h: 600 })
+		expect(editor.getShapePageBounds(boxId)).toMatchObject(boxPageBoundsBefore)
+	})
+
+	it('keeps the children in place when the frame is rotated', () => {
+		const frameId = createShapeId()
+		const boxId = createShapeId()
+		editor.createShapes([
+			{ id: frameId, type: 'frame', x: 0, y: 0, rotation: Math.PI / 2, props: { w: 800, h: 600 } },
+			{ id: boxId, type: 'geo', parentId: frameId, x: 300, y: 200, props: { w: 100, h: 100 } },
+		])
+		editor.select(frameId)
+
+		const boxPageBoundsBefore = editor.getShapePageBounds(boxId)!
+
+		const bounds = editor.getSelectionPageBounds()!
+		editor.doubleClick(bounds.maxX, bounds.midY, { target: 'selection', handle: 'right' })
+
+		// The frame moved by the same 290 as above, but along its own rotated x axis
+		const frame = editor.getShape(frameId)!
+		expect(frame.x).toBeCloseTo(0)
+		expect(frame.y).toBeCloseTo(290)
+
+		const boxPageBoundsAfter = editor.getShapePageBounds(boxId)!
+		expect(boxPageBoundsAfter.x).toBeCloseTo(boxPageBoundsBefore.x)
+		expect(boxPageBoundsAfter.y).toBeCloseTo(boxPageBoundsBefore.y)
+	})
+})


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where double-clicking a frame edge to fit it to its content moved the content across the canvas.

### Before

`FrameShapeUtil.onDoubleClickEdge` shifted the frame's children by `(dx, dy)` in frame space and shrank the frame, but never moved the frame's own `x/y` to compensate (unlike `fitFrameToContent`). A child at local `(300, 200)` in an 800×600 frame at the origin ended up at page `x = 10` after double-clicking the right edge.

### After

The returned frame partial also moves the frame by the rotated `(dx, dy)` in the opposite direction, so children keep their canvas positions.

### API changes

- `FrameShapeUtil.onDoubleClickEdge`'s inferred return type now includes `x` and `y` (api report updated)

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame with a shape inside it, away from the frame's edges.
2. Double-click the frame's right edge.
3. The frame shrinks to the content and the shape does not move on the canvas.

- [x] Unit tests

### Release notes

- Fix frame content jumping when double-clicking a frame edge to fit it

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -0    |