### PR TITLE
fix(arrows): fix the start point when only the end shape intersects a straight arrow

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -108,9 +108,11 @@ export function getStraightArrowInfo(
 	) {
 		if (endShapeInfo.didIntersect && !startShapeInfo.didIntersect) {
 			// ...and if only the end shape intersected, then make it
-			// a short arrow ending at the end shape intersection.
+			// a short arrow ending at the end shape intersection. The start
+			// sits MIN_ARROW_LENGTH before it along the arrow's direction;
+			// adding would put it past the intersection, inside the end shape.
 			if (startShapeInfo.isClosed) {
-				a.setTo(b.clone().add(uAB.clone().mul(MIN_ARROW_LENGTH * shape.props.scale)))
+				a.setTo(b.clone().sub(uAB.clone().mul(MIN_ARROW_LENGTH * shape.props.scale)))
 			}
 		} else if (!endShapeInfo.didIntersect) {
 			// ...and if only the end shape intersected, or if neither


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a straight arrow between two overlapping shapes collapsed to a short stub inside the end shape.

### Before

In `getStraightArrowInfo`, when only the end shape intersected the arrow line and the start shape is closed, the start point was set to `b + uAB * MIN_ARROW_LENGTH` — past the end intersection, inside the end shape. The arrow then pointed backwards over 10px.

### After

The start point is `b - uAB * MIN_ARROW_LENGTH`, a short arrow ending at the end shape's edge as the comment intended.

### Change type

- [x] `bugfix`

### Test plan

1. Create a wide box and a tall box overlapping its right end.
2. Draw an arrow from the centre of the wide box to the centre of the tall box.
3. The arrow ends at the tall box's left edge instead of a stub floating inside it.

- [ ] Unit tests

### Release notes

- Fix straight arrows between overlapping shapes collapsing to a stub

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -2    |