### PR TITLE
fix(arrows): give elbow arrow point terminals their own expanded box

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/elbow/getElbowArrowInfo.tsx
@@ -142,12 +142,14 @@ export function getElbowArrowInfo(
 	}
 
 	// We expand the bounds of the terminals so we can route arrows around them without the arrows
-	// being too close to the shapes.
+	// being too close to the shapes. Always a separate Box from `bounds`: ElbowArrowWorkingInfo
+	// transforms `original` and `expanded` in place, so sharing one object would transform a point
+	// terminal twice (a no-op for flips, a 180° turn for rotations) and corrupt the route.
 	const expandedA = aTerminal.isPoint
-		? aTerminal.bounds
+		? aTerminal.bounds.clone()
 		: aTerminal.bounds.clone().expandBy(options.expandElbowLegLength)
 	const expandedB = bTerminal.isPoint
-		? bTerminal.bounds
+		? bTerminal.bounds.clone()
 		: bTerminal.bounds.clone().expandBy(options.expandElbowLegLength)
 
 	const common: ElbowArrowBox = {


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where an elbow arrow with one free (point) terminal sometimes routed through the bound shape, or routed differently depending on where in arrow space the shapes sat.

### Before

`getElbowArrowInfo` used the same `Box` instance for a point terminal's `original` and `expanded` bounds. `ElbowArrowWorkingInfo.apply()` / `reset()` transform both in place, so the one box was transformed twice: a no-op for flips, but a 180° turn for rotations, and a corrupted box after composite transforms. The returned `info.A.original` was also left in the transformed state.

### After

Point terminals get `bounds.clone()` for `expanded`, so each box is transformed exactly once.

### Change type

- [x] `bugfix`

### Test plan

1. Create a box. Draw an elbow arrow from a free point just to the right of the box into the box.
2. The arrow enters from the right edge instead of routing through the box to its centre.

- [ ] Unit tests

### Release notes

- Fix elbow arrows with a free terminal sometimes routing through the bound shape

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -3    |