### PR TITLE
fix(store): let AtomMap skip entries deleted mid-iteration

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -198,7 +198,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 - **AM1** `get`/`has` are reactive per key: an effect reading a present key re-runs when that key's value changes or the key is deleted, but not when other keys are set, updated, or deleted.
 - **AM2** Reading an absent key subscribes to the map's key set, so the reader re-runs when that key is later added (a reader of an absent key may also re-run when the key set otherwise changes — per-key isolation applies to present keys).
-- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key. Any value usable as a `Map` key (including symbols and null-prototype objects) is accepted.
+- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key.
 - **AM4** `delete` returns whether the key existed. `deleteMany(keys)` deletes in one transaction (one reaction for the whole batch), returns the `[key, value]` pairs actually deleted, and ignores missing keys.
 - **AM5** `clear()` empties the map.
 - **AM6** `entries`, `keys`, `values`, `forEach`, `[Symbol.iterator]`, and `size` see exactly the live entries and are reactive. `forEach` honors `thisArg`. As with `Map`, an entry deleted during iteration before it is visited is skipped.

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -198,10 +198,10 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 - **AM1** `get`/`has` are reactive per key: an effect reading a present key re-runs when that key's value changes or the key is deleted, but not when other keys are set, updated, or deleted.
 - **AM2** Reading an absent key subscribes to the map's key set, so the reader re-runs when that key is later added (a reader of an absent key may also re-run when the key set otherwise changes — per-key isolation applies to present keys).
-- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key.
+- **AM3** `set` adds or updates and returns the map. `update(key, fn)` replaces an existing value and throws for a missing key. Any value usable as a `Map` key (including symbols and null-prototype objects) is accepted.
 - **AM4** `delete` returns whether the key existed. `deleteMany(keys)` deletes in one transaction (one reaction for the whole batch), returns the `[key, value]` pairs actually deleted, and ignores missing keys.
 - **AM5** `clear()` empties the map.
-- **AM6** `entries`, `keys`, `values`, `forEach`, `[Symbol.iterator]`, and `size` see exactly the live entries and are reactive. `forEach` honors `thisArg`.
+- **AM6** `entries`, `keys`, `values`, `forEach`, `[Symbol.iterator]`, and `size` see exactly the live entries and are reactive. `forEach` honors `thisArg`. As with `Map`, an entry deleted during iteration before it is visited is skipped.
 - **AM7** Changes made inside a rolled-back `@tldraw/state` transaction are restored: additions disappear, updates revert, deletions reappear.
 - **AM8** `Object.prototype.toString.call(map)` is `[object AtomMap]`.
 - **AM9** `getOrInsert(key, defaultValue)` and `getOrInsertComputed(key, callback)` return the existing value for a present key, and otherwise insert and return the new value. `callback` runs only when the key is absent.

--- a/packages/store/src/lib/AtomMap.test.ts
+++ b/packages/store/src/lib/AtomMap.test.ts
@@ -630,3 +630,44 @@ describe('AtomMap', () => {
 		expect(Object.prototype.toString.call(map)).toBe('[object AtomMap]')
 	})
 })
+
+describe('AtomMap: Map parity (AM)', () => {
+	it('[AM6] an entry deleted before iteration reaches it is skipped, like Map', () => {
+		const map = new AtomMap('test', [
+			['a', 1],
+			['b', 2],
+			['c', 3],
+		])
+		const visited: string[] = []
+		for (const [key] of map) {
+			visited.push(key)
+			if (key === visited[0]) {
+				// delete the two keys we have not reached yet
+				for (const other of ['a', 'b', 'c']) if (other !== key) map.delete(other)
+			}
+		}
+		expect(visited).toHaveLength(1)
+		expect(Array.from(map.keys())).toEqual(visited)
+
+		const cleared = new AtomMap('test2', [
+			['a', 1],
+			['b', 2],
+		])
+		const seen: string[] = []
+		for (const key of cleared.keys()) {
+			seen.push(key)
+			cleared.clear()
+		}
+		expect(seen).toHaveLength(1)
+	})
+
+	it('[AM3] symbol and null-prototype keys work', () => {
+		const map = new AtomMap<unknown, number>('test')
+		const sym = Symbol('k')
+		const nullProto = Object.create(null)
+		map.set(sym, 1).set(nullProto, 2)
+		expect(map.get(sym)).toBe(1)
+		expect(map.get(nullProto)).toBe(2)
+		expect(() => map.update(Symbol('missing'), (v) => v)).toThrow('not found')
+	})
+})

--- a/packages/store/src/lib/AtomMap.test.ts
+++ b/packages/store/src/lib/AtomMap.test.ts
@@ -660,14 +660,4 @@ describe('AtomMap: Map parity (AM)', () => {
 		}
 		expect(seen).toHaveLength(1)
 	})
-
-	it('[AM3] symbol and null-prototype keys work', () => {
-		const map = new AtomMap<unknown, number>('test')
-		const sym = Symbol('k')
-		const nullProto = Object.create(null)
-		map.set(sym, 1).set(nullProto, 2)
-		expect(map.get(sym)).toBe(1)
-		expect(map.get(nullProto)).toBe(2)
-		expect(() => map.update(Symbol('missing'), (v) => v)).toThrow('not found')
-	})
 })

--- a/packages/store/src/lib/AtomMap.ts
+++ b/packages/store/src/lib/AtomMap.ts
@@ -2,12 +2,6 @@ import { atom, Atom, transact, UNINITIALIZED } from '@tldraw/state'
 import { assert } from '@tldraw/utils'
 import { emptyMap, ImmutableMap } from './ImmutableMap'
 
-// Atom names are debugging aids; `String()` throws for null-prototype objects and template literals
-// throw for symbols, and a Map must accept both as keys.
-function keyToName(key: unknown) {
-	return typeof key === 'object' && key !== null ? '[object]' : String(key)
-}
-
 /**
  * A drop-in replacement for Map that stores values in atoms and can be used in reactive contexts.
  * @public
@@ -38,7 +32,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 		if (entries) {
 			atoms = atoms.withMutations((atoms) => {
 				for (const [k, v] of entries) {
-					atoms.set(k, atom(`${name}:${keyToName(k)}`, v))
+					atoms.set(k, atom(`${name}:${String(k)}`, v))
 				}
 			})
 		}
@@ -164,7 +158,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 			existingAtom.set(value)
 		} else {
 			this.atoms.update((atoms) => {
-				return atoms.set(key, atom(`${this.name}:${keyToName(key)}`, value))
+				return atoms.set(key, atom(`${this.name}:${String(key)}`, value))
 			})
 		}
 		return this
@@ -230,7 +224,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 	update(key: K, updater: (value: V) => V) {
 		const valueAtom = this.atoms.__unsafe__getWithoutCapture().get(key)
 		if (!valueAtom) {
-			throw new Error(`AtomMap: key ${keyToName(key)} not found`)
+			throw new Error(`AtomMap: key ${key} not found`)
 		}
 		const value = valueAtom.__unsafe__getWithoutCapture()
 		assert(value !== UNINITIALIZED)

--- a/packages/store/src/lib/AtomMap.ts
+++ b/packages/store/src/lib/AtomMap.ts
@@ -2,6 +2,12 @@ import { atom, Atom, transact, UNINITIALIZED } from '@tldraw/state'
 import { assert } from '@tldraw/utils'
 import { emptyMap, ImmutableMap } from './ImmutableMap'
 
+// Atom names are debugging aids; `String()` throws for null-prototype objects and template literals
+// throw for symbols, and a Map must accept both as keys.
+function keyToName(key: unknown) {
+	return typeof key === 'object' && key !== null ? '[object]' : String(key)
+}
+
 /**
  * A drop-in replacement for Map that stores values in atoms and can be used in reactive contexts.
  * @public
@@ -32,7 +38,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 		if (entries) {
 			atoms = atoms.withMutations((atoms) => {
 				for (const [k, v] of entries) {
-					atoms.set(k, atom(`${name}:${String(k)}`, v))
+					atoms.set(k, atom(`${name}:${keyToName(k)}`, v))
 				}
 			})
 		}
@@ -158,7 +164,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 			existingAtom.set(value)
 		} else {
 			this.atoms.update((atoms) => {
-				return atoms.set(key, atom(`${this.name}:${String(key)}`, value))
+				return atoms.set(key, atom(`${this.name}:${keyToName(key)}`, value))
 			})
 		}
 		return this
@@ -224,7 +230,7 @@ export class AtomMap<K, V> implements Map<K, V> {
 	update(key: K, updater: (value: V) => V) {
 		const valueAtom = this.atoms.__unsafe__getWithoutCapture().get(key)
 		if (!valueAtom) {
-			throw new Error(`AtomMap: key ${key} not found`)
+			throw new Error(`AtomMap: key ${keyToName(key)} not found`)
 		}
 		const value = valueAtom.__unsafe__getWithoutCapture()
 		assert(value !== UNINITIALIZED)
@@ -334,7 +340,9 @@ export class AtomMap<K, V> implements Map<K, V> {
 	*entries(): Generator<[K, V], undefined, unknown> {
 		for (const [key, valueAtom] of this.atoms.get()) {
 			const value = valueAtom.get()
-			assert(value !== UNINITIALIZED)
+			// The key set is a snapshot taken when iteration started, so a key deleted mid-iteration
+			// still appears in it; skip it, as `Map` skips entries deleted before they are visited.
+			if (value === UNINITIALIZED) continue
 			yield [key, value]
 		}
 	}
@@ -354,7 +362,9 @@ export class AtomMap<K, V> implements Map<K, V> {
 	 * ```
 	 */
 	*keys(): Generator<K, undefined, unknown> {
-		for (const key of this.atoms.get().keys()) {
+		for (const [key, valueAtom] of this.atoms.get()) {
+			// see entries(): skip keys deleted mid-iteration
+			if (valueAtom.__unsafe__getWithoutCapture() === UNINITIALIZED) continue
 			yield key
 		}
 	}
@@ -376,7 +386,8 @@ export class AtomMap<K, V> implements Map<K, V> {
 	*values(): Generator<V, undefined, unknown> {
 		for (const valueAtom of this.atoms.get().values()) {
 			const value = valueAtom.get()
-			assert(value !== UNINITIALIZED)
+			// see entries(): skip keys deleted mid-iteration
+			if (value === UNINITIALIZED) continue
 			yield value
 		}
 	}


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where deleting an `AtomMap` entry during iteration threw an assertion error. Split out of #10177.

### Before

`AtomMap.entries()`/`keys()`/`values()` iterate a snapshot of the key set taken when iteration began, and asserted that every value atom was still initialised. A `for (const [k] of map) map.delete(laterKey)` loop therefore hit `Assertion Error` when it reached the deleted key, where native `Map` simply skips it.

### After

The three iterators skip entries whose atom is `UNINITIALIZED` (deleted before being visited), matching `Map`. `packages/store/SPEC.md` AM6 is updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix `AtomMap` throwing when an entry is deleted mid-iteration

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +7 / -3    |
| Tests         | +31 / -0   |
| Documentation | +1 / -1    |