### PR TITLE
fix(geo): mark the x-box second diagonal as internal

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
+++ b/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
@@ -447,7 +447,9 @@ function getXBoxPath(
 			geometry: { isInternal: true, isFilled: false },
 		})
 		.lineTo(clamp(w - sw * inset, 0, w), clamp(h - sw * inset, 0, h))
-		.moveTo(clamp(w - sw * inset, 0, w), clamp(sw * inset, 0, h))
+		.moveTo(clamp(w - sw * inset, 0, w), clamp(sw * inset, 0, h), {
+			geometry: { isInternal: true, isFilled: false },
+		})
 		.lineTo(clamp(sw * inset, 0, w), clamp(h - sw * inset, 0, h))
 
 	return path


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where one of the two diagonals of an x-box geo shape was treated as part of the outer outline.

### Before

`getXBoxPath` marked the first diagonal `isInternal: true` but not the second, so the second diagonal contributed vertices and nearest points to operations that filter out internal geometry (snapping, outline nearest-point) while the first diagonal did not.

### After

Both diagonals carry `geometry: { isInternal: true, isFilled: false }`.

### Change type

- [x] `bugfix`

### Test plan

1. Create an x-box shape and drag another shape near it with snapping on.
2. Snap points are offered along the outline only, not along either diagonal.

- [ ] Unit tests

### Release notes

- Fix the second diagonal of an x-box shape being treated as an outer edge

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |