### PR TITLE
fix(store): stop reverseRecordsDiff aliasing its input and squashRecordDiffs mutating shared tuples

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -36,9 +36,9 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 4. RecordsDiff (D)
 
 - **D1** `createEmptyRecordsDiff()` returns `{ added: {}, updated: {}, removed: {} }`; `isRecordsDiffEmpty` is true exactly when all three collections are empty.
-- **D2** `reverseRecordsDiff` swaps added and removed and reverses each `[from, to]` pair.
+- **D2** `reverseRecordsDiff` swaps added and removed and reverses each `[from, to]` pair. The result shares no collections or pairs with the input, so squashing into it leaves the input untouched.
 - **D3** `squashRecordDiffs(diffs)` combines sequential diffs into one. Per record id: add then update → add with the final value; add then remove → nothing; update then update → one update from the original `from` to the final `to`; update then remove → remove of the original `from`; remove then add → update from the removed value to the added value, unless the added value is reference-identical to the removed one, in which case nothing.
-- **D4** `squashRecordDiffs` does not mutate its inputs unless `mutateFirstDiff: true`, in which case the first diff is the (mutated) result. `squashRecordDiffsMutable(target, diffs)` applies diffs onto `target` in place with the same semantics.
+- **D4** `squashRecordDiffs` does not mutate its inputs unless `mutateFirstDiff: true`, in which case the first diff is the (mutated) result (an empty diff when there are no diffs); its `[from, to]` pairs are replaced rather than mutated in place. `squashRecordDiffsMutable(target, diffs)` applies diffs onto `target` in place with the same semantics; the target must own its pairs (start from `createEmptyRecordsDiff()`).
 
 ## 5. Store: reading and writing (S)
 

--- a/packages/store/src/lib/RecordsDiff.test.ts
+++ b/packages/store/src/lib/RecordsDiff.test.ts
@@ -148,3 +148,30 @@ describe('squashing diffs (D)', () => {
 		expect(mutableTarget).toEqual(immutableResult)
 	})
 })
+
+describe('diff ownership (D)', () => {
+	it('[D2] reverseRecordsDiff does not share its collections with the input', () => {
+		const input = diff({ 'book:1': book('book:1', 'Added') })
+		const reversed = reverseRecordsDiff(input)
+		squashRecordDiffsMutable(reversed, [diff({ 'book:1': book('book:1', 'Older') })])
+		expect(input).toEqual(diff({ 'book:1': book('book:1', 'Added') }))
+	})
+
+	it('[D4] mutateFirstDiff with no diffs returns an empty diff', () => {
+		expect(squashRecordDiffs([], { mutateFirstDiff: true })).toEqual(createEmptyRecordsDiff())
+	})
+
+	it('[D4] mutateFirstDiff does not mutate the [from, to] tuples of the first diff in place', () => {
+		const v1 = book('book:1', 'v1')
+		const v2 = book('book:1', 'v2')
+		const v3 = book('book:1', 'v3')
+		const tuple: [Book, Book] = [v1, v2]
+		const first = diff({}, { 'book:1': tuple })
+		const result = squashRecordDiffs([first, diff({}, { 'book:1': [v2, v3] })], {
+			mutateFirstDiff: true,
+		})
+		expect(result).toBe(first)
+		expect(result.updated['book:1' as RecordId<Book>]).toEqual([v1, v3])
+		expect(tuple).toEqual([v1, v2])
+	})
+})

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -78,7 +78,13 @@ export function createEmptyRecordsDiff<R extends UnknownRecord>(): RecordsDiff<R
  * @public
  */
 export function reverseRecordsDiff(diff: RecordsDiff<any>) {
-	const result: RecordsDiff<any> = { added: diff.removed, removed: diff.added, updated: {} }
+	// Copy the collections rather than aliasing them: callers squash into the reversed diff
+	// (`squashRecordDiffsMutable`), which would otherwise write through to the input.
+	const result: RecordsDiff<any> = {
+		added: { ...diff.removed },
+		removed: { ...diff.added },
+		updated: {},
+	}
 	for (const [from, to] of objectMapValues(diff.updated)) {
 		result.updated[from.id] = [to, from]
 	}
@@ -162,6 +168,14 @@ export function squashRecordDiffs<T extends UnknownRecord>(
 ): RecordsDiff<T> {
 	if (options?.mutateFirstDiff) {
 		const result = diffs[0]
+		if (!result) return createEmptyRecordsDiff()
+		// The squash mutates the target's `[from, to]` tuples in place, which is only safe when the
+		// target owns them. The first diff's tuples may be shared with other holders, so copy them.
+		for (const _id in result.updated) {
+			const id = _id as IdOf<T>
+			const [from, to] = result.updated[id]
+			result.updated[id] = [from, to]
+		}
 		squashRecordDiffsMutable(result, diffs, 1)
 		return result
 	}
@@ -180,6 +194,10 @@ export function squashRecordDiffs<T extends UnknownRecord>(
  * - Added records: If the record was previously removed, convert to an update; otherwise add it
  * - Updated records: Chain updates together, preserving the original 'from' state
  * - Removed records: If the record was added in this sequence, cancel both operations
+ *
+ * The target's `updated` tuples are mutated in place, so the target must own them: start from
+ * `createEmptyRecordsDiff()` (or a diff built by earlier squashes into it) rather than a diff whose
+ * tuples are shared with another holder.
  *
  * @param target - The diff to modify in-place (will be mutated)
  * @param diffs - Array of diffs to apply to the target


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where undoing after a `bailToMark` could remove records the user never undid, because `reverseRecordsDiff` shared its `added`/`removed` collections with the diff it reversed. Split out of #10177.

### Before

`reverseRecordsDiff` built its result as `{ added: diff.removed, removed: diff.added, updated: {} }`, aliasing the input's collections. `HistoryManager._undo` reverses the pending diff, pushes the original onto the redo stack, and then calls `squashRecordDiffsMutable(reversed, …)` — which wrote through to the diff now sitting on the redo stack, so a `bailToMark` followed by `undo` removed three records instead of one. Relatedly, `squashRecordDiffs([], { mutateFirstDiff: true })` returned `undefined`, and with `mutateFirstDiff` the squash mutated the first diff's `[from, to]` tuples in place, which could be shared with other holders.

### After

`reverseRecordsDiff` copies `added` and `removed`. `squashRecordDiffs` with `mutateFirstDiff: true` returns `createEmptyRecordsDiff()` for empty input and replaces the first diff's tuples with fresh copies before squashing into it. The `squashRecordDiffsMutable` doc states that the target must own its tuples. `packages/store/SPEC.md` D2 and D4 are updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change
- [x] `packages/editor` `HistoryManager` tests pass

### Release notes

- Fix undo after `bailToMark` removing records that were not part of the undone change

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +19 / -1   |
| Tests         | +27 / -0   |
| Documentation | +2 / -2    |