### PR TITLE
fix(draw): tolerate draw and highlight shapes with no segments

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId, TLDrawShape } from '@tldraw/editor'
+import { Circle2d, createShapeId, TLDrawShape } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
 import { createDrawSegments, pointsToBase64 } from '../../utils/test-helpers'
 
@@ -25,6 +25,22 @@ describe('DrawShapeUtil dot detection', () => {
 		])
 		return editor.getShape(shapeId) as TLDrawShape
 	}
+
+	describe('empty segments', () => {
+		it('treats a shape created from its default props as a dot', () => {
+			editor.createShape({ id: shapeId, type: 'draw' })
+			const shape = editor.getShape<TLDrawShape>(shapeId)!
+			expect(shape.props.segments).toEqual([])
+			expect(editor.getShapeGeometry(shape)).toBeInstanceOf(Circle2d)
+			expect(editor.getShapeAtPoint({ x: 0, y: 0 })?.id).toBe(shapeId)
+		})
+
+		it('treats a single segment with an empty path as a dot', () => {
+			const shape = createDrawShape([{ type: 'free', path: '' }])
+			expect(editor.getShapeGeometry(shape)).toBeInstanceOf(Circle2d)
+			expect(editor.getShapeAtPoint({ x: 0, y: 0 })?.id).toBe(shapeId)
+		})
+	})
 
 	describe('getIsDot behavior via hideResizeHandles', () => {
 		it('treats a shape with one segment and zero points as a dot', () => {

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -119,6 +119,12 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 
 		const sw = (getDisplayValues(this, shape).strokeWidth + 1) * shape.props.scale
 
+		// No points yet (the default props have no segments): a dot at the origin, so geometry
+		// lookups don't throw on a shape created from its defaults.
+		if (points.length === 0) {
+			return new Circle2d({ x: -sw, y: -sw, radius: sw, isFilled: true })
+		}
+
 		// A dot
 		if (shape.props.segments.length === 1) {
 			const box = Box.FromPoints(points)
@@ -202,7 +208,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 		const solidStrokePath =
 			strokePoints.length > 1
 				? getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed)
-				: getDot(allPointsFromSegments[0], sw)
+				: getDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, sw)
 
 		return new Path2D(solidStrokePath)
 	}
@@ -367,7 +373,7 @@ function DrawShapeSvg({
 	const fill = isDot || shape.props.isClosed ? shape.props.fill : 'none'
 
 	const solidStrokePath = isDot
-		? getDot(allPointsFromSegments[0], 0)
+		? getDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, 0)
 		: getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed && fill !== 'none')
 
 	return (

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -119,7 +119,7 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 
 		const sw = (getDisplayValues(this, shape).strokeWidth + 1) * shape.props.scale
 
-		// No points yet (the default props have no segments): a dot at the origin, so geometry
+		// No decoded points (the default props have no segments): a dot at the origin, so geometry
 		// lookups don't throw on a shape created from its defaults.
 		if (points.length === 0) {
 			return new Circle2d({ x: -sw, y: -sw, radius: sw, isFilled: true })

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId, TLHighlightShape } from '@tldraw/editor'
+import { Circle2d, createShapeId, TLHighlightShape } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
 import { createDrawSegments, pointsToBase64 } from '../../utils/test-helpers'
 
@@ -25,6 +25,16 @@ describe('HighlightShapeUtil dot detection', () => {
 		])
 		return editor.getShape(shapeId) as TLHighlightShape
 	}
+
+	describe('empty segments', () => {
+		it('treats a shape created from its default props as a dot', () => {
+			editor.createShape({ id: shapeId, type: 'highlight' })
+			const shape = editor.getShape<TLHighlightShape>(shapeId)!
+			expect(shape.props.segments).toEqual([])
+			expect(editor.getShapeGeometry(shape)).toBeInstanceOf(Circle2d)
+			expect(editor.getShapeAtPoint({ x: 0, y: 0 })?.id).toBe(shapeId)
+		})
+	})
 
 	describe('getIsDot behavior via hideResizeHandles', () => {
 		it('treats a shape with one segment and zero points as a dot', () => {

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -104,7 +104,8 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	getGeometry(shape: TLHighlightShape) {
 		const dv = getDisplayValues(this, shape)
 		const strokeWidth = dv.strokeWidth * shape.props.scale
-		if (getIsDot(shape)) {
+		// No segments yet (the default props): treat it as a dot so geometry lookups don't throw.
+		if (getIsDot(shape) || shape.props.segments.length === 0) {
 			return new Circle2d({
 				x: -strokeWidth / 2,
 				y: -strokeWidth / 2,
@@ -178,7 +179,7 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 
 		let strokePath
 		if (strokePoints.length < 2) {
-			strokePath = getIndicatorDot(allPointsFromSegments[0], sw)
+			strokePath = getIndicatorDot(allPointsFromSegments[0] ?? { x: 0, y: 0 }, sw)
 		} else {
 			strokePath = getSvgPathFromStrokePoints(strokePoints, false)
 		}
@@ -330,7 +331,7 @@ function HighlightRenderer({
 	const solidStrokePath =
 		strokePoints.length > 1
 			? getSvgPathFromStrokePoints(strokePoints, false)
-			: getShapeDot(allPointsFromSegments[0])
+			: getShapeDot(allPointsFromSegments[0] ?? { x: 0, y: 0 })
 
 	return (
 		<path


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a draw or highlight shape created from its default props (`segments: []`) threw in geometry and rendering, breaking hit testing for the page.

### Before

`DrawShapeUtil.getGeometry` built a `Polyline2d` / `Polygon2d` from zero points and `HighlightShapeUtil.getGeometry` did the same; both constructors require at least two points. The indicator and SVG paths also indexed `allPointsFromSegments[0]` on an empty array. `editor.createShape({ type: 'draw' })` was enough to trigger it.

### After

Both utils return a dot at the origin when there are no points, and the indicator / SVG dot fallbacks use the origin when there is no first point.

### Change type

- [x] `bugfix`

### Test plan

1. `editor.createShape({ type: 'draw' })` then `editor.getShapeAtPoint({ x: 0, y: 0 })` — no throw.
2. Select the shape — the indicator renders without error.

- [ ] Unit tests

### Release notes

- Fix draw and highlight shapes created with no segments throwing in geometry and rendering

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +12 / -5   |