### PR TITLE
fix(highlight): interpolate props from the nearer shape

### DIFF
--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.test.ts
@@ -144,3 +144,35 @@ describe('HighlightShapeUtil dot detection', () => {
 		})
 	})
 })
+
+describe('HighlightShapeUtil getInterpolatedProps', () => {
+	const segments = createDrawSegments([
+		[
+			{ x: 0, y: 0, z: 0.5 },
+			{ x: 10, y: 10, z: 0.5 },
+		],
+	])
+
+	function createHighlightShape(id: string, props: Partial<TLHighlightShape['props']>) {
+		const shapeId = createShapeId(id)
+		editor.createShapes([{ id: shapeId, type: 'highlight', props: { segments, ...props } }])
+		return editor.getShape(shapeId) as TLHighlightShape
+	}
+
+	it('takes discrete props from the nearer shape', () => {
+		const start = createHighlightShape('start', { color: 'red', size: 's', scale: 1 })
+		const end = createHighlightShape('end', { color: 'blue', size: 'xl', scale: 3 })
+		const util = editor.getShapeUtil('highlight')
+
+		expect(util.getInterpolatedProps!(start, end, 0.25)).toMatchObject({
+			color: 'red',
+			size: 's',
+			scale: 1.5,
+		})
+		expect(util.getInterpolatedProps!(start, end, 0.75)).toMatchObject({
+			color: 'blue',
+			size: 'xl',
+			scale: 2.5,
+		})
+	})
+})

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -241,7 +241,6 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	): TLHighlightShapeProps {
 		return {
 			...(t > 0.5 ? endShape.props : startShape.props),
-			...endShape.props,
 			segments: interpolateSegments(startShape.props.segments, endShape.props.segments, t),
 			scale: lerp(startShape.props.scale, endShape.props.scale, t),
 		}


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `HighlightShapeUtil.getInterpolatedProps` always took the end shape's props regardless of `t`.

### Before

The spread `...(t > 0.5 ? endShape.props : startShape.props)` was immediately overwritten by `...endShape.props`, so the first half of an animation already showed the end shape's color and size.

### After

The dead second spread is removed; props come from the nearer shape, with `segments` and `scale` interpolated, matching `DrawShapeUtil`.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a stroke with the highlight tool.
2. With the stroke selected, animate it toward a recolored copy from the console:
   ```js
   const s = editor.getOnlySelectedShape()
   editor.animateShape({ ...s, props: { ...s.props, color: 'violet' } }, { animation: { duration: 3000 } })
   ```
3. On `main`, the stroke shows the end color for the whole animation, switching the moment it starts. With this change it keeps the start color for the first half and switches at the midpoint, matching draw shapes.

- [ ] Unit tests

### Release notes

- Fix highlight shape animations switching to the end shape's props immediately

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +0 / -1    |
