### PR TITLE
fix(lines): do not mutate the caller's points in onBeforeCreate

### DIFF
--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
@@ -365,6 +365,29 @@ describe('Misc', () => {
 		expect(Array.from(editor.getCurrentPageShapeIds().values()).length).toEqual(2)
 	})
 
+	it('duplicates a zero-length line without mutating the source', () => {
+		// onBeforeCreate nudges on create, so collapse the points afterwards
+		editor.updateShapes([
+			{
+				id,
+				type: 'line',
+				props: {
+					points: {
+						a1: { id: 'a1', index: 'a1' as IndexKey, x: 5, y: 5 },
+						a2: { id: 'a2', index: 'a2' as IndexKey, x: 5, y: 5 },
+					},
+				},
+			},
+		])
+		const before = structuredClone(getShape().props.points)
+
+		expect(() => editor.duplicateShapes([id])).not.toThrow()
+
+		expect(getShape().props.points).toEqual(before)
+		const duplicate = editor.getCurrentPageShapes().find((s) => s.id !== id) as TLLineShape
+		expect(duplicate.props.points.a2).toMatchObject({ x: 5.1, y: 5.1 })
+	})
+
 	it('deletes', () => {
 		editor.select(id)
 

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -167,13 +167,23 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 			return point.x === firstPoint.x && point.y === firstPoint.y
 		})
 		if (allSame) {
+			// Copy rather than mutate: createShapes spreads the partial's props shallowly, so
+			// `points` is the caller's object — on duplicate, the frozen source record's.
 			const lastKey = pointKeys[pointKeys.length - 1]
-			points[lastKey] = {
-				...points[lastKey],
-				x: points[lastKey].x + 0.1,
-				y: points[lastKey].y + 0.1,
+			return {
+				...next,
+				props: {
+					...next.props,
+					points: {
+						...points,
+						[lastKey]: {
+							...points[lastKey],
+							x: points[lastKey].x + 0.1,
+							y: points[lastKey].y + 0.1,
+						},
+					},
+				},
 			}
-			return next
 		}
 		return
 	}


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where duplicating a zero-length line threw.

### Before

`LineShapeUtil.onBeforeCreate` nudged the last point in place when all points were identical. `createShapes` spreads the partial's props shallowly, so `points` was the caller's object — on duplicate, the frozen source record's — and the write threw.

### After

The nudge returns a new record with a copied `points` object.

### Change type

- [x] `bugfix`

### Test plan

1. Create a line whose points are all the same (e.g. a click without drag).
2. Duplicate it (Cmd+D) — no error.

- [ ] Unit tests

### Release notes

- Fix duplicating a zero-length line throwing

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +15 / -5   |