### PR TITLE
fix(docs): restore the sync demo and editor API shortcuts in the examples sidebar

### DIFF
--- a/apps/docs/components/docs/docs-sidebar-utils.ts
+++ b/apps/docs/components/docs/docs-sidebar-utils.ts
@@ -13,6 +13,10 @@ function hasChildren(
 	return 'children' in link
 }
 
+// Examples duplicated into the examples sidebar's "Getting started" category. Matched by url,
+// not article id: ids (`examples/collaboration/sync-demo`) change when an example moves category.
+const EXAMPLES_ALSO_IN_GETTING_STARTED = ['/examples/sync-demo', '/examples/api']
+
 /**
  * Processes sidebar content by extracting elements and handling special cases
  * like copying examples to the getting-started category.
@@ -25,29 +29,22 @@ export function processSidebarContent(
 	const elements =
 		skipFirstLevel && hasChildren(sidebar.links[0]) ? sidebar.links[0].children : sidebar.links
 
-	// Manually copy the sync example and the editor API example to the getting started category
 	if (sectionId === 'examples') {
-		const gettingStartedCategory = elements.find(
-			(v: any) => v?.url === '/examples/getting-started'
-		) as SidebarContentCategoryLink
-		const collaborationCategory = elements.find(
-			(v: any) => v?.url === '/examples/collaboration'
-		) as SidebarContentCategoryLink
-		const editorApiCategory = elements.find(
-			(v: any) => v?.url === '/examples/editor-api'
-		) as SidebarContentCategoryLink
-		const syncDemoExample = collaborationCategory.children.find(
-			(v: any) => v?.articleId === 'sync-demo'
-		) as SidebarContentArticleLink | undefined
-		const editorApiExample = editorApiCategory.children.find((v: any) => v?.articleId === 'api') as
-			| SidebarContentArticleLink
-			| undefined
+		const categories = elements.filter(
+			(v): v is SidebarContentCategoryLink => v.type === 'category'
+		)
+		const gettingStartedCategory = categories.find((v) => v.url === '/examples/getting-started')
 
-		// An example that's been renamed or moved won't be found. Pushing the `undefined` would
-		// crash the sidebar, which renders every entry.
-		for (const example of [syncDemoExample, editorApiExample]) {
-			if (example && !gettingStartedCategory.children.includes(example)) {
-				gettingStartedCategory.children.push(example)
+		// An example that's been renamed or moved won't be found. Pushing `undefined` would crash
+		// the sidebar, which renders every entry. The cached link tree is shared between renders,
+		// so don't push the same example twice either.
+		if (gettingStartedCategory) {
+			for (const url of EXAMPLES_ALSO_IN_GETTING_STARTED) {
+				if (gettingStartedCategory.children.some((v) => v.url === url)) continue
+				const example = categories
+					.flatMap((category) => category.children)
+					.find((v): v is SidebarContentArticleLink => v.type === 'article' && v.url === url)
+				if (example) gettingStartedCategory.children.push(example)
 			}
 		}
 	}


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the "Getting started" category of the tldraw.dev examples sidebar only listed "Tldraw component": the sync demo and editor API examples that are meant to be copied into it were missing. Split out of #10258.

### Before

`processSidebarContent` looked the two examples up by `articleId === 'sync-demo'` / `'api'`, but since #7507 `ContentDatabase` sets `articleId` to the composite article id (`examples/collaboration/sync-demo`), so the lookups were always `undefined` and the `example &&` guard added in #9970 skipped the push.

### After

The shortcuts are matched by url (`/examples/sync-demo`, `/examples/api`), which doesn't change when an example moves category, searched across all categories rather than a hard-coded one, and deduplicated against the shared cached link tree.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn dev-docs`, open any example — "Getting started" lists Tldraw component, Sync demo, and Editor API.

### Release notes

- Fix the sync demo and editor API examples missing from the examples sidebar's "Getting started" category

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +18 / -21  |