### PR TITLE
fix(docs): ignore the "/" search shortcut inside text fields

### DIFF
--- a/apps/docs/components/search/SearchButton.tsx
+++ b/apps/docs/components/search/SearchButton.tsx
@@ -11,6 +11,16 @@ import { twJoin } from 'tailwind-merge'
 import { cn } from '@/utils/cn'
 import { Search } from '.'
 
+function isEditableElement(target: EventTarget | null) {
+	if (!(target instanceof HTMLElement)) return false
+	return (
+		target.isContentEditable ||
+		target.tagName === 'INPUT' ||
+		target.tagName === 'TEXTAREA' ||
+		target.tagName === 'SELECT'
+	)
+}
+
 export function SearchButton({
 	type,
 	layout,
@@ -28,6 +38,10 @@ export function SearchButton({
 
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key === '/') {
+				// A bare "/" is only a shortcut outside text fields, otherwise typing a path into
+				// the feedback textarea opens the dialog and steals focus mid-word.
+				if (isEditableElement(e.target)) return
+				e.preventDefault()
 				setOpen(true)
 			} else if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
 				setOpen((open) => !open)


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where typing `/` into any text field on tldraw.dev — the feedback textarea, for instance — opened the search dialog and stole focus mid-word. Split out of #10258.

### Before

`SearchButton` registered a document-level `keydown` listener that opened search on any `/` keypress without checking the event target. Typing "see /docs" into the "Is this page helpful?" textarea left it as "see /", mounted the dialog with "docs" in its autofocused combobox, and Escape returned focus to `body` rather than the textarea.

### After

The shortcut is ignored when the target is an input, textarea, select, or contenteditable element, and `preventDefault` stops the `/` from being typed into whatever would receive it otherwise.

### Change type

- [x] `bugfix`

### Test plan

1. Focus the feedback textarea on any article, type `a/b` — no dialog, text intact. Press `/` with nothing focused — dialog opens.

### Release notes

- Fix the "/" search shortcut firing while typing in text fields

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +14 / -0   |