### PR TITLE
fix(docs): show the edit link on articles that have no author

### DIFF
--- a/apps/docs/components/docs/docs-article-info.tsx
+++ b/apps/docs/components/docs/docs-article-info.tsx
@@ -7,8 +7,9 @@ import { Article } from '@/types/content-types'
 const githubContentRoot = 'https://github.com/tldraw/tldraw/blob/main/apps/docs/content/'
 
 export function DocsArticleInfo({ article }: { article: Article }) {
-	if (article.authorId === 'api') {
-		// This article is actually source code and we link to it already in 'See source code'
+	if (article.sectionId === 'reference') {
+		// Reference pages are source code and already link to it via 'See source code'. Keyed on
+		// section, not `authorId === 'api'`: that's also the default for articles with no `author:`.
 		return null
 	}
 


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where most hand-written tldraw.dev articles had no "Edit this page on GitHub" link or "Last edited" date. Split out of #10258.

### Before

`DocsArticleInfo` returned null when `article.authorId === 'api'`, a sentinel meant to hide the box on generated reference pages. But `generateSection` defaults `author` to `'api'` for any article without an `author:` frontmatter key, so 70 of the 93 docs/sdk-features/community/getting-started articles (e.g. `/sdk-features/accessibility`) lost the link while `/docs/editor` (`author: steveruizok`) kept it.

### After

The check is keyed on `article.sectionId === 'reference'`, which is what the sentinel was standing in for.

### Change type

- [x] `bugfix`

### Test plan

1. Open `/sdk-features/accessibility` — the article info box with the GitHub edit link renders; reference pages still don't show it.

### Release notes

- Fix the "Edit this page on GitHub" link missing from articles without an author

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +3 / -2    |