### PR TITLE
fix(docs): tolerate examples without component code and articles without an embed

### DIFF
--- a/apps/docs/app/(docs)/[...slug]/page.tsx
+++ b/apps/docs/app/(docs)/[...slug]/page.tsx
@@ -107,7 +107,7 @@ export default async function Page(props: { params: Promise<{ slug: string | str
 								className="mb-6"
 							/>
 						)}
-						<StarterKitEmbed id={content.article.embed ?? content.article.id} />
+						{content.article.embed && <StarterKitEmbed id={content.article.embed} />}
 					</div>
 					<div className="flex flex-col xl:flex-row gap-6 relative">
 						<DocsStarterSidebar article={content.article} />

--- a/apps/docs/components/content/example.tsx
+++ b/apps/docs/components/content/example.tsx
@@ -4,9 +4,10 @@ import { CodeFiles } from './code-files'
 
 export function Example({ article }: { article: Article }) {
 	const server = 'https://examples.tldraw.com'
-	const additionalFiles = JSON.parse(article.componentCodeFiles ?? '')
+	// both are null when the README has no `component:` frontmatter
+	const additionalFiles = article.componentCodeFiles ? JSON.parse(article.componentCodeFiles) : {}
 	const files = [
-		{ name: 'App.tsx', content: article.componentCode },
+		...(article.componentCode ? [{ name: 'App.tsx', content: article.componentCode }] : []),
 		...Object.keys(additionalFiles).map((key) => ({ name: key, content: additionalFiles[key] })),
 	]
 


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes two crashes-in-waiting in the docs article page. Split out of #10258.

### Before

`Example` did `JSON.parse(article.componentCodeFiles ?? '')` and always pushed `{ name: 'App.tsx', content: article.componentCode }`; both columns are null for an example README with no `component:` frontmatter, so `JSON.parse('')` threw. The starter-kits page rendered `<StarterKitEmbed id={article.embed ?? article.id} />`, so an article without an `embed` tried to embed a sandbox named after its own id (`starter-kits/overview`).

### After

`Example` parses the files only when present and omits `App.tsx` when there is no component code; `StarterKitEmbed` renders only when `embed` is set.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn dev-docs`, open `/starter-kits` (no embed) and an example page — both render; no console errors.

### Release notes

- Fix the docs article page crashing on examples without component code

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +4 / -3    |