### PR TITLE
fix(draw): keep the stroke updating after releasing shift during a straight segment

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -132,8 +132,18 @@ export class Drawing extends StateNode {
 					break
 				}
 				case 'starting_straight': {
-					this.pagePointWhereNextSegmentChanged = null
-					this.segmentMode = 'free'
+					// 'starting_straight' is entered from 'free' and from 'starting_free'. In the
+					// latter case the last segment is still the straight one we were leaving, so
+					// going to 'free' here would append free points to a straight segment and the
+					// stroke would stop updating; go back to 'starting_free' instead.
+					const shape =
+						this.initialShape && this.editor.getShape<DrawableShape>(this.initialShape.id)
+					if (shape && last(shape.props.segments)?.type === 'straight') {
+						this.segmentMode = 'starting_free'
+					} else {
+						this.pagePointWhereNextSegmentChanged = null
+						this.segmentMode = 'free'
+					}
 					break
 				}
 			}

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -132,10 +132,9 @@ export class Drawing extends StateNode {
 					break
 				}
 				case 'starting_straight': {
-					// 'starting_straight' is entered from 'free' and from 'starting_free'. In the
-					// latter case the last segment is still the straight one we were leaving, so
-					// going to 'free' here would append free points to a straight segment and the
-					// stroke would stop updating; go back to 'starting_free' instead.
+					// Entered from 'starting_free' the last segment is still straight. A straight
+					// segment renders only its first two points, so writing free points into it
+					// freezes the stroke: go back to 'starting_free' instead of 'free'.
 					const shape =
 						this.initialShape && this.editor.getShape<DrawableShape>(this.initialShape.id)
 					if (shape && last(shape.props.segments)?.type === 'straight') {

--- a/packages/tldraw/src/test/drawing-shift-keyup.test.ts
+++ b/packages/tldraw/src/test/drawing-shift-keyup.test.ts
@@ -1,0 +1,79 @@
+import { TLDrawShape, TLHighlightShape, last } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { base64ToPoints } from '../lib/utils/test-helpers'
+import { TestEditor } from './TestEditor'
+
+vi.useFakeTimers()
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+type DrawableShape = TLDrawShape | TLHighlightShape
+
+for (const toolType of ['draw', 'highlight'] as const) {
+	describe(`When ${toolType}ing...`, () => {
+		it('keeps the stroke updating after a quick shift release during a straight segment', () => {
+			editor
+				.setCurrentTool(toolType)
+				.pointerDown(10, 10)
+				.pointerMove(20, 20)
+				.keyDown('Shift')
+				.pointerMove(40, 40)
+				// straight segment committed; release shift before moving (starting_free)
+				.keyUp('Shift')
+				// tap shift again before the free segment starts: starting_free -> starting_straight -> ?
+				.keyDown('Shift')
+				.keyUp('Shift')
+				.pointerMove(50, 50)
+				.pointerMove(60, 60)
+				.pointerMove(70, 70)
+
+			const shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight', 'free'])
+
+			const before = base64ToPoints(
+				last(shape.props.segments)!.path,
+				last(shape.props.segments)!.dim
+			)
+
+			editor.pointerMove(80, 80).pointerMove(90, 90)
+
+			const updated = editor.getCurrentPageShapes()[0] as DrawableShape
+			const after = base64ToPoints(
+				last(updated.props.segments)!.path,
+				last(updated.props.segments)!.dim
+			)
+			// the free segment keeps growing and following the pointer
+			expect(after.length).toBe(before.length + 2)
+			expect(last(after)!.x).toBeCloseTo(last(before)!.x + 20, 0)
+			expect(last(after)!.y).toBeCloseTo(last(before)!.y + 20, 0)
+		})
+
+		it('goes back to free when shift is released before the straight segment starts', () => {
+			editor
+				.setCurrentTool(toolType)
+				.pointerDown(10, 10)
+				.pointerMove(20, 20)
+				.keyDown('Shift')
+				.keyUp('Shift')
+
+			const shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free'])
+			const before = base64ToPoints(shape.props.segments[0].path, shape.props.segments[0].dim)
+
+			editor.pointerMove(30, 30).pointerMove(40, 40)
+
+			const updated = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(updated.props.segments.map((s) => s.type)).toEqual(['free'])
+			const after = base64ToPoints(updated.props.segments[0].path, updated.props.segments[0].dim)
+			expect(after.length).toBe(before.length + 2)
+		})
+	})
+}


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where releasing shift while drawing could freeze the stroke until the next shift press.

### Before

`Drawing.onKeyUp` handled `segmentMode === 'starting_straight'` by going to `'free'`. But `'starting_straight'` is entered both from `'free'` and from `'starting_free'`; in the latter case the last segment is still the straight one being left, so free points were appended to a straight segment and the stroke stopped updating.

### After

If the last segment is still straight, shift-keyup goes back to `'starting_free'`, otherwise to `'free'` as before.

### Change type

- [x] `bugfix`

### Test plan

1. Start drawing, hold shift, release shift, immediately press and release shift again while moving.
2. The stroke keeps following the pointer.

- [x] Unit tests — the new test fails on `main` (segments stay `['free', 'straight']`) and passes with this change

### Release notes

- Fix the draw tool freezing the stroke after a quick shift release during a straight segment

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -2   |
| Tests     | +79 / -0   |
