### PR TITLE
fix(images): keep rotated images centred when cropping changes their size

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -442,7 +442,18 @@ interface CropChange {
 	y: number
 }
 
-// Base function for calculating crop changes
+/**
+ * Top-left position that keeps the image's visual centre where it is after its display size
+ * changes. The half-size delta is in the shape's own space, so it has to be rotated by the
+ * shape's rotation; a plain `center - newSize / 2` only holds for unrotated images.
+ */
+function getPositionKeepingCenter(imageShape: TLImageShape, newW: number, newH: number) {
+	const delta = new Vec((imageShape.props.w - newW) / 2, (imageShape.props.h - newH) / 2).rot(
+		imageShape.rotation
+	)
+	return { x: imageShape.x + delta.x, y: imageShape.y + delta.y }
+}
+
 function calculateCropChange(
 	imageShape: TLImageShape,
 	newCropWidth: number,
@@ -452,10 +463,6 @@ function calculateCropChange(
 ): CropChange {
 	const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
 	const currentCrop = imageShape.props.crop || getDefaultCrop()
-
-	// Calculate image and crop centers
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
 
 	let cropCenterX, cropCenterY
 	if (centerOnCurrentCrop) {
@@ -484,8 +491,7 @@ function calculateCropChange(
 		crop: newCrop,
 		w: croppedW,
 		h: croppedH,
-		x: imageCenterX - croppedW / 2,
-		y: imageCenterY - croppedH / 2,
+		...getPositionKeepingCenter(imageShape, croppedW, croppedH),
 	}
 }
 
@@ -526,10 +532,9 @@ export function getCroppedImageDataWhenZooming(
 	result.h *= scaleFactor
 
 	// Recenter
-	const imageCenterX = imageShape.x + imageShape.props.w / 2
-	const imageCenterY = imageShape.y + imageShape.props.h / 2
-	result.x = imageCenterX - result.w / 2
-	result.y = imageCenterY - result.h / 2
+	const { x, y } = getPositionKeepingCenter(imageShape, result.w, result.h)
+	result.x = x
+	result.y = y
 
 	return result
 }
@@ -603,19 +608,11 @@ export function getCroppedImageDataForReplacedImage(
 		)
 	}
 
-	// Position so visual center stays put
-	const pageCenterX = imageShape.x + origDisplayW / 2
-	const pageCenterY = imageShape.y + origDisplayH / 2
-
-	const newX = pageCenterX - newDisplayW / 2
-	const newY = pageCenterY - newDisplayH / 2
-
 	return {
 		crop,
 		w: newDisplayW,
 		h: newDisplayH,
-		x: newX,
-		y: newY,
+		...getPositionKeepingCenter(imageShape, newDisplayW, newDisplayH),
 	}
 }
 
@@ -629,15 +626,12 @@ export function getCroppedImageDataForAspectRatio(
 	// If original aspect ratio is requested, use default crop
 	if (aspectRatioOption === 'original') {
 		const { w, h } = getUncroppedSize(imageShape.props, imageShape.props.crop ?? getDefaultCrop())
-		const imageCenterX = imageShape.x + imageShape.props.w / 2
-		const imageCenterY = imageShape.y + imageShape.props.h / 2
 
 		return {
 			crop: getDefaultCrop(),
 			w,
 			h,
-			x: imageCenterX - w / 2,
-			y: imageCenterY - h / 2,
+			...getPositionKeepingCenter(imageShape, w, h),
 		}
 	}
 
@@ -753,18 +747,10 @@ export function getCroppedImageDataForAspectRatio(
 	const newW = baseW * currentScale
 	const newH = baseH * currentScale
 
-	// Calculate the new top-left position (x, y) for the shape
-	// to keep the visual center of the cropped area fixed on the page.
-	const currentCenterXPage = imageShape.x + imageShape.props.w / 2
-	const currentCenterYPage = imageShape.y + imageShape.props.h / 2
-	const newX = currentCenterXPage - newW / 2
-	const newY = currentCenterYPage - newH / 2
-
 	return {
 		crop: newCrop,
 		w: newW,
 		h: newH,
-		x: newX,
-		y: newY,
+		...getPositionKeepingCenter(imageShape, newW, newH),
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where changing a rotated image's aspect ratio, zoom, or replacing it made the image jump on the canvas.

### Before

The crop helpers in `crop.ts` (`calculateCropChange`, `getCroppedImageDataWhenZooming`, `getCroppedImageDataForReplacedImage`, `getCroppedImageDataForAspectRatio` ×2) recomputed `x/y` as `centre - newSize / 2` in parent space. The half-size delta is in the shape's own space, so for a rotated image the new top-left was wrong and the visual centre moved.

### After

A `getPositionKeepingCenter(shape, newW, newH)` helper rotates the half-size delta by `shape.rotation`; all five sites use it.

### Change type

- [x] `bugfix`

### Test plan

1. Add an image and rotate it ~45°.
2. From the image toolbar, change the aspect ratio, then zoom the crop.
3. The image stays centred where it was.

- [ ] Unit tests

### Release notes

- Fix rotated images jumping on the canvas when their aspect ratio or crop zoom changes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +19 / -33  |