### PR TITLE
fix(docs): keep prev/next article links out of hidden sections and stop section index collisions

### DIFF
--- a/apps/docs/scripts/lib/generateExamplesContent.ts
+++ b/apps/docs/scripts/lib/generateExamplesContent.ts
@@ -25,11 +25,15 @@ const section: InputSection = {
 	sidebar_behavior: 'show-links',
 }
 
+// Prev/next footer links walk to the section at idx ± 1. Examples have their own sidebar and
+// must not neighbor the regular sections (0..n) or reference (999999).
+const EXAMPLES_SECTION_INDEX = 888888
+
 export async function generateExamplesContent(): Promise<GeneratedContent> {
 	const articles: Articles = {}
 
 	try {
-		const outputExamplesSection = generateSection(section, articles, 0)
+		const outputExamplesSection = generateSection(section, articles, EXAMPLES_SECTION_INDEX)
 		const contentComplete = { sections: [outputExamplesSection], articles }
 
 		return contentComplete

--- a/apps/docs/utils/ContentDatabase.ts
+++ b/apps/docs/utils/ContentDatabase.ts
@@ -118,16 +118,10 @@ export class ContentDatabase {
 			sectionIndex
 		)
 
-		// If there's no next, then get the LAST article from the prev section
+		// If there's no prev, then get the LAST article from the prev section
 		if (!prev) {
-			const { idx } = await db.get(
-				`SELECT idx FROM sections WHERE sections.id = ?`,
-				article.sectionId
-			)
-
-			const prevSection = await db.get(`SELECT id FROM sections WHERE sections.idx = ?`, idx - 1)
-			if (prevSection) {
-				const { id: prevSectionId } = prevSection
+			const prevSectionId = await this.getAdjacentSectionId(article.sectionId, -1)
+			if (prevSectionId) {
 				// get the article with the section id and the highest section index
 				prev = await db.get<Article>(
 					// here we only need certian info for the link
@@ -155,15 +149,8 @@ export class ContentDatabase {
 
 		// If there's no next, then get the FIRST article from the next section
 		if (!next) {
-			const { idx } = await db.get(
-				`SELECT idx FROM sections WHERE sections.id = ?`,
-				article.sectionId
-			)
-
-			const nextSection = await db.get(`SELECT id FROM sections WHERE sections.idx = ?`, idx + 1)
-
-			if (nextSection) {
-				const { id: nextSectionId } = nextSection
+			const nextSectionId = await this.getAdjacentSectionId(article.sectionId, 1)
+			if (nextSectionId) {
 				next = await db.get<Article>(
 					`SELECT id, title, categoryId, sectionId, path FROM articles
 					 	 WHERE articles.sectionId = ?
@@ -174,6 +161,30 @@ export class ContentDatabase {
 		}
 
 		return { prev: prev ?? null, next: next ?? null }
+	}
+
+	/**
+	 * The section the prev/next footer links cross into from the edge of `sectionId`, or null.
+	 * Sections only neighbor each other at consecutive idx values, so far-away idx (reference,
+	 * examples) stay self-contained. Hidden sections (release notes) are stepped over and never
+	 * link out themselves.
+	 */
+	private async getAdjacentSectionId(sectionId: string, direction: -1 | 1) {
+		const db = await this.getDb()
+		const section = await db.get<Pick<Section, 'id' | 'sidebar_behavior'> & { idx: number }>(
+			`SELECT id, idx, sidebar_behavior FROM sections WHERE id = ?`,
+			sectionId
+		)
+		if (!section || section.sidebar_behavior === 'hidden') return null
+
+		for (let idx = section.idx + direction; ; idx += direction) {
+			const neighbor = await db.get<Pick<Section, 'id' | 'sidebar_behavior'>>(
+				`SELECT id, sidebar_behavior FROM sections WHERE idx = ?`,
+				idx
+			)
+			if (!neighbor) return null
+			if (neighbor.sidebar_behavior !== 'hidden') return neighbor.id
+		}
 	}
 
 	// TODO(mime): make this more generic, not per docs area

--- a/apps/docs/utils/addContent.ts
+++ b/apps/docs/utils/addContent.ts
@@ -52,12 +52,14 @@ export async function addContentToDb(
     ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	)
 
-	for (let i = 0; i < content.sections.length; i++) {
-		const section = content.sections[i]
+	for (const section of content.sections) {
 		try {
+			// `section.index` is assigned by the generators across all content sources (regular
+			// sections 0..n, examples and reference far away). addContentToDb is called once per
+			// source, so a per-call loop index would give two sections the same idx.
 			await sectionInsert.run(
 				section.id,
-				section.id === 'reference' ? 99999 : i,
+				section.index,
 				section.title,
 				section.description,
 				section.path,


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the prev/next footer links on tldraw.dev walked into the hidden release-notes section: `/docs/editor` linked Prev → "v2.0.0", the last example linked Next → "Next release", and `/releases/v2.0.0` linked Next → `/docs/editor`. Split out of #10258.

### Before

`addContentToDb` stored each section's `idx` as the loop index of that call instead of the `index` the generator computed. It is called once per content source, so examples (idx 0) collided with getting-started (idx 0) while releases sat at 1 and docs at 2. `ContentDatabase.getArticleLinks` then stepped to `idx ± 1` without checking `sidebar_behavior`, so it crossed into the hidden releases section and out of it again.

### After

`addContentToDb` writes `section.index`; examples get a far-away index (888888, alongside reference's 999999) so they never neighbor the regular sections. `getArticleLinks` resolves the adjacent section through `getAdjacentSectionId`, which skips hidden sections and never links out of one. `/docs/editor` Prev now goes to the Releases page, the last example has no Next, and release notes don't link to docs.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn refresh-content` in `apps/docs`, `sqlite3 content.db 'select id, idx from sections'` — examples=888888, reference=999999, the rest 0..n.
2. Open `/docs/editor`, `/examples/timeline-scrubber`, and `/releases/v2.0.0` and check the footer links.

### Release notes

- Fix prev/next article links on tldraw.dev pointing into the release notes

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +39 / -22  |