### PR TITLE
fix(images): treat an explicit isCircle:false crop as the original crop when replacing an image

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -551,7 +551,13 @@ export function getCroppedImageDataForReplacedImage(
 	let crop = defaultCrop
 	let newDisplayW = origDisplayW
 	let newDisplayH = origDisplayH
-	const isOriginalCrop = isEqual(imageShape.props.crop, defaultCrop)
+	// Compare the bounds, not the whole object: an explicit `isCircle: false` must still count
+	// as the original crop.
+	const isOriginalCrop =
+		!!imageShape.props.crop &&
+		isEqual(imageShape.props.crop.topLeft, defaultCrop.topLeft) &&
+		isEqual(imageShape.props.crop.bottomRight, defaultCrop.bottomRight) &&
+		!imageShape.props.crop.isCircle
 
 	if (isOriginalCrop) {
 		newDisplayW = origDisplayW


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where replacing an uncropped image sometimes zoomed the replacement by up to 3×.

### Before

`getCroppedImageDataForReplacedImage` decided whether the image was "uncropped" with `isEqual(crop, defaultCrop)`. A crop of `{ topLeft: 0,0, bottomRight: 1,1, isCircle: false }` — which the crop zoom helpers write when the zoom goes back to 0 — is not deep-equal to the default crop, so the image went down the crop-preserving branch and the replacement was scaled as if it had been zoomed.

### After

The check compares `topLeft`, `bottomRight` and `isCircle` individually, so an explicit `isCircle: false` still counts as the original crop.

### Change type

- [x] `bugfix`

### Test plan

1. Add an image, zoom the crop with the toolbar slider, then slide it back to 0 (the crop is now the full image with `isCircle: false`).
2. Replace the image from the toolbar.
3. The replacement keeps the same display size.

- [ ] Unit tests

### Release notes

- Fix a replaced image being zoomed when the original had an explicit default crop

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -1    |