### PR TITLE
fix(docs): highlight .tsx example files with the tsx grammar

### DIFF
--- a/apps/docs/components/content/code-files.tsx
+++ b/apps/docs/components/content/code-files.tsx
@@ -2,6 +2,7 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript'
 import { createHighlighterCoreSync, hastToHtml } from 'shiki/core'
 import css from 'shiki/dist/langs/css.mjs'
+import tsx from 'shiki/dist/langs/tsx.mjs'
 import ts from 'shiki/dist/langs/typescript.mjs'
 import theme from 'shiki/dist/themes/github-dark.mjs'
 import { cn } from '@/utils/cn'
@@ -11,7 +12,7 @@ import { CopyButton } from './copy-button'
 // So here we create a synchronous version of the highlighter.
 const shiki = createHighlighterCoreSync({
 	themes: [theme],
-	langs: [ts, css],
+	langs: [ts, tsx, css],
 	engine: createJavaScriptRegexEngine(),
 })
 
@@ -55,7 +56,12 @@ export function CodeFiles({
 				)}
 			>
 				{files.map(({ content, name }, index) => {
-					const lang = name.endsWith('.css') ? 'css' : 'ts'
+					// the typescript grammar has no JSX, so .tsx/.jsx need the tsx grammar
+					const lang = name.endsWith('.css')
+						? 'css'
+						: name.endsWith('.tsx') || name.endsWith('.jsx')
+							? 'tsx'
+							: 'ts'
 					const ast = shiki.codeToHast(content, { lang, theme })
 					const codeElem = (ast.children[0] as any).children[0]
 					return (


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the code tabs on tldraw.dev example pages rendered JSX with broken highlighting. Split out of #10258.

### Before

`CodeFiles` highlighted every non-`.css` file with the `typescript` grammar (the only TS grammar loaded into the sync shiki instance), which has no JSX support. On `/examples/basic`, `<div className="tldraw__editor">` rendered as an operator token plus plain text; nearly all 212 example pages are `.tsx`.

### After

The `tsx` grammar is loaded alongside `typescript`, and `.tsx`/`.jsx` files use it. The built `examples/basic.html` now emits tag and attribute tokens (`<span style="color:#85E89D">div</span>`).

### Change type

- [x] `bugfix`

### Test plan

1. Open `/examples/basic` — JSX tags and attributes are colored.

### Release notes

- Fix JSX highlighting in example code tabs on tldraw.dev

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +8 / -2    |