### PR TITLE
fix(images): do not memoize failed image and video export promises

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -231,26 +231,34 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 		const { w } = getUncroppedSize(shape.props, props.crop)
 
-		const src = await imageSvgExportCache.get(asset, async () => {
-			let src = await ctx.resolveAssetUrl(asset.id, w)
-			if (!src) return null
-			if (
-				src.startsWith('blob:') ||
-				src.startsWith('http') ||
-				src.startsWith('/') ||
-				src.startsWith('./')
-			) {
-				// If it's a remote image, we need to fetch it and convert it to a data URI
-				src = (await getDataURIFromURL(src)) || ''
-			}
+		const src = await imageSvgExportCache
+			.get(asset, async () => {
+				let src = await ctx.resolveAssetUrl(asset.id, w)
+				if (!src) return null
+				if (
+					src.startsWith('blob:') ||
+					src.startsWith('http') ||
+					src.startsWith('/') ||
+					src.startsWith('./')
+				) {
+					// If it's a remote image, we need to fetch it and convert it to a data URI
+					src = (await getDataURIFromURL(src)) || ''
+				}
 
-			// If it's animated then we need to get the first frame
-			if (getIsAnimated(this.editor, asset.id)) {
-				const { promise } = getFirstFrameOfAnimatedImage(src)
-				src = await promise
-			}
-			return src
-		})
+				// If it's animated then we need to get the first frame
+				if (getIsAnimated(this.editor, asset.id)) {
+					const { promise } = getFirstFrameOfAnimatedImage(src)
+					src = await promise
+				}
+				return src
+			})
+			.catch(() => {
+				// Don't memoize a failure (e.g. a CORS-blocked fetch): the next export should retry
+				// instead of failing forever for this asset. Skip the image rather than failing the
+				// whole export, as the unresolvable-url path above does.
+				imageSvgExportCache.items.delete(asset)
+				return null
+			})
 
 		if (!src) return null
 
@@ -342,10 +350,15 @@ const ImageShape = memo(function ImageShape({ shape }: { shape: TLImageShape }) 
 		if (url && isAnimated) {
 			const { promise, cancel } = getFirstFrameOfAnimatedImage(url)
 
-			promise.then((dataUrl) => {
-				setStaticFrameSrc(dataUrl)
-				setLoadedUrl(url)
-			})
+			promise.then(
+				(dataUrl) => {
+					setStaticFrameSrc(dataUrl)
+					setLoadedUrl(url)
+				},
+				() => {
+					// couldn't decode a first frame; keep showing the animated source
+				}
+			)
 
 			return () => {
 				cancel()
@@ -610,7 +623,9 @@ function SvgImage({ shape, src }: { shape: TLImageShape; src: string }) {
 function getFirstFrameOfAnimatedImage(url: string) {
 	let cancelled = false
 
-	const promise = new Promise<string>((resolve) => {
+	// Must settle on failure too: an image that never loads would otherwise leave the
+	// export awaiting this promise forever.
+	const promise = new Promise<string>((resolve, reject) => {
 		const image = Image()
 		image.onload = () => {
 			if (cancelled) return
@@ -620,11 +635,15 @@ function getFirstFrameOfAnimatedImage(url: string) {
 			canvas.height = image.height
 
 			const ctx = canvas.getContext('2d')
-			if (!ctx) return
+			if (!ctx) {
+				reject(new Error('Could not get a 2d canvas context'))
+				return
+			}
 
 			ctx.drawImage(image, 0, 0)
 			resolve(canvas.toDataURL())
 		}
+		image.onerror = () => reject(new Error(`Could not load image: ${url}`))
 		image.crossOrigin = 'anonymous'
 		image.src = url
 	})

--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -231,34 +231,34 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 
 		const { w } = getUncroppedSize(shape.props, props.crop)
 
-		const src = await imageSvgExportCache
-			.get(asset, async () => {
-				let src = await ctx.resolveAssetUrl(asset.id, w)
-				if (!src) return null
-				if (
-					src.startsWith('blob:') ||
-					src.startsWith('http') ||
-					src.startsWith('/') ||
-					src.startsWith('./')
-				) {
-					// If it's a remote image, we need to fetch it and convert it to a data URI
-					src = (await getDataURIFromURL(src)) || ''
-				}
+		const promise = imageSvgExportCache.get(asset, async () => {
+			let src = await ctx.resolveAssetUrl(asset.id, w)
+			if (!src) return null
+			if (
+				src.startsWith('blob:') ||
+				src.startsWith('http') ||
+				src.startsWith('/') ||
+				src.startsWith('./')
+			) {
+				// If it's a remote image, we need to fetch it and convert it to a data URI
+				src = (await getDataURIFromURL(src)) || ''
+			}
 
-				// If it's animated then we need to get the first frame
-				if (getIsAnimated(this.editor, asset.id)) {
-					const { promise } = getFirstFrameOfAnimatedImage(src)
-					src = await promise
-				}
-				return src
-			})
-			.catch(() => {
-				// Don't memoize a failure (e.g. a CORS-blocked fetch): the next export should retry
-				// instead of failing forever for this asset. Skip the image rather than failing the
-				// whole export, as the unresolvable-url path above does.
-				imageSvgExportCache.items.delete(asset)
-				return null
-			})
+			// If it's animated then we need to get the first frame
+			if (getIsAnimated(this.editor, asset.id)) {
+				const { promise } = getFirstFrameOfAnimatedImage(src)
+				src = await promise
+			}
+			return src
+		})
+		const src = await promise.catch((error) => {
+			// A failure (e.g. a CORS-blocked fetch) must not stay memoized, or every later export of
+			// this asset fails too. Only evict our own entry: a concurrent export may have started a
+			// fresh one in the meantime. Skip the image rather than failing the whole export.
+			if (imageSvgExportCache.items.get(asset) === promise) imageSvgExportCache.items.delete(asset)
+			console.error(`Could not export image ${asset.id}`, error)
+			return null
+		})
 
 		if (!src) return null
 
@@ -643,7 +643,10 @@ function getFirstFrameOfAnimatedImage(url: string) {
 			ctx.drawImage(image, 0, 0)
 			resolve(canvas.toDataURL())
 		}
-		image.onerror = () => reject(new Error(`Could not load image: ${url}`))
+		image.onerror = () => {
+			if (cancelled) return
+			reject(new Error(`Could not load image: ${url}`))
+		}
 		image.crossOrigin = 'anonymous'
 		image.src = url
 	})

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -116,12 +116,18 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const asset = this.editor.getAsset<TLAsset>(props.assetId)
 		if (!asset) return null
 
-		const src = await videoSvgExportCache.get(asset, async () => {
-			const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
-			if (!assetUrl) return null
-			const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
-			return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
-		})
+		const src = await videoSvgExportCache
+			.get(asset, async () => {
+				const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
+				if (!assetUrl) return null
+				const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
+				return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
+			})
+			.catch((error) => {
+				// Don't memoize a failure: the next export should retry for this asset.
+				videoSvgExportCache.items.delete(asset)
+				throw error
+			})
 
 		if (!src) return null
 

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -116,18 +116,21 @@ export class VideoShapeUtil extends BaseBoxShapeUtil<TLVideoShape> {
 		const asset = this.editor.getAsset<TLAsset>(props.assetId)
 		if (!asset) return null
 
-		const src = await videoSvgExportCache
-			.get(asset, async () => {
-				const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
-				if (!assetUrl) return null
-				const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
-				return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
-			})
-			.catch((error) => {
-				// Don't memoize a failure: the next export should retry for this asset.
-				videoSvgExportCache.items.delete(asset)
-				throw error
-			})
+		const promise = videoSvgExportCache.get(asset, async () => {
+			const assetUrl = await ctx.resolveAssetUrl(asset.id, props.w)
+			if (!assetUrl) return null
+			const video = await MediaHelpers.loadVideo(assetUrl, this.editor.getContainerDocument())
+			return await MediaHelpers.getVideoFrameAsDataUrl(video, 0)
+		})
+		const src = await promise.catch((error) => {
+			// A failure must not stay memoized, or every later export of this asset fails too. Only
+			// evict our own entry: a concurrent export may have started a fresh one. Skip the video
+			// rather than rejecting: toSvg rejections are not caught by the exporter, which then
+			// waits out the export delay and emits an SVG with no shapes at all.
+			if (videoSvgExportCache.items.get(asset) === promise) videoSvgExportCache.items.delete(asset)
+			console.error(`Could not export video ${asset.id}`, error)
+			return null
+		})
 
 		if (!src) return null
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where one failed export of an animated image (or video) poisoned every later export containing that asset.

### Before

`imageSvgExportCache` and `videoSvgExportCache` memoised the export promise per asset. `getFirstFrameOfAnimatedImage` had no `onerror` handler and returned without resolving when `getContext('2d')` failed, so a CORS-blocked or 404 animated GIF left a promise that never settled — and the cache kept handing it out, hanging that export and every subsequent one until the asset record changed.

### After

`getFirstFrameOfAnimatedImage` rejects on `onerror` and on a missing context (this also covers an empty `src` after a failed data-URI fetch, which used to hang the same way). Both caches evict their own entry when the promise rejects, leaving a fresh entry started by a concurrent export alone. Image and video `toSvg` then log the error and return `null` so the shape is skipped rather than failing the whole export: a `toSvg` rejection is not caught by the exporter, which then waits out the export delay and emits an SVG with no shapes. The in-canvas component ignores the rejection and keeps showing the animated source.

### Change type

- [x] `bugfix`

### Test plan

1. Add an animated GIF whose url is blocked by CORS. Export the page — the export completes without that image.
2. Fix the url (or add a working GIF) and export again — the image is included.

- [ ] Unit tests

### Release notes

- Fix a failed animated-image or video export hanging all later exports of the same asset

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +57 / -32  |