### PR TITLE
fix(docs): give overloads and same-named exports a shared reference page

### DIFF
--- a/apps/docs/scripts/lib/createApiMarkdown.ts
+++ b/apps/docs/scripts/lib/createApiMarkdown.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { ApiItem } from '@microsoft/api-extractor-model'
 import { APIGroup, InputSection } from '@/types/content-types'
 import { nicelog } from '@/utils/nicelog'
 import { TldrawApiModel } from '@/utils/TldrawApiModel'
@@ -72,14 +73,33 @@ export async function createApiMarkdown() {
 
 		const entrypoint = packageModel.entryPoints[0]
 
-		for (let j = 0; j < entrypoint.members.length; j++) {
-			const item = entrypoint.members[j]
+		// Overloads and same-named declarations (an interface and a const both called
+		// `Geometry2dFilters`, the four `computed` overloads) share a slug and therefore a page.
+		// Writing each item to `${slug}.mdx` in turn would leave only the last one documented.
+		const membersBySlug = new Map<string, ApiItem[]>()
+		for (const item of entrypoint.members) {
+			const slug = getSlug(item)
+			membersBySlug.set(slug, [...(membersBySlug.get(slug) ?? []), item])
+		}
 
-			const outputFileName = `${getSlug(item)}.mdx`
+		let order = 0
+		for (const [slug, items] of membersBySlug) {
+			const outputFileName = `${slug}.mdx`
 
-			const result = await getApiMarkdown(model, categoryName, item, j)
+			let frontmatter = ''
+			const bodies: string[] = []
+			for (const item of items) {
+				const result = await getApiMarkdown(model, categoryName, item, order)
+				frontmatter ||= result.frontmatter
+				bodies.push(result.markdown)
+			}
+			order++
+
 			nicelog(`✎ ${outputFileName}`)
-			fs.writeFileSync(path.join(OUTPUT_DIR, outputFileName), result.markdown)
+			fs.writeFileSync(
+				path.join(OUTPUT_DIR, outputFileName),
+				frontmatter + bodies.join('\n---\n\n')
+			)
 		}
 	}
 
@@ -87,10 +107,10 @@ export async function createApiMarkdown() {
 
 	const sectionsJsonPath = path.join(CONTENT_DIR, 'sections.json')
 	const sectionsJson = JSON.parse(fs.readFileSync(sectionsJsonPath, 'utf8')) as InputSection[]
-	sectionsJson.splice(
-		sectionsJson.findIndex((s) => s.id === 'reference'),
-		1
-	)
+	// findIndex returns -1 when there's no reference section yet, and splice(-1, 1) would drop
+	// the last real section instead
+	const existingIndex = sectionsJson.findIndex((s) => s.id === 'reference')
+	if (existingIndex !== -1) sectionsJson.splice(existingIndex, 1)
 	sectionsJson.push(apiInputSection)
 	fs.writeFileSync(sectionsJsonPath, JSON.stringify(sectionsJson, null, '\t') + '\n')
 

--- a/apps/docs/scripts/lib/getApiMarkdown.ts
+++ b/apps/docs/scripts/lib/getApiMarkdown.ts
@@ -6,6 +6,7 @@ import {
 	ApiDocumentedItem,
 	ApiEnum,
 	ApiFunction,
+	ApiIndexSignature,
 	ApiInterface,
 	ApiItem,
 	ApiItemKind,
@@ -29,7 +30,6 @@ import { MarkdownWriter, formatWithPrettier, getPath, getSlug } from './utils'
 
 interface Result {
 	markdown: string
-	keywords: string[]
 }
 
 const date = new Intl.DateTimeFormat('en-US', {
@@ -43,15 +43,20 @@ interface Member {
 	inheritedFrom: ApiItem | null
 }
 
+/**
+ * Markdown for one API item, split into the page frontmatter and the body so that items that
+ * share a page (overloads, a type and a value with the same name) can be concatenated after a
+ * single frontmatter block.
+ */
 export async function getApiMarkdown(
 	model: TldrawApiModel,
 	categoryName: string,
 	item: ApiItem,
-	j: number
+	order: number
 ) {
-	const result: Result = { markdown: '', keywords: [] }
-	const toc: Result = { markdown: '', keywords: [] }
-	const membersResult: Result = { markdown: '', keywords: [] }
+	const result: Result = { markdown: '' }
+	const toc: Result = { markdown: '' }
+	const membersResult: Result = { markdown: '' }
 
 	const isComponent = model.isComponent(item)
 	const componentProps = isComponent ? model.getReactPropsItem(item) : null
@@ -59,7 +64,7 @@ export async function getApiMarkdown(
 	const contents = collectMembersAndExtends(model, item)
 
 	if (contents.constructors.length) {
-		const constructorResult: Result = { markdown: '', keywords: [] }
+		const constructorResult: Result = { markdown: '' }
 		for (const member of contents.constructors) {
 			await addMarkdownForMember(model, constructorResult, member)
 			addHorizontalRule(constructorResult)
@@ -68,7 +73,7 @@ export async function getApiMarkdown(
 	}
 
 	if (contents.properties.length || isComponent) {
-		const propertiesResult: Result = { markdown: '', keywords: [] }
+		const propertiesResult: Result = { markdown: '' }
 		if (componentProps) addExtends(propertiesResult, item, contents.heritage)
 		for (const member of contents.properties) {
 			const slug = getSlug(member.item)
@@ -99,7 +104,7 @@ export async function getApiMarkdown(
 	}
 
 	if (contents.methods.length) {
-		const methodsResult: Result = { markdown: '', keywords: [] }
+		const methodsResult: Result = { markdown: '' }
 		addMarkdown(toc, `- [Methods](#methods)\n`)
 		addMarkdown(methodsResult, `## Methods\n\n`)
 		for (const member of contents.methods) {
@@ -111,7 +116,6 @@ export async function getApiMarkdown(
 		addMarkdown(membersResult, methodsResult.markdown)
 	}
 
-	await addFrontmatter(model, result, item, categoryName, j)
 	await addDeprecationNotice(result, item)
 
 	if (toc.markdown.length) {
@@ -131,7 +135,10 @@ export async function getApiMarkdown(
 		addMarkdown(result, membersResult.markdown)
 	}
 
-	return result
+	return {
+		frontmatter: getFrontmatter(model, item, categoryName, order),
+		markdown: result.markdown,
+	}
 }
 
 /* --------------------- Helpers -------------------- */
@@ -165,6 +172,7 @@ function collectMembersAndExtends(model: TldrawApiModel, item: ApiItem) {
 					case ApiItemKind.Variable:
 					case ApiItemKind.Property:
 					case ApiItemKind.PropertySignature:
+					case ApiItemKind.IndexSignature:
 						addMember(properties, member, inheritedFrom)
 						break
 					case ApiItemKind.Method:
@@ -254,23 +262,12 @@ async function addMarkdownForMember(
 	await addDocComment(model, result, item)
 }
 
-async function addFrontmatter(
+function getFrontmatter(
 	model: TldrawApiModel,
-	result: Result,
 	member: ApiItem,
 	categoryName: string,
 	order: number
-) {
-	let kw = ''
-
-	if (result.keywords.length) {
-		kw += `\nkeywords:`
-		for (const k of result.keywords) {
-			if (k.startsWith('_')) continue
-			kw += `\n  - ${k.trim().split('\n')[0]}`
-		}
-	}
-
+): string {
 	const frontmatter: Record<string, string> = {
 		title: member.displayName,
 		status: 'published',
@@ -285,10 +282,9 @@ async function addFrontmatter(
 		frontmatter.sourceUrl = member.sourceLocation.fileUrl
 	}
 
-	result.markdown += [
+	return [
 		'---',
 		...Object.entries(frontmatter).map(([key, value]) => `${key}: ${value}`),
-		kw,
 		'---',
 		'',
 	].join('\n')
@@ -357,6 +353,7 @@ async function addDocComment(model: TldrawApiModel, result: Result, member: ApiI
 			member instanceof ApiTypeAlias ||
 			member instanceof ApiProperty ||
 			member instanceof ApiPropertySignature ||
+			member instanceof ApiIndexSignature ||
 			member instanceof ApiClass ||
 			member instanceof ApiFunction ||
 			member instanceof ApiInterface ||
@@ -439,6 +436,7 @@ async function addDocComment(model: TldrawApiModel, result: Result, member: ApiI
 		member instanceof ApiTypeAlias ||
 		member instanceof ApiProperty ||
 		member instanceof ApiPropertySignature ||
+		member instanceof ApiIndexSignature ||
 		member instanceof ApiClass ||
 		member instanceof ApiInterface ||
 		member instanceof ApiEnum ||


### PR DESCRIPTION
**Risk: medium · Importance: medium**

This PR fixes a bug where API members that share a display name overwrote each other's reference page, so tldraw.dev documented only the last declaration. Split out of #10258.

### Before

`createApiMarkdown` wrote every entry-point member to `${getSlug(item)}.mdx` in turn. The four `computed` overloads, `Geometry2dFilters` (interface + const), `EffectScheduler`, `clamp`, `useValue`, `useComputed`, `UNINITIALIZED`, `RESET_VALUE`, `WithDiff`, `PORTRAIT_BREAKPOINT`, `MigrationFailureReason`, `TLSyncErrorCloseEventReason`, and `ElbowArrowSnap` all map to one slug each, so only the last-written item survived — `/reference/state/computed` showed only the decorator-factory overload. `sectionsJson.splice(findIndex(...), 1)` also dropped the last real section when there was no `reference` entry yet.

### After

Members are grouped by slug and written as one page: one frontmatter block followed by each item's body separated by a horizontal rule. `getApiMarkdown` returns `{ frontmatter, markdown }` separately to make that possible; the dead `Result.keywords` plumbing is gone, `IndexSignature` members are documented like properties, and the `splice(-1)` case is guarded.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn create-api-markdown` in `apps/docs`, then open `content/reference/state/computed.mdx` and `content/reference/editor/Geometry2dFilters.mdx` — all declarations on one page with a single frontmatter block.

### Release notes

- Fix reference pages for overloaded and same-named exports documenting only the last declaration

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +52 / -34  |