### PR TITLE
fix(docs): stop the link checker accepting section and category paths as pages

### DIFF
--- a/apps/docs/scripts/lib/checkBrokenLinks.ts
+++ b/apps/docs/scripts/lib/checkBrokenLinks.ts
@@ -15,6 +15,11 @@ const INTERNAL_REWRITES: Record<string, string> = {
 	'/installation': '/getting-started/installation',
 }
 
+// Section and category paths are not pages: only article paths are generated
+// (dynamicParams = false) and page.tsx 404s for anything else. These section roots are
+// reachable only because next.config.js redirects them to an article.
+const REDIRECTED_SECTION_PATHS = ['/docs', '/examples', '/reference', '/starter-kits']
+
 // Path prefixes that are served by another system (e.g. the marketing site)
 // rather than this Next.js app, so they will never appear in the docs DB.
 // Matches the prefix as an exact path OR as a parent of a subpath:
@@ -140,17 +145,12 @@ export async function checkBrokenLinks(): Promise<number> {
 	const articles = await db.all<{ path: string | null; content: string }[]>(
 		'SELECT path, content FROM articles'
 	)
-	const sections = await db.all<{ path: string }[]>('SELECT path FROM sections')
-	const categories = await db.all<{ path: string | null }[]>('SELECT path FROM categories')
 
 	for (const row of articles) {
 		if (row.path) validPaths.add(row.path)
 	}
-	for (const row of sections) {
-		if (row.path) validPaths.add(row.path)
-	}
-	for (const row of categories) {
-		if (row.path) validPaths.add(row.path)
+	for (const path of REDIRECTED_SECTION_PATHS) {
+		validPaths.add(path)
 	}
 
 	// Add internal rewrite sources (these are valid URLs that rewrite to DB paths)


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where `yarn check-links --fail` accepted links to section and category paths (`/examples/collaboration`, `/community`, …) that 404 on the live site. Split out of #10258.

### Before

`checkBrokenLinks` seeded its valid-path set from the `sections` and `categories` tables as well as `articles`. But only article paths are generated (`dynamicParams = false` in `page.tsx`), and a section root such as `/docs` or `/examples` only works because `next.config.js` redirects it to an article. Category paths have no redirect at all, so a content link to one passed the checker and shipped broken.

### After

Only article paths plus the four redirected section roots (`/docs`, `/examples`, `/reference`, `/starter-kits`) count as valid internal targets.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn check-links --fail` in `apps/docs` still passes on current content; adding `[x](/examples/collaboration)` to an article now fails it.

### Release notes

- Fix the docs link checker accepting links to non-existent section and category pages

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +7 / -7    |