### PR TITLE
fix(store): attribute changes made by operationComplete handlers after a remote merge to the user

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -62,7 +62,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 - **AO5** `afterChange` fires only when the before and after records differ by deep equality. (Putting a structurally-equal copy still records a history entry per S3/H1 — only the callback is suppressed.)
 - **AO6** After-handlers run when the outermost atomic's function completes, still inside the transaction. Changes they make trigger another round of after-events, repeating until quiescent. More than 100 rounds throws `Maximum store update depth exceeded`.
 - **AO7** `operationComplete` handlers fire after the after-events of an operation settle; if an `operationComplete` handler makes further changes, the flush (including `operationComplete`) runs again until quiescent.
-- **AO8** `mergeRemoteChanges(fn)` runs `fn` atomically with source `'remote'`; nested calls inside another `mergeRemoteChanges` just run `fn`. After the merge the integrity checker runs. Changes that side-effect handlers make in response to remote changes are attributed to `'user'`.
+- **AO8** `mergeRemoteChanges(fn)` runs `fn` atomically with source `'remote'`; nested calls inside another `mergeRemoteChanges` just run `fn`. After the merge the integrity checker runs. Changes that side-effect handlers — `after*` and `operationComplete` alike — make in response to remote changes are attributed to `'user'`, as are the callback rounds they trigger.
 
 ## 7. Side effect handlers (SE)
 

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -1204,11 +1204,10 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 
 			if (!this.pendingAfterEvents) {
 				this.sideEffects.handleOperationComplete(source)
-			} else {
-				// if the side effects triggered by a remote operation resulted in more effects,
-				// those extra effects should not be marked as originating remotely.
-				source = 'user'
 			}
+			// Whatever the after-handlers or the operation-complete handlers changed in response to
+			// a remote operation is not itself remote: later rounds are attributed to 'user'.
+			source = 'user'
 		}
 	}
 	private _isInAtomicOp = false

--- a/packages/store/src/lib/StoreSideEffects.test.ts
+++ b/packages/store/src/lib/StoreSideEffects.test.ts
@@ -626,3 +626,34 @@ describe('atomic operations (AO)', () => {
 		])
 	})
 })
+
+describe('remote attribution (AO)', () => {
+	it('[AO8] changes made by operationComplete handlers after a remote operation are attributed to user', () => {
+		store.put([book1, book2])
+		const log: string[] = []
+		store.addHistoryInterceptor((_entry, source) => log.push('history:' + source))
+		store.sideEffects.registerAfterChangeHandler('book', (_prev, _next, source) =>
+			log.push('afterChange:' + source)
+		)
+		let once = true
+		store.sideEffects.registerOperationCompleteHandler((source) => {
+			log.push('operationComplete:' + source)
+			if (once) {
+				once = false
+				store.put([{ ...book2, title: 'renamed' }])
+			}
+		})
+
+		store.mergeRemoteChanges(() => store.remove([book1Id]))
+
+		expect(log).toEqual([
+			'history:remote',
+			'operationComplete:remote',
+			'history:user',
+			'afterChange:user',
+			'operationComplete:user',
+			// the integrity check after the merge is its own (empty) user operation
+			'operationComplete:user',
+		])
+	})
+})


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where changes made by an `operationComplete` handler in response to a remote merge were attributed to `'remote'` rather than `'user'`. Split out of #10177.

### Before

In `flushAtomicCallbacks`, `source = 'user'` sat in the `else` branch of `if (!this.pendingAfterEvents)`, so it only ran when after-events were pending. When a remote operation had no after-events, `handleOperationComplete('remote')` ran and `source` stayed `'remote'` for the next round: with `mergeRemoteChanges(() => remove([a]))` and an `operationComplete` handler that does a `put`, the second round's `afterChange` and `operationComplete` callbacks (and the history entry) were marked `'remote'`, although the change was made locally.

### After

`source = 'user'` runs after every round regardless of which handlers fired. Whatever the after-handlers or the operation-complete handlers changed in response to a remote operation is attributed to `'user'`, as SPEC AO8 already stated for after-handlers. `packages/store/SPEC.md` AO8 is updated to name `operationComplete` handlers too.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new `[AO8]` test fails on `main` and passes with this change

### Release notes

- Fix changes made by `operationComplete` handlers after a remote merge being attributed to the remote source

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +3 / -4    |
| Tests         | +31 / -0   |
| Documentation | +1 / -1    |