### PR TITLE
fix(geo): scale the label over-shrink offset when resizing a scaled geo shape

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -559,6 +559,9 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 
 		const scaledW = unscaledW * shape.props.scale
 		const scaledH = unscaledH * shape.props.scale
+		// the offset is in the shape's (scaled) units, so the label over-shrink must be scaled too
+		const scaledOverShrinkX = overShrinkX * shape.props.scale
+		const scaledOverShrinkY = overShrinkY * shape.props.scale
 
 		const offset = new Vec(0, 0)
 
@@ -569,7 +572,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		if (handle === 'left' || handle === 'top_left' || handle === 'bottom_left') {
-			offset.x += scaleX < 0 ? overShrinkX : -overShrinkX
+			offset.x += scaleX < 0 ? scaledOverShrinkX : -scaledOverShrinkX
 		}
 
 		// y offsets
@@ -579,7 +582,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		}
 
 		if (handle === 'top' || handle === 'top_left' || handle === 'top_right') {
-			offset.y += scaleY < 0 ? overShrinkY : -overShrinkY
+			offset.y += scaleY < 0 ? scaledOverShrinkY : -scaledOverShrinkY
 		}
 
 		const { x, y } = offset.rot(shape.rotation).add(newPoint)


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where resizing a geo shape with `props.scale != 1` past its label's minimum size made the supposedly fixed opposite edge drift.

### Before

`GeoShapeUtil.onResize` computed `overShrinkX/Y` (how much the label stopped the shape from shrinking) in unscaled units and added them to `offset`, which is in the shape's scaled units. With `scale = 2` the offset was off by `overShrink * (scale - 1)`, so dragging the left handle moved the right edge.

### After

The over-shrink is multiplied by `shape.props.scale` before it is added to the offset.

### Change type

- [x] `bugfix`

### Test plan

1. Create a wide geo shape with a label, set its scale to 2 (e.g. via `updateShape`).
2. Drag the left resize handle past the label's minimum width.
3. The right edge stays put.

- [ ] Unit tests

### Release notes

- Fix the opposite edge of a scaled geo shape drifting when resized past its label's minimum size

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -2    |