### PR TITLE
fix(images): clear the resolved asset when a shape's assetId is removed

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
@@ -7,28 +7,31 @@ import { useImageOrVideoAsset } from './useImageOrVideoAsset'
 
 let editor: Editor
 const assetId = AssetRecordType.createId('image')
+const otherAssetId = AssetRecordType.createId('image2')
+
+function imageAsset(id: TLAssetId, w: number) {
+	return {
+		id,
+		type: 'image' as const,
+		typeName: 'asset' as const,
+		props: {
+			w,
+			h: 100,
+			name: 'image.png',
+			isAnimated: false,
+			mimeType: 'image/png',
+			src: 'http://localhost/image.png',
+		},
+		meta: {},
+	}
+}
 
 beforeEach(async () => {
 	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
 		waitForPatterns: false,
 	})
 	editor = result.editor
-	editor.createAssets([
-		{
-			id: assetId,
-			type: 'image',
-			typeName: 'asset',
-			props: {
-				w: 100,
-				h: 100,
-				name: 'image.png',
-				isAnimated: false,
-				mimeType: 'image/png',
-				src: 'http://localhost/image.png',
-			},
-			meta: {},
-		},
-	])
+	editor.createAssets([imageAsset(assetId, 100)])
 })
 
 async function flush() {
@@ -37,14 +40,18 @@ async function flush() {
 	})
 }
 
-it('clears the resolved asset when the assetId is removed, and resolves it again when re-attached', async () => {
+function renderAssetHook(initialAssetId: TLAssetId | null) {
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<EditorProvider editor={editor}>{children}</EditorProvider>
 	)
-	const { result, rerender } = renderHook(
+	return renderHook(
 		({ assetId }: { assetId: TLAssetId | null }) => useImageOrVideoAsset({ assetId, width: 100 }),
-		{ wrapper, initialProps: { assetId: assetId as TLAssetId | null } }
+		{ wrapper, initialProps: { assetId: initialAssetId } }
 	)
+}
+
+it('clears the resolved asset when the assetId is removed, and resolves it again when re-attached', async () => {
+	const { result, rerender } = renderAssetHook(assetId)
 	await flush()
 	expect(result.current).toMatchObject({
 		url: 'http://localhost/image.png',
@@ -60,5 +67,39 @@ it('clears the resolved asset when the assetId is removed, and resolves it again
 	expect(result.current).toMatchObject({
 		url: 'http://localhost/image.png',
 		asset: { id: assetId },
+	})
+})
+
+it('resolves the asset again when its record is deleted and recreated', async () => {
+	const { result } = renderAssetHook(assetId)
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+
+	await act(async () => editor.deleteAssets([assetId]))
+	await flush()
+	expect(result.current).toMatchObject({ url: null, asset: null })
+
+	await act(async () => editor.createAssets([imageAsset(assetId, 100)]))
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+})
+
+it('returns the new asset when switching to one that resolves to the same url', async () => {
+	editor.createAssets([imageAsset(otherAssetId, 200)])
+	const { result, rerender } = renderAssetHook(assetId)
+	await flush()
+	expect(result.current.asset).toMatchObject({ id: assetId, props: { w: 100 } })
+
+	rerender({ assetId: otherAssetId })
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: otherAssetId, props: { w: 200 } },
 	})
 })

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
@@ -123,3 +123,31 @@ it('shows the new asset, not the old one, when switching to an asset that has no
 	await flush()
 	expect(result.current).toMatchObject({ url: null, asset: { id: otherAssetId } })
 })
+
+it('ignores a resolution that was still in flight when the asset record was deleted', async () => {
+	const { result } = renderAssetHook(assetId)
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+
+	let finishResolving!: (url: string) => void
+	vi.spyOn(editor, 'resolveAssetUrl').mockImplementation(
+		() => new Promise<string>((resolve) => (finishResolving = resolve))
+	)
+	// Zoom triggers a debounced re-resolution; drive the debounce with ticks until it fires
+	await act(async () => {
+		editor.setCamera({ x: 0, y: 0, z: 2 })
+		for (let i = 0; i < 40; i++) editor.emit('tick', 16)
+	})
+	expect(editor.resolveAssetUrl).toHaveBeenCalled()
+
+	await act(async () => editor.deleteAssets([assetId]))
+	await flush()
+	expect(result.current).toMatchObject({ url: null, asset: null })
+
+	await act(async () => finishResolving('http://localhost/image.png'))
+	await flush()
+	expect(result.current).toMatchObject({ url: null, asset: null })
+})

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react'
+import { AssetRecordType, Editor, EditorProvider, TLAssetId } from '@tldraw/editor'
+import { ReactNode } from 'react'
+import { renderTldrawComponentWithEditor } from '../../../test/testutils/renderTldrawComponent'
+import { Tldraw } from '../../Tldraw'
+import { useImageOrVideoAsset } from './useImageOrVideoAsset'
+
+let editor: Editor
+const assetId = AssetRecordType.createId('image')
+
+beforeEach(async () => {
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+	editor.createAssets([
+		{
+			id: assetId,
+			type: 'image',
+			typeName: 'asset',
+			props: {
+				w: 100,
+				h: 100,
+				name: 'image.png',
+				isAnimated: false,
+				mimeType: 'image/png',
+				src: 'http://localhost/image.png',
+			},
+			meta: {},
+		},
+	])
+})
+
+async function flush() {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0))
+	})
+}
+
+it('clears the resolved asset when the assetId is removed, and resolves it again when re-attached', async () => {
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<EditorProvider editor={editor}>{children}</EditorProvider>
+	)
+	const { result, rerender } = renderHook(
+		({ assetId }: { assetId: TLAssetId | null }) => useImageOrVideoAsset({ assetId, width: 100 }),
+		{ wrapper, initialProps: { assetId: assetId as TLAssetId | null } }
+	)
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+
+	rerender({ assetId: null })
+	await flush()
+	expect(result.current).toMatchObject({ url: null, asset: null })
+
+	rerender({ assetId })
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+})

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { AssetRecordType, Editor, EditorProvider, TLAssetId } from '@tldraw/editor'
 import { ReactNode } from 'react'
+import { vi } from 'vitest'
 import { renderTldrawComponentWithEditor } from '../../../test/testutils/renderTldrawComponent'
 import { Tldraw } from '../../Tldraw'
 import { useImageOrVideoAsset } from './useImageOrVideoAsset'
@@ -9,7 +10,7 @@ let editor: Editor
 const assetId = AssetRecordType.createId('image')
 const otherAssetId = AssetRecordType.createId('image2')
 
-function imageAsset(id: TLAssetId, w: number) {
+function imageAsset(id: TLAssetId, w: number, src = 'http://localhost/image.png') {
 	return {
 		id,
 		type: 'image' as const,
@@ -20,7 +21,7 @@ function imageAsset(id: TLAssetId, w: number) {
 			name: 'image.png',
 			isAnimated: false,
 			mimeType: 'image/png',
-			src: 'http://localhost/image.png',
+			src,
 		},
 		meta: {},
 	}
@@ -102,4 +103,23 @@ it('returns the new asset when switching to one that resolves to the same url', 
 		url: 'http://localhost/image.png',
 		asset: { id: otherAssetId, props: { w: 200 } },
 	})
+})
+
+it('shows the new asset, not the old one, when switching to an asset that has no url yet', async () => {
+	// Like the dotcom asset stores, resolve an asset without a src to null rather than ''
+	const resolve = editor.resolveAssetUrl.bind(editor)
+	vi.spyOn(editor, 'resolveAssetUrl').mockImplementation(
+		async (id, ctx) => (await resolve(id, ctx)) || null
+	)
+	editor.createAssets([imageAsset(otherAssetId, 200, '')])
+	const { result, rerender } = renderAssetHook(assetId)
+	await flush()
+	expect(result.current).toMatchObject({
+		url: 'http://localhost/image.png',
+		asset: { id: assetId },
+	})
+
+	rerender({ assetId: otherAssetId })
+	await flush()
+	expect(result.current).toMatchObject({ url: null, asset: { id: otherAssetId } })
 })

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -78,7 +78,17 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 			shouldRunImmediately.current = true
 		}
 
-		if (!assetId) return
+		if (!assetId) {
+			// The asset was removed from the shape: drop the previous asset/url rather than
+			// keep rendering it
+			if (assetIdChanged) {
+				// Forget the old url too, or re-attaching the same asset is treated as "same url"
+				// in resolve() and the image stays blank
+				previousUrl.current = null
+				setResult((prev) => ({ ...prev, asset: null, url: null }))
+			}
+			return
+		}
 
 		let isCancelled = false
 		let cancelDebounceFn: (() => void) | undefined

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -73,18 +73,17 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		const assetIdChanged = previousAssetId.current !== assetId
 		previousAssetId.current = assetId
 
-		// Set flag to run immediately (skip debouncing) for the next resolution
 		if (assetIdChanged) {
+			// Resolve immediately (skip debouncing), and forget the old url: resolve() skips a url
+			// equal to the previous one, which would leave the state stale when a different asset
+			// resolves to the same url, or when the same asset is re-attached after being removed
 			shouldRunImmediately.current = true
+			previousUrl.current = null
 		}
 
 		if (!assetId) {
-			// Asset removed from the shape: stop rendering it. Also forget the url, or re-attaching
-			// the same asset is skipped as "same url" in resolve()
-			if (assetIdChanged) {
-				previousUrl.current = null
-				setResult({ asset: null, url: null })
-			}
+			// Asset removed from the shape: stop rendering it
+			if (assetIdChanged) setResult({ asset: null, url: null })
 			return
 		}
 
@@ -97,7 +96,11 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 			// Get the fresh asset
 			const asset = editor.getAsset<TLImageAsset | TLVideoAsset>(assetId)
 			if (!asset) {
-				// If the asset is deleted, such as when an upload fails, set the URL to null
+				// The asset record is gone (failed upload, deleted and later undone). Treat a record
+				// that comes back like a new asset: resolve it immediately, and forget the url or a
+				// record recreated with the same src is skipped as "same url" in resolve()
+				shouldRunImmediately.current = true
+				previousUrl.current = null
 				setResult((prev) => ({ ...prev, asset: null, url: null }))
 				return
 			}

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -89,6 +89,9 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 
 		let isCancelled = false
 		let cancelDebounceFn: (() => void) | undefined
+		// Bumped when the asset record disappears, so a resolution already in flight for the old
+		// record cannot put it back on screen
+		let generation = 0
 
 		const cleanupEffectScheduler = react('update state', () => {
 			if (!exportInfo && shapeId && editor.getCulledShapes().has(shapeId)) return
@@ -100,6 +103,8 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 				// with the same src resolves like a new asset
 				shouldRunImmediately.current = true
 				previousUrl.current = undefined
+				generation++
+				cancelDebounceFn?.()
 				setResult((prev) =>
 					prev.asset === null && prev.url === null ? prev : { asset: null, url: null }
 				)
@@ -125,8 +130,10 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 				? exportInfo.scale * (width / asset.props.w)
 				: editor.getEfficientZoomLevel() * (width / asset.props.w)
 
+			const resolveGeneration = generation
 			function resolve(asset: TLImageAsset | TLVideoAsset, url: string | null) {
 				if (isCancelled) return // don't update if the hook has remounted
+				if (resolveGeneration !== generation) return // the record was deleted meanwhile
 				if (previousUrl.current === url) return // don't update the state if the url is the same
 				didAlreadyResolve.current = true // mark that we've resolved our first image
 				previousUrl.current = url // keep the url around to compare with the next one

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -65,8 +65,10 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 	// Track whether we should run immediately (skip debouncing) for the next resolution
 	const shouldRunImmediately = useRef(false)
 
-	// The last URL that we've seen for the shape
-	const previousUrl = useRef<string | null>(null)
+	// The last url passed to setResult, or undefined once the asset changes or vanishes. resolve()
+	// skips a url equal to this one, so a plain null here would swallow a legitimate null result
+	// (an asset still uploading) and leave the previous asset on screen
+	const previousUrl = useRef<string | null | undefined>(undefined)
 
 	useEffect(() => {
 		// Check if the assetId changed (not just resolution/scale updates)
@@ -74,15 +76,13 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		previousAssetId.current = assetId
 
 		if (assetIdChanged) {
-			// Resolve immediately (skip debouncing), and forget the old url: resolve() skips a url
-			// equal to the previous one, which would leave the state stale when a different asset
-			// resolves to the same url, or when the same asset is re-attached after being removed
+			// New asset: skip the debounce and drop the stale url (see previousUrl)
 			shouldRunImmediately.current = true
-			previousUrl.current = null
+			previousUrl.current = undefined
 		}
 
 		if (!assetId) {
-			// Asset removed from the shape: stop rendering it
+			// Asset detached: without this the last resolved url keeps rendering
 			if (assetIdChanged) setResult({ asset: null, url: null })
 			return
 		}
@@ -96,12 +96,13 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 			// Get the fresh asset
 			const asset = editor.getAsset<TLImageAsset | TLVideoAsset>(assetId)
 			if (!asset) {
-				// The asset record is gone (failed upload, deleted and later undone). Treat a record
-				// that comes back like a new asset: resolve it immediately, and forget the url or a
-				// record recreated with the same src is skipped as "same url" in resolve()
+				// Record gone (failed upload, deleted before undo): reset so a record that comes back
+				// with the same src resolves like a new asset
 				shouldRunImmediately.current = true
-				previousUrl.current = null
-				setResult((prev) => ({ ...prev, asset: null, url: null }))
+				previousUrl.current = undefined
+				setResult((prev) =>
+					prev.asset === null && prev.url === null ? prev : { asset: null, url: null }
+				)
 				return
 			}
 

--- a/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useImageOrVideoAsset.ts
@@ -79,13 +79,11 @@ export function useImageOrVideoAsset({ shapeId, assetId, width }: UseImageOrVide
 		}
 
 		if (!assetId) {
-			// The asset was removed from the shape: drop the previous asset/url rather than
-			// keep rendering it
+			// Asset removed from the shape: stop rendering it. Also forget the url, or re-attaching
+			// the same asset is skipped as "same url" in resolve()
 			if (assetIdChanged) {
-				// Forget the old url too, or re-attaching the same asset is treated as "same url"
-				// in resolve() and the image stays blank
 				previousUrl.current = null
-				setResult((prev) => ({ ...prev, asset: null, url: null }))
+				setResult({ asset: null, url: null })
 			}
 			return
 		}


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where an image or video shape kept rendering its old asset after `assetId` was set to `null`. It also fixes the same stale-url check leaving a shape on the broken-asset icon after its asset record was deleted and recreated (failed upload retried, `deleteAssets` then undo), and leaving the hook returning the previous asset record when switching to another asset that resolves to the same url.

### Before

`useImageOrVideoAsset` returned early when `assetId` was falsy without touching the previous result, so the stale `asset`/`url` stayed in state and the old image kept rendering, through the removal and any re-attach.

### After

When `assetId` changes to `null` the hook clears the result. Whenever `assetId` changes, and whenever the asset record disappears, it forgets `previousUrl` and resolves the next asset immediately, so a re-attached, recreated, or same-url asset is not skipped as "same url" in `resolve()`.

### Change type

- [x] `bugfix`

### Test plan

1. `editor.updateShape({ id, type: 'image', props: { assetId: null } })` — the image disappears (on `main` it stays).
2. Set the same `assetId` back — the image reappears.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix image and video shapes keeping a removed asset on screen

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -1   |