### PR TITLE
fix(arrows): read the real display-values option keys in getArrowInfo

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/getArrowInfo.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/getArrowInfo.ts
@@ -18,8 +18,9 @@ const arrowInfoCache = createComputedCache<Editor, TLArrowInfo, TLArrowShape>(
 	(editor: Editor, shape: TLArrowShape): TLArrowInfo => {
 		const bindings = getArrowBindings(editor, shape)
 		const util = editor.getShapeUtil(shape)
+		// A replacement arrow util may not carry display values; fall back to the theme width.
 		const sw =
-			'getDisplayValues' in util.options
+			'getDefaultDisplayValues' in util.options && 'getCustomDisplayValues' in util.options
 				? (getDisplayValues(util as any, shape) as { strokeWidth: number }).strokeWidth
 				: editor.getCurrentTheme().strokeWidth * STROKE_SIZES[shape.props.size]
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a custom arrow stroke width from `getCustomDisplayValues` was ignored when computing arrow geometry.

### Before

`getArrowInfo` checked `'getDisplayValues' in util.options`, a key that does not exist (the options are `getDefaultDisplayValues` and `getCustomDisplayValues`), so it always fell back to the theme stroke width. An arrow configured with a 20px stroke rendered at 20px but its terminal offsets, arrowhead sizes and elbow minimum length were computed for the default width, overlapping bound shapes.

### After

The check tests for both real option keys and uses `getDisplayValues` when they are present, falling back to the theme width only for a replacement util that does not carry display values.

### Change type

- [x] `bugfix`

### Test plan

1. `ArrowShapeUtil.configure({ getCustomDisplayValues: () => ({ strokeWidth: 20 }) })`
2. Bind an arrow to a box — the arrowhead sits outside the box instead of overlapping it.

- [ ] Unit tests

### Release notes

- Fix arrow geometry ignoring a custom stroke width from `getCustomDisplayValues`

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -1    |