### PR TITLE
fix(docs): add the users example category and fail on unknown example categories

### DIFF
--- a/apps/docs/scripts/lib/generateExamplesContent.ts
+++ b/apps/docs/scripts/lib/generateExamplesContent.ts
@@ -3,6 +3,9 @@ import { generateSection } from './generateSection'
 
 const { log: nicelog } = console
 
+// Keep in sync with `categories` in apps/examples/src/examples.tsx. An example whose folder
+// isn't listed here has no category row, so it disappears from the sidebar and llms.txt;
+// generateSection throws for that case.
 export const EXAMPLES_CATEGORIES = [
 	{ id: 'getting-started', title: 'Getting started', description: '', groups: [], hero: null },
 	{ id: 'configuration', title: 'Configuration', description: '', groups: [], hero: null },
@@ -11,6 +14,7 @@ export const EXAMPLES_CATEGORIES = [
 	{ id: 'layout', title: 'Page layout', description: '', groups: [], hero: null },
 	{ id: 'events', title: 'Events & effects', description: '', groups: [], hero: null },
 	{ id: 'shapes/tools', title: 'Shapes & tools', description: '', groups: [], hero: null },
+	{ id: 'users', title: 'Users', description: '', groups: [], hero: null },
 	{ id: 'collaboration', title: 'Collaboration', description: '', groups: [], hero: null },
 	{ id: 'data/assets', title: 'Data & assets', description: '', groups: [], hero: null },
 	{ id: 'use-cases', title: 'Use cases', description: '', groups: [], hero: null },

--- a/apps/docs/scripts/lib/generateSection.ts
+++ b/apps/docs/scripts/lib/generateSection.ts
@@ -78,6 +78,13 @@ export function generateSection(section: InputSection, articles: Articles, index
 					// Otherwise, add it to the category's list of articles
 					sectionCategoryArticles[article.categoryId].push(article)
 				}
+			} else if (isExamplesSection) {
+				// An example's category comes from its folder. Falling back to "uncategorized" would
+				// keep the unknown categoryId on the article, and an article whose category has no
+				// row is silently missing from the sidebar and llms.txt.
+				throw new Error(
+					`Unknown example category "${categoryId}" for ${pathname}. Add it to EXAMPLES_CATEGORIES in generateExamplesContent.ts.`
+				)
 			} else {
 				// otherwise, add it to the section's uncategorized list
 				sectionUncategorizedArticles.push(article)


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the four examples in `apps/examples/src/examples/users/` were missing from the tldraw.dev examples sidebar and from `llms-examples.txt` / `llms-full.txt`. Split out of #10258.

### Before

`EXAMPLES_CATEGORIES` in `generateExamplesContent.ts` is a hand-copied duplicate of `categories` in `apps/examples/src/examples.tsx` and never got the `users` category added in #8147. `generateSection` filed examples with an unknown `categoryId` as uncategorized while keeping `categoryId = 'users'` on the article, which has no category row — so the sidebar builder (which iterates category rows) never listed `custom-user`, `sync-custom-user`, `attribution`, or `attribution-timeline`, and `generateLllmsTxt` (which filters by `EXAMPLES_CATEGORIES`) dropped them too.

### After

The `users` category is listed, and `generateSection` throws for an example whose folder isn't in `EXAMPLES_CATEGORIES` so the next missing category fails `refresh-content` instead of silently hiding examples.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn refresh-content` in `apps/docs`, then check the examples sidebar shows a "Users" category with four entries.

### Release notes

- Fix the users examples missing from the tldraw.dev examples sidebar

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +11 / -0   |