### PR TITLE
fix(draw): do not shift-extend a previous shape left on another page

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -233,7 +233,13 @@ export class Drawing extends StateNode {
 		if (this.initialShape) {
 			const shape = this.editor.getShape<DrawableShape>(this.initialShape.id)
 
-			if (shape && this.segmentMode === 'straight') {
+			// The previous shape may be on another page now (page switched with the tool
+			// still active); don't extend a shape the user can't see.
+			if (
+				shape &&
+				this.segmentMode === 'straight' &&
+				this.editor.getCurrentPageShapeIds().has(shape.id)
+			) {
 				// Connect dots
 
 				this.didJustShiftClickToExtendPreviousShapeLine = true

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -28,10 +28,11 @@ export class Pointing extends StateNode {
 
 		this.markId = undefined
 
-		// Previously created line shape that we might be extending
+		// Previously created line shape that we might be extending (it may have been left
+		// on another page if the page was switched with the tool still active)
 		const shape = info.shapeId && this.editor.getShape<TLLineShape>(info.shapeId)
 
-		if (shape && inputs.getShiftKey()) {
+		if (shape && inputs.getShiftKey() && this.editor.getCurrentPageShapeIds().has(shape.id)) {
 			// Extending a previous shape
 			this.markId = this.editor.markHistoryStoppingPoint(`creating_line:${shape.id}`)
 			this.shape = shape


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where shift-clicking with the draw or line tool after switching pages extended a shape on the previous page.

### Before

Both tools remember the last created shape so that shift-click extends it. Neither checked that the shape is still on the current page, so after a page switch with the tool still active the hidden shape on the old page was extended.

### After

`Drawing.ts` and the line tool's `Pointing` state only extend the previous shape when `getCurrentPageShapeIds()` contains it.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a line with the line tool. Switch to another page.
2. Shift-click on the new page — a new line starts instead of extending the old one.

- [ ] Unit tests

### Release notes

- Fix the draw and line tools extending a shape on another page after a page switch

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -3   |