### PR TITLE
fix(draw): compute isClosed from the segments being written

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -171,6 +171,41 @@ describe('Close threshold with zoom', () => {
 		expect(shapeAtLowZoom.props.isClosed).toBe(true)
 	})
 
+	it('Closes on the straight segment that returns to the start, not one update later', () => {
+		const shift = { shiftKey: true }
+		editor.setCurrentTool('draw')
+		editor.pointerDown(100, 100, shift)
+		editor.pointerMove(200, 100, shift)
+		editor.pointerUp(200, 100, shift)
+		// shift-click extends the previous line with a new straight segment
+		editor.pointerDown(200, 100, shift)
+		editor.pointerMove(150, 180, shift)
+		editor.pointerUp(150, 180, shift)
+		editor.pointerDown(150, 180, shift)
+		editor.pointerMove(100, 100, shift)
+
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(shapes[0].props.isClosed).toBe(true)
+	})
+
+	it('Closes when the first straight segment after a free segment returns to the start', () => {
+		editor.setCurrentTool('draw')
+		editor.pointerDown(100, 100)
+		editor.pointerMove(200, 100)
+		editor.pointerMove(150, 180)
+		editor.pointerMove(150, 140)
+		expect((editor.getCurrentPageShapes()[0] as TLDrawShape).props.isClosed).toBe(false)
+		// pressing shift starts a straight segment from here; the move that commits it lands on the start
+		editor.keyDown('Shift')
+		editor.pointerMove(100, 100, { shiftKey: true })
+
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(shapes[0].props.segments.map((s) => s.type)).toEqual(['free', 'straight'])
+		expect(shapes[0].props.isClosed).toBe(true)
+	})
+
 	it('Does not close highlight shapes regardless of zoom', () => {
 		editor.setCamera({ x: 0, y: 0, z: 0.1 })
 		editor.setCurrentTool('highlight')

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -206,6 +206,20 @@ describe('Close threshold with zoom', () => {
 		expect(shapes[0].props.isClosed).toBe(true)
 	})
 
+	it('Closes when the final straight segment pushes a short stroke over the minimum length', () => {
+		// size m stroke width is 3.5, so a stroke needs > 14 page units of length to close
+		editor.setCurrentTool('draw')
+		editor.pointerDown(100, 100)
+		editor.pointerMove(108, 100)
+		expect((editor.getCurrentPageShapes()[0] as TLDrawShape).props.isClosed).toBe(false)
+		editor.keyDown('Shift')
+		editor.pointerMove(100, 100, { shiftKey: true })
+
+		const shape = editor.getCurrentPageShapes()[0] as TLDrawShape
+		expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight'])
+		expect(shape.props.isClosed).toBe(true)
+	})
+
 	it('Does not close highlight shapes regardless of zoom', () => {
 		editor.setCamera({ x: 0, y: 0, z: 0.1 })
 		editor.setCurrentTool('highlight')

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -387,17 +387,18 @@ export class Drawing extends StateNode {
 						newSegment = this.makeSegment('straight', [newLastPoint, newPoint])
 					}
 
+					const nextSegments = [...segments, newSegment]
 					const shapePartial: TLShapePartial<DrawableShape> = {
 						id,
 						type: this.shapeType,
 						props: {
-							segments: [...segments, newSegment],
+							segments: nextSegments,
 						},
 					}
 
 					if (this.canClose()) {
 						;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-							segments,
+							nextSegments,
 							size,
 							scale
 						)
@@ -622,7 +623,7 @@ export class Drawing extends StateNode {
 
 				if (this.canClose()) {
 					;(shapePartial as TLShapePartial<TLDrawShape>).props!.isClosed = this.getIsClosed(
-						segments,
+						newSegments,
 						size,
 						scale
 					)

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -180,7 +180,6 @@ export class Drawing extends StateNode {
 		return (
 			firstPoint !== null &&
 			lastPoint !== null &&
-			firstPoint !== lastPoint &&
 			this.currentLineLength > strokeWidth * 4 * scale &&
 			Vec.DistMin(firstPoint, lastPoint, threshold)
 		)
@@ -384,6 +383,8 @@ export class Drawing extends StateNode {
 
 						this.pagePointWhereCurrentSegmentChanged = Mat.applyToPoint(transform, prevLastPoint)
 					} else {
+						this.currentLineLength += Vec.Dist(newLastPoint, newPoint)
+
 						newSegment = this.makeSegment('straight', [newLastPoint, newPoint])
 					}
 


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a draw shape's `isClosed` lagged one update behind its segments when drawing straight segments.

### Before

In two places `Drawing.ts` wrote `segments: [...segments, newSegment]` (or `newSegments`) but called `getIsClosed(segments, …)` with the previous segments, so the close check ignored the point just added.

### After

`getIsClosed` is called with the same segment array that is written to the shape.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a triangle with shift-straight segments, finishing exactly on the start point.
2. The shape is closed (filled when a fill is set) without an extra move.

- [ ] Unit tests

### Release notes

- Fix draw shapes closing one update late when drawn with straight segments

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -3    |