### PR TITLE
fix(notes): centre a new note correctly inside a rotated frame

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -183,10 +183,12 @@ export function createNoteShape(editor: Editor, id: TLShapeId, center: Vec) {
 
 	editor.select(id)
 	const bounds = editor.getShapeGeometry(shape).bounds
-	const newPoint = maybeSnapToGrid(
-		new Vec(shape.x - bounds.width / 2, shape.y - bounds.height / 2),
-		editor
-	)
+	// shape.x/y are in the parent's space (createShape may have parented the note into a
+	// rotated frame), so the half-size offset has to be rotated into that space too
+	const delta = new Vec(bounds.width / 2, bounds.height / 2)
+	const parentTransform = editor.getShapeParentTransform(shape)
+	if (parentTransform) delta.rot(-parentTransform.rotation())
+	const newPoint = maybeSnapToGrid(new Vec(shape.x - delta.x, shape.y - delta.y), editor)
 
 	// Center the text around the created point
 	editor.updateShapes([


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where clicking with the note tool inside a rotated frame placed the note off-centre from the click.

### Before

`createNoteShape` centred the note by subtracting half its size from `shape.x/y`. Those are in the parent's space, and when `createShape` has parented the note into a rotated frame the half-size offset needs to be rotated into that space too; it wasn't.

### After

The offset is rotated by the inverse of the parent transform's rotation before it is applied.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame and rotate it 45°.
2. With the note tool, click inside the frame.
3. The note appears centred on the click.

- [ ] Unit tests

### Release notes

- Fix notes created inside a rotated frame appearing off-centre from the click

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -4    |