### PR TITLE
fix(lines): tolerate lines with fewer than two points

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -359,6 +359,12 @@ function getPathForLineShape(shape: TLLineShape): PathBuilder {
 	return pathCache.get(shape, () => {
 		const points = linePointsToArray(shape).map(Vec.From)
 
+		// A line needs two points to have a path. onBeforeCreate lets 0/1-point lines through
+		// (they can also arrive via updateShape or a file), and without this every geometry
+		// lookup on the page would throw — getShapeAtPoint included.
+		if (points.length === 0) points.push(new Vec(0, 0))
+		if (points.length === 1) points.push(points[0].clone().addXY(0.1, 0.1))
+
 		switch (shape.props.spline) {
 			case 'cubic': {
 				return PathBuilder.cubicSplineThroughPoints(points, { endOffsets: 0 })


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a line shape with zero or one points broke geometry lookups for the whole page.

### Before

`onBeforeCreate` and the validator both allow a line with fewer than two points (they can also arrive via `updateShape` or a file). `getPathForLineShape` then built a `PathBuilder` from `points[0]` or a `Polyline2d` with too few points, which throws — and because `getShapeAtPoint` iterates every shape on the page, one such line broke hit testing everywhere.

### After

`getPathForLineShape` pads to two points (origin, then a point 0.1 away), so the line renders as a dot and geometry lookups succeed.

### Change type

- [x] `bugfix`

### Test plan

1. `editor.createShape({ type: 'line', props: { points: {} } })`
2. `editor.getShapeAtPoint({ x: 0, y: 0 })` returns without throwing.

- [ ] Unit tests

### Release notes

- Fix a line shape with fewer than two points breaking hit testing for the page

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -0    |