### PR TITLE
fix(docs): scope auto-linked heading lookups to the linked article

### DIFF
--- a/apps/docs/utils/autoLinkDocs.ts
+++ b/apps/docs/utils/autoLinkDocs.ts
@@ -51,7 +51,12 @@ export async function autoLinkDocsForArticle(
 		let str = ''
 
 		if (heading) {
-			const headingRow = await db.get('SELECT slug FROM headings WHERE slug = ?', heading)
+			// scoped to the article: the same slug (`children`, `dispose`...) exists on many pages
+			const headingRow = await db.get(
+				'SELECT slug FROM headings WHERE articleId = ? AND slug = ?',
+				article.id,
+				heading
+			)
 			if (!headingRow) throw Error(`Could not find heading for ${_title} (${heading}) in ${id}`)
 			str = `[\`${title}.${heading}\`](/${article.id}#${headingRow.slug})`
 		} else {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `[Editor.dispose](?)`-style auto-links in docs content were validated against headings from any page, so a typo'd member name still passed as long as some other page had a heading with that slug. Split out of #10258.

### Before

`autoLinkDocsForArticle` checked `SELECT slug FROM headings WHERE slug = ?` with no `articleId`. Slugs like `children`, `dispose`, or `id` exist on many reference pages, so the check never failed for them even when the target article had no such member, and the generated link pointed at a non-existent anchor.

### After

The lookup is `WHERE articleId = ? AND slug = ?`, so an auto-link only resolves when the heading exists on the article being linked.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn refresh-content` and `yarn check-links --fail` in `apps/docs` both still pass; an `[Editor.nope](?)` link in a content file now fails the refresh with "Could not find heading".

### Release notes

- Fix auto-linked API member references validating against headings from other pages

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +6 / -1    |