### PR TITLE
fix(store): collect ids before deleting non-document records in migrateStorage

### DIFF
--- a/packages/store/src/lib/StoreSchema.test.ts
+++ b/packages/store/src/lib/StoreSchema.test.ts
@@ -982,6 +982,63 @@ describe('migrateStorage (MA)', () => {
 		expect((changing as any).changed).toBeUndefined()
 	})
 
+	it('[MA5] removes every non-document record even when the storage iterator is live', () => {
+		interface SessionThing extends BaseRecord<'sessionThing', RecordId<SessionThing>> {
+			label: string
+		}
+		const SessionThing = createRecordType<SessionThing>('sessionThing', {
+			scope: 'session',
+		}).withDefaultProperties(() => ({ label: '' }))
+		const migrations = [
+			createMigrationSequence({
+				sequenceId: 'foo',
+				sequence: [{ id: 'foo/1', scope: 'record', up: () => {} }],
+			}),
+		]
+		const schema = StoreSchema.create(
+			{ test: TestRecordType, sessionThing: SessionThing },
+			{ migrations }
+		)
+
+		// Cursor-style storage: entries() walks the backing array by index, so deleting the
+		// current entry mid-iteration shifts the next one into its place and it is skipped.
+		const rows: [string, any][] = [
+			['sessionThing:a', SessionThing.create({ id: SessionThing.createId('a') })],
+			['sessionThing:b', SessionThing.create({ id: SessionThing.createId('b') })],
+			['sessionThing:c', SessionThing.create({ id: SessionThing.createId('c') })],
+		]
+		const doc = makeTestRecord({ schemaVersion: 2, sequences: {} })
+		rows.push([doc.id, doc])
+		const persisted = schema.serializeEarliestVersion()
+		const storage: SynchronousStorage<any> = {
+			get: (id) => rows.find(([rowId]) => rowId === id)?.[1],
+			set: (id, record) => {
+				const row = rows.find(([rowId]) => rowId === id)
+				if (row) row[1] = record
+				else rows.push([id, record])
+			},
+			delete: (id) => {
+				const index = rows.findIndex(([rowId]) => rowId === id)
+				if (index !== -1) rows.splice(index, 1)
+			},
+			*keys() {
+				for (let i = 0; i < rows.length; i++) yield rows[i][0]
+			},
+			*values() {
+				for (let i = 0; i < rows.length; i++) yield rows[i][1]
+			},
+			*entries() {
+				for (let i = 0; i < rows.length; i++) yield rows[i]
+			},
+			getSchema: () => persisted,
+			setSchema: () => {},
+		}
+
+		schema.migrateStorage(storage)
+
+		expect(rows.map(([id]) => id)).toEqual([doc.id])
+	})
+
 	it('[MA7] does nothing when no migrations are needed', () => {
 		const schema = StoreSchema.create({ test: TestRecordType }, { migrations: [] })
 		const record = makeTestRecord({ schemaVersion: 2, sequences: {} })

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -626,10 +626,15 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 		// Clean up by filtering out any non-document records.
 		// This is mainly legacy support for extremely early days tldraw.
+		// Collect first, then delete, for the same live-iterator reason as the record loop above.
+		const nonDocumentIds: string[] = []
 		for (const [id, state] of storage.entries()) {
 			if (this.getType(state.typeName).scope !== 'document') {
-				storage.delete(id)
+				nonDocumentIds.push(id)
 			}
+		}
+		for (const id of nonDocumentIds) {
+			storage.delete(id)
 		}
 	}
 


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where `StoreSchema.migrateStorage` could leave some non-document records behind when the `SynchronousStorage` hands out a live `entries()` iterator. Split out of #10177.

### Before

The legacy cleanup at the end of `migrateStorage` called `storage.delete(id)` while iterating `storage.entries()`. The record-migration loop just above already collects updates first because live iterators (e.g. SQLite cursors) misbehave when the table changes under them, but the cleanup loop did not; with a cursor-style storage, deleting the current row shifts the next one into its place and it is skipped, so consecutive non-document records were only partially removed.

### After

The cleanup loop collects the non-document ids first and deletes them in a second pass, matching the record-migration loop.

### Implementation notes

The umbrella PR had no dedicated test for this; the new `[MA5]` test uses an array-backed storage whose `entries()` walks by index, which reproduces the skip on `main`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix `migrateStorage` skipping some non-document records when the storage iterator is live

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -1    |
| Tests     | +57 / -0   |