### PR TITLE
fix(arrows): tolerate custom size values when computing bound arrow offsets

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/curved-arrow.ts
@@ -182,7 +182,7 @@ export function getCurvedArrowInfo(
 				const strokeOffset =
 					arrowSW / 2 +
 					('size' in startShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
+						? (theme.strokeWidth * (STROKE_SIZES[startShapeInfo.shape.props.size] ?? 0)) / 2
 						: 0)
 				offsetA = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale
@@ -265,7 +265,7 @@ export function getCurvedArrowInfo(
 				const strokeOffset =
 					arrowSW / 2 +
 					('size' in endShapeInfo.shape.props
-						? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
+						? (theme.strokeWidth * (STROKE_SIZES[endShapeInfo.shape.props.size] ?? 0)) / 2
 						: 0)
 				offsetB = (BOUND_ARROW_OFFSET + strokeOffset) * shape.props.scale
 				minLength += strokeOffset * shape.props.scale

--- a/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/straight-arrow.ts
@@ -139,7 +139,7 @@ export function getStraightArrowInfo(
 			strokeOffsetA =
 				arrowSW / 2 +
 				('size' in startShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[startShapeInfo.shape.props.size]) / 2
+					? (theme.strokeWidth * (STROKE_SIZES[startShapeInfo.shape.props.size] ?? 0)) / 2
 					: 0)
 			offsetA = (BOUND_ARROW_OFFSET + strokeOffsetA) * shape.props.scale
 			minLength += strokeOffsetA * shape.props.scale
@@ -156,7 +156,7 @@ export function getStraightArrowInfo(
 			strokeOffsetB =
 				arrowSW / 2 +
 				('size' in endShapeInfo.shape.props
-					? (theme.strokeWidth * STROKE_SIZES[endShapeInfo.shape.props.size]) / 2
+					? (theme.strokeWidth * (STROKE_SIZES[endShapeInfo.shape.props.size] ?? 0)) / 2
 					: 0)
 			offsetB = (BOUND_ARROW_OFFSET + strokeOffsetB) * shape.props.scale
 			minLength += strokeOffsetB * shape.props.scale


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where an arrow bound to a custom shape with a `size` prop outside `s | m | l | xl` produced `NaN` geometry.

### Before

`getStraightArrowInfo` and `getCurvedArrowInfo` indexed `STROKE_SIZES[shape.props.size]` for any bound shape with a `size` prop. A custom shape using its own size scale got `undefined`, which turned the offsets and minimum length into `NaN` and the arrow disappeared.

### After

The lookups fall back to `0` (`STROKE_SIZES[size] ?? 0`), treating an unknown size as having no extra stroke offset.

### Change type

- [x] `bugfix`

### Test plan

1. Register a custom shape with a `size: 'xxl'` prop and bind an arrow to it.
2. The arrow renders and its terminal sits at the shape's edge.

- [ ] Unit tests

### Release notes

- Fix arrows bound to custom shapes with non-standard `size` values rendering as `NaN`

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -4    |