### PR TITLE
fix(notes): keep theme font faces for attributed notes

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -308,13 +308,16 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					style: 'normal',
 				})
 
-		if (shape.props.textLastEditedBy && !isEmptyRichText(shape.props.richText)) {
-			return [...fonts, DefaultFontFaces.tldraw_sans.normal.normal]
-		}
 		const themeFaces = getThemeFontFaces(this.editor.getCurrentTheme(), shape.props.font)
-		if (themeFaces) return [...themeFaces, ...fonts]
+		const textFaces = themeFaces ? [...themeFaces, ...fonts] : fonts
 
-		return fonts.length ? fonts : EMPTY_ARRAY
+		// The attribution line renders in the default sans face regardless of the note's font.
+		// Theme faces come first so an attributed note keeps its custom font (export included).
+		if (shape.props.textLastEditedBy && !isEmptyRichText(shape.props.richText)) {
+			return [...textFaces, DefaultFontFaces.tldraw_sans.normal.normal]
+		}
+
+		return textFaces.length ? textFaces : EMPTY_ARRAY
 	}
 
 	component(shape: TLNoteShape) {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where a note with an attribution line lost its custom font in exports.

### Before

`NoteShapeUtil.getFontFaces` returned early for attributed notes with `[...fonts, tldraw_sans]`, skipping the theme font faces that the non-attributed branch adds, so an exported attributed note fell back to the default face.

### After

Theme faces are resolved first and included in both branches; the attribution's sans face is appended.

### Change type

- [x] `bugfix`

### Test plan

1. Enable attribution, create a note with a non-default font and type in it.
2. Export as SVG — the note text uses its font.

- [ ] Unit tests

### Release notes

- Fix attributed notes losing their font in exports

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -4    |