### PR TITLE
fix(store): don't skip the next side-effect handler when one removes itself mid-dispatch

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -66,7 +66,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 ## 7. Side effect handlers (SE)
 
-- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all.
+- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all. Removing or registering a handler while handlers are being dispatched takes effect from the next dispatch: every handler registered when an event started is still called for it.
 - **SE2** `beforeCreate` runs before validation on create; its return value is what gets validated and stored. Multiple handlers chain, each receiving the previous one's output.
 - **SE3** `beforeChange` runs before validation on update, receiving `(prev, next, source)`; its return value is stored. Returning `prev` blocks the update (with a reference-preserving validator this makes the put a complete no-op per S3).
 - **SE4** `beforeDelete` may return `false` to prevent that record's deletion; other records in the same `remove` call are still deleted.

--- a/packages/store/src/lib/StoreSideEffects.test.ts
+++ b/packages/store/src/lib/StoreSideEffects.test.ts
@@ -657,3 +657,32 @@ describe('remote attribution (AO)', () => {
 		])
 	})
 })
+
+describe('handler removal during dispatch (SE)', () => {
+	it('[SE1] a handler that removes itself while running does not stop later handlers from running', () => {
+		const calls: string[] = []
+		const removeA = store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			removeA()
+		})
+		store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A', 'B'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'B', 'B'])
+	})
+
+	it('[SE1] an operationComplete handler that removes itself does not skip the next one', () => {
+		const calls: string[] = []
+		const removeA = store.sideEffects.registerOperationCompleteHandler(() => {
+			calls.push('A')
+			removeA()
+		})
+		store.sideEffects.registerOperationCompleteHandler(() => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A', 'B'])
+	})
+})

--- a/packages/store/src/lib/StoreSideEffects.test.ts
+++ b/packages/store/src/lib/StoreSideEffects.test.ts
@@ -685,4 +685,41 @@ describe('handler removal during dispatch (SE)', () => {
 		store.put([book1])
 		expect(calls).toEqual(['A', 'B'])
 	})
+
+	// The two tests below pin the other half of SE1: a list edit made mid-dispatch is not seen by the
+	// dispatch it happens in. Removal is deliberately not a way to cancel a handler for the event in
+	// flight, so don't "fix" these to match the pre-copy-on-write behaviour without changing SE1 too.
+
+	it('[SE1] removing a later handler mid-dispatch only takes effect from the next event', () => {
+		const calls: string[] = []
+		let removeB = () => {}
+		store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			removeB()
+		})
+		removeB = store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A', 'B'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'B', 'A'])
+	})
+
+	it('[SE1] registering a handler mid-dispatch only takes effect from the next event', () => {
+		const calls: string[] = []
+		let hasRegistered = false
+		store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			if (hasRegistered) return
+			hasRegistered = true
+			store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+		})
+
+		store.put([book1])
+		expect(calls).toEqual(['A'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'A', 'B'])
+	})
 })

--- a/packages/store/src/lib/StoreSideEffects.ts
+++ b/packages/store/src/lib/StoreSideEffects.ts
@@ -217,6 +217,16 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	private _operationCompleteHandlers: StoreOperationCompleteHandler[] = []
 
 	private _isEnabled = true
+
+	// Handler arrays are replaced, never mutated in place: dispatch iterates the array it looked up,
+	// so a handler that removes itself (or registers another) while running must not shift the
+	// entries out from under that iteration.
+	private addHandler<H>(handlers: { [K in string]?: H[] }, typeName: string, handler: H) {
+		handlers[typeName] = [...(handlers[typeName] ?? []), handler]
+		return () => {
+			handlers[typeName] = withoutFirst(handlers[typeName] ?? [], handler)
+		}
+	}
 	/**
 	 * Checks whether side effects are currently enabled.
 	 * When disabled, all side effect handlers are bypassed.
@@ -478,10 +488,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeCreateHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeCreateHandlers[typeName] as StoreBeforeCreateHandler<any>[]
-		if (!handlers) this._beforeCreateHandlers[typeName] = []
-		this._beforeCreateHandlers[typeName]!.push(handler)
-		return () => remove(this._beforeCreateHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeCreateHandlers, typeName, handler)
 	}
 
 	/**
@@ -510,10 +517,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterCreateHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterCreateHandlers[typeName] as StoreAfterCreateHandler<any>[]
-		if (!handlers) this._afterCreateHandlers[typeName] = []
-		this._afterCreateHandlers[typeName]!.push(handler)
-		return () => remove(this._afterCreateHandlers[typeName]!, handler)
+		return this.addHandler(this._afterCreateHandlers, typeName, handler)
 	}
 
 	/**
@@ -546,10 +550,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeChangeHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeChangeHandlers[typeName] as StoreBeforeChangeHandler<any>[]
-		if (!handlers) this._beforeChangeHandlers[typeName] = []
-		this._beforeChangeHandlers[typeName]!.push(handler)
-		return () => remove(this._beforeChangeHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeChangeHandlers, typeName, handler)
 	}
 
 	/**
@@ -577,10 +578,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterChangeHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterChangeHandlers[typeName] as StoreAfterChangeHandler<any>[]
-		if (!handlers) this._afterChangeHandlers[typeName] = []
-		this._afterChangeHandlers[typeName]!.push(handler as StoreAfterChangeHandler<any>)
-		return () => remove(this._afterChangeHandlers[typeName]!, handler)
+		return this.addHandler(this._afterChangeHandlers, typeName, handler)
 	}
 
 	/**
@@ -610,10 +608,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreBeforeDeleteHandler<R & { typeName: T }>
 	) {
-		const handlers = this._beforeDeleteHandlers[typeName] as StoreBeforeDeleteHandler<any>[]
-		if (!handlers) this._beforeDeleteHandlers[typeName] = []
-		this._beforeDeleteHandlers[typeName]!.push(handler as StoreBeforeDeleteHandler<any>)
-		return () => remove(this._beforeDeleteHandlers[typeName]!, handler)
+		return this.addHandler(this._beforeDeleteHandlers, typeName, handler)
 	}
 
 	/**
@@ -644,10 +639,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		typeName: T,
 		handler: StoreAfterDeleteHandler<R & { typeName: T }>
 	) {
-		const handlers = this._afterDeleteHandlers[typeName] as StoreAfterDeleteHandler<any>[]
-		if (!handlers) this._afterDeleteHandlers[typeName] = []
-		this._afterDeleteHandlers[typeName]!.push(handler as StoreAfterDeleteHandler<any>)
-		return () => remove(this._afterDeleteHandlers[typeName]!, handler)
+		return this.addHandler(this._afterDeleteHandlers, typeName, handler)
 	}
 
 	/**
@@ -677,14 +669,16 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	 * @public
 	 */
 	registerOperationCompleteHandler(handler: StoreOperationCompleteHandler) {
-		this._operationCompleteHandlers.push(handler)
-		return () => remove(this._operationCompleteHandlers, handler)
+		// copy on write, see addHandler
+		this._operationCompleteHandlers = [...this._operationCompleteHandlers, handler]
+		return () => {
+			this._operationCompleteHandlers = withoutFirst(this._operationCompleteHandlers, handler)
+		}
 	}
 }
 
-function remove(array: any[], item: any) {
+function withoutFirst<T>(array: T[], item: T): T[] {
 	const index = array.indexOf(item)
-	if (index >= 0) {
-		array.splice(index, 1)
-	}
+	if (index < 0) return array
+	return [...array.slice(0, index), ...array.slice(index + 1)]
 }


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where a side-effect handler that removed itself while running caused the next handler registered for the same event to be skipped. Split out of #10177.

### Before

`StoreSideEffects` kept each handler list as a mutable array and the remover spliced the handler out in place. Dispatch iterates that same array by index, so when handler A (registered first for `afterCreate`) disposed itself during a `put`, handler B shifted into A's slot and the loop moved past it: only A ran for that event. The same applied to `operationComplete` handlers.

### After

Handler lists are copy-on-write: an `addHandler` helper replaces the six per-type push/splice blocks, `_operationCompleteHandlers` is reassigned rather than mutated, and `withoutFirst` returns a new array. Dispatch keeps iterating the array it looked up, so removing or registering a handler mid-dispatch takes effect from the next dispatch and every handler registered when the event started is still called. `packages/store/SPEC.md` SE1 is updated.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix a side-effect handler being skipped when the previous handler for the same event removes itself while running

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +24 / -30  |
| Tests         | +29 / -0   |
| Documentation | +1 / -1    |