### PR TITLE
fix(store): don't emit empty added/removed sets from IncrementalSetConstructor

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -225,7 +225,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 ## 26. IncrementalSetConstructor — internal (ISC)
 
 - **ISC1** `get()` returns `undefined` when there are no net changes: nothing done, adding already-present items, removing absent items, or add/remove round trips that cancel out.
-- **ISC2** Otherwise `get()` returns `{ value, diff }`, where `value` is the new set and `diff` is the `CollectionDiff` relative to the original set; the original set is not mutated.
+- **ISC2** Otherwise `get()` returns `{ value, diff }`, where `value` is the new set and `diff` is the `CollectionDiff` relative to the original set, with `added`/`removed` present only when non-empty; the original set is not mutated.
 - **ISC3** Re-adding an item removed earlier in the construction restores it (and removes it from `diff.removed`); removing an item added earlier cancels the add.
 
 ## 27. ImmutableMap — internal (IM)

--- a/packages/store/src/lib/IncrementalSetConstructor.test.ts
+++ b/packages/store/src/lib/IncrementalSetConstructor.test.ts
@@ -104,3 +104,13 @@ describe('IncrementalSetConstructor (ISC)', () => {
 		})
 	})
 })
+
+describe('IncrementalSetConstructor: diff shape (ISC)', () => {
+	it('[ISC2] an add/remove round trip does not leave an empty set in the diff', () => {
+		const constructor = new IncrementalSetConstructor(new Set(['a']))
+		constructor.add('b')
+		constructor.remove('b')
+		constructor.remove('a')
+		expect(constructor.get()).toEqual({ value: new Set(), diff: { removed: new Set(['a']) } })
+	})
+})

--- a/packages/store/src/lib/IncrementalSetConstructor.ts
+++ b/packages/store/src/lib/IncrementalSetConstructor.ts
@@ -74,6 +74,10 @@ export class IncrementalSetConstructor<T> {
 		if (numRemoved === 0 && numAdded === 0) {
 			return undefined
 		}
+		// An add/remove round trip leaves an empty set behind; drop it so that consumers can treat
+		// the presence of `added`/`removed` as "there are additions/removals".
+		if (numAdded === 0) delete this.diff!.added
+		if (numRemoved === 0) delete this.diff!.removed
 		return { value: this.nextValue!, diff: this.diff! }
 	}
 


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `IncrementalSetConstructor.get()` could return a `CollectionDiff` containing an empty `added` or `removed` set. Split out of #10177.

### Before

`IncrementalSetConstructor` creates the `added`/`removed` sets lazily when an item is first added or removed. An add/remove round trip (`add('b')` then `remove('b')`) emptied the set again but left it on the diff, so `get()` returned e.g. `{ removed: Set(['a']), added: Set() }`. Consumers that treat the presence of the key as "there are additions" (the `index()` and `ids()` history diffs are built from these) misfired.

### After

`get()` deletes `added`/`removed` from the diff when they are empty, so each key is present only when non-empty. `packages/store/SPEC.md` ISC2 is updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new `[ISC2]` test fails on `main` and passes with this change

### Release notes

- Fix `CollectionDiff`s from `store.query.ids()`/`index()` containing an empty `added` or `removed` set after an add/remove round trip

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +4 / -0    |
| Tests         | +10 / -0   |
| Documentation | +1 / -1    |