### PR TITLE
fix(docs): order llms.txt release lists by version

### DIFF
--- a/apps/docs/scripts/lib/generateLllmsTxt.ts
+++ b/apps/docs/scripts/lib/generateLllmsTxt.ts
@@ -27,8 +27,10 @@ async function getMarkdownForOverview(db: DbType) {
 	let result = `# tldraw SDK\n\n`
 
 	const features = await db.all('SELECT * FROM articles WHERE sectionId = "sdk-features"')
+	// sectionIndex carries the version order generateSection worked out for the sidebar; sorting
+	// by id would be a string sort that puts v3.9.0 above v3.10.0
 	const releases = await db.all(
-		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY id DESC`
+		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY sectionIndex ASC`
 	)
 	const examples = await db.all('SELECT * FROM articles WHERE sectionId = "examples"')
 
@@ -71,7 +73,7 @@ async function getMarkdownForDocs(db: DbType) {
 async function getMarkdownForReleases(db: DbType) {
 	let result = `# tldraw SDK releases\n`
 	const releases = await db.all(
-		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY id DESC`
+		`SELECT * FROM articles WHERE sectionId = "releases" AND id NOT LIKE '%/next' ORDER BY sectionIndex ASC`
 	)
 
 	for (const release of releases) {
@@ -124,9 +126,9 @@ const ALLOWED_FILE_TYPES = ['tsx', 'ts', 'js', 'jsx', 'md', 'css', 'html']
 function getMarkdownForFile(fileName: string, fileContent: string) {
 	const type = fileName.split('.').pop()
 
-	// Skip non-code files, eg: PDFs, PNGs
+	// Skip non-code files, eg: PDFs, PNGs, SVGs (which generateSection does collect)
 	if (!ALLOWED_FILE_TYPES.includes(type ?? '')) {
-		return
+		return ''
 	}
 
 	let result = `\n\n## ${fileName}`


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where the release lists in `llms.txt` and `llms-full.txt` were in string order rather than version order. Split out of #10258.

### Before

`generateLllmsTxt` selected releases with `ORDER BY id DESC`. Ids are strings, so `v3.9.0` sorted above `v3.10.0` and `v4.0.0`. `getMarkdownForFile` also returned `undefined` for non-code files (SVGs collected by `generateSection`), which ends up as the literal text "undefined" in `llms-full.txt`.

### After

Releases are ordered by `sectionIndex`, the version order `generateSection` already computes for the sidebar; skipped files contribute an empty string.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn create-llms-txt` in `apps/docs` and check the release list in `public/llms.txt` runs newest to oldest with `v3.10.0` above `v3.9.0`.

### Release notes

- Fix release ordering in the tldraw.dev llms.txt files

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +6 / -4    |