### PR TITLE
fix(draw): track the straight segment length correctly while drawing

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -384,6 +384,8 @@ export class Drawing extends StateNode {
 
 						this.pagePointWhereCurrentSegmentChanged = Mat.applyToPoint(transform, prevLastPoint)
 					} else {
+						this.currentLineLength += Vec.Dist(newLastPoint, newPoint)
+
 						newSegment = this.makeSegment('straight', [newLastPoint, newPoint])
 					}
 
@@ -595,21 +597,17 @@ export class Drawing extends StateNode {
 				// then the user just did a click-and-immediately-press-shift to create a new straight line
 				// without continuing the previous line. In this case, we want to remove the previous segment.
 
+				// A straight segment is just [first, last]; swap its previous length for the new one
+				// (adding the whole length on every move would let tiny strokes close as if long).
+				const firstPoint = b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!
+				const prevLastPoint = b64Vecs.decodeLastPoint(newSegment.path, newSegment.dim)!
 				this.currentLineLength +=
-					newSegments.length && b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)
-						? Vec.Dist(
-								b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!,
-								Vec.From(newPoint)
-							)
-						: 0
+					Vec.Dist(firstPoint, Vec.From(newPoint)) - Vec.Dist(firstPoint, prevLastPoint)
 
 				newSegments[newSegments.length - 1] = {
 					...newSegment,
 					type: 'straight',
-					path: b64Vecs.encodePoints(
-						[b64Vecs.decodeFirstPoint(newSegment.path, newSegment.dim)!, Vec.From(newPoint)],
-						newSegment.dim
-					),
+					path: b64Vecs.encodePoints([firstPoint, Vec.From(newPoint)], newSegment.dim),
 				}
 
 				const shapePartial: TLShapePartial<DrawableShape> = {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a short stroke with straight segments could be auto-closed as if it were long.

### Before

`currentLineLength` drives whether a draw shape closes when the end comes near the start. When a straight segment was created its length was not added, and on every subsequent pointer move the full first-to-current distance was added again, so the length grew with pointer events rather than with the stroke.

### After

The segment's length is added once on creation, and each move swaps the previous last-point distance for the new one.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a small shape using shift for straight segments, wiggling the pointer a lot.
2. It does not close unless the stroke is actually long enough.

- [ ] Unit tests

### Release notes

- Fix short draw strokes with straight segments auto-closing

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -10   |