### PR TITLE
fix(lines): give cloned interpolation points unique indices

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
@@ -462,9 +462,9 @@ describe('Line points: id-mapped object with a decoupled index', () => {
 		expect(vertexHandles).toHaveLength(2)
 	})
 
-	it('tolerates a line animation that transiently produces duplicate indices (#9397)', () => {
-		// animating to a different point count makes getInterpolatedProps emit duplicate
-		// indices each tick; reading handles must not throw while that is in the store.
+	it('keeps every point while animating to a line with more points (#9397)', () => {
+		// getInterpolatedProps used to clone extra start points with duplicate indices, which
+		// linePointsToArray collapsed, so the line lost points until the animation ended.
 		const id = createShapeId('line-animate')
 		editor.createShapes([
 			{
@@ -498,7 +498,7 @@ describe('Line points: id-mapped object with a decoupled index', () => {
 
 		for (let i = 0; i < 12; i++) {
 			editor.emit('tick', 16)
-			expect(() => editor.getShapeHandles(id)).not.toThrow()
+			expect(getHandlesFor(id).filter((h) => h.type === 'vertex')).toHaveLength(3)
 		}
 	})
 })

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -305,16 +305,19 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				index = getIndexAbove(index)
 			}
 		} else if (endPoints.length > startPoints.length) {
-			// we'll need to converge points
+			// we'll need to converge points. The start points become the output's points, so they
+			// need fresh indices too: extra points cloned from the last start point would otherwise
+			// share its index and be dropped by linePointsToArray until the animation ends.
 			for (let i = 0; i < endPoints.length; i++) {
 				pointsToUseEnd[i] = { ...endPoints[i] }
 				if (startPoints[i] === undefined) {
 					pointsToUseStart[i] = {
 						...startPoints[startPoints.length - 1],
 						id: index,
+						index,
 					}
 				} else {
-					pointsToUseStart[i] = { ...startPoints[i], id: index }
+					pointsToUseStart[i] = { ...startPoints[i], id: index, index }
 				}
 				index = getIndexAbove(index)
 			}

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -305,9 +305,8 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 				index = getIndexAbove(index)
 			}
 		} else if (endPoints.length > startPoints.length) {
-			// we'll need to converge points. The start points become the output's points, so they
-			// need fresh indices too: extra points cloned from the last start point would otherwise
-			// share its index and be dropped by linePointsToArray until the animation ends.
+			// we'll need to converge points. Clones of the last start point would share its index
+			// and get dropped by linePointsToArray, so hand out fresh indices to every start point.
 			for (let i = 0; i < endPoints.length; i++) {
 				pointsToUseEnd[i] = { ...endPoints[i] }
 				if (startPoints[i] === undefined) {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where animating a line to one with more points dropped the extra points until the animation ended.

### Before

When `getInterpolatedProps` converges a shorter start line to a longer end line, the extra start points were cloned from the last start point with a new `id` but the same `index`. `linePointsToArray` dedupes by index, so those points vanished mid-animation.

### After

Each interpolated start point gets a fresh `index` as well as a fresh `id`.

### Change type

- [x] `bugfix`

### Test plan

1. `editor.animateShape` from a 2-point line to a 4-point line.
2. All four points are visible throughout the animation.

- [ ] Unit tests

### Release notes

- Fix line animations dropping points when the target line has more points

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -2    |