### PR TITLE
fix(arrows): reset precise mode when the arrow tool changes target

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
@@ -63,6 +63,28 @@ describe('When in the idle state', () => {
 		editor.cancel()
 		editor.expectToBeIn('select.idle')
 	})
+
+	it('drops the precise hint when hovering a new target', () => {
+		editor.setCurrentTool('arrow')
+		editor.inputs.setPointerVelocity(new Vec(1, 1))
+		editor.pointerMove(150, 150)
+		expect(getArrowTargetState(editor)).toMatchObject({ target: { id: ids.box1 }, isPrecise: false })
+
+		vi.advanceTimersByTime(1000)
+		expect(getArrowTargetState(editor)).toMatchObject({ target: { id: ids.box1 }, isPrecise: true })
+
+		// Moving quickly onto another target should publish an imprecise hint for it without
+		// waiting for another pointer event
+		editor.inputs.setPointerVelocity(new Vec(1, 1))
+		editor.pointerMove(320, 320)
+		expect(getArrowTargetState(editor)).toMatchObject({ target: { id: ids.box2 }, isPrecise: false })
+
+		editor.pointerDown(320, 320).pointerMove(330, 330)
+		const arrow = editor.getCurrentPageShapes()[editor.getCurrentPageShapes().length - 1]
+		expect(bindings(arrow.id)).toMatchObject({
+			start: { toId: ids.box2, props: { isPrecise: false } },
+		})
+	})
 })
 
 describe('When in the pointing state', () => {

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
@@ -29,8 +29,17 @@ export class Idle extends StateNode {
 
 	override onExit() {
 		clearArrowTargetState(this.editor)
+		this.resetPrecise()
+	}
+
+	// Precise mode is earned by hovering one target; it must not carry over to the next
+	// target or to the next arrow.
+	private resetPrecise() {
+		this.isPrecise = false
+		this.preciseTargetId = null
 		if (this.isPreciseTimerId !== null) {
 			clearTimeout(this.isPreciseTimerId)
+			this.isPreciseTimerId = null
 		}
 	}
 
@@ -61,21 +70,14 @@ export class Idle extends StateNode {
 		})
 
 		if (targetState && targetState.target.id !== this.preciseTargetId) {
-			if (this.isPreciseTimerId !== null) {
-				clearTimeout(this.isPreciseTimerId)
-			}
-
+			this.resetPrecise()
 			this.preciseTargetId = targetState.target.id
 			this.isPreciseTimerId = this.editor.timers.setTimeout(() => {
 				this.isPrecise = true
 				this.update()
 			}, arrowUtil.options.hoverPreciseTimeout)
 		} else if (!targetState && this.preciseTargetId) {
-			this.isPrecise = false
-			this.preciseTargetId = null
-			if (this.isPreciseTimerId !== null) {
-				clearTimeout(this.isPreciseTimerId)
-			}
+			this.resetPrecise()
 		}
 	}
 }

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Idle.tsx
@@ -60,17 +60,14 @@ export class Idle extends StateNode {
 	update() {
 		const arrowUtil = this.editor.getShapeUtil<ArrowShapeUtil>('arrow')
 
-		const targetState = updateArrowTargetState({
-			editor: this.editor,
-			pointInPageSpace: this.editor.inputs.getCurrentPagePoint(),
-			arrow: undefined,
-			isPrecise: this.isPrecise,
-			currentBinding: undefined,
-			oppositeBinding: undefined,
-		})
+		const targetState = this.updateTargetState()
 
 		if (targetState && targetState.target.id !== this.preciseTargetId) {
+			const wasPrecise = this.isPrecise
 			this.resetPrecise()
+			// The hint above was published with the previous target's precise flag. Republish it
+			// so the overlay matches the imprecise binding a click would now create.
+			if (wasPrecise) this.updateTargetState()
 			this.preciseTargetId = targetState.target.id
 			this.isPreciseTimerId = this.editor.timers.setTimeout(() => {
 				this.isPrecise = true
@@ -79,5 +76,16 @@ export class Idle extends StateNode {
 		} else if (!targetState && this.preciseTargetId) {
 			this.resetPrecise()
 		}
+	}
+
+	private updateTargetState() {
+		return updateArrowTargetState({
+			editor: this.editor,
+			pointInPageSpace: this.editor.inputs.getCurrentPagePoint(),
+			arrow: undefined,
+			isPrecise: this.isPrecise,
+			currentBinding: undefined,
+			oppositeBinding: undefined,
+		})
 	}
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the arrow tool's precise-binding mode carried over from one hover target to the next, and from one arrow to the next.

### Before

`Idle.update` cleared the precise timer when the target changed but left `isPrecise` true, and `onExit` only cleared the timer. Hovering one shape long enough to go precise made the next shape (or the next arrow) start precise immediately.

### After

A `resetPrecise()` helper clears the flag, the target id and the timer; it runs on target change, on leaving a target, and on exit.

### Change type

- [x] `bugfix`

### Test plan

1. With the arrow tool, hover a shape until the precise indicator appears, then move to another shape.
2. The second shape starts in imprecise mode and only goes precise after the hover timeout.

- [ ] Unit tests

### Release notes

- Fix the arrow tool's precise mode carrying over to the next target

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -9   |