### PR TITLE
fix(docs): sort examples without a priority after the prioritized ones

### DIFF
--- a/apps/docs/scripts/lib/generateSection.ts
+++ b/apps/docs/scripts/lib/generateSection.ts
@@ -211,7 +211,7 @@ function getArticleData({
 }): Article {
 	const {
 		group = null,
-		priority = -1,
+		priority = null,
 		hero = null,
 		thumbnail = null,
 		socialImage = null,
@@ -240,7 +240,8 @@ function getArticleData({
 		sectionIndex: 0,
 		groupIndex: -1,
 		groupId: group,
-		categoryIndex: order ?? priority,
+		// Like the examples app, an article without a priority sorts after the prioritized ones
+		categoryIndex: order ?? priority ?? 999999,
 		priority,
 		sectionId: sectionId,
 		author: [author],


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where examples with no `priority` in their README sorted to the top of their category in the tldraw.dev examples sidebar, above examples explicitly given `priority: 0` ("most basic"). Split out of #10258.

### Before

`getArticleData` in `generateSection.ts` defaulted a missing `priority` to `-1` and used `order ?? priority` as `categoryIndex`, so unprioritized examples sorted first — `custom-shape-wrapper` above `custom-shape` in "Shapes & tools", `toolbar-groups` at the top of "UI & theming", `d3-map` at the top of "Use cases". The examples app treats a missing priority as `999999`.

### After

A missing priority is `null` in the db and sorts as `999999`, matching the examples app, so unprioritized examples come last.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn refresh-content` in `apps/docs`; `custom-shape` now heads "Shapes & tools" and `custom-shape-wrapper` sorts last.

### Release notes

- Fix unprioritized examples sorting first in the tldraw.dev examples sidebar

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +3 / -2    |