### PR TITLE
fix(docs): publish the sidebar link cache only after the walk completes

### DIFF
--- a/apps/docs/utils/ContentDatabase.ts
+++ b/apps/docs/utils/ContentDatabase.ts
@@ -177,10 +177,7 @@ export class ContentDatabase {
 	}
 
 	// TODO(mime): make this more generic, not per docs area
-	private _sidebarContentLinks: SidebarContentLink[] | undefined
-	private _sidebarReferenceContentLinks: SidebarContentLink[] | undefined
-	private _sidebarExamplesContentLinks: SidebarContentLink[] | undefined
-	private _sidebarStarterKitsContentLinks: SidebarContentLink[] | undefined
+	private _sidebarLinksBySidebar = new Map<string, SidebarContentLink[]>()
 
 	async getSidebarContentList({
 		sectionId,
@@ -193,14 +190,8 @@ export class ContentDatabase {
 	}): Promise<SidebarContentList> {
 		let links: SidebarContentLink[]
 
-		const cachedLinks =
-			sectionId === 'examples'
-				? this._sidebarExamplesContentLinks
-				: sectionId === 'reference'
-					? this._sidebarReferenceContentLinks
-					: sectionId === 'starter-kits'
-						? this._sidebarStarterKitsContentLinks
-						: this._sidebarContentLinks
+		const sidebar = getSidebarForSection(sectionId)
+		const cachedLinks = this._sidebarLinksBySidebar.get(sidebar)
 		if (cachedLinks && process.env.NODE_ENV !== 'development') {
 			// Use the previously cached sidebar links
 			links = cachedLinks
@@ -220,24 +211,7 @@ export class ContentDatabase {
 					continue
 				}
 
-				if (
-					(sectionId === 'reference' && section.id !== 'reference') ||
-					(sectionId !== 'reference' && section.id === 'reference')
-				) {
-					continue
-				}
-
-				if (
-					(sectionId === 'examples' && section.id !== 'examples') ||
-					(sectionId !== 'examples' && section.id === 'examples')
-				) {
-					continue
-				}
-
-				if (
-					(sectionId === 'starter-kits' && section.id !== 'starter-kits') ||
-					(sectionId !== 'starter-kits' && section.id === 'starter-kits')
-				) {
+				if (getSidebarForSection(section.id) !== sidebar) {
 					continue
 				}
 
@@ -319,18 +293,12 @@ export class ContentDatabase {
 					url: section.path,
 					children,
 				})
-
-				// Cache the links structure for next time
-				if (sectionId === 'examples') {
-					this._sidebarExamplesContentLinks = links
-				} else if (sectionId === 'reference') {
-					this._sidebarReferenceContentLinks = links
-				} else if (sectionId === 'starter-kits') {
-					this._sidebarStarterKitsContentLinks = links
-				} else {
-					this._sidebarContentLinks = links
-				}
 			}
+
+			// Only publish the cache once the walk is complete: concurrent callers (the
+			// force-dynamic /search route, static generation) would otherwise pick up the
+			// half-built array and render a sidebar missing its later sections.
+			this._sidebarLinksBySidebar.set(sidebar, links)
 		}
 
 		return {
@@ -340,6 +308,13 @@ export class ContentDatabase {
 			links,
 		}
 	}
+}
+
+// These sections each get a sidebar of their own; everything else shares the docs sidebar.
+const STANDALONE_SIDEBAR_SECTIONS = new Set(['reference', 'examples', 'starter-kits'])
+
+function getSidebarForSection(sectionId: string | undefined) {
+	return sectionId && STANDALONE_SIDEBAR_SECTIONS.has(sectionId) ? sectionId : 'docs'
 }
 
 export const db = new ContentDatabase()


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a tldraw.dev page could render a sidebar missing its later sections. Split out of #10258.

### Before

`ContentDatabase.getSidebarContentList` assigned the in-progress `links` array to the per-sidebar cache field from inside the section loop, on the first iteration that produced a section. Concurrent callers — the `force-dynamic` `/search` route, parallel static generation workers — could pick up the half-built array and render from it. The cache was also four hand-named fields selected by a nested ternary, with a matching set of `if` blocks to skip sections that belong to another sidebar.

### After

The cache is a `Map` keyed by sidebar id (`docs`, `reference`, `examples`, `starter-kits`), written once after the walk finishes, and the "which sidebar does this section belong to" logic lives in one `getSidebarForSection` helper used for both the lookup and the filter.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn build` in `apps/docs` — every built page's sidebar has the full section list.

### Release notes

- Fix tldraw.dev pages occasionally rendering a partial sidebar

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +16 / -41  |