### PR TITLE
fix(bookmarks): apply the asset change when a bookmark url changes

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -577,25 +577,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
         y: number;
     };
     // (undocumented)
-    onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape): {
-        id: TLShapeId_2;
-        index: IndexKey;
-        isLocked: boolean;
-        meta: JsonObject;
-        opacity: TLOpacityType;
-        parentId: TLParentId;
-        props: {
-            assetId: null | TLAssetId;
-            h: number;
-            url: string;
-            w: number;
-        };
-        rotation: number;
-        type: "bookmark";
-        typeName: 'shape';
-        x: number;
-        y: number;
-    } | undefined;
+    onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape): TLBookmarkShape | undefined;
     // (undocumented)
     options: BookmarkShapeOptions;
     // (undocumented)

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -117,19 +117,19 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 	}
 
 	override onBeforeUpdate(prev: TLBookmarkShape, shape: TLBookmarkShape) {
+		let next = shape
 		if (prev.props.url !== shape.props.url) {
 			if (!T.linkUrl.isValid(shape.props.url)) {
 				return { ...shape, props: { ...shape.props, url: prev.props.url } }
-			} else {
-				updateBookmarkAssetOnUrlChange(this.editor, shape)
 			}
+			next = updateBookmarkAssetOnUrlChange(this.editor, shape)
 		}
 
-		if (prev.props.assetId !== shape.props.assetId) {
-			return setBookmarkHeight(this.editor, shape)
+		if (prev.props.assetId !== next.props.assetId) {
+			return setBookmarkHeight(this.editor, next)
 		}
 
-		return undefined
+		return next === shape ? undefined : next
 	}
 	override getInterpolatedProps(
 		startShape: TLBookmarkShape,

--- a/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/bookmark/BookmarkShapeUtil.tsx
@@ -29,7 +29,7 @@ import {
 	getHumanReadableAddress,
 	getResolvedBookmarkAssetId,
 	setBookmarkHeight,
-	updateBookmarkAssetOnUrlChange,
+	resolveBookmarkAssetForUrlChange,
 } from './bookmarks'
 
 /** @public */
@@ -122,7 +122,7 @@ export class BookmarkShapeUtil extends BaseBoxShapeUtil<TLBookmarkShape> {
 			if (!T.linkUrl.isValid(shape.props.url)) {
 				return { ...shape, props: { ...shape.props, url: prev.props.url } }
 			}
-			next = updateBookmarkAssetOnUrlChange(this.editor, shape)
+			next = resolveBookmarkAssetForUrlChange(this.editor, shape)
 		}
 
 		if (prev.props.assetId !== next.props.assetId) {

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -51,38 +51,31 @@ export function getHumanReadableAddress(url: string) {
 	}
 }
 
-export function updateBookmarkAssetOnUrlChange(editor: Editor, shape: TLBookmarkShape) {
+/**
+ * Resolve the asset for a bookmark whose url just changed: the existing asset for the new url
+ * if there is one, otherwise `null` while a new one is fetched in the background.
+ *
+ * Returns the shape to store rather than writing it. This runs inside `onBeforeUpdate`, where
+ * a nested `updateShapes` is overwritten by the outer put and the old asset would stick.
+ */
+export function updateBookmarkAssetOnUrlChange(
+	editor: Editor,
+	shape: TLBookmarkShape
+): TLBookmarkShape {
 	const { url } = shape.props
 
 	// Derive the asset id from the URL
 	const assetId: TLAssetId = AssetRecordType.createId(getHashForString(url))
 
 	if (editor.getAsset(assetId)) {
-		// Existing asset for this URL?
-		if (shape.props.assetId !== assetId) {
-			editor.updateShapes([
-				{
-					id: shape.id,
-					type: shape.type,
-					props: { assetId },
-				},
-			])
-		}
-	} else {
-		// No asset for this URL?
-
-		// First, clear out the existing asset reference
-		editor.updateShapes([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { assetId: null },
-			},
-		])
-
-		// Then try to asyncronously create a new one
-		createBookmarkAssetOnUrlChange(editor, shape)
+		if (shape.props.assetId === assetId) return shape
+		return { ...shape, props: { ...shape.props, assetId } }
 	}
+
+	// No asset for this URL yet: drop the stale reference and fetch one asynchronously
+	createBookmarkAssetOnUrlChange(editor, shape)
+	if (shape.props.assetId === null) return shape
+	return { ...shape, props: { ...shape.props, assetId: null } }
 }
 
 /**

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -55,10 +55,10 @@ export function getHumanReadableAddress(url: string) {
  * Resolve the asset for a bookmark whose url just changed: the existing asset for the new url
  * if there is one, otherwise `null` while a new one is fetched in the background.
  *
- * Returns the shape to store rather than writing it. This runs inside `onBeforeUpdate`, where
- * a nested `updateShapes` is overwritten by the outer put and the old asset would stick.
+ * Must not write to the store: this runs inside `onBeforeUpdate`, where a nested `updateShapes`
+ * is overwritten by the outer put and the old asset would stick.
  */
-export function updateBookmarkAssetOnUrlChange(
+export function resolveBookmarkAssetForUrlChange(
 	editor: Editor,
 	shape: TLBookmarkShape
 ): TLBookmarkShape {

--- a/packages/tldraw/src/test/bookmark-shapes.test.ts
+++ b/packages/tldraw/src/test/bookmark-shapes.test.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 import { defaultHandleExternalUrlAsset } from '../lib/defaultExternalContentHandlers'
 import {
 	createBookmarkFromUrl,
+	getBookmarkHeight,
 	getBookmarkShapeHeight,
 	getHumanReadableAddress,
 	getResolvedBookmarkAssetId,
@@ -481,6 +482,82 @@ describe('createBookmarkFromUrl', () => {
 		// resolved short bookmark, not the 320px placeholder.
 		expect(getBookmarkShapeHeight(editor, redone)).toBe(shortHeight)
 		expect(editor.getShapeGeometry(redone.id).bounds.height).toBe(shortHeight)
+	})
+})
+
+describe('changing a bookmark url', () => {
+	function createBookmarkAsset(url: string, description: string) {
+		const id = AssetRecordType.createId(getHashForString(url))
+		editor.createAssets([
+			{
+				id,
+				typeName: 'asset',
+				type: 'bookmark',
+				props: { src: url, title: url, description, image: '', favicon: '' },
+				meta: {},
+			},
+		])
+		return id
+	}
+
+	it('switches to the existing asset for the new url in the same update', () => {
+		const urlA = 'https://a.example.com'
+		const urlB = 'https://b.example.com'
+		const assetA = createBookmarkAsset(urlA, 'short')
+		const assetB = createBookmarkAsset(urlB, 'a much longer description for the second site')
+		const id = createShapeId()
+		editor.createShape<TLBookmarkShape>({
+			id,
+			type: 'bookmark',
+			props: { url: urlA, assetId: assetA },
+		})
+		const fetchSpy = vi.spyOn(editor, 'getAssetForExternalContent')
+
+		editor.updateShape<TLBookmarkShape>({ id, type: 'bookmark', props: { url: urlB } })
+
+		expect(editor.getShape<TLBookmarkShape>(id)!.props).toMatchObject({
+			url: urlB,
+			assetId: assetB,
+			h: getBookmarkHeight(editor, assetB),
+		})
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it('drops the old asset while a new one is fetched for an unknown url', async () => {
+		vi.useFakeTimers()
+		try {
+			const urlA = 'https://a.example.com'
+			const urlC = 'https://c.example.com'
+			const assetA = createBookmarkAsset(urlA, 'short')
+			const id = createShapeId()
+			editor.createShape<TLBookmarkShape>({
+				id,
+				type: 'bookmark',
+				props: { url: urlA, assetId: assetA },
+			})
+			const assetC = AssetRecordType.createId(getHashForString(urlC))
+			const fetchSpy = vi.spyOn(editor, 'getAssetForExternalContent').mockResolvedValue({
+				id: assetC,
+				typeName: 'asset',
+				type: 'bookmark',
+				props: { src: urlC, title: urlC, description: '', image: '', favicon: '' },
+				meta: {},
+			})
+
+			editor.updateShape<TLBookmarkShape>({ id, type: 'bookmark', props: { url: urlC } })
+
+			expect(editor.getShape<TLBookmarkShape>(id)!.props).toMatchObject({
+				url: urlC,
+				assetId: null,
+				h: getBookmarkHeight(editor, null),
+			})
+
+			await vi.advanceTimersByTimeAsync(600)
+			expect(fetchSpy).toHaveBeenCalledWith({ type: 'url', url: urlC })
+			expect(editor.getShape<TLBookmarkShape>(id)!.props.assetId).toBe(assetC)
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 })
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where changing a bookmark's url kept the old preview.

### Before

`BookmarkShapeUtil.onBeforeUpdate` called `updateBookmarkAssetOnUrlChange`, which wrote the new `assetId` through a nested `editor.updateShapes`, and then returned the unchanged record. The outer store put overwrote the nested write, so the shape kept the old `assetId`: forever if the new url's asset already existed, and until the async fetch landed otherwise.

### After

`updateBookmarkAssetOnUrlChange` returns the record to store (new `assetId`, or `null` while a fresh asset is fetched) and `onBeforeUpdate` returns it, so the change goes through the same put.

### API changes

- `BookmarkShapeUtil.onBeforeUpdate`'s inferred return type is now `TLBookmarkShape | undefined` (api report updated)
- Internal only: `updateBookmarkAssetOnUrlChange` is renamed to `resolveBookmarkAssetForUrlChange` since it no longer writes to the store. Not exported from the package.

### Change type

- [x] `bugfix`

### Test plan

1. Create two bookmarks for different urls.
2. Edit the first bookmark's url to the second bookmark's url.
3. Its preview switches to the second url's preview immediately.

- [x] Unit tests: `bookmark-shapes.test.ts` covers the existing-asset switch and the unknown-url fetch path; both fail on `main`

### Release notes

- Fix a bookmark keeping its old preview after its url changes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +24 / -49  |
| Tests     | +70 / -0   |
