### PR TITLE
fix(docs): serialize content refreshes in the dev watcher

### DIFF
--- a/apps/docs/watcher.ts
+++ b/apps/docs/watcher.ts
@@ -8,21 +8,30 @@ import { nicelog } from './utils/nicelog'
 // @ts-expect-error whatever
 process.env.NODE_ENV = 'development'
 
-refreshContent({ silent: true })
-
-fs.watch(
-	'content',
-	{ persistent: true, recursive: true },
-	debounce(async (eventType, fileName) => {
-		nicelog(`Refreshing after ${eventType}: ${fileName}`)
-		// todo: if a file was only updated, then only update the file that changed, any links that point to it, etc.
+// Refreshes are chained so they never overlap: each one drops and rebuilds every table in
+// content.db, and two running at once fail with "no such table" / UNIQUE violations and can
+// leave the db half-filled.
+let refreshQueue: Promise<void> = Promise.resolve()
+function queueRefresh(reason: string) {
+	refreshQueue = refreshQueue.then(async () => {
+		nicelog(`Refreshing after ${reason}`)
 		try {
 			await refreshContent({ silent: true })
 			clients.forEach((ws) => ws.send('refresh'))
 		} catch (e: any) {
+			// an unhandled rejection would take down `yarn dev` (concurrently --kill-others)
 			nicelog(`x Could not refresh content: ${e.message}`)
 		}
-	}, 250)
+	})
+}
+
+queueRefresh('startup')
+
+fs.watch(
+	'content',
+	{ persistent: true, recursive: true },
+	// todo: if a file was only updated, then only update the file that changed, any links that point to it, etc.
+	debounce((eventType, fileName) => queueRefresh(`${eventType}: ${fileName}`), 250)
 )
 
 const wss = new WebSocketServer({ port: 3201 })


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where saving several docs files in quick succession during `yarn dev-docs` could leave `content.db` half-built or crash the dev process. Split out of #10258.

### Before

`watcher.ts` kicked off `refreshContent()` on startup and again from a debounced `fs.watch` callback, with nothing preventing two refreshes from overlapping. Each refresh drops and rebuilds every table, so a second one starting mid-way failed with "no such table" / UNIQUE violations and could leave the db partially filled. The startup call's rejection was also unhandled, which takes down the whole `yarn dev` (`concurrently --kill-others`).

### After

Refreshes go through a promise queue so each starts after the previous one settles, and the startup refresh uses the same guarded path so a failure is logged rather than crashing the dev server.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn dev-docs`, then save two content files within a second of each other — both refreshes complete in order and the sidebar reloads.

### Release notes

- Fix overlapping content refreshes in the docs dev watcher

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +18 / -9   |