### PR TITLE
fix(editor): apply fixes from a full review of packages/editor

### DIFF
--- a/apps/docs/content/sdk-features/camera.mdx
+++ b/apps/docs/content/sdk-features/camera.mdx
@@ -53,7 +53,7 @@ editor.setCameraOptions({
 
 Set `isLocked` to freeze the camera for fixed-viewport apps. Camera methods then do nothing unless you pass `force: true`.
 
-`wheelBehavior` decides what the mouse wheel or trackpad scroll does: `'pan'`, `'zoom'`, or `'none'`. If the user has set an input mode in their preferences, that preference wins: `'trackpad'` pans and `'mouse'` zooms.
+`wheelBehavior` decides what the mouse wheel or trackpad scroll does: `'pan'`, `'zoom'`, or `'none'`. If the user has set an input mode in their preferences, that preference wins between the two: `'trackpad'` pans and `'mouse'` zooms. `'none'` disables the wheel regardless of the preference.
 
 `panSpeed` and `zoomSpeed` are multipliers on input sensitivity. Values below 1 slow movement down, values above 1 speed it up.
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1212,6 +1212,10 @@ export class Editor extends EventEmitter<TLEventMap> {
     deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
         isolateShapes?: boolean | undefined;
     }): this;
+    // @internal (undocumented)
+    _deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
+        isolateShapes?: boolean | undefined;
+    }): this;
     deletePage(page: TLPage | TLPageId): this;
     deleteShape(id: TLShapeId): this;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -138,7 +138,7 @@ export class Arc2d extends Geometry2d {
     // (undocumented)
     getVertices(): Vec[];
     // (undocumented)
-    hitTestLineSegment(A: VecLike, B: VecLike): boolean;
+    hitTestLineSegment(A: VecLike, B: VecLike, distance?: number): boolean;
     // (undocumented)
     nearestPoint(point: VecLike): Vec;
 }
@@ -627,7 +627,7 @@ export class CubicSpline2d extends Geometry2d {
     // (undocumented)
     getVertices(): Vec[];
     // (undocumented)
-    hitTestLineSegment(A: VecLike, B: VecLike): boolean;
+    hitTestLineSegment(A: VecLike, B: VecLike, distance?: number): boolean;
     // (undocumented)
     nearestPoint(A: VecLike): Vec;
     // (undocumented)
@@ -1777,7 +1777,7 @@ export class Ellipse2d extends Geometry2d {
     // (undocumented)
     getVertices(): any[];
     // (undocumented)
-    hitTestLineSegment(A: VecLike, B: VecLike): boolean;
+    hitTestLineSegment(A: VecLike, B: VecLike, distance?: number): boolean;
     // (undocumented)
     nearestPoint(A: VecLike): Vec;
 }
@@ -1821,6 +1821,8 @@ export class FontManager {
     dispose(): void;
     // (undocumented)
     ensureFontIsLoaded(font: TLFontFace): Promise<void>;
+    // @internal (undocumented)
+    getFontLoadEpoch(): number;
     // (undocumented)
     getShapeFontFaces(shape: TLShape | TLShapeId): TLFontFace[];
     // (undocumented)
@@ -3244,7 +3246,7 @@ export class Stadium2d extends Geometry2d {
     // (undocumented)
     getVertices(): Vec[];
     // (undocumented)
-    hitTestLineSegment(A: VecLike, B: VecLike): boolean;
+    hitTestLineSegment(A: VecLike, B: VecLike, distance?: number): boolean;
     // (undocumented)
     nearestPoint(A: VecLike): Vec;
 }

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -311,18 +311,23 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const ErrorFallback =
 		components?.ErrorFallback === undefined ? DefaultErrorFallback : components?.ErrorFallback
 
-	// Merge deprecated props with options
-	// options values take precedence over the deprecated props
+	// Merge deprecated props with options (options win). Nested option objects are
+	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
+	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
+	const camera = useShallowObjectIdentity(_options?.camera)
+	const text = useShallowObjectIdentity(_options?.text ?? _textOptions)
+	const _mergedDeepLinks = _options?.deepLinks ?? _deepLinks
+	const _deepLinkOptions = useShallowObjectIdentity(
+		_mergedDeepLinks === true ? undefined : _mergedDeepLinks
+	)
+	const deepLinks = _mergedDeepLinks === true ? true : _deepLinkOptions
 	const mergedOptions = useMemo(() => {
 		let result = _options
-		if (_textOptions) {
-			result = { ...result, text: result?.text ?? _textOptions }
-		}
-		if (_deepLinks !== undefined) {
-			result = { ...result, deepLinks: result?.deepLinks ?? _deepLinks }
-		}
+		if (camera !== undefined) result = { ...result, camera }
+		if (text !== undefined) result = { ...result, text }
+		if (deepLinks !== undefined) result = { ...result, deepLinks }
 		return result
-	}, [_options, _textOptions, _deepLinks])
+	}, [_options, camera, text, deepLinks])
 
 	// apply defaults. if you're using the bare @tldraw/editor package, we
 	// default these to the "tldraw zero" configuration. We have different
@@ -660,19 +665,22 @@ function TldrawEditorWithReadyStore({
 	useEffect(
 		function handleFocusOnPointerDownForPreserveFocusMode() {
 			if (!editor) return
+			const container = editor.getContainer()
 
 			function handleFocusOnPointerDown() {
 				if (!editor) return
 				editor.focus()
 			}
 
-			function handleBlurOnPointerDown() {
+			function handleBlurOnPointerDown(e: PointerEvent) {
 				if (!editor) return
+				// The same pointerdown bubbles from the container to the body; blurring here would
+				// cancel the interaction the container listener just focused for.
+				if (container.contains(e.target as Node | null)) return
 				editor.blur()
 			}
 
 			if (autoFocus && noAutoFocus()) {
-				const container = editor.getContainer()
 				container.addEventListener('pointerdown', handleFocusOnPointerDown)
 				container.ownerDocument.body.addEventListener('pointerdown', handleBlurOnPointerDown)
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -46,7 +46,7 @@ import { EditorProvider, useEditor } from './hooks/useEditor'
 import { EditorComponentsProvider } from './hooks/useEditorComponents'
 import { useEvent } from './hooks/useEvent'
 import { useForceUpdate } from './hooks/useForceUpdate'
-import { useShallowObjectIdentity } from './hooks/useIdentity'
+import { useDeepObjectIdentity, useShallowObjectIdentity } from './hooks/useIdentity'
 import { useLocalStore } from './hooks/useLocalStore'
 import { useRefState } from './hooks/useRefState'
 import { useStateAttribute } from './hooks/useStateAttribute'
@@ -314,13 +314,13 @@ export const TldrawEditor = memo(function TldrawEditor({
 	// Merge deprecated props with options (options win). Nested option objects are
 	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
 	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
-	const camera = useShallowObjectIdentity(_options?.camera)
+	const camera = useDeepObjectIdentity(_options?.camera)
 	const text = useShallowObjectIdentity(_options?.text ?? _textOptions)
-	const _mergedDeepLinks = _options?.deepLinks ?? _deepLinks
-	const _deepLinkOptions = useShallowObjectIdentity(
-		_mergedDeepLinks === true ? undefined : _mergedDeepLinks
+	const mergedDeepLinks = _options?.deepLinks ?? _deepLinks
+	const deepLinkOptions = useDeepObjectIdentity(
+		mergedDeepLinks === true ? undefined : mergedDeepLinks
 	)
-	const deepLinks = _mergedDeepLinks === true ? true : _deepLinkOptions
+	const deepLinks = mergedDeepLinks === true ? true : deepLinkOptions
 	const mergedOptions = useMemo(() => {
 		let result = _options
 		if (camera !== undefined) result = { ...result, camera }

--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -72,6 +72,22 @@ export function MenuClickCapture() {
 			const button = getPointerEventButton(e)
 			if (button !== 0 && button !== 2) return
 
+			if (button === 2 && editor.options.rightClickPanning) {
+				// Forward right-click pointerdown through the canvas's own handler so
+				// pointer capture is set on the canvas (load-bearing: without this
+				// the context menu briefly flashes closed during consecutive right-clicks).
+				// The canvas owns the rest of the gesture, so don't capture or mark
+				// pointing here: this element's pointerup would never fire, leaving it
+				// mounted over the canvas after the menu closes.
+				// We don't clearOpenMenus() — Radix's DismissableLayer closes the menu
+				// via outside-click detection, keeping its internal state in sync.
+				const canvas =
+					editor.getContainer().querySelector<HTMLDivElement>('.tl-canvas') ?? e.currentTarget
+				canvasEvents.onPointerDown?.({ ...e, currentTarget: canvas })
+				swallowNextNativeContextMenu()
+				return
+			}
+
 			flushSync(() => setIsPointing(true))
 			setPointerCapture(e.currentTarget, e)
 			rPointerState.current = {
@@ -82,23 +98,9 @@ export function MenuClickCapture() {
 			}
 
 			if (button === 2) {
-				if (!editor.options.rightClickPanning) {
-					// Right-click panning off: close the open menu and swallow the native
-					// contextmenu that would otherwise briefly open a new one (causing a flash).
-					swallowNextNativeContextMenu()
-					editor.menus.clearOpenMenus()
-					return
-				}
-				// Forward right-click pointerdown through the canvas's own handler so
-				// pointer capture is also set on the canvas (load-bearing: without this
-				// the context menu briefly flashes closed during consecutive right-clicks).
-				// We don't clearOpenMenus() — Radix's DismissableLayer closes the menu
-				// via outside-click detection, keeping its internal state in sync.
-				const canvas =
-					editor.getContainer().querySelector<HTMLDivElement>('.tl-canvas') ?? e.currentTarget
-				canvasEvents.onPointerDown?.({ ...e, currentTarget: canvas })
+				// Right-click panning off: swallow the native contextmenu that would otherwise
+				// briefly open a new menu (causing a flash) once the open one closes below.
 				swallowNextNativeContextMenu()
-				return
 			}
 
 			editor.menus.clearOpenMenus()
@@ -113,8 +115,7 @@ export function MenuClickCapture() {
 
 			// Left-click: wait for the drag threshold before forwarding anything, then
 			// replay pointerdown at the original start so the editor records the
-			// correct drag origin. Right-click forwards moves immediately (pointerdown
-			// was already dispatched in handlePointerDown).
+			// correct drag origin. Right-click forwards moves immediately.
 			if (state.button !== 2 && !state.isDragging) {
 				if (
 					Vec.Dist2(state.start, new Vec(e.clientX, e.clientY)) <=

--- a/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
+++ b/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
@@ -94,11 +94,9 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 					if (!shape || shape.type === 'group') continue
 
 					const geometry = editor.getShapeGeometry(shape)
-					const pageTransform = editor.getShapePageTransform(shape)
-					if (!pageTransform) continue
+					const m = editor.getShapePageTransform(shape)
 
 					ctx.save()
-					const m = pageTransform
 					ctx.transform(m.a, m.b, m.c, m.d, m.e, m.f)
 
 					// Outline

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -220,7 +220,7 @@ My browser: ${navigator.userAgent}`
 									Reset data
 								</button>
 								<button className="tlui-button tl-error-boundary__refresh" onClick={refresh}>
-									Refresh Page
+									Refresh page
 								</button>
 							</div>
 						</div>

--- a/packages/editor/src/lib/config/TLUserPreferences.test.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { deleteFromLocalStorage, setInLocalStorage } from '@tldraw/utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defaultUserPreferences, userTypeValidator } from './TLUserPreferences'
 
 describe('TLUserPreferences consistency', () => {
@@ -37,5 +38,21 @@ describe('TLUserPreferences consistency', () => {
 		const expected = ['id', ...interfaceKeys].sort()
 
 		expect(validatorKeys).toEqual(expected)
+	})
+})
+
+describe('loading stored preferences', () => {
+	afterEach(() => {
+		deleteFromLocalStorage('TLDRAW_USER_DATA_v3')
+		vi.resetModules()
+	})
+
+	it.each([
+		['corrupt json', '{not json'],
+		['a snapshot whose user is not an object', JSON.stringify({ version: 1, user: null })],
+	])('falls back to fresh preferences for %s', async (_label, stored) => {
+		setInLocalStorage('TLDRAW_USER_DATA_v3', stored)
+		const { getUserPreferences } = await import('./TLUserPreferences')
+		expect(getUserPreferences().id).toEqual(expect.any(String))
 	})
 })

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -201,9 +201,9 @@ function migrateUserPreferences(userData: unknown): TLUserPreferences {
 
 	const snapshot = structuredClone(userData) as any
 
-	migrateSnapshot(snapshot)
-
 	try {
+		// migration dereferences `user`, which malformed stored data may not have as an object
+		migrateSnapshot(snapshot)
 		return userTypeValidator.validate(snapshot.user)
 	} catch {
 		return getFreshUserPreferences()
@@ -211,8 +211,12 @@ function migrateUserPreferences(userData: unknown): TLUserPreferences {
 }
 
 function loadUserPreferences(): TLUserPreferences {
-	const userData = (JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null') ??
-		null) as null | UserDataSnapshot
+	let userData: unknown = null
+	try {
+		userData = JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null')
+	} catch {
+		// corrupt stored data is treated as absent rather than blocking the editor from mounting
+	}
 
 	return migrateUserPreferences(userData)
 }

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -181,7 +181,7 @@ export function createTLStore({
 			},
 			onMount: (editor) => {
 				assert(editor instanceof Editor)
-				onMount?.(editor)
+				return onMount?.(editor)
 			},
 			collaboration,
 		},

--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -1101,6 +1101,51 @@ describe('dispatch event emission', () => {
 
 		expect(eventHandler).toHaveBeenCalledWith(pinchEndEvent)
 	})
+
+	it('still ends a pinch when the camera is locked mid-gesture', () => {
+		const pinchStartEvent = {
+			type: 'pinch' as const,
+			name: 'pinch_start' as const,
+			point: { x: 100, y: 100, z: 1 },
+			delta: { x: 0, y: 0, z: 0 },
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+		}
+		testEditor.dispatch(pinchStartEvent)
+		testEditor.emit('tick', 16)
+		expect(testEditor.inputs.getIsPinching()).toBe(true)
+
+		// Locking only stops the camera: pinch_end must still clear isPinching, otherwise
+		// every pointer event is ignored from here on.
+		testEditor.setCameraOptions({ isLocked: true })
+		testEditor.dispatch({ ...pinchStartEvent, name: 'pinch_end' })
+		testEditor.emit('tick', 16)
+		expect(testEditor.inputs.getIsPinching()).toBe(false)
+	})
+
+	it('ignores the stylus eraser button when no eraser tool is registered', () => {
+		const pointerDown = {
+			type: 'pointer' as const,
+			name: 'pointer_down' as const,
+			target: 'canvas' as const,
+			point: { x: 100, y: 100, z: 0.5 },
+			pointerId: 1,
+			button: 5,
+			isPen: true,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+		}
+
+		expect(() => testEditor.dispatch(pointerDown)).not.toThrow()
+		expect(() => testEditor.dispatch({ ...pointerDown, name: 'pointer_up' })).not.toThrow()
+		expect(testEditor.getCrashingError()).toBeNull()
+	})
 })
 
 describe('setTool', () => {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2828,7 +2828,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 					if (!id) return
 
-					// Set the new editing shape
 					this.select(id)
 					this._updateCurrentPageState({ editingShapeId: id })
 
@@ -3268,7 +3267,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	private _getFitZoom(fit: TLCameraConstraints['initialZoom']): number {
 		const cameraOptions = this.getCameraOptions()
-		// If no camera constraints are provided, or the fit is default, the zoom is 100%
 		if (!cameraOptions.constraints || fit === 'default') return 1
 
 		const { zx, zy } = getCameraFitXFitY(this, cameraOptions)
@@ -3954,9 +3952,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const remaining = duration - elapsed
 		const t = easing(1 - remaining / duration)
 
-		const left = start.minX + (end.minX - start.minX) * t
-		const top = start.minY + (end.minY - start.minY) * t
-		const right = start.maxX + (end.maxX - start.maxX) * t
+		const left = lerp(start.minX, end.minX, t)
+		const top = lerp(start.minY, end.minY, t)
+		const right = lerp(start.maxX, end.maxX, t)
 
 		this._setCamera(new Vec(-left, -top, this.getViewportScreenBounds().width / (right - left)), {
 			force: true,
@@ -6854,7 +6852,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
 		if (this.getIsReadonly()) return this
+		return this._deleteBindings(bindings, { isolateShapes })
+	}
 
+	// Unguarded so that withIsolatedShapes can transiently isolate shapes (copy, duplicate)
+	// in readonly mode; the public deleteBindings is what readonly blocks.
+	/** @internal */
+	_deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
 		const ids = bindings.map((binding) => (typeof binding === 'string' ? binding : binding.id))
 		if (isolateShapes) {
 			this.store.atomic(() => {
@@ -8933,7 +8937,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const parentId = this.findCommonAncestor(shapesToGroup) ?? this.getCurrentPageId()
 
-		// If the select tool is mid-interaction, cancel it (get back to idle) before regrouping
+		// If the select tool is mid-interaction, cancel it (get back to idle) before grouping
 		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
@@ -9008,7 +9012,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapesToUngroup.length === 0) return this
 
-		// If the select tool is mid-interaction, cancel it (get back to idle) before regrouping
+		// If the select tool is mid-interaction, cancel it (get back to idle) before ungrouping
 		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
@@ -11766,7 +11770,7 @@ function withIsolatedShapes<T>(
 					}
 				}
 
-				editor.deleteBindings([...bindingsToRemove], { isolateShapes: true })
+				editor._deleteBindings([...bindingsToRemove], { isolateShapes: true })
 
 				try {
 					result = Result.ok(callback(bindingsWithBoth))

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -72,6 +72,7 @@ import {
 	Result,
 	ZERO_INDEX_KEY,
 	annotateError,
+	areArraysShallowEqual,
 	assert,
 	assertExists,
 	bind,
@@ -129,7 +130,13 @@ import { Geometry2d } from '../primitives/geometry/Geometry2d'
 import { Group2d } from '../primitives/geometry/Group2d'
 import { intersectPolygonPolygon } from '../primitives/intersect'
 import { Mat, MatLike } from '../primitives/Mat'
-import { PI, approximately, areAnglesCompatible, clamp, pointInPolygon } from '../primitives/utils'
+import {
+	HALF_PI,
+	approximately,
+	areAnglesCompatible,
+	clamp,
+	pointInPolygon,
+} from '../primitives/utils'
 import { Vec, VecLike } from '../primitives/Vec'
 import { areShapesContentEqual } from '../utils/areShapesContentEqual'
 import { dataUrlToFile } from '../utils/assets'
@@ -187,6 +194,7 @@ import { TLHistoryBatchOptions } from './types/history-types'
 import {
 	OptionalKeys,
 	RequiredKeys,
+	TLCameraConstraints,
 	TLCameraMoveOptions,
 	TLCameraOptions,
 	TLGetShapeAtPointOptions,
@@ -297,7 +305,6 @@ export interface TLEditorOptions {
 	 * Additional configuration options for the tldraw editor.
 	 */
 	options?: Partial<TldrawOptions>
-	// --- Deprecated ----
 	/**
 	 * Options for the editor's camera.
 	 *
@@ -545,6 +552,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				nextPageState.editingShapeId = null
 			}
 
+			if (
+				prevPageState.croppingShapeId &&
+				shapesNoLongerInPage.has(prevPageState.croppingShapeId)
+			) {
+				if (!nextPageState) nextPageState = { ...prevPageState }
+				nextPageState.croppingShapeId = null
+			}
+
 			const hintingShapeIds = prevPageState.hintingShapeIds.filter(
 				(id) => !shapesNoLongerInPage.has(id)
 			)
@@ -736,7 +751,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 						}
 
 						if (deleteBindingIds.length) {
-							this.deleteBindings(deleteBindingIds)
+							// straight to the store: this cleanup must run even when deleteBindings would
+							// refuse (readonly), e.g. for a deletion that arrived from a remote peer
+							this.store.remove(deleteBindingIds)
 						}
 					},
 				},
@@ -830,10 +847,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						if (prev?.selectedShapeIds !== next?.selectedShapeIds) {
 							// ensure that descendants and ancestors are not selected at the same time
+							const selectedShapeIds = new Set(next.selectedShapeIds)
 							const filtered = next.selectedShapeIds.filter((id) => {
 								let parentId = this.getShape(id)?.parentId
 								while (isShapeId(parentId)) {
-									if (next.selectedShapeIds.includes(parentId)) {
+									if (selectedShapeIds.has(parentId)) {
 										return false
 									}
 									parentId = this.getShape(parentId)?.parentId
@@ -938,7 +956,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const mode = this.store.props.collaboration.mode
 			this.disposables.add(
 				react('update collaboration mode', () => {
-					this.store.put([{ ...this.getInstanceState(), isReadonly: mode.get() === 'readonly' }])
+					const isReadonly = mode.get() === 'readonly'
+					// only track `mode`, and keep the sync out of the user's undo history
+					unsafe__withoutCapture(() =>
+						this._updateInstanceState({ isReadonly }, { history: 'ignore' })
+					)
 				})
 			)
 		}
@@ -1245,8 +1267,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.removeAllListeners()
 	}
 
-	/* ------------------ Themes (shadowing the theme manager) ------------------ */
-
 	/**
 	 * Get the current color mode (`'light'` or `'dark'`), based on the user's dark mode preference.
 	 *
@@ -1355,8 +1375,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this
 	}
 
-	/* ------------------- Shape Utils ------------------ */
-
 	/**
 	 * A map of shape utility classes (TLShapeUtils) by shape type.
 	 *
@@ -1390,7 +1408,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	getShapeUtil(arg: string | { type: string }) {
 		const type = typeof arg === 'string' ? arg : arg.type
 		const shapeUtil = getOwnProperty(this.shapeUtils, type)
-		assert(shapeUtil, `No shape util found for type "${type}"`)
+		// hot path: avoid building the message (and the assert wrapper) on every successful call
+		if (!shapeUtil) throw new Error(`No shape util found for type "${type}"`)
 		return shapeUtil
 	}
 
@@ -1421,7 +1440,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return getOwnProperty(this._shapeUtilsByAssetType, assetType)
 	}
 
-	/* ------------------- Binding Utils ------------------ */
 	/**
 	 * A map of shape utility classes (TLShapeUtils) by shape type.
 	 *
@@ -1455,8 +1473,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		assert(bindingUtil, `No binding util found for type "${type}"`)
 		return bindingUtil
 	}
-
-	/* ------------------- Asset Utils ------------------ */
 
 	/**
 	 * A map of asset utility classes by asset type.
@@ -1505,8 +1521,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 		return null
 	}
-
-	/* --------------------- History -------------------- */
 
 	/**
 	 * A manager for the editor's history.
@@ -1715,8 +1729,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this
 	}
 
-	/* --------------------- Errors --------------------- */
-
 	/** @internal */
 	annotateError(
 		error: unknown,
@@ -1804,8 +1816,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.emit('crash', { error })
 		return this
 	}
-
-	/* ------------------- Statechart ------------------- */
 
 	/**
 	 * The editor's current path of active states.
@@ -1930,8 +1940,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return state as T
 	}
 
-	/* ---------------- Document Settings --------------- */
-
 	/**
 	 * The global document settings that apply to all users.
 	 *
@@ -1947,6 +1955,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 **/
 	updateDocumentSettings(settings: Partial<TLDocument>): this {
+		if (this.getIsReadonly()) return this
 		this.run(
 			() => {
 				this.store.put([{ ...this.getDocumentSettings(), ...settings }])
@@ -1955,8 +1964,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		)
 		return this
 	}
-
-	/* ----------------- Instance State ----------------- */
 
 	/**
 	 * The current instance's state.
@@ -2016,8 +2023,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	menus = tlmenus.forContext(this.contextId)
 
-	/* --------------------- Cursor --------------------- */
-
 	/**
 	 * Set the cursor.
 	 *
@@ -2040,8 +2045,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.updateInstanceState({ cursor: { ...current, ...cursor } })
 		return this
 	}
-
-	/* ------------------- Page State ------------------- */
 
 	/**
 	 * Page states.
@@ -2279,10 +2282,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let adjacentShapeId: TLShapeId
 		if (direction === 'next' || direction === 'prev') {
 			const shapeIds = readingOrderShapes.map((shape) => shape.id)
+			if (shapeIds.length === 0) return
 
 			const currentIndex = currentShapeId ? shapeIds.indexOf(currentShapeId) : -1
 			const adjacentIndex =
-				(currentIndex + (direction === 'next' ? 1 : -1) + shapeIds.length) % shapeIds.length
+				currentIndex === -1
+					? direction === 'next'
+						? 0
+						: shapeIds.length - 1
+					: (currentIndex + (direction === 'next' ? 1 : -1) + shapeIds.length) % shapeIds.length
 			adjacentShapeId = shapeIds[adjacentIndex]
 		} else {
 			if (!currentShapeId) return
@@ -2424,8 +2432,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// Ok, now score that subset of shapes.
 		const lowestScoringShape = minBy(shapesInDirection, ({ center }) => {
-			// Distance is the primary weighting factor.
-			const distance = Vec.Dist2(currentCenter, center)
+			// Distance is the primary weighting factor. Keep it linear so the off-axis, diagonal and
+			// angle penalties below are in the same units; squared distance swamps them all.
+			const distance = Vec.Dist(currentCenter, center)
 
 			// Distance along the primary axis.
 			const dirProp = ['left', 'right'].includes(direction) ? 'x' : 'y'
@@ -2435,9 +2444,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const offProp = ['left', 'right'].includes(direction) ? 'y' : 'x'
 			const offAxisDeviation = Math.abs(center[offProp] - currentCenter[offProp])
 
-			// Angle in degrees
-			const angle = Math.abs(Vec.Angle(currentCenter, center) * (180 / Math.PI))
-			const angleDeviation = Math.abs(angle - directionToAngle[direction])
+			// Angle in degrees, normalised to 0..360 so that 'up' (270) compares correctly
+			const angle = (Vec.Angle(currentCenter, center) * (180 / Math.PI) + 360) % 360
+			const rawAngleDeviation = Math.abs(angle - directionToAngle[direction])
+			const angleDeviation = Math.min(rawAngleDeviation, 360 - rawAngleDeviation)
 
 			// Calculate final score (lower is better).
 			// Weight factors to prioritize:
@@ -2467,9 +2477,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const selectedShapes = this.getSelectedShapes()
 		if (!selectedShapes.length) return
 		const selectedShape = selectedShapes[0]
-		const children = this.getSortedChildIdsForParent(selectedShape.id)
-			.map((id) => this.getShape(id))
-			.filter((i) => i) as TLShape[]
+		const children = compact(
+			this.getSortedChildIdsForParent(selectedShape.id).map((id) => this.getShape(id))
+		)
 		const sortedChildren = this._getShapesInReadingOrder(children)
 		if (sortedChildren.length === 0) return
 		this._selectShapesAndZoom([sortedChildren[0].id])
@@ -2570,20 +2580,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @internal
 	 */
 	getShapesSharedRotation(shapeIds: TLShapeId[]) {
-		let foundFirst = false // annoying but we can't use an i===0 check because we need to skip over undefineds
 		let rotation = 0
 		for (let i = 0, n = shapeIds.length; i < n; i++) {
-			const pageTransform = this.getShapePageTransform(shapeIds[i])
-			if (!pageTransform) continue
-			if (foundFirst) {
-				if (pageTransform.rotation() !== rotation) {
-					// There are at least 2 different rotations, so the common rotation is zero
-					return 0
-				}
-			} else {
-				// First rotation found
-				foundFirst = true
-				rotation = pageTransform.rotation()
+			const pageRotation = this.getShapePageTransform(shapeIds[i]).rotation()
+			if (i === 0) {
+				rotation = pageRotation
+			} else if (pageRotation !== rotation) {
+				// There are at least 2 different rotations, so the common rotation is zero
+				return 0
 			}
 		}
 
@@ -2615,7 +2619,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapeIds.length === 1) {
 			const bounds = this.getShapeGeometry(shapeIds[0]).bounds.clone()
-			const pageTransform = this.getShapePageTransform(shapeIds[0])!
+			const pageTransform = this.getShapePageTransform(shapeIds[0])
 			bounds.point = pageTransform.applyToPoint(bounds.point)
 			return bounds
 		}
@@ -2623,11 +2627,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// need to 'un-rotate' all the outlines of the existing nodes so we can fit them inside a box
 		const boxFromRotatedVertices = Box.FromPoints(
 			shapeIds
-				.flatMap((id) => {
-					const pageTransform = this.getShapePageTransform(id)
-					if (!pageTransform) return []
-					return pageTransform.applyToPoints(this.getShapeGeometry(id).bounds.corners)
-				})
+				.flatMap((id) =>
+					this.getShapePageTransform(id).applyToPoints(this.getShapeGeometry(id).bounds.corners)
+				)
 				.map((p) => p.rot(-selectionRotation))
 		)
 		// now position box so that it's top-left corner is in the right place
@@ -2654,9 +2656,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	@computed getSelectionRotatedScreenBounds(): Box | undefined {
 		const bounds = this.getSelectionRotatedPageBounds()
 		if (!bounds) return undefined
-		const { x, y } = this.pageToScreen(bounds.point)
-		const zoom = this.getZoomLevel()
-		return new Box(x, y, bounds.width * zoom, bounds.height * zoom)
+		// Don't use pageToScreen here: it reads the screen bounds without capturing them, so this
+		// computed would never invalidate when the container moves
+		const screenBounds = this.getViewportScreenBounds()
+		const { x: cx, y: cy, z: zoom } = this.getCamera()
+		return new Box(
+			(bounds.x + cx) * zoom + screenBounds.x,
+			(bounds.y + cy) * zoom + screenBounds.y,
+			bounds.width * zoom,
+			bounds.height * zoom
+		)
 	}
 
 	// Focus Group
@@ -2796,57 +2805,39 @@ export class Editor extends EventEmitter<TLEventMap> {
 	setEditingShape(shape: TLShapeId | TLShape | null): this {
 		const id = typeof shape === 'string' ? shape : (shape?.id ?? null)
 
-		if (!id) {
-			// setting the editing shape to null
+		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
+		if (id && !this.canEditShape(id)) return this
+
+		this.run(() => {
+			// Clean up the previous editing shape. This runs outside the history-ignored batch below,
+			// otherwise document changes made by onEditEnd (e.g. deleting an empty text shape) are
+			// never recorded and leave a phantom undo entry whose redo resurrects the shape.
+			const prevEditingShapeId = this.getEditingShapeId()
+			if (prevEditingShapeId) {
+				const prevEditingShape = this.getShape(prevEditingShapeId)
+				if (prevEditingShape) {
+					this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
+				}
+			}
+
 			this.run(
 				() => {
-					// Clean up the previous editing shape
-					const prevEditingShapeId = this.getEditingShapeId()
-					if (prevEditingShapeId) {
-						const prevEditingShape = this.getShape(prevEditingShapeId)
-						if (prevEditingShape) {
-							this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-						}
-					}
-
 					// Clean up the editing shape state and rich text editor
 					this._updateCurrentPageState({ editingShapeId: null })
 					this._currentRichTextEditor.set(null)
+
+					if (!id) return
+
+					// Set the new editing shape
+					this.select(id)
+					this._updateCurrentPageState({ editingShapeId: id })
+
+					const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
+					this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
 				},
 				{ history: 'ignore' }
 			)
-
-			return this
-		}
-
-		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
-		if (!this.canEditShape(id)) return this
-
-		// id was provided and the next editing shape is editable, so set the rich text editor to null
-		this.run(
-			() => {
-				// Clean up the previous editing shape
-				const prevEditingShapeId = this.getEditingShapeId()
-				if (prevEditingShapeId) {
-					const prevEditingShape = this.getShape(prevEditingShapeId)
-					if (prevEditingShape) {
-						this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-					}
-				}
-
-				// Clean up the editing shape state and rich text editor
-				this._updateCurrentPageState({ editingShapeId: null })
-				this._currentRichTextEditor.set(null)
-
-				// Set the new editing shape
-				this.select(id)
-				this._updateCurrentPageState({ editingShapeId: id })
-
-				const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
-				this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
-			},
-			{ history: 'ignore' }
-		)
+		})
 
 		return this
 	}
@@ -3011,26 +3002,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setErasingShapes(shapes: TLShapeId[] | TLShape[]): this {
+		// copy before sorting: the caller may pass a store-owned (frozen) array
 		const ids =
 			typeof shapes[0] === 'string'
-				? (shapes as TLShapeId[])
+				? (shapes as TLShapeId[]).slice()
 				: (shapes as TLShape[]).map((shape) => shape.id)
 		ids.sort() // sort the incoming ids
 		const erasingShapeIds = this.getErasingShapeIds()
 		this.run(
 			() => {
-				if (ids.length === erasingShapeIds.length) {
-					// if the new ids are the same length as the current ids, they might be the same.
-					// presuming the current ids are also sorted, check each item to see if it's the same;
-					// if we find any unequal, then we know the new ids are different.
-					for (let i = 0; i < ids.length; i++) {
-						if (ids[i] !== erasingShapeIds[i]) {
-							this._updateCurrentPageState({ erasingShapeIds: ids })
-							break
-						}
-					}
-				} else {
-					// if the ids are a different length, then we know they're different.
+				// the current ids are also sorted, so a shallow comparison tells us whether they changed
+				if (!areArraysShallowEqual(ids, erasingShapeIds)) {
 					this._updateCurrentPageState({ erasingShapeIds: ids })
 				}
 			},
@@ -3117,8 +3099,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return assertExists(this._textOptions.get(), 'Cannot use text without setting textOptions')
 	}
 
-	/* --------------------- Camera --------------------- */
-
 	/** @internal */
 	@computed
 	private _unsafe_getCameraId() {
@@ -3146,11 +3126,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const collaborators = this.getCollaborators()
 		let leaderPresence = null as null | TLInstancePresence
 		while (targetUserId && !visited.includes(targetUserId)) {
-			leaderPresence = collaborators.find((c) => c.userId === targetUserId) ?? null
-			targetUserId = leaderPresence?.followingUserId ?? null
-			if (leaderPresence) {
-				visited.push(leaderPresence.userId)
-			}
+			const nextPresence = collaborators.find((c) => c.userId === targetUserId)
+			// Stop at the last resolvable presence, otherwise a leader whose own leader has left
+			// (or whose presence hasn't arrived yet) can't be followed at all
+			if (!nextPresence) break
+			leaderPresence = nextPresence
+			targetUserId = nextPresence.followingUserId ?? null
+			visited.push(nextPresence.userId)
 		}
 		return leaderPresence
 	}
@@ -3268,44 +3250,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public */
 	getInitialZoom() {
-		const cameraOptions = this.getCameraOptions()
-		// If no camera constraints are provided, the default zoom is 100%
-		if (!cameraOptions.constraints) return 1
-
-		// When defaultZoom is default, the default zoom is 100%
-		if (cameraOptions.constraints.initialZoom === 'default') return 1
-
-		const { zx, zy } = getCameraFitXFitY(this, cameraOptions)
-
-		switch (cameraOptions.constraints.initialZoom) {
-			case 'fit-min': {
-				return Math.max(zx, zy)
-			}
-			case 'fit-max': {
-				return Math.min(zx, zy)
-			}
-			case 'fit-x': {
-				return zx
-			}
-			case 'fit-y': {
-				return zy
-			}
-			case 'fit-min-100': {
-				return Math.min(1, Math.max(zx, zy))
-			}
-			case 'fit-max-100': {
-				return Math.min(1, Math.min(zx, zy))
-			}
-			case 'fit-x-100': {
-				return Math.min(1, zx)
-			}
-			case 'fit-y-100': {
-				return Math.min(1, zy)
-			}
-			default: {
-				throw exhaustiveSwitchError(cameraOptions.constraints.initialZoom)
-			}
-		}
+		return this._getFitZoom(this.getCameraOptions().constraints?.initialZoom ?? 'default')
 	}
 
 	/**
@@ -3318,16 +3263,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 *
 	 * @public */
 	getBaseZoom() {
-		const cameraOptions = this.getCameraOptions()
-		// If no camera constraints are provided, the default zoom is 100%
-		if (!cameraOptions.constraints) return 1
+		return this._getFitZoom(this.getCameraOptions().constraints?.baseZoom ?? 'default')
+	}
 
-		// When defaultZoom is default, the default zoom is 100%
-		if (cameraOptions.constraints.baseZoom === 'default') return 1
+	private _getFitZoom(fit: TLCameraConstraints['initialZoom']): number {
+		const cameraOptions = this.getCameraOptions()
+		// If no camera constraints are provided, or the fit is default, the zoom is 100%
+		if (!cameraOptions.constraints || fit === 'default') return 1
 
 		const { zx, zy } = getCameraFitXFitY(this, cameraOptions)
 
-		switch (cameraOptions.constraints.baseZoom) {
+		switch (fit) {
 			case 'fit-min': {
 				return Math.max(zx, zy)
 			}
@@ -3353,7 +3299,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				return Math.min(1, zy)
 			}
 			default: {
-				throw exhaustiveSwitchError(cameraOptions.constraints.baseZoom)
+				throw exhaustiveSwitchError(fit)
 			}
 		}
 	}
@@ -3390,7 +3336,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			...this._cameraOptions.__unsafe__getWithoutCapture(),
 			...opts,
 		})
-		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
+		// `undefined < 1` is false, so an explicit `zoomSteps: undefined` would otherwise get through
+		// and make every later camera move throw
+		if (!next.zoomSteps || next.zoomSteps.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
 		this.setCamera(this.getCamera())
 		return this
@@ -3436,8 +3384,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const { constraints } = cameraOptions
 
 				// Clamp padding to half the viewport size on either dimension
-				const py = Math.min(constraints.padding.y, vsb.w / 2)
-				const px = Math.min(constraints.padding.x, vsb.h / 2)
+				const px = Math.min(constraints.padding.x, vsb.w / 2)
+				const py = Math.min(constraints.padding.y, vsb.h / 2)
 
 				// Expand the bounds by the padding
 				const bounds = Box.From(cameraOptions.constraints.bounds)
@@ -3506,14 +3454,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 						}
 						case 'inside': {
 							// When below fit zoom, constrain the camera so that the bounds stay completely within the viewport
-							if (z < zx) x = clamp(x, minX, (vsb.w - px) / z - bounds.w)
+							if (z < zx) x = clamp(x, minX, (vsb.w - px) / z - bounds.w - bounds.x)
 							// When above fit zoom, keep the bounds within padding distance of the viewport edge
 							else x = clamp(x, minX + freeW, minX)
 							break
 						}
 						case 'outside': {
 							// Constrain the camera so that the bounds never leaves the viewport
-							x = clamp(x, px / z - bounds.w, (vsb.w - px) / z)
+							x = clamp(x, px / z - bounds.w - bounds.x, (vsb.w - px) / z - bounds.x)
 							break
 						}
 						case 'free': {
@@ -3538,12 +3486,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 							break
 						}
 						case 'inside': {
-							if (z < zy) y = clamp(y, minY, (vsb.h - py) / z - bounds.h)
+							if (z < zy) y = clamp(y, minY, (vsb.h - py) / z - bounds.h - bounds.y)
 							else y = clamp(y, minY + freeH, minY)
 							break
 						}
 						case 'outside': {
-							y = clamp(y, py / z - bounds.h, (vsb.h - py) / z)
+							y = clamp(y, py / z - bounds.h - bounds.y, (vsb.h - py) / z - bounds.y)
 							break
 						}
 						case 'free': {
@@ -3638,11 +3586,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.stopFollowingUser()
 		}
 
-		const _point = Vec.Cast(point)
-
-		if (!Number.isFinite(_point.x)) _point.x = 0
-		if (!Number.isFinite(_point.y)) _point.y = 0
-		if (_point.z === undefined || !Number.isFinite(_point.z)) point.z = this.getZoomLevel()
+		// Resolve the zoom before building the Vec: Vec.Cast would default a missing z to 1,
+		// and a missing or non-finite z should keep the current zoom level instead
+		const _point = new Vec(
+			Number.isFinite(point.x) ? point.x : 0,
+			Number.isFinite(point.y) ? point.y : 0,
+			Number.isFinite(point.z) ? point.z! : this.getZoomLevel()
+		)
 
 		const camera = this.getConstrainedCamera(_point, opts)
 
@@ -3978,6 +3928,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		easing(t: number): number
 		start: Box
 		end: Box
+		opts: TLCameraMoveOptions
 	}
 
 	/** @internal */
@@ -3986,12 +3937,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this._viewportAnimation.elapsed += ms
 
-		const { elapsed, easing, duration, start, end } = this._viewportAnimation
+		const { elapsed, easing, duration, start, end, opts } = this._viewportAnimation
 
 		if (elapsed > duration) {
 			this.off('tick', this._animateViewport)
 			this._viewportAnimation = null
-			this._setCamera(new Vec(-end.x, -end.y, this.getViewportScreenBounds().width / end.width))
+			// Forward the caller's options, otherwise a forced move to a position outside the
+			// constraints animates there and then snaps back on this last frame
+			this._setCamera(
+				new Vec(-end.x, -end.y, this.getViewportScreenBounds().width / end.width),
+				opts
+			)
 			return
 		}
 
@@ -4045,6 +4001,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			easing,
 			start: viewportPageBounds.clone(),
 			end: targetViewportPage.clone(),
+			opts: rest,
 		}
 
 		// If we ever get a "stop-camera-animation" event, we stop
@@ -4115,9 +4072,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			let newCy = cy + dy
 			let newCz = cz
 
-			// animate zoom if z direction is passed in
+			// animate zoom if z direction is passed in. Use an exponential factor so that a single
+			// long frame can't drive the zoom to zero or negative (which would give NaN coordinates)
 			if (dirZ !== 0) {
-				newCz = cz * (1 + dirZ * currentSpeed * elapsed)
+				newCz = cz * Math.exp(dirZ * currentSpeed * elapsed)
 				// Adjust x/y to keep the viewport center fixed while zooming
 				const center = this.getViewportScreenCenter()
 				newCx += center.x / newCz - center.x / cz
@@ -4702,7 +4660,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let nextIndex = this.options.maxShapesPerPage * 2
 		let nextBackgroundIndex = this.options.maxShapesPerPage
 
-		const erasingShapeIds = this.getErasingShapeIds()
+		const erasingShapeIds = new Set(this.getErasingShapeIds())
 
 		const addShapeById = (id: TLShapeId, opacity: number, isAncestorErasing: boolean) => {
 			const shape = this.getShape(id)
@@ -4710,7 +4668,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			if (this.isShapeHidden(shape)) {
 				// process children just in case they are overriding the hidden state
-				const isErasing = isAncestorErasing || erasingShapeIds.includes(id)
+				const isErasing = isAncestorErasing || erasingShapeIds.has(id)
 				for (const childId of this.getSortedChildIdsForParent(id)) {
 					addShapeById(childId, opacity, isErasing)
 				}
@@ -4722,7 +4680,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const util = this.getShapeUtil(shape)
 
 			if (useEditorState) {
-				isShapeErasing = !isAncestorErasing && erasingShapeIds.includes(id)
+				isShapeErasing = !isAncestorErasing && erasingShapeIds.has(id)
 				if (isShapeErasing) {
 					opacity *= 0.32
 				}
@@ -4875,8 +4833,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	private _renderingShapesSortCache: Map<TLShapeId, number> | null = null
-
-	/* --------------------- Pages ---------------------- */
 
 	@computed private _getAllPagesQuery() {
 		return this.store.query.records('page')
@@ -5150,8 +5106,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.setCamera(prevCamera)
 
 			if (content) {
-				// If we had content on the previous page, put it on the new page
-				return this.putContentOntoCurrentPage(content)
+				// If we had content on the previous page, put it on the new page at the same coordinates
+				// (otherwise offscreen content gets re-centred on the viewport)
+				return this.putContentOntoCurrentPage(content, { preservePosition: true })
 			}
 		})
 
@@ -5177,8 +5134,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.updatePage({ id, name })
 		return this
 	}
-
-	/* --------------------- Assets --------------------- */
 
 	/** @internal */
 	@computed private _getAllAssetsQuery() {
@@ -5265,7 +5220,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.run(
 			() => {
-				this.store.props.assets.remove?.(ids)
+				// the asset store's remove is async; surface failures instead of leaving an unhandled rejection
+				Promise.resolve(this.store.props.assets.remove?.(ids)).catch((err) =>
+					console.error('Error while removing assets from the asset store:', err)
+				)
 				this.store.remove(ids)
 			},
 			{ history: 'ignore' }
@@ -5332,8 +5290,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	): Promise<{ src: string; meta?: JsonObject }> {
 		return await this.store.props.assets.upload(asset, file, abortSignal)
 	}
-
-	/* --------------------- Shapes --------------------- */
 
 	private _shapeGeometryCaches: Record<string, ComputedCache<Geometry2d, TLShape>> = {}
 
@@ -5481,11 +5437,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	@computed private _getShapePageBoundsCache(): ComputedCache<Box, TLShape> {
 		return this.store.createComputedCache<Box, TLShape>('pageBoundsCache', (shape) => {
-			const pageTransform = this.getShapePageTransform(shape)
-			if (!pageTransform) return undefined
-
 			return Box.FromPoints(
-				pageTransform.applyToPoints(this.getShapeGeometry(shape).boundsVertices)
+				this.getShapePageTransform(shape).applyToPoints(this.getShapeGeometry(shape).boundsVertices)
 			)
 		})
 	}
@@ -5624,7 +5577,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (pageMask) {
 				if (pageMask.length === 0) return undefined
 				const { corners } = pageBounds
-				if (corners.every((p, i) => p && Vec.Equals(p, pageMask[i]))) return pageBounds.clone()
+				// the mask may have fewer than four points (e.g. a triangular clip path)
+				if (
+					pageMask.length === corners.length &&
+					corners.every((p, i) => Vec.Equals(p, pageMask[i]))
+				) {
+					return pageBounds.clone()
+				}
 				const intersection = intersectPolygonPolygon(pageMask, corners)
 				if (!intersection) return
 				return Box.FromPoints(intersection)
@@ -5875,14 +5834,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getSelectedShapeAtPoint(point: VecLike): TLShape | undefined {
 		const selectedShapeIds = this.getSelectedShapeIds()
-		const margin = this.options.hitTestMargin / this.getZoomLevel()
+		if (selectedShapeIds.length === 0) return undefined
+		const selectedShapeIdSet = new Set(selectedShapeIds)
+		const margin = this.getHitTestMargin()
 		const sortedShapes = this.getCurrentPageShapesSorted()
 
 		// iterate from the top (highest z-index) to find the top-most matching shape
 		for (let i = sortedShapes.length - 1; i >= 0; i--) {
 			const shape = sortedShapes[i]
 			if (shape.type === 'group') continue
-			if (!selectedShapeIds.includes(shape.id)) continue
+			if (!selectedShapeIdSet.has(shape.id)) continue
 			if (
 				this.getShapeGeometry(shape).hitTestPoint(
 					this.getPointInShapeSpace(shape, point),
@@ -5952,17 +5913,19 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			const pointInShapeSpace = this.getPointInShapeSpace(shape, point)
 
-			// Check labels first
+			// Check labels first. Only group geometries can carry a label child; a frame-like
+			// shape util may still return a plain geometry.
 			const shapeUtil = this.getShapeUtil(shape)
 			const isShapeFrameLike = this.isShapeFrameLike(shape)
 			if (
-				isShapeFrameLike ||
-				((this.isShapeOfType(shape, 'note') ||
-					this.isShapeOfType(shape, 'arrow') ||
-					(this.isShapeOfType(shape, 'geo') && shape.props.fill === 'none')) &&
-					shapeUtil.getText(shape)?.trim())
+				isGroup &&
+				(isShapeFrameLike ||
+					((this.isShapeOfType(shape, 'note') ||
+						this.isShapeOfType(shape, 'arrow') ||
+						(this.isShapeOfType(shape, 'geo') && shape.props.fill === 'none')) &&
+						shapeUtil.getText(shape)?.trim()))
 			) {
-				for (const childGeometry of (geometry as Group2d).children) {
+				for (const childGeometry of geometry.children) {
 					if (childGeometry.isLabel && childGeometry.isPointInBounds(pointInShapeSpace)) {
 						return shape
 					}
@@ -6051,9 +6014,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// other hits would be occluded by the shape.
 						return inMarginClosestToEdgeHit || shape
 					} else {
-						// If the shape is bigger than the viewport, then skip it.
-						if (this.getShapePageBounds(shape)!.contains(viewportPageBounds)) continue
-
 						// If we're close to the edge of the shape, and if it's the closest edge among
 						// all the edges that we've gotten close to so far, then we will want to hit the
 						// shape unless we hit something else or closer in later iterations.
@@ -6074,6 +6034,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 								inMarginClosestToEdgeHit = shape
 							}
 						} else if (!inMarginClosestToEdgeHit) {
+							// If the shape is bigger than the viewport, then skip it. (Only here: its
+							// edges should still be hittable within the margin.)
+							if (this.getShapePageBounds(shape)!.contains(viewportPageBounds)) continue
+
 							// If we're not within margin distance to any edge, and if the
 							// shape is hollow, then we want to hit the shape with the
 							// smallest area. (There's a bug here with self-intersecting
@@ -6092,6 +6056,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// If the distance is less than the margin, return the shape as the hit.
 				// Use the editor's configurable hit test margin.
 				if (distance < this.getHitTestMargin()) {
+					// An edge we already hit (above this shape) that is at least as close still wins,
+					// matching the closest-edge rule used for hollow shapes
+					if (inMarginClosestToEdgeHit && inMarginClosestToEdgeDistance <= distance) {
+						return inMarginClosestToEdgeHit
+					}
 					return shape
 				}
 			}
@@ -6239,9 +6208,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!freshShape) return new Vec(0, 0)
 		if (isPageId(freshShape.parentId)) return Vec.From(point)
 
-		const parentTransform = this.getShapePageTransform(freshShape.parentId)
-		if (!parentTransform) return Vec.From(point)
-		return parentTransform.clone().invert().applyToPoint(point)
+		return this.getShapePageTransform(freshShape.parentId).clone().invert().applyToPoint(point)
 	}
 
 	/**
@@ -6408,26 +6375,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	isShapeInPage(shape: TLShape | TLShapeId, pageId = this.getCurrentPageId()): boolean {
-		const id = typeof shape === 'string' ? shape : shape.id
-		const shapeToCheck = this.getShape(id)
-		if (!shapeToCheck) return false
-
-		let shapeIsInPage = false
-
-		if (shapeToCheck.parentId === pageId) {
-			shapeIsInPage = true
-		} else {
-			let parent = this.getShape(shapeToCheck.parentId)
-			isInPageSearch: while (parent) {
-				if (parent.parentId === pageId) {
-					shapeIsInPage = true
-					break isInPageSearch
-				}
-				parent = this.getShape(parent.parentId)
-			}
-		}
-
-		return shapeIsInPage
+		return this.getAncestorPageId(shape) === pageId
 	}
 
 	/**
@@ -6538,13 +6486,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				for (let i = 0; i < shapesToReparent.length; i++) {
 					const shape = shapesToReparent[i]
 
-					const pageTransform = this.getShapePageTransform(shape)!
-					if (!pageTransform) continue
-
-					const pagePoint = pageTransform.point()
-					if (!pagePoint) continue
-
-					const newPoint = invertedParentTransform.applyToPoint(pagePoint)
+					const pageTransform = this.getShapePageTransform(shape)
+					const newPoint = invertedParentTransform.applyToPoint(pageTransform.point())
 					const newRotation = pageTransform.rotation() - parentPageRotation
 
 					if (shape.id === parentId) {
@@ -6645,7 +6588,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getShapeAndDescendantIds(ids: TLShapeId[]): Set<TLShapeId> {
 		const shapeIds = new Set<TLShapeId>()
-		for (const shape of ids.map((id) => this.getShape(id)!).sort(sortByIndex)) {
+		for (const shape of compact(ids.map((id) => this.getShape(id))).sort(sortByIndex)) {
 			shapeIds.add(shape.id)
 			this.visitDescendants(shape, (descendantId) => {
 				shapeIds.add(descendantId)
@@ -6669,6 +6612,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const draggingShapes = compact(droppingShapes.map((s) => this.getShape(s))).filter(
 			(s) => !s.isLocked && !this.isShapeHidden(s)
 		)
+		// Descendants of the dragged shapes can't be the target, otherwise dragging a frame out of
+		// its parent reports a nested child as the target and the parent never sees the drag leave
+		const excludedIds = this.getShapeAndDescendantIds(draggingShapes.map((s) => s.id))
 
 		const maybeDraggingOverShapes = this.getShapesAtPoint(point, {
 			hitInside: true,
@@ -6678,7 +6624,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				!droppingShapes.includes(s) &&
 				!s.isLocked &&
 				!this.isShapeHidden(s) &&
-				!draggingShapes.includes(s)
+				!excludedIds.has(s.id)
 		)
 
 		for (const maybeDraggingOverShape of maybeDraggingOverShapes) {
@@ -6734,8 +6680,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		return match
 	}
-
-	/* -------------------- Bindings -------------------- */
 
 	@computed
 	private _getBindingsIndexCache() {
@@ -6829,6 +6773,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * binding, but the `type`, `toId`, and `fromId` must all be provided.
 	 */
 	createBindings<B extends TLBinding = TLBinding>(partials: TLBindingCreate<B>[]) {
+		if (this.getIsReadonly()) return this
+
 		const bindings: TLBinding[] = []
 		for (const partial of partials) {
 			const fromShape = this.getShape(partial.fromId)
@@ -6868,6 +6814,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * binding is skipped. The changes from the partial are merged into the existing record.
 	 */
 	updateBindings(partials: (TLBindingUpdate | null | undefined)[]) {
+		if (this.getIsReadonly()) return this
+
 		const updated: TLBinding[] = []
 
 		for (const partial of partials) {
@@ -6905,6 +6853,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Delete several bindings by their IDs. If a binding ID doesn't exist, it's ignored.
 	 */
 	deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
+		if (this.getIsReadonly()) return this
+
 		const ids = bindings.map((binding) => (typeof binding === 'string' ? binding : binding.id))
 		if (isolateShapes) {
 			this.store.atomic(() => {
@@ -6958,8 +6908,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.getShapeUtil(toShapeType).canBind(canBindOpts)
 		)
 	}
-
-	/* -------------------- Commands -------------------- */
 
 	/**
 	 * Rotate shapes by a delta in radians.
@@ -7052,8 +7000,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		for (const id of ids) {
 			const shape = this.getShape(id)!
 			const localDelta = Vec.From(offset)
-			const parentTransform = this.getShapeParentTransform(shape)
-			if (parentTransform) localDelta.rot(-parentTransform.rotation())
+			localDelta.rot(-this.getShapeParentTransform(shape).rotation())
 
 			changes.push(this.getChangesToTranslateShape(shape, localDelta.add(shape)))
 		}
@@ -7123,7 +7070,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 						let ox = 0
 						let oy = 0
 
-						if (offset && initialIds.has(originalId)) {
+						// Only offset the roots of the duplicated tree: a descendant that was also passed in
+						// follows its duplicated parent, so offsetting it too would move it twice
+						if (
+							offset &&
+							initialIds.has(originalId) &&
+							!shapeIdSet.has(originalShape.parentId as TLShapeId)
+						) {
 							const parentTransform = this.getShapeParentTransform(originalShape)
 							const vec = new Vec(offset.x, offset.y).rot(-parentTransform!.rotation())
 							ox = vec.x
@@ -7247,10 +7200,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const fromPageZ = this.getCamera().z
 
 		this.run(() => {
-			// Delete the shapes on the current page
 			this.deleteShapes(ids)
-
-			// Move to the next page
 			this.setCurrentPage(pageId)
 
 			// Put the shape content onto the new page; parents and indices will
@@ -7456,9 +7406,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// optionally filter to axis-aligned shapes (rotation is a multiple of 90 degrees)
 		if (opts?.filterAxisAligned) {
-			freshShapes = freshShapes.filter(
-				(s) => this.getShapePageTransform(s)?.rotation() % (PI / 2) === 0
-			)
+			freshShapes = freshShapes.filter((s) => {
+				// Page rotations come back through atan2 on a composed matrix, so a 270° shape can land
+				// a hair either side of the multiple; an exact === 0 check drops it
+				const remainder = Math.abs(this.getShapePageTransform(s).rotation() % HALF_PI)
+				return Math.min(remainder, HALF_PI - remainder) < 1e-9
+			})
 		}
 
 		const clusters: { shapes: TLShape[]; pageBounds: Box }[] = []
@@ -7484,8 +7437,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shapesMovingTogether = [shape]
 			const boundsOfShapesMovingTogether: Box[] = [shapePageBounds]
 
+			// Seed with bindings in both directions, otherwise an arrow visited before the shapes it
+			// binds ends up in a cluster of its own and the result depends on input order
 			this.collectShapesViaArrowBindings({
-				bindings: this.getBindingsToShape(shape.id, 'arrow'),
+				bindings: this.getBindingsInvolvingShape(shape.id, 'arrow'),
 				initialShapes: freshShapes,
 				resultShapes: shapesMovingTogether,
 				resultBounds: boundsOfShapesMovingTogether,
@@ -7679,12 +7634,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let shapeGap: number = 0
 
+		// Stack in spatial order rather than input (z) order, otherwise shapes swap places
+		shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
+
 		if (_gap === 0) {
 			// note: this is not used in the current tldraw.com; there we use a specified stack
 
 			const gaps: Record<number, number> = {}
-
-			shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
 
 			// Collect all of the gaps between shapes. We want to find
 			// patterns (equal gaps between shapes) and use the most common
@@ -7738,8 +7694,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// todo: ensure that the parent isn't being aligned together with its children
 				const parent = this.getShapeParent(shape)
 				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
+					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
 				}
 
 				shapeDelta.add(shape) // add the shape's x and y to the delta
@@ -7789,10 +7744,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const maxWidth = commonBounds.width
 
-		// sort the shape clusters by width and then height, descending
+		// sort the shape clusters by width and then height, descending: potpack fills each row's
+		// right-hand space with the shapes that follow, so they must be no taller than the row
 		shapeClustersToPack
-			.sort((a, b) => a.pageBounds.width - b.pageBounds.width)
-			.sort((a, b) => a.pageBounds.height - b.pageBounds.height)
+			.sort((a, b) => b.pageBounds.width - a.pageBounds.width)
+			.sort((a, b) => b.pageBounds.height - a.pageBounds.height)
 
 		// Start with is (sort of) the square of the area
 		const startWidth = Math.max(Math.ceil(Math.sqrt(area / 0.95)), maxWidth)
@@ -7862,8 +7818,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				const parent = this.getShapeParent(shape)
 				if (parent) {
-					const parentTransform = this.getShapeParentTransform(shape)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
+					shapeDelta.rot(-this.getShapeParentTransform(shape).rotation())
 				}
 
 				shapeDelta.add(shape)
@@ -7953,8 +7908,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// todo: ensure that the parent isn't being aligned together with its children
 				const parent = this.getShapeParent(shape)
 				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
+					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
 				}
 
 				shapeDelta.add(shape) // add the shape's x and y to the delta
@@ -8054,8 +8008,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// todo: ensure that the parent isn't being aligned together with its children
 				const parent = this.getShapeParent(shape)
 				if (parent) {
-					const parentTransform = this.getShapePageTransform(parent)
-					if (parentTransform) shapeDelta.rot(-parentTransform.rotation())
+					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
 				}
 
 				shapeDelta.add(shape) // add the shape's x and y to the delta
@@ -8123,8 +8076,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				for (const shape of shapes) {
 					// First translate
 					const shapeLocalOffset = localOffset.clone()
-					const parentTransform = this.getShapeParentTransform(shape)
-					if (parentTransform) shapeLocalOffset.rot(-parentTransform.rotation())
+					shapeLocalOffset.rot(-this.getShapeParentTransform(shape).rotation())
 					shapeLocalOffset.add(shape)
 					const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
 					this.updateShape(changes)
@@ -8195,8 +8147,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			for (const shape of shapes) {
 				// First translate
 				const shapeLocalOffset = localOffset.clone()
-				const parentTransform = this.getShapeParentTransform(shape)
-				if (parentTransform) shapeLocalOffset.rot(-parentTransform.rotation())
+				shapeLocalOffset.rot(-this.getShapeParentTransform(shape).rotation())
 				shapeLocalOffset.add(shape)
 				const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
 				this.updateShape(changes)
@@ -8260,11 +8211,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const pageTransform = opts.initialPageTransform
 			? Mat.Cast(opts.initialPageTransform)
 			: this.getShapePageTransform(id)
-		if (!pageTransform) return null
 
 		const pageRotation = pageTransform.rotation()
-
-		if (pageRotation == null) return null
 
 		const scaleAxisRotation = opts.scaleAxisRotation ?? pageRotation
 
@@ -8446,6 +8394,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			initialShape: TLShape
 			isAspectRatioLocked: boolean
 			initialPageTransform: MatLike
+			dragHandle?: TLResizeHandle
+			mode?: TLResizeMode
+			skipStartAndEndCallbacks?: boolean
 		}
 	) {
 		const { type } = options.initialShape
@@ -8470,19 +8421,25 @@ export class Editor extends EventEmitter<TLEventMap> {
 			initialBounds: options.initialBounds,
 			isAspectRatioLocked: options.isAspectRatioLocked,
 			initialPageTransform: options.initialPageTransform,
+			dragHandle: options.dragHandle,
+			mode: options.mode,
+			// this is one frame of the same resize, not a new one, so don't fire start/end again
+			skipStartAndEndCallbacks: options.skipStartAndEndCallbacks,
 		})
 
 		// then if the shape is flipped in one axis only, we need to apply an extra rotation
 		// to make sure the shape is mirrored correctly
 		if (Math.sign(scale.x) * Math.sign(scale.y) < 0) {
-			// We need to compute the new local rotation that will result in the negated page rotation.
-			// For a shape with local rotation `localRot` and parent page rotation `parentRot`:
+			// Mirroring across an axis at angle `axisRot` maps a page rotation `pageRot` to
+			// `2 * axisRot - pageRot`. For a shape with local rotation `localRot` and parent page
+			// rotation `parentRot`:
 			// - pageRot = parentRot + localRot
-			// - newPageRot = -pageRot (we want to negate the page rotation)
+			// - newPageRot = 2 * axisRot - pageRot
 			// - newPageRot = parentRot + newLocalRot (parent hasn't changed)
-			// - Therefore: newLocalRot = -pageRot - parentRot = -(parentRot + localRot) - parentRot = -localRot - 2*parentRot
+			// - Therefore: newLocalRot = 2 * axisRot - localRot - 2 * parentRot
 			const parentRotation = this.getShapeParentTransform(id).rotation()
-			const rotation = -options.initialShape.rotation - 2 * parentRotation
+			const rotation =
+				2 * options.scaleAxisRotation - options.initialShape.rotation - 2 * parentRotation
 			this.updateShapes([{ id, type, rotation }])
 		}
 
@@ -8502,7 +8459,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		)
 
 		// now calculate how far away the shape is from where it needs to be
-		const pageTransform = this.getShapePageTransform(id)!
+		const pageTransform = this.getShapePageTransform(id)
 		// We need to use the local bounds center transformed to page space, not the axis-aligned
 		// page bounds center. This is because the page bounds are axis-aligned and their center
 		// changes when the rotation changes, but we want to use the same reference point as
@@ -8510,7 +8467,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const currentLocalBounds = this.getShapeGeometry(id).bounds
 		const currentPageCenter = Mat.applyToPoint(pageTransform, currentLocalBounds.center)
 		const shapePageTransformOrigin = pageTransform.point()
-		if (!currentPageCenter || !shapePageTransformOrigin) return this
 		const pageDelta = Vec.Sub(postScaleShapePageCenter, currentPageCenter)
 
 		// and finally figure out what the shape's new position should be
@@ -8856,6 +8812,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shape = this.getShape(partial.id)!
 			if (!shape) continue
 
+			// Apply the same lock rule as updateShapes up front: the intermediate frames go through
+			// _updateShapes, which doesn't check locks, so a locked shape would otherwise be moved by
+			// every frame but the last and end up stranded at the penultimate one
+			const unlocks = shape.isLocked && Object.hasOwn(partial, 'isLocked') && !partial.isLocked
+			if (!this._shouldIgnoreShapeLock && !unlocks && this.isShapeOrAncestorLocked(shape)) {
+				continue
+			}
+
 			result = {
 				start: structuredClone(shape),
 				end: applyPartialToRecordWithProps(structuredClone(shape), partial),
@@ -8898,10 +8862,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				updates.push({
 					...end,
-					x: start.x + (end.x - start.x) * t,
-					y: start.y + (end.y - start.y) * t,
-					opacity: start.opacity + (end.opacity - start.opacity) * t,
-					rotation: start.rotation + (end.rotation - start.rotation) * t,
+					x: lerp(start.x, end.x, t),
+					y: lerp(start.y, end.y, t),
+					opacity: lerp(start.opacity, end.opacity, t),
+					rotation: lerp(start.rotation, end.rotation, t),
 					props: this.getShapeUtil(end).getInterpolatedProps?.(start, end, t) ?? end.props,
 				})
 			}
@@ -8948,13 +8912,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes.map((s) => (s as TLShape).id) as TLShapeId[])
 
-		if (ids.length <= 1) return this
-
 		const shapesToGroup = compact(
 			(this._shouldIgnoreShapeLock ? ids : this._getUnlockedShapeIds(ids)).map((id) =>
 				this.getShape(id)
 			)
 		)
+		// Check the count after dropping locked / missing shapes, otherwise two locked ids get
+		// past this and Box.Common([]) throws below
+		if (shapesToGroup.length <= 1) return this
+
 		const sortedShapeIds = shapesToGroup.sort(sortByIndex).map((s) => s.id)
 		const childBounds = compact(shapesToGroup.map((shape) => this.getShapePageBounds(shape)))
 		const pageBounds = Box.Common(childBounds)
@@ -8967,11 +8933,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const parentId = this.findCommonAncestor(shapesToGroup) ?? this.getCurrentPageId()
 
-		// Only group when the select tool is active
-		if (this.getCurrentToolId() !== 'select') return this
-
-		// If not already in idle, cancel the current interaction (get back to idle)
-		if (!this.isIn('select.idle')) {
+		// If the select tool is mid-interaction, cancel it (get back to idle) before regrouping
+		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
 
@@ -8981,6 +8944,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			.sort(sortByIndex)
 
 		const highestIndex = shapesWithRootParent[shapesWithRootParent.length - 1]?.index
+
+		// createShapes bails out when the page is full, so check first; otherwise the shapes get
+		// reparented into a group that was never created and vanish from the page
+		if (!this.canCreateShapes([groupId])) {
+			alertMaxShapes(this)
+			return this
+		}
 
 		this.run(() => {
 			this.createShapes([
@@ -9038,9 +9008,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapesToUngroup.length === 0) return this
 
-		// todo: the editor shouldn't know about the select tool, move to group / ungroup actions
-		if (this.getCurrentToolId() !== 'select') return this
-		if (!this.isIn('select.idle')) {
+		// If the select tool is mid-interaction, cancel it (get back to idle) before regrouping
+		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
 
@@ -9063,10 +9032,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (groups.length === 0) return this
 
 		this.run(() => {
-			let group: TLGroupShape
-
 			for (let i = 0, n = groups.length; i < n; i++) {
-				group = groups[i]
+				// Re-read the group: ungrouping an outer group earlier in this loop reparents the
+				// inner ones, and the stale parentId would send their children into a group that's
+				// about to be deleted
+				const group = this.getShape<TLGroupShape>(groups[i].id)
+				if (!group) continue
 				const childIds = this.getSortedChildIdsForParent(group.id)
 
 				for (let j = 0, n = childIds.length; j < n; j++) {
@@ -9117,7 +9088,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	updateShapes<T extends TLShape>(partials: (TLShapePartial<T> | null | undefined)[]) {
-		const compactedPartials: TLShapePartial<T>[] = Array(partials.length)
+		const compactedPartials: TLShapePartial<T>[] = []
 
 		for (let i = 0, n = partials.length; i < n; i++) {
 			const partial = partials[i]
@@ -9193,7 +9164,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/** @internal */
 	private _getUnlockedShapeIds(ids: TLShapeId[]): TLShapeId[] {
-		return ids.filter((id) => !this.getShape(id)?.isLocked)
+		// Match updateShapes, which also refuses shapes under a locked ancestor; otherwise a child
+		// of a locked frame can't be moved but can still be deleted or duplicated
+		return ids.filter((id) => !this.isShapeOrAncestorLocked(id))
 	}
 
 	/**
@@ -9260,29 +9233,26 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this
 	}
 
-	/* --------------------- Styles --------------------- */
-
 	/**
-	 * Get all the current styles among the users selected shapes
+	 * Groups have no styles of their own: a style read or write on a selection applies to the
+	 * non-group shapes beneath each group, however deeply nested. Returns those shapes.
 	 *
 	 * @internal
 	 */
-	private _extractSharedStyles(shape: TLShape, sharedStyleMap: SharedStyleMap) {
-		if (this.isShapeOfType(shape, 'group')) {
-			// For groups, ignore the styles of the group shape and instead include the styles of the
-			// group's children. These are the shapes that would have their styles changed if the
-			// user called `setStyle` on the current selection.
-			const childIds = this._parentIdsToChildIds.get()[shape.id]
-			if (!childIds) return
-
-			for (let i = 0, n = childIds.length; i < n; i++) {
-				this._extractSharedStyles(this.getShape(childIds[i])!, sharedStyleMap)
-			}
-		} else {
-			for (const [style, propKey] of this.styleProps[shape.type]) {
-				sharedStyleMap.applyValue(style, getOwnProperty(shape.props, propKey))
+	private _getStyleableShapes(shapes: TLShape[]): TLShape[] {
+		const result: TLShape[] = []
+		const visit = (shape: TLShape) => {
+			if (this.isShapeOfType(shape, 'group')) {
+				for (const childId of this.getSortedChildIdsForParent(shape.id)) {
+					const child = this.getShape(childId)
+					if (child) visit(child)
+				}
+			} else {
+				result.push(shape)
 			}
 		}
+		for (const shape of shapes) visit(shape)
+		return result
 	}
 
 	/**
@@ -9292,11 +9262,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	@computed
 	private _getSelectionSharedStyles(): ReadonlySharedStyleMap {
-		const selectedShapes = this.getSelectedShapes()
-
 		const sharedStyles = new SharedStyleMap()
-		for (const selectedShape of selectedShapes) {
-			this._extractSharedStyles(selectedShape, sharedStyles)
+		for (const shape of this._getStyleableShapes(this.getSelectedShapes())) {
+			for (const [style, propKey] of this.styleProps[shape.type]) {
+				sharedStyles.applyValue(style, getOwnProperty(shape.props, propKey))
+			}
 		}
 
 		return sharedStyles
@@ -9354,18 +9324,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (!currentTool) return styles
 
 		if (currentTool.shapeType) {
-			if (
-				currentTool.shapeType === 'frame' &&
-				!(this.getShapeUtil('frame')!.options as any).showColors
-			) {
-				for (const style of this.styleProps[currentTool.shapeType].keys()) {
-					if (style.id === 'tldraw:color') continue
-					styles.applyValue(style, this.getStyleForNextShape(style))
-				}
-			} else {
-				for (const style of this.styleProps[currentTool.shapeType].keys()) {
-					styles.applyValue(style, this.getStyleForNextShape(style))
-				}
+			for (const style of this.styleProps[currentTool.shapeType].keys()) {
+				styles.applyValue(style, this.getStyleForNextShape(style))
 			}
 		}
 
@@ -9381,27 +9341,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	@computed getSharedOpacity(): SharedStyle<number> {
 		if (this.isIn('select') && this.getSelectedShapeIds().length > 0) {
-			const shapesToCheck: TLShape[] = []
-			const addShape = (shapeId: TLShapeId) => {
-				const shape = this.getShape(shapeId)
-				if (!shape) return
-				// For groups, ignore the opacity of the group shape and instead include
-				// the opacity of the group's children. These are the shapes that would have
-				// their opacity changed if the user called `setOpacity` on the current selection.
-				if (this.isShapeOfType(shape, 'group')) {
-					for (const childId of this.getSortedChildIdsForParent(shape.id)) {
-						addShape(childId)
-					}
-				} else {
-					shapesToCheck.push(shape)
-				}
-			}
-			for (const shapeId of this.getSelectedShapeIds()) {
-				addShape(shapeId)
-			}
-
 			let opacity: number | null = null
-			for (const shape of shapesToCheck) {
+			for (const shape of this._getStyleableShapes(this.getSelectedShapes())) {
 				if (opacity === null) {
 					opacity = shape.opacity
 				} else if (opacity !== shape.opacity) {
@@ -9444,33 +9385,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const selectedShapes = this.getSelectedShapes()
 
 		if (selectedShapes.length > 0) {
-			const shapesToUpdate: TLShape[] = []
-
-			// We can have many deep levels of grouped shape
-			// Making a recursive function to look through all the levels
-			const addShapeById = (shape: TLShape) => {
-				if (this.isShapeOfType(shape, 'group')) {
-					const childIds = this.getSortedChildIdsForParent(shape)
-					for (const childId of childIds) {
-						addShapeById(this.getShape(childId)!)
-					}
-				} else {
-					shapesToUpdate.push(shape)
-				}
-			}
-
-			for (const id of selectedShapes) {
-				addShapeById(id)
-			}
-
 			this.updateShapes(
-				shapesToUpdate.map((shape) => {
-					return {
-						id: shape.id,
-						type: shape.type,
-						opacity,
-					}
-				})
+				this._getStyleableShapes(selectedShapes).map((shape) => ({
+					id: shape.id,
+					type: shape.type,
+					opacity,
+				}))
 			)
 		}
 
@@ -9524,49 +9444,23 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const selectedShapes = this.getSelectedShapes()
 
 		if (selectedShapes.length > 0) {
-			const updates: {
-				util: ShapeUtil
-				originalShape: TLShape
-				updatePartial: TLShapePartial
-			}[] = []
-
-			// We can have many deep levels of grouped shape
-			// Making a recursive function to look through all the levels
-			const addShapeById = (shape: TLShape) => {
-				if (this.isShapeOfType(shape, 'group')) {
-					const childIds = this.getSortedChildIdsForParent(shape.id)
-					for (const childId of childIds) {
-						addShapeById(this.getShape(childId)!)
-					}
-				} else {
-					const util = this.getShapeUtil(shape)
-					const stylePropKey = this.styleProps[shape.type].get(style)
-					if (stylePropKey) {
-						const shapePartial: TLShapePartial = {
-							id: shape.id,
-							type: shape.type,
-							props: { [stylePropKey]: value },
-						}
-						updates.push({
-							util,
-							originalShape: shape,
-							updatePartial: shapePartial,
-						})
-					}
+			const updates: TLShapePartial[] = []
+			for (const shape of this._getStyleableShapes(selectedShapes)) {
+				const stylePropKey = this.styleProps[shape.type].get(style)
+				if (stylePropKey) {
+					updates.push({
+						id: shape.id,
+						type: shape.type,
+						props: { [stylePropKey]: value },
+					})
 				}
 			}
 
-			for (const shape of selectedShapes) {
-				addShapeById(shape)
-			}
-
-			this.updateShapes(updates.map(({ updatePartial }) => updatePartial))
+			this.updateShapes(updates)
 		}
 
 		return this
 	}
-
-	/* --------------------- Content -------------------- */
 
 	/** @internal */
 	externalAssetContentHandlers: {
@@ -9857,21 +9751,30 @@ export class Editor extends EventEmitter<TLEventMap> {
 					!asset.props.src?.startsWith('data:video') &&
 					!asset.props.src?.startsWith('http')
 				) {
-					const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
-					const objectUrl = await this.store.props.assets.resolve(asset, {
-						screenScale: 1,
-						steppedScreenScale: 1,
-						dpr: 1,
-						networkEffectiveType: null,
-						shouldResolveToOriginal: true,
-					})
-					assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
-						await fetch(objectUrl!).then((r) => r.blob())
-					)
-					assets.push(assetWithDataUrl)
-				} else {
-					assets.push(asset)
+					// If the asset can't be inlined (unresolvable src, fetch failure), fall through and
+					// keep the original record; dropping it leaves the pasted shapes pointing at an
+					// asset that doesn't exist
+					try {
+						const objectUrl = await this.store.props.assets.resolve(asset, {
+							screenScale: 1,
+							steppedScreenScale: 1,
+							dpr: 1,
+							networkEffectiveType: null,
+							shouldResolveToOriginal: true,
+						})
+						if (objectUrl) {
+							const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
+							assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
+								await fetch(objectUrl).then((r) => r.blob())
+							)
+							assets.push(assetWithDataUrl)
+							return
+						}
+					} catch {
+						// keep the original asset
+					}
 				}
+				assets.push(asset)
 			})
 		)
 		content.assets = assets
@@ -10092,7 +9995,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (shapeIdMap.has(newShape.parentId)) {
 				newShape.parentId = shapeIdMap.get(oldShape.parentId)!
 			} else {
-				rootShapeIds.push(newShape.id)
 				// newShape.parentId = pasteParentId
 				newShape.index = index
 				index = getIndexAbove(index)
@@ -10135,10 +10037,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				(asset.type === 'video' && asset.props.src?.startsWith('data:video'))
 			) {
 				// it's src is a base64 image or video; we need to create a new asset without the src,
-				// then create a new asset from the original src. So we save a copy of the original asset,
-				// then delete the src from the original asset.
-				assetsToUpdate.push(structuredClone(asset as TLImageAsset | TLVideoAsset))
-				asset.props.src = null
+				// then create a new asset from the original src. So we keep the original asset for the
+				// upload and create a copy with its src removed. Copy rather than mutate: when no
+				// migration applies, migrateStoreSnapshot hands back the caller's own record objects.
+				assetsToUpdate.push(asset as TLImageAsset | TLVideoAsset)
+				const assetWithoutSrc = structuredClone(asset as TLImageAsset | TLVideoAsset)
+				assetWithoutSrc.props.src = null
+				assetsToCreate.push(assetWithoutSrc)
+				continue
 			}
 
 			// Add the asset to the list of assets to create
@@ -10188,7 +10094,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				)
 			}
 
-			// --- POSITIONING ---
 			const rootBounds = Box.Common(compact(rootShapes.map((s) => this.getShapePageBounds(s.id))))
 
 			if (point === undefined) {
@@ -10414,8 +10319,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			height,
 		}
 	}
-
-	/* --------------------- Events --------------------- */
 
 	/**
 	 * Dispatch a cancel event.
@@ -11189,7 +11092,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		switch (type) {
 			case 'pinch': {
-				if (cameraOptions.isLocked) return
+				// A lock stops the camera, not the gesture: pinch_end must still run, otherwise
+				// locking mid-pinch leaves isPinching stuck and every pointer event is ignored.
+				if (cameraOptions.isLocked && info.name !== 'pinch_end') return
 				clearTimeout(this._longPressTimeout)
 				this.inputs.updateFromEvent(info)
 
@@ -11300,8 +11205,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				let wheelBehavior = cameraOptions.wheelBehavior
 				const inputMode = this.user.getUserPreferences().inputMode
 
-				// If the user has set their input mode preference, then use that to determine the wheel behavior
-				if (inputMode !== null) {
+				// The user's input mode preference picks between pan and zoom, but it must not
+				// re-enable a wheel the app disabled with `wheelBehavior: 'none'`.
+				if (inputMode !== null && wheelBehavior !== 'none') {
 					wheelBehavior = inputMode === 'trackpad' ? 'pan' : 'zoom'
 				}
 
@@ -11375,15 +11281,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// Ignore pointer events while we're pinching
 				if (inputs.getIsPinching()) return
 
-				this.inputs.updateFromEvent(info)
 				const { isPen } = info
 				const { isPenMode } = instanceState
 
+				// In pen mode, reject non-pen input (a resting palm) before it touches any
+				// state: otherwise updateFromEvent moves the origin point out from under the
+				// pen's drag, and a palm pointer_up clears the pen's isPointing/isDragging.
+				if (isPenMode && !isPen) return
+
+				this.inputs.updateFromEvent(info)
+
 				switch (info.name) {
 					case 'pointer_down': {
-						// If we're in pen mode and the input is not a pen type, then stop here
-						if (isPenMode && !isPen) return
-
 						// A pointer down starts a new interaction, so flush any modifier that's
 						// still lingering in its release-debounce window: treat it as released now.
 						this._releaseDebouncedModifiers()
@@ -11418,10 +11327,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// If it's a left-mouse-click, we store the pointer id for later user
 						if (info.button === LEFT_MOUSE_BUTTON) this.capturedPointerId = info.pointerId
 
-						// Add the button from the buttons set
 						inputs.buttons.add(info.button)
 
-						// Start pointing and stop dragging
 						inputs.setIsPointing(true)
 						inputs.setIsDragging(false)
 
@@ -11435,8 +11342,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.interrupt()
 						}
 
-						// On devices with erasers (like the Surface Pen or Wacom Pen), button 5 is the eraser
-						if (info.button === STYLUS_ERASER_BUTTON) {
+						// On devices with erasers (like the Surface Pen or Wacom Pen), button 5 is the eraser.
+						// Guarded on the eraser tool existing: the bare editor can be configured without
+						// it, and an unguarded transition would throw and crash the editor.
+						if (info.button === STYLUS_ERASER_BUTTON && this.getStateDescendant('eraser')) {
 							this._restoreToolId = this.getCurrentToolId()
 							this.complete()
 							this.setCurrentTool('eraser')
@@ -11464,9 +11373,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						break
 					}
 					case 'pointer_move': {
-						// If the user is in pen mode, but the pointer is not a pen, stop here.
-						if (!isPen && isPenMode) return
-
 						const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.getCamera())
 
 						// Right-click pointing: waiting to see if this becomes a drag
@@ -11522,15 +11428,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 						break
 					}
 					case 'pointer_up': {
-						// Stop dragging / pointing
 						inputs.setIsDragging(false)
 						inputs.setIsPointing(false)
 						clearTimeout(this._longPressTimeout)
-						// Remove the button from the buttons set
 						inputs.buttons.delete(info.button)
-
-						// If we're in pen mode and we're not using a pen, stop here
-						if (instanceState.isPenMode && !isPen) return
 
 						// Right-click pointing ended without dragging—this is a static
 						// right-click, so let it through to the state chart as right_click.
@@ -11601,7 +11502,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								})
 							}
 						} else {
-							if (info.button === STYLUS_ERASER_BUTTON) {
+							if (info.button === STYLUS_ERASER_BUTTON && this.getStateDescendant('eraser')) {
 								// If we were erasing with a stylus button, restore the tool we were using before we started erasing
 								this.complete()
 								this.setCurrentTool(this._restoreToolId)
@@ -11619,15 +11520,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'keyboard': {
-				// please, please
-				if (info.key === 'ShiftRight') info.key = 'ShiftLeft'
-				if (info.key === 'AltRight') info.key = 'AltLeft'
+				// Fold the right-hand modifiers into the left codes that `inputs.keys` consumers check.
+				if (info.code === 'ShiftRight') info.code = 'ShiftLeft'
+				if (info.code === 'AltRight') info.code = 'AltLeft'
 				if (info.code === 'ControlRight') info.code = 'ControlLeft'
 				if (info.code === 'MetaRight') info.code = 'MetaLeft'
 
 				switch (info.name) {
 					case 'key_down': {
-						// Add the key from the keys set
 						inputs.keys.add(info.code)
 
 						if (this.options.spacebarPanning) {
@@ -11667,7 +11567,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 									}
 								}
 
-								if (offset) {
+								// `_animateToViewport` bypasses `setCamera`, so honor the lock here.
+								if (offset && !cameraOptions.isLocked) {
 									const bounds = this.getViewportPageBounds()
 									const next = bounds.clone().translate(offset.mulV({ x: bounds.w, y: bounds.h }))
 									this._animateToViewport(next, { animation: { duration: 320 } })
@@ -11678,7 +11579,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						break
 					}
 					case 'key_up': {
-						// Remove the key from the keys set
 						inputs.keys.delete(info.code)
 
 						if (this.options.spacebarPanning) {
@@ -11729,9 +11629,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				this.setCurrentTool('select')
 			}
 
-			// If a left click pointer event, send the event to the click manager.
+			// Send the event to the click manager. In pen mode only pen clicks count; otherwise
+			// every pointer does, including an indirect tablet stylus (a pen that never enables
+			// pen mode), which would otherwise never produce double-click events.
 			const { isPenMode } = this.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
-			if (info.isPen === isPenMode) {
+			if (!isPenMode || info.isPen) {
 				// The click manager may return a new event, i.e. a double click event
 				// depending on the event coming in and its own state. If the event has
 				// changed then hand both events to the statechart
@@ -11887,10 +11789,10 @@ function withIsolatedShapes<T>(
 
 function getCameraFitXFitY(editor: Editor, cameraOptions: TLCameraOptions) {
 	if (!cameraOptions.constraints) throw Error('Should have constraints here')
-	const {
-		padding: { x: px, y: py },
-	} = cameraOptions.constraints
 	const vsb = editor.getViewportScreenBounds()
+	// Clamp padding to half the viewport size on either dimension, as getConstrainedCamera does
+	const px = Math.min(cameraOptions.constraints.padding.x, vsb.w / 2)
+	const py = Math.min(cameraOptions.constraints.padding.y, vsb.h / 2)
 	const bounds = Box.From(cameraOptions.constraints.bounds)
 	const zx = (vsb.w - px * 2) / bounds.w
 	const zy = (vsb.h - py * 2) / bounds.h

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11520,9 +11520,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'keyboard': {
-				// Fold the right-hand modifiers into the left codes that `inputs.keys` consumers check.
-				if (info.code === 'ShiftRight') info.code = 'ShiftLeft'
-				if (info.code === 'AltRight') info.code = 'AltLeft'
+				// please, please
+				if (info.key === 'ShiftRight') info.key = 'ShiftLeft'
+				if (info.key === 'AltRight') info.key = 'AltLeft'
 				if (info.code === 'ControlRight') info.code = 'ControlLeft'
 				if (info.code === 'MetaRight') info.code = 'MetaLeft'
 

--- a/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
+++ b/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
@@ -18,6 +18,8 @@ function fromScratch(bindingsQuery: Computed<TLBinding[], unknown>) {
 		} else {
 			bindingsForFromShape.push(binding)
 		}
+		// A binding from a shape to itself belongs in that shape's array once, not twice
+		if (toId === fromId) continue
 		const bindingsForToShape = shapesToBindings.get(toId)
 		if (!bindingsForToShape) {
 			shapesToBindings.set(toId, [binding])
@@ -83,6 +85,7 @@ export function bindingsIndex(editor: Editor): Computed<TLBindingsIndex> {
 
 		function addBinding(binding: TLBinding) {
 			ensureNewArray(binding.fromId).push(binding)
+			if (binding.toId === binding.fromId) return
 			ensureNewArray(binding.toId).push(binding)
 		}
 

--- a/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
+++ b/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
@@ -75,9 +75,15 @@ export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: ()
 				}
 			}
 
-			for (const [_from, to] of Object.values(changes.updated)) {
+			for (const [from, to] of Object.values(changes.updated)) {
 				if (isShape(to)) {
-					if (isShapeInPage(store, currentPageId, to)) {
+					const inPage = isShapeInPage(store, currentPageId, to)
+					// A reparent that moves a shape onto or off this page takes its descendants
+					// with it, but they are not in the diff; rebuild so they don't keep stale membership
+					if (isShape(from) && from.parentId !== to.parentId && inPage !== prevValue.has(to.id)) {
+						return fromScratch()
+					}
+					if (inPage) {
 						builder.add(to.id)
 					} else {
 						builder.remove(to.id)

--- a/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
+++ b/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
@@ -94,7 +94,7 @@ export class ClickManager {
 				switch (this._clickState) {
 					case 'pendingDouble': {
 						this._clickState = 'pendingOverflow'
-						this._clickTimeout = this._getClickTimeout(this._clickState)
+						this._getClickTimeout(this._clickState)
 						return {
 							...info,
 							type: 'click',
@@ -114,7 +114,7 @@ export class ClickManager {
 						// overflow
 					}
 				}
-				this._clickTimeout = this._getClickTimeout(this._clickState)
+				this._getClickTimeout(this._clickState)
 				return info
 			}
 			case 'pointer_up': {
@@ -141,10 +141,12 @@ export class ClickManager {
 				return info
 			}
 			case 'pointer_move': {
+				// Compare in client coordinates like _clickScreenPoint; the container-relative
+				// inputs screen point would add the container offset and cancel on any movement.
 				if (
 					this._clickState !== 'idle' &&
 					this._clickScreenPoint &&
-					Vec.Dist2(this._clickScreenPoint, this.editor.inputs.getCurrentScreenPoint()) >
+					Vec.Dist2(this._clickScreenPoint, info.point) >
 						(this.editor.getInstanceState().isCoarsePointer
 							? this.editor.options.coarseDragDistanceSquared
 							: this.editor.options.dragDistanceSquared)

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -1,6 +1,6 @@
 import { EMPTY_ARRAY, atom, computed } from '@tldraw/state'
 import type { TLInstancePresence } from '@tldraw/tlschema'
-import { areArraysShallowEqual, maxBy } from '@tldraw/utils'
+import { areArraysShallowEqual } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
 
 /**
@@ -54,14 +54,14 @@ export class CollaboratorsManager {
 	getCollaborators(): TLInstancePresence[] {
 		const allPresenceRecords = this._getCollaboratorsQuery().get()
 		if (!allPresenceRecords.length) return EMPTY_ARRAY
-		const userIds = [...new Set(allPresenceRecords.map((c) => c.userId))].sort()
-		return userIds.map((id) => {
-			const latestPresence = maxBy(
-				allPresenceRecords.filter((c) => c.userId === id),
-				(p) => p.lastActivityTimestamp ?? 0
-			)
-			return latestPresence!
-		})
+		const latestByUserId = new Map<string, TLInstancePresence>()
+		for (const presence of allPresenceRecords) {
+			const latest = latestByUserId.get(presence.userId)
+			if (!latest || (presence.lastActivityTimestamp ?? 0) > (latest.lastActivityTimestamp ?? 0)) {
+				latestByUserId.set(presence.userId, presence)
+			}
+		}
+		return [...latestByUserId.keys()].sort().map((id) => latestByUserId.get(id)!)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -1,4 +1,4 @@
-import { computed, EMPTY_ARRAY, transact } from '@tldraw/state'
+import { atom, computed, EMPTY_ARRAY, transact } from '@tldraw/state'
 import { AtomMap } from '@tldraw/store'
 import { TLFontFace, TLShape, TLShapeId } from '@tldraw/tlschema'
 import {
@@ -8,6 +8,7 @@ import {
 	mapObjectMapValues,
 	objectMapEntries,
 } from '@tldraw/utils'
+import { areShapesContentEqual } from '../../../utils/areShapesContentEqual'
 import type { Editor } from '../../Editor'
 
 interface FontState {
@@ -41,7 +42,7 @@ export class FontManager {
 			},
 			{
 				areResultsEqual: areArraysShallowEqual,
-				areRecordsEqual: (a, b) => a.props === b.props && a.meta === b.meta,
+				areRecordsEqual: areShapesContentEqual,
 			}
 		)
 
@@ -101,6 +102,22 @@ export class FontManager {
 		return this.fontStates.get(font) ?? null
 	}
 
+	// One signal for consumers that deliberately avoid per-shape font tracking (the
+	// spatial index); otherwise their cached text bounds stay at the fallback-font size.
+	private readonly fontLoadEpoch = atom('font load epoch', 0)
+
+	/** @internal */
+	getFontLoadEpoch(): number {
+		return this.fontLoadEpoch.get()
+	}
+
+	private setFontState(font: TLFontFace, state: FontState['state']) {
+		transact(() => {
+			this.fontStates.update(font, (s) => ({ ...s, state }))
+			this.fontLoadEpoch.update((n) => n + 1)
+		})
+	}
+
 	ensureFontIsLoaded(font: TLFontFace): Promise<void> {
 		const existingState = this.getFontState(font)
 		if (existingState) return existingState.loadingPromise
@@ -122,7 +139,7 @@ export class FontManager {
 						return
 					}
 					this.editor.getContainerDocument().fonts.add(instance)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'ready' }))
+					this.setFontState(font, 'ready')
 				})
 				.catch((err) => {
 					if (isStale()) {
@@ -131,7 +148,7 @@ export class FontManager {
 						return
 					}
 					console.error(err)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'error' }))
+					this.setFontState(font, 'error')
 				}),
 		}
 

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
@@ -173,8 +173,6 @@ export class PerformanceManager {
 		this.emitter.removeAllListeners()
 	}
 
-	// --- Internal notification methods ---
-
 	/** @internal */
 	_notifyInteractionStart(name: string, path: string) {
 		if (
@@ -288,8 +286,6 @@ export class PerformanceManager {
 		}
 		this.emitter.emit(type, event)
 	}
-
-	// --- Private helpers ---
 
 	private _startCameraSession(type: 'panning' | 'zooming') {
 		this.activeCamera = {
@@ -432,8 +428,6 @@ export class PerformanceManager {
 		this.emitter.emit('shapes-deleted', event)
 	}
 
-	// --- LoAF observer ---
-
 	private _startLoafObserver() {
 		if (typeof PerformanceObserver === 'undefined') return
 
@@ -472,8 +466,6 @@ export class PerformanceManager {
 			this.loafObserver = null
 		}
 	}
-
-	// --- Lazy listener management ---
 
 	private _needsFrameListener(): boolean {
 		return (

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -62,8 +62,6 @@ export class ScribbleManager {
 
 	constructor(private editor: Editor) {}
 
-	// ==================== SESSION API ====================
-
 	/**
 	 * Start a new session for grouping scribbles.
 	 * Returns a session ID that can be used with other session methods.
@@ -255,8 +253,6 @@ export class ScribbleManager {
 		return session?.state === 'active'
 	}
 
-	// ==================== SIMPLE API (for eraser, select, etc.) ====================
-
 	/**
 	 * Add a scribble using the default self-consuming behavior.
 	 * Creates an implicit session for the scribble.
@@ -388,8 +384,6 @@ export class ScribbleManager {
 			this.editor.updateInstanceState({ scribbles })
 		})
 	}
-
-	// ==================== PRIVATE HELPERS ====================
 
 	// Called on every pointer move and laser tick, so keep one pending timer per
 	// session and re-arm it only when it fires early. Otherwise every call leaves a

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -51,6 +51,7 @@ interface Session {
 	state: 'active' | 'stopping' | 'complete'
 	options: Required<Omit<ScribbleSessionOptions, 'id'>>
 	idleTimeoutHandle?: number
+	idleDeadline: number
 	fadeElapsed: number
 	totalPointsAtFadeStart: number
 }
@@ -84,6 +85,7 @@ export class ScribbleManager {
 				fadeEasing: options.fadeEasing ?? (options.fadeMode === 'grouped' ? 'ease-in' : 'linear'),
 				fadeDurationMs: options.fadeDurationMs ?? this.editor.options.laserFadeoutMs,
 			},
+			idleDeadline: 0,
 			fadeElapsed: 0,
 			totalPointsAtFadeStart: 0,
 		}
@@ -389,11 +391,26 @@ export class ScribbleManager {
 
 	// ==================== PRIVATE HELPERS ====================
 
+	// Called on every pointer move and laser tick, so keep one pending timer per
+	// session and re-arm it only when it fires early. Otherwise every call leaves a
+	// timer id behind in editor.timers for the editor's lifetime.
 	private resetIdleTimeout(session: Session): void {
-		this.clearIdleTimeout(session)
+		session.idleDeadline = Date.now() + session.options.idleTimeoutMs
+		if (session.idleTimeoutHandle === undefined) {
+			this.armIdleTimeout(session, session.options.idleTimeoutMs)
+		}
+	}
+
+	private armIdleTimeout(session: Session, delay: number): void {
 		session.idleTimeoutHandle = this.editor.timers.setTimeout(() => {
-			this.stopSession(session.id)
-		}, session.options.idleTimeoutMs)
+			session.idleTimeoutHandle = undefined
+			const remaining = session.idleDeadline - Date.now()
+			if (remaining > 0) {
+				this.armIdleTimeout(session, remaining)
+			} else {
+				this.stopSession(session.id)
+			}
+		}, delay)
 	}
 
 	private clearIdleTimeout(session: Session): void {
@@ -433,10 +450,13 @@ export class ScribbleManager {
 			}
 		}
 
-		// Remove completed items in individual fade mode
+		// Remove faded-out items in individual fade mode. A scribble that has not
+		// received its first point yet is also empty but must stay, otherwise the
+		// session is dropped before the tool gets to add a point.
 		if (session.options.fadeMode === 'individual') {
 			for (let i = session.items.length - 1; i >= 0; i--) {
-				if (session.items[i].scribble.points.length === 0) {
+				const { scribble } = session.items[i]
+				if (scribble.points.length === 0 && scribble.state === 'stopping') {
 					session.items.splice(i, 1)
 				}
 			}

--- a/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
@@ -159,6 +159,22 @@ function findAdjacentGaps(
 	return matches
 }
 
+// Adjacent evenly spaced items produce many center snaps whose gaps cover the
+// same breadth; only the smallest such gap needs showing, so find the one a new
+// gap would be redundant with. Touching breadths don't count as overlapping.
+function findOverlappingCenterSnap(snaps: NearestSnap[], gap: Gap) {
+	return snaps.find(
+		(snap): snap is Extract<NearestSnap, { type: 'gap_center' }> =>
+			snap.type === 'gap_center' &&
+			rangesOverlap(
+				gap.breadthIntersection[0],
+				gap.breadthIntersection[1],
+				snap.gap.breadthIntersection[0],
+				snap.gap.breadthIntersection[1]
+			)
+	)
+}
+
 function dedupeGapSnaps(snaps: Array<Extract<SnapIndicator, { type: 'gaps' }>>) {
 	// sort by descending order of number of gaps
 	snaps.sort((a, b) => b.gaps.length - a.gaps.length)
@@ -206,12 +222,10 @@ export class BoundsSnaps {
 		const { editor } = this
 		return editor.store.createComputedCache<BoundsSnapPoint[], TLShape>('snapPoints', (shape) => {
 			const pageTransform = editor.getShapePageTransform(shape.id)
-			if (!pageTransform) return undefined
 			const boundsSnapGeometry = editor.getShapeUtil(shape).getBoundsSnapGeometry(shape)
 			const snapPoints =
 				boundsSnapGeometry.points ?? editor.getShapeGeometry(shape).bounds.cornersAndCenter
 
-			if (!pageTransform || !snapPoints) return undefined
 			return snapPoints.map((point, i) => {
 				const { x, y } = Mat.applyToPoint(pageTransform, point)
 				return { x, y, id: `${shape.id}:${i}` }
@@ -599,9 +613,8 @@ export class BoundsSnaps {
 		// which are closest to it in each axis
 		for (const thisSnapPoint of selectionSnapPoints) {
 			for (const otherSnapPoint of otherNodeSnapPoints) {
-				const offset = Vec.Sub(thisSnapPoint, otherSnapPoint)
-				const offsetX = Math.abs(offset.x)
-				const offsetY = Math.abs(offset.y)
+				const offsetX = Math.abs(thisSnapPoint.x - otherSnapPoint.x)
+				const offsetY = Math.abs(thisSnapPoint.y - otherSnapPoint.y)
 
 				if (round(offsetX) <= round(minOffset.x)) {
 					if (round(offsetX) < round(minOffset.x)) {
@@ -720,23 +733,14 @@ export class BoundsSnaps {
 				//              │         │
 				//              └─────────┘
 
-				const otherCenterSnap = nearestSnapsX.find(({ type }) => type === 'gap_center') as
-					| Extract<NearestSnap, { type: 'gap_center' }>
-					| undefined
+				const overlappingCenterSnap = findOverlappingCenterSnap(nearestSnapsX, gap)
 
-				const gapBreadthsOverlap =
-					otherCenterSnap &&
-					rangeIntersection(
-						gap.breadthIntersection[0],
-						gap.breadthIntersection[1],
-						otherCenterSnap.gap.breadthIntersection[0],
-						otherCenterSnap.gap.breadthIntersection[1]
-					)
-
-				// if there is another center snap and it's bigger than this one, and it overlaps with this one, replace it
-				if (otherCenterSnap && otherCenterSnap.gap.length > gap.length && gapBreadthsOverlap) {
-					nearestSnapsX[nearestSnapsX.indexOf(otherCenterSnap)] = snap
-				} else if (!otherCenterSnap || !gapBreadthsOverlap) {
+				// if there is another center snap that overlaps with this one, keep only the smaller gap
+				if (overlappingCenterSnap) {
+					if (overlappingCenterSnap.gap.length > gap.length) {
+						nearestSnapsX[nearestSnapsX.indexOf(overlappingCenterSnap)] = snap
+					}
+				} else {
 					nearestSnapsX.push(snap)
 				}
 			}
@@ -855,26 +859,16 @@ export class BoundsSnaps {
 				//              │         │
 				//              └─────────┘
 
-				const otherCenterSnap = nearestSnapsY.find(({ type }) => type === 'gap_center') as
-					| Extract<NearestSnap, { type: 'gap_center' }>
-					| undefined
+				const overlappingCenterSnap = findOverlappingCenterSnap(nearestSnapsY, gap)
 
-				const gapBreadthsOverlap =
-					otherCenterSnap &&
-					rangesOverlap(
-						otherCenterSnap.gap.breadthIntersection[0],
-						otherCenterSnap.gap.breadthIntersection[1],
-						gap.breadthIntersection[0],
-						gap.breadthIntersection[1]
-					)
-
-				// if there is another center snap and it's bigger than this one, and it overlaps with this one, replace it
-				if (otherCenterSnap && otherCenterSnap.gap.length > gap.length && gapBreadthsOverlap) {
-					nearestSnapsY[nearestSnapsY.indexOf(otherCenterSnap)] = snap
-				} else if (!otherCenterSnap || !gapBreadthsOverlap) {
+				// if there is another center snap that overlaps with this one, keep only the smaller gap
+				if (overlappingCenterSnap) {
+					if (overlappingCenterSnap.gap.length > gap.length) {
+						nearestSnapsY[nearestSnapsY.indexOf(overlappingCenterSnap)] = snap
+					}
+				} else {
 					nearestSnapsY.push(snap)
 				}
-				continue
 			}
 
 			// check for duplication top match

--- a/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
@@ -1,7 +1,8 @@
 import { computed } from '@tldraw/state'
 import { TLHandle, TLShape, TLShapeId, VecModel } from '@tldraw/tlschema'
 import { assertExists, uniqueId } from '@tldraw/utils'
-import { Geometry2d } from '../../../primitives/geometry/Geometry2d'
+import { Geometry2d, Geometry2dFilters } from '../../../primitives/geometry/Geometry2d'
+import { Group2d } from '../../../primitives/geometry/Group2d'
 import { Vec } from '../../../primitives/Vec'
 import type { Editor } from '../../Editor'
 import type { PointsSnapIndicator, SnapData, SnapManager } from './SnapManager'
@@ -156,11 +157,21 @@ export class HandleSnaps {
 		let minDistanceForOutline = snapThreshold
 		let nearestPointOnOutline: Vec | null = null
 
+		// Labels and internal detail (a note's label, a geo check mark) are not outlines
+		// to snap to. Group2d.nearestPoint throws when the filter leaves no child, so
+		// skip those groups.
+		const filters = Geometry2dFilters.EXCLUDE_NON_STANDARD
 		for (const { shapeId, outline } of this.iterateSnapOutlines(currentShapeId, handle)) {
+			if (
+				outline instanceof Group2d &&
+				outline.children.every((child) => child.isExcludedByFilter(filters))
+			) {
+				continue
+			}
 			const shapePageTransform = assertExists(this.editor.getShapePageTransform(shapeId))
 			const pointInShapeSpace = this.editor.getPointInShapeSpace(shapeId, handleInPageSpace)
 
-			const nearestShapePointInShapeSpace = outline.nearestPoint(pointInShapeSpace)
+			const nearestShapePointInShapeSpace = outline.nearestPoint(pointInShapeSpace, filters)
 			const nearestInPageSpace = shapePageTransform.applyToPoint(nearestShapePointInShapeSpace)
 
 			if (Vec.DistMin(handleInPageSpace, nearestInPageSpace, minDistanceForOutline)) {

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.test.ts
@@ -78,6 +78,7 @@ describe('SnapManager', () => {
 			getShapePageBounds: vi.fn(),
 			isShapeOfType: vi.fn(),
 			isShapeFrameLike: vi.fn(() => false),
+			isShapeHidden: vi.fn(() => false),
 		} as any
 
 		editor.getShapeUtil.mockReturnValue({
@@ -332,6 +333,18 @@ describe('SnapManager', () => {
 			editor.getShapeUtil.mockReturnValue({
 				canSnap: vi.fn(() => false),
 			} as any)
+
+			const result = snapManager.getSnappableShapes()
+			expect(result.has(shapeId)).toBe(false)
+		})
+
+		it('should exclude hidden shapes', () => {
+			const shapeId = createShapeId('shape1')
+
+			editor.getSortedChildIdsForParent.mockReturnValue([shapeId])
+			editor.getShape.mockReturnValue(createMockShape(shapeId) as any)
+			editor.getShapePageBounds.mockReturnValue(new Box(10, 10, 50, 50))
+			editor.isShapeHidden.mockReturnValue(true)
 
 			const result = snapManager.getSnappableShapes()
 			expect(result.has(shapeId)).toBe(false)

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
@@ -65,21 +65,21 @@ export class SnapManager {
 	@computed getSnappableShapes(): Set<TLShapeId> {
 		const { editor } = this
 		const renderingBounds = editor.getViewportPageBounds()
-		const selectedShapeIds = editor.getSelectedShapeIds()
+		const selectedShapeIds = new Set(editor.getSelectedShapeIds())
 
 		const snappableShapes: Set<TLShapeId> = new Set()
 
 		const collectSnappableShapesFromParent = (parentId: TLParentId) => {
 			if (isShapeId(parentId)) {
 				const parent = editor.getShape(parentId)
-				if (parent && editor.isShapeFrameLike(parent)) {
+				if (parent && editor.isShapeFrameLike(parent) && !editor.isShapeHidden(parent)) {
 					snappableShapes.add(parentId)
 				}
 			}
 			const sortedChildIds = editor.getSortedChildIdsForParent(parentId)
 			for (const childId of sortedChildIds) {
 				// Skip any selected ids
-				if (selectedShapeIds.includes(childId)) continue
+				if (selectedShapeIds.has(childId)) continue
 				const childShape = editor.getShape(childId)
 				if (!childShape) continue
 				const util = editor.getShapeUtil(childShape)
@@ -88,11 +88,13 @@ export class SnapManager {
 				// Only consider shapes if they're inside of the viewport page bounds
 				const pageBounds = editor.getShapePageBounds(childId)
 				if (!(pageBounds && renderingBounds.includes(pageBounds))) continue
-				// Snap to children of groups but not group itself
+				// Snap to children of groups but not group itself. A hidden group's
+				// children may still override to visible, so recurse before the check.
 				if (editor.isShapeOfType(childShape, 'group')) {
 					collectSnappableShapesFromParent(childId)
 					continue
 				}
+				if (editor.isShapeHidden(childShape)) continue
 				snappableShapes.add(childId)
 			}
 		}

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -41,6 +41,7 @@ export class SpatialIndexManager {
 	private rbush: RBushIndex
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
+	private lastFontLoadEpoch = -1
 
 	// Bumps only when the rbush content may have changed. Consumers subscribe
 	// via the computed; a stable epoch lets prop-only diffs skip downstream
@@ -66,21 +67,27 @@ export class SpatialIndexManager {
 		const bindingHistory = this.editor.store.query.filterHistory('binding')
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
-			// These three reads are the computed's only tracked dependencies.
-			// Every input to a shape's page bounds is a shape or binding record,
-			// so the two histories cover all invalidation; the rebuild/update
-			// paths below run without capture to avoid registering a dependency
-			// per checked shape on every update (and ~page-size dependencies on
-			// every rebuild).
+			// These four reads are the computed's only tracked dependencies. A
+			// shape's page bounds derive from shape and binding records plus, for
+			// text, the font load state (measured text resizes when its font swaps
+			// in), so the histories and the font load epoch cover all invalidation.
+			// The rebuild/update paths below run without capture to avoid
+			// registering a dependency per checked shape on every update (and
+			// ~page-size dependencies on every rebuild).
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
 			const bindingDiff = bindingHistory.getDiffSince(lastComputedEpoch)
 			const currentPageId = this.editor.getCurrentPageId()
+			const fontLoadEpoch = this.editor.fonts.getFontLoadEpoch()
 
 			if (
 				isUninitialized(_prevValue) ||
 				shapeDiff === RESET_VALUE ||
 				bindingDiff === RESET_VALUE ||
-				this.lastPageId !== currentPageId
+				this.lastPageId !== currentPageId ||
+				// Which shapes a font load resizes isn't known without visiting
+				// every shape, so rebuild; loads are rare and bounded by the
+				// number of distinct fonts.
+				this.lastFontLoadEpoch !== fontLoadEpoch
 			) {
 				return unsafe__withoutCapture(() => this.rebuildAndBumpEpoch())
 			}
@@ -97,6 +104,7 @@ export class SpatialIndexManager {
 	private buildFromScratch(): void {
 		this.rbush.clear()
 		this.lastPageId = this.editor.getCurrentPageId()
+		this.lastFontLoadEpoch = this.editor.fonts.getFontLoadEpoch()
 
 		const elements: SpatialElement[] = []
 		for (const shape of this.editor.getCurrentPageShapes()) {

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -307,6 +307,37 @@ describe('TextManager', () => {
 			expect(result.spans[0].text).toBe(`a${family}b`)
 		})
 
+		it('should measure each text node with its own offsets', () => {
+			const starts: [unknown, number][] = []
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn((node: unknown, offset: number) => starts.push([node, offset])),
+					setEnd: vi.fn(),
+					getClientRects: vi.fn(() => [
+						{ width: 10, height: 16, left: 0, top: 0, right: 10, bottom: 16 },
+					]),
+				}
+			})
+
+			const first = { nodeType: 3, textContent: 'ab' }
+			const second = { nodeType: 3, textContent: 'cd' }
+			const mockElementWithText = {
+				childNodes: [first, { nodeType: 1 }, second],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			textManager.measureElementTextNodeSpans(mockElementWithText as any)
+
+			// the range must be placed in the node being measured, not the first one
+			expect(starts).toEqual([
+				[first, 0],
+				[first, 1],
+				[second, 0],
+				[second, 1],
+			])
+		})
+
 		it('should handle truncation option', () => {
 			const mockTextNode = {
 				nodeType: 3, // TEXT_NODE

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -292,10 +292,8 @@ export class TextManager extends EditorManager {
 		const offsetX = -elmBounds.left
 		const offsetY = -elmBounds.top
 
-		// we measure by creating a range that spans each character in the elements text node
+		// we measure by creating a range that spans each character in the elements text nodes
 		const range = new Range()
-		const textNode = element.childNodes[0]
-		let idx = 0
 
 		let currentSpan = null
 		let prevCharWasSpaceCharacter = null
@@ -303,12 +301,15 @@ export class TextManager extends EditorManager {
 		let prevCharLeftForRTLTest = 0
 		let didTruncate = false
 		for (const childNode of element.childNodes) {
+			if (didTruncate) break
 			if (childNode.nodeType !== Node.TEXT_NODE) continue
 
+			// offsets are per text node, or the range would index past the node's end
+			let idx = 0
 			for (const segment of iterateGraphemes(childNode.textContent ?? '')) {
 				// place the range around the grapheme we're interested in
-				range.setStart(textNode, idx)
-				range.setEnd(textNode, idx + segment.length)
+				range.setStart(childNode, idx)
+				range.setEnd(childNode, idx + segment.length)
 				// measure the range. some browsers return multiple rects for the
 				// first char in a new line - one for the line break, and one for
 				// the character itself. we're only interested in the character.

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
@@ -10,6 +10,7 @@ export class UserPreferencesManager {
 	disposables = new Set<() => void>()
 	dispose() {
 		this.disposables.forEach((d) => d())
+		this.disposables.clear()
 	}
 	constructor(
 		private readonly user: TLCurrentUser,

--- a/packages/editor/src/lib/editor/overlays/OverlayManager.ts
+++ b/packages/editor/src/lib/editor/overlays/OverlayManager.ts
@@ -1,4 +1,5 @@
 import { atom, computed } from '@tldraw/state'
+import { WeakCache } from '@tldraw/utils'
 import { Geometry2d } from '../../primitives/geometry/Geometry2d'
 import { VecLike } from '../../primitives/Vec'
 import type { Editor } from '../Editor'
@@ -119,7 +120,7 @@ export class OverlayManager {
 	// while getActiveOverlayEntries() keeps returning the same overlay
 	// instances; when its reactive deps change, getOverlays() emits fresh
 	// objects and stale entries fall out by GC.
-	private _geometryCache = new WeakMap<TLOverlay, Geometry2d | null>()
+	private _geometryCache = new WeakCache<TLOverlay, Geometry2d | null>()
 
 	/**
 	 * Get hit-test geometry for an overlay, cached by overlay identity. Lets
@@ -130,12 +131,7 @@ export class OverlayManager {
 	 * @public
 	 */
 	getOverlayGeometry(overlay: TLOverlay): Geometry2d | null {
-		const cached = this._geometryCache.get(overlay)
-		if (cached !== undefined) return cached
-		const util = this.getOverlayUtil(overlay)
-		const geometry = util.getGeometry(overlay)
-		this._geometryCache.set(overlay, geometry)
-		return geometry
+		return this._geometryCache.get(overlay, (o) => this.getOverlayUtil(o).getGeometry(o))
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/overlays/strokeShapeIndicators.ts
+++ b/packages/editor/src/lib/editor/overlays/strokeShapeIndicators.ts
@@ -40,7 +40,6 @@ export function strokeShapeIndicators(
 		if (!shape || shape.isLocked) continue
 
 		const pageTransform = editor.getShapePageTransform(shape)
-		if (!pageTransform) continue
 
 		const indicatorPath = indicatorPathCache.get(editor, shape.id)
 		if (!indicatorPath) continue

--- a/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
@@ -93,7 +93,11 @@ export abstract class BaseFrameLikeShapeUtil<
 			const currentChildren = compact(
 				editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))
 			)
-			if (previousChildren.every((s) => !currentChildren.find((c) => c.index === s.index))) {
+			if (
+				previousChildren.every(
+					(s) => !currentChildren.find((c) => c.index === initialIndices.get(s.id))
+				)
+			) {
 				canRestoreOriginalIndices = true
 			}
 		}

--- a/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
@@ -87,6 +87,9 @@ export function getPerfectDashProps(
 
 	dashCount = Math.floor(totalLength / dashLength / (2 * ratio))
 	dashCount -= dashCount % snap
+	// A path shorter than one dash period (or of zero length, where the count is NaN) would
+	// otherwise divide by zero below and produce an invalid dasharray; draw a single dash instead
+	if (!(dashCount >= 1)) dashCount = 1
 
 	if (dashCount < 3 && style === 'dashed') {
 		if (totalLength / strokeWidth < 4) {

--- a/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
@@ -1,5 +1,6 @@
 import { VecModel } from '@tldraw/tlschema'
 import { Box } from '../../../primitives/Box'
+import { clamp } from '../../../primitives/utils'
 import { Vec } from '../../../primitives/Vec'
 import { TLResizeHandle } from '../../types/selection-types'
 import type { TLBaseBoxShape } from '../BaseBoxShapeUtil'
@@ -36,29 +37,31 @@ export function resizeBox<T extends TLBaseBoxShape>(
 	const offset = new Vec(0, 0)
 
 	if (w > 0) {
-		if (w < minWidth) {
+		const clampedW = clamp(w, minWidth, maxWidth)
+		if (clampedW !== w) {
 			switch (handle) {
 				case 'top_left':
 				case 'left':
 				case 'bottom_left': {
-					offset.x = w - minWidth
+					offset.x = w - clampedW
 					break
 				}
 				case 'top':
 				case 'bottom': {
-					offset.x = (w - minWidth) / 2
+					offset.x = (w - clampedW) / 2
 					break
 				}
 				default: {
 					offset.x = 0
 				}
 			}
-			w = minWidth
+			w = clampedW
 		}
 	} else {
 		offset.x = w
 		w = -w
-		if (w < minWidth) {
+		const clampedW = clamp(w, minWidth, maxWidth)
+		if (clampedW !== w) {
 			switch (handle) {
 				case 'top_left':
 				case 'left':
@@ -67,26 +70,27 @@ export function resizeBox<T extends TLBaseBoxShape>(
 					break
 				}
 				default: {
-					offset.x = -minWidth
+					offset.x = -clampedW
 				}
 			}
 
-			w = minWidth
+			w = clampedW
 		}
 	}
 
 	if (h > 0) {
-		if (h < minHeight) {
+		const clampedH = clamp(h, minHeight, maxHeight)
+		if (clampedH !== h) {
 			switch (handle) {
 				case 'top_left':
 				case 'top':
 				case 'top_right': {
-					offset.y = h - minHeight
+					offset.y = h - clampedH
 					break
 				}
 				case 'right':
 				case 'left': {
-					offset.y = (h - minHeight) / 2
+					offset.y = (h - clampedH) / 2
 					break
 				}
 				default: {
@@ -94,12 +98,13 @@ export function resizeBox<T extends TLBaseBoxShape>(
 				}
 			}
 
-			h = minHeight
+			h = clampedH
 		}
 	} else {
 		offset.y = h
 		h = -h
-		if (h < minHeight) {
+		const clampedH = clamp(h, minHeight, maxHeight)
+		if (clampedH !== h) {
 			switch (handle) {
 				case 'top_left':
 				case 'top':
@@ -108,10 +113,10 @@ export function resizeBox<T extends TLBaseBoxShape>(
 					break
 				}
 				default: {
-					offset.y = -minHeight
+					offset.y = -clampedH
 				}
 			}
-			h = minHeight
+			h = clampedH
 		}
 	}
 
@@ -122,8 +127,8 @@ export function resizeBox<T extends TLBaseBoxShape>(
 		x,
 		y,
 		props: {
-			w: Math.min(maxWidth, w),
-			h: Math.min(maxHeight, h),
+			w,
+			h,
 		},
 	}
 }

--- a/packages/editor/src/lib/editor/tools/StateNode.test.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.test.ts
@@ -238,6 +238,70 @@ describe('StateNode.addChild', () => {
 	})
 })
 
+describe('StateNode.enter', () => {
+	let idleExits = 0
+
+	class Idle extends StateNode {
+		static override id = 'idle'
+		override onExit() {
+			idleExits++
+		}
+	}
+
+	class Pointing extends StateNode {
+		static override id = 'pointing'
+	}
+
+	class ToolWithEnterTransition extends StateNode {
+		static override id = 'enterTransition'
+		static override initial = 'idle'
+		static override children() {
+			return [Idle, Pointing]
+		}
+
+		override onEnter(info: { startPointing?: boolean }) {
+			if (info?.startPointing) this.transition('pointing', info)
+		}
+	}
+
+	class OtherTool extends StateNode {
+		static override id = 'other'
+	}
+
+	let editor: Editor
+
+	beforeEach(() => {
+		idleExits = 0
+		editor = new Editor({
+			initialState: 'other',
+			shapeUtils: [],
+			bindingUtils: [],
+			tools: [OtherTool, ToolWithEnterTransition],
+			store: createTLStore({ shapeUtils: [], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+	})
+
+	it('enters the initial child when onEnter does not transition', () => {
+		editor.setCurrentTool('enterTransition')
+		expect(editor.root.getPath()).toBe('root.enterTransition.idle')
+		expect(editor.root.children!['enterTransition'].children!['idle'].getIsActive()).toBe(true)
+	})
+
+	it('does not enter the initial child on top of a child that onEnter transitioned to', () => {
+		editor.setCurrentTool('enterTransition', { startPointing: true })
+		const tool = editor.root.children!['enterTransition']
+		expect(editor.root.getPath()).toBe('root.enterTransition.pointing')
+		expect(tool.children!['pointing'].getIsActive()).toBe(true)
+		expect(tool.children!['idle'].getIsActive()).toBe(false)
+		// The stale (never re-entered) idle child must not get a spurious onExit
+		expect(idleExits).toBe(0)
+
+		editor.setCurrentTool('other')
+		expect(tool.children!['pointing'].getIsActive()).toBe(false)
+	})
+})
+
 describe('current tool id mask', () => {
 	// Tool mask test classes
 	class ToolA extends StateNode {

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -152,7 +152,9 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			}
 
 			if (prevChildState?.id !== nextChildState.id) {
-				prevChildState?.exit(info, id)
+				// The previous child is inactive when transitioning from a parent's onEnter (or from a
+				// node that was already exited); exiting it again would fire a spurious onExit
+				if (prevChildState?.getIsActive()) prevChildState.exit(info, id)
 				currState._current.set(nextChildState)
 				nextChildState.enter(info, prevChildState?.id || 'initial')
 				if (!nextChildState.getIsActive()) break
@@ -188,10 +190,18 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			this.editor.performance._notifyInteractionStart(this.id, this.getPath())
 		}
 
+		const currentBeforeEnter = this.getCurrent()
 		this._isActive.set(true)
 		this.onEnter?.(info, from)
 
-		if (this.children && this.initial && this.getIsActive()) {
+		// If onEnter already transitioned to a child, entering the initial child on top of it would
+		// leave that child active but orphaned
+		if (
+			this.children &&
+			this.initial &&
+			this.getIsActive() &&
+			this.getCurrent() === currentBeforeEnter
+		) {
 			const initial = this.children[this.initial]
 			this._current.set(initial)
 			initial.enter(info, from)

--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -1,4 +1,4 @@
-import { bind, sleep } from '@tldraw/utils'
+import { bind, noop, promiseWithResolve, sleep } from '@tldraw/utils'
 
 /**
  * Export delay is a helper class that allows you to wait for a set of promises to resolve before
@@ -11,8 +11,20 @@ import { bind, sleep } from '@tldraw/utils'
 export class ExportDelay {
 	private isResolved = false
 	private readonly promisesToWaitFor: Promise<void>[] = []
+	private readonly failure = promiseWithResolve<never>()
 
-	constructor(private readonly maxDelayTimeMs: number) {}
+	constructor(private readonly maxDelayTimeMs: number) {
+		// only observed inside `resolve`, so a `fail` before then would otherwise be an unhandled rejection
+		this.failure.catch(noop)
+	}
+
+	/**
+	 * Abort the export: `resolve` rejects with this error instead of waiting out the delay and
+	 * snapshotting a broken svg.
+	 */
+	@bind fail(error: unknown): void {
+		this.failure.reject(error)
+	}
 
 	@bind waitUntil(promise: Promise<void>): void {
 		if (this.isResolved) {
@@ -40,9 +52,9 @@ export class ExportDelay {
 		const timeoutPromise = sleep(this.maxDelayTimeMs).then(() => 'timeout' as const)
 		const resolvePromise = this.resolvePromises().then(() => 'resolved' as const)
 
-		const result = await Promise.race([timeoutPromise, resolvePromise])
+		const result = await Promise.race([timeoutPromise, resolvePromise, this.failure])
 		if (result === 'timeout') {
-			console.warn('[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms')
+			console.warn(`[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms`)
 		}
 
 		this.isResolved = true

--- a/packages/editor/src/lib/exports/FontEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.test.ts
@@ -1,0 +1,30 @@
+import { FontEmbedder } from './FontEmbedder'
+
+describe('FontEmbedder', () => {
+	let style: HTMLStyleElement
+
+	beforeEach(() => {
+		style = document.createElement('style')
+		style.textContent = `
+			@font-face { font-family: 'Font A'; src: url('/font-a.woff2'); }
+			@font-face { font-family: 'Font B'; src: url('/font-b.woff2'); }
+		`
+		document.head.appendChild(style)
+	})
+
+	afterEach(() => {
+		style.remove()
+	})
+
+	it('embeds every family in a font-family list, even when an earlier one was already seen', async () => {
+		const embedder = new FontEmbedder()
+		embedder.startFindingDocumentFontFaces(document)
+
+		embedder.onFontFamilyValue(`'Font A'`)
+		embedder.onFontFamilyValue(`'Font A', 'Font B'`)
+
+		const css = await embedder.createCss()
+		expect(css).toContain('Font A')
+		expect(css).toContain('Font B')
+	})
+})

--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -36,7 +36,7 @@ export class FontEmbedder {
 
 		const fonts = parseCssFontFamilyValue(fontFamilyValue)
 		for (const font of fonts) {
-			if (this.foundFontNames.has(font)) return
+			if (this.foundFontNames.has(font)) continue
 			this.foundFontNames.add(font)
 
 			this.pendingPromises.push(

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -92,10 +92,18 @@ export class StyleEmbedder {
 					if (urlMatches.length === 0) continue
 
 					promises.push(
-						...urlMatches.map(async ({ url, original }) => {
-							const dataUrl = (await resourceToDataUrl(url)) ?? 'data:'
-							styles[property] = value.replace(original, `url("${dataUrl}")`)
-						})
+						(async () => {
+							// resolve every url first, then rewrite the value in one pass - replacing
+							// per-url from the original value would keep only the last replacement
+							const dataUrls = await Promise.all(
+								urlMatches.map(({ url }) => resourceToDataUrl(url))
+							)
+							styles[property] = urlMatches.reduce(
+								(result, { original }, i) =>
+									result.replace(original, `url("${dataUrls[i] ?? 'data:'}")`),
+								value
+							)
+						})()
 					)
 				}
 			}

--- a/packages/editor/src/lib/exports/fetchCache.test.ts
+++ b/packages/editor/src/lib/exports/fetchCache.test.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest'
+import { fetchCache } from './fetchCache'
+
+describe('fetchCache', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('caches successes but retries after a failure', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		const fetchSpy = vi
+			.spyOn(window, 'fetch')
+			.mockResolvedValueOnce({ ok: false } as Response)
+			.mockResolvedValue({ ok: true, text: async () => 'hello' } as Response)
+		const fetchText = fetchCache((response) => response.text())
+
+		expect(await fetchText('https://example.com/a')).toBe(null)
+		expect(await fetchText('https://example.com/a')).toBe('hello')
+		expect(await fetchText('https://example.com/a')).toBe('hello')
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+	})
+})

--- a/packages/editor/src/lib/exports/fetchCache.ts
+++ b/packages/editor/src/lib/exports/fetchCache.ts
@@ -18,6 +18,10 @@ export function fetchCache<T>(cb: (response: Response) => Promise<T>, init?: Req
 			}
 		})()
 		cache.set(url, promise)
+		// only keep successes, otherwise a transient failure poisons this url for the whole session
+		promise.then((result) => {
+			if (result === null && cache.get(url) === promise) cache.delete(url)
+		})
 		return promise
 	}
 }

--- a/packages/editor/src/lib/exports/getSvgAsImage.ts
+++ b/packages/editor/src/lib/exports/getSvgAsImage.ts
@@ -145,7 +145,13 @@ function measureContentBounds(
 	// (extraPx * 2 >= w means declaredRight <= declaredLeft, producing zero/negative crop)
 	if (extraPx <= 0 || extraPx * 2 >= w || extraPx * 2 >= h) return null
 
-	const imageData = ctx.getImageData(0, 0, w, h)
+	let imageData: ImageData
+	try {
+		imageData = ctx.getImageData(0, 0, w, h)
+	} catch {
+		// a tainted or unallocatable canvas can't be measured; export untrimmed rather than fail
+		return null
+	}
 	const data = imageData.data
 
 	// Determine how to detect "empty" pixels.
@@ -302,9 +308,11 @@ export async function trimSvgToContent(
 
 	if (trimPadding <= 0) return null
 
-	// Render SVG to a temporary canvas at 1:1 pixel ratio
-	const canvasWidth = Math.floor(width)
-	const canvasHeight = Math.floor(height)
+	// Render SVG to a temporary canvas at 1:1 pixel ratio, clamped like the raster path so a
+	// large export doesn't exceed the browser's canvas limits
+	let [canvasWidth, canvasHeight] = clampToBrowserMaxCanvasSize(width, height)
+	canvasWidth = Math.floor(canvasWidth)
+	canvasHeight = Math.floor(canvasHeight)
 
 	if (canvasWidth <= 0 || canvasHeight <= 0) return null
 
@@ -313,7 +321,7 @@ export async function trimSvgToContent(
 	if (!canvas) return null
 
 	// Measure content bounds on the canvas
-	const trimPaddingPx = trimPadding * scale
+	const trimPaddingPx = trimPadding * scale * (canvasWidth / width)
 	const bounds = measureContentBounds(canvas, trimPaddingPx)
 	if (!bounds) return null
 

--- a/packages/editor/src/lib/exports/getSvgJsx.test.ts
+++ b/packages/editor/src/lib/exports/getSvgJsx.test.ts
@@ -1,4 +1,13 @@
-import { Geometry2d, RecordProps, Rectangle2d, ShapeUtil, T, TLShape, createShapeId } from '../..'
+import {
+	BaseFrameLikeShapeUtil,
+	Geometry2d,
+	RecordProps,
+	Rectangle2d,
+	ShapeUtil,
+	T,
+	TLShape,
+	createShapeId,
+} from '../..'
 import { createTLStore } from '../config/createTLStore'
 import { Editor } from '../editor/Editor'
 import { Box } from '../primitives/Box'
@@ -859,5 +868,38 @@ describe('getExportDefaultBounds', () => {
 			expect(result.box?.w).toBe(100)
 			expect(result.box?.h).toBe(80)
 		})
+	})
+})
+
+// Deliberately not registered in TLGlobalShapePropsMap (test-only types leak into the api report)
+const FRAME_LIKE_TYPE = 'test-frame-like'
+
+class FrameLikeShape extends BaseFrameLikeShapeUtil<any> {
+	static override type = FRAME_LIKE_TYPE
+	static override props = { w: T.number, h: T.number }
+	getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	getIndicatorPath() {
+		return undefined
+	}
+	component() {}
+}
+
+describe('exporting a single frame-like shape', () => {
+	it('does not need the default frame shape util to be registered', async () => {
+		const editor = new Editor({
+			shapeUtils: [FrameLikeShape],
+			bindingUtils: [],
+			tools: [],
+			store: createTLStore({ shapeUtils: [FrameLikeShape], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+		const id = createShapeId('frame-like')
+		editor.createShape({ id, type: FRAME_LIKE_TYPE, x: 0, y: 0, props: { w: 100, h: 100 } } as any)
+
+		const result = await editor.getSvgElement([id], { background: true })
+		expect(result?.svg.style.backgroundColor).not.toBe('')
+		expect(result?.svg.style.backgroundColor).not.toBe('transparent')
 	})
 })

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useValue } from '@tldraw/state-react'
-import { TLFrameShape, TLShape, TLShapeId } from '@tldraw/tlschema'
+import { TLShape, TLShapeId } from '@tldraw/tlschema'
 import { TLFontFace } from '@tldraw/tlschema'
 import { hasOwnProperty, promiseWithResolve, uniqueId } from '@tldraw/utils'
 import {
@@ -117,6 +117,7 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 			colorMode={colorMode}
 			renderingShapes={renderingShapes}
 			onMount={initialEffectPromise.resolve}
+			onError={exportDelay.fail}
 			waitUntil={exportDelay.waitUntil}
 		>
 			{}
@@ -208,6 +209,7 @@ function SvgExport({
 	colorMode,
 	renderingShapes,
 	onMount,
+	onError,
 	waitUntil,
 }: {
 	editor: Editor
@@ -221,6 +223,7 @@ function SvgExport({
 	colorMode: 'light' | 'dark'
 	renderingShapes: TLRenderingShape[]
 	onMount(): void
+	onError(error: unknown): void
 	waitUntil(promise: Promise<void>): void
 }) {
 	const masksId = useUniqueSafeId()
@@ -283,6 +286,8 @@ function SvgExport({
 			throw new Error('SvgExport should only render once - do not use with react strict mode')
 		}
 		didRenderRef.current = true
+		// the promise is caught at the end: a throwing `toSvg` would otherwise leave `onMount`
+		// pending forever, so the export would wait out its max delay and snapshot an empty svg
 		;(async () => {
 			const shapeDefs: Record<string, { pending: false; element: ReactElement }> = {}
 
@@ -418,8 +423,17 @@ function SvgExport({
 					defsById: { ...state.defsById, ...shapeDefs },
 				}))
 			})
-		})()
-	}, [bbox, editor, exportContext, masksId, renderingShapes, singleFrameShapeId, stateAtom])
+		})().catch(onError)
+	}, [
+		bbox,
+		editor,
+		exportContext,
+		masksId,
+		onError,
+		renderingShapes,
+		singleFrameShapeId,
+		stateAtom,
+	])
 
 	useEffect(() => {
 		const fontsInUse = new Set<TLFontFace>()
@@ -449,19 +463,12 @@ function SvgExport({
 	let backgroundColor = background ? colors.background : 'transparent'
 
 	if (singleFrameShapeId && background) {
-		const frameShapeUtil = editor.getShapeUtil('frame') as any as
-			| undefined
-			| {
-					options: {
-						showColors: boolean
-					}
-			  }
-		if (frameShapeUtil?.options.showColors) {
-			const shape = editor.getShape(singleFrameShapeId)! as TLFrameShape
-			backgroundColor = getColorValue(colors, shape.props.color, 'frameFill')
-		} else {
-			backgroundColor = colors.solid
-		}
+		// the frame-like shape's own util decides this - it may not be the default 'frame' util
+		const shape = editor.getShape(singleFrameShapeId)!
+		const { showColors } = editor.getShapeUtil(shape).options as { showColors?: boolean }
+		const color = showColors && 'color' in shape.props ? shape.props.color : null
+		backgroundColor =
+			typeof color === 'string' ? getColorValue(colors, color, 'frameFill') : colors.solid
 	}
 
 	return (

--- a/packages/editor/src/lib/exports/parseCss.test.ts
+++ b/packages/editor/src/lib/exports/parseCss.test.ts
@@ -120,6 +120,10 @@ test('parseCss', () => {
 		  ],
 		  "imports": [
 		    {
+		      "extras": "",
+		      "url": "https://example.com/font.css",
+		    },
+		    {
 		      "extras": " screen and (min-width: 900px)",
 		      "url": "thing.css",
 		    },

--- a/packages/editor/src/lib/exports/parseCss.ts
+++ b/packages/editor/src/lib/exports/parseCss.ts
@@ -18,7 +18,7 @@ export interface ParsedFontFace {
 // Parse @import declarations:
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@import#formal_syntax
 const importsRegex =
-	/@import\s+(?:"([^"]+)"|'([^']+)'|url\s*\(\s*(?:"([^"]+)"|'([^']+)'|([^'")]+))\s*\))([^;]+);/gi
+	/@import\s+(?:"([^"]+)"|'([^']+)'|url\s*\(\s*(?:"([^"]+)"|'([^']+)'|([^'")]+))\s*\))([^;]*);/gi
 
 // Locate @font-face declarations:
 const fontFaceRegex = /@font-face\s*{([^}]+)}/gi

--- a/packages/editor/src/lib/globals/menus.test.ts
+++ b/packages/editor/src/lib/globals/menus.test.ts
@@ -1,0 +1,33 @@
+import { tlmenus } from './menus'
+
+describe('tlmenus', () => {
+	afterEach(() => {
+		tlmenus.clearOpenMenus()
+		tlmenus._hiddenMenus = []
+	})
+
+	it('reports whether a menu is open with and without a context', () => {
+		tlmenus.addOpenMenu('main')
+		tlmenus.addOpenMenu('main', 'editor-1')
+
+		expect(tlmenus.isMenuOpen('main')).toBe(true)
+		expect(tlmenus.isMenuOpen('main', 'editor-1')).toBe(true)
+		expect(tlmenus.isMenuOpen('main', 'editor-2')).toBe(false)
+		expect(tlmenus.isMenuOpen('other')).toBe(false)
+	})
+
+	it('hides and restores the open menus of a context', () => {
+		tlmenus.addOpenMenu('main', 'editor-1')
+		tlmenus.addOpenMenu('main', 'editor-2')
+
+		tlmenus.hideOpenMenus('editor-1')
+		expect(tlmenus.getOpenMenus()).toEqual(['main-editor-2'])
+
+		tlmenus.showOpenMenus('editor-1')
+		expect(tlmenus.getOpenMenus().sort()).toEqual(['main-editor-1', 'main-editor-2'])
+
+		// closing the real menu afterwards leaves nothing behind
+		tlmenus.deleteOpenMenu('main', 'editor-1')
+		expect(tlmenus.hasOpenMenus('editor-1')).toBe(false)
+	})
+})

--- a/packages/editor/src/lib/globals/menus.ts
+++ b/packages/editor/src/lib/globals/menus.ts
@@ -106,10 +106,12 @@ export const tlmenus = {
 	 * @public
 	 */
 	hideOpenMenus(contextId?: string) {
+		// ids read back from the store already carry their context suffix, so they are deleted
+		// (and later re-added) as-is rather than suffixed again
 		this._hiddenMenus = [...this.getOpenMenus(contextId)]
 		if (this._hiddenMenus.length === 0) return
 		for (const menu of this._hiddenMenus) {
-			this.deleteOpenMenu(menu, contextId)
+			this.deleteOpenMenu(menu)
 		}
 	},
 
@@ -128,10 +130,15 @@ export const tlmenus = {
 	 */
 	showOpenMenus(contextId?: string) {
 		if (this._hiddenMenus.length === 0) return
+		const stillHidden: string[] = []
 		for (const menu of this._hiddenMenus) {
-			this.addOpenMenu(menu, contextId)
+			if (!contextId || menu.endsWith('-' + contextId)) {
+				this.addOpenMenu(menu)
+			} else {
+				stillHidden.push(menu)
+			}
 		}
-		this._hiddenMenus = []
+		this._hiddenMenus = stillHidden
 	},
 
 	/**
@@ -148,7 +155,7 @@ export const tlmenus = {
 	 * @public
 	 */
 	isMenuOpen(id: string, contextId?: string): boolean {
-		return this.getOpenMenus(contextId).includes(`${id}-${contextId}`)
+		return this.getOpenMenus(contextId).includes(contextId ? `${id}-${contextId}` : id)
 	},
 
 	/**

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -23,8 +23,9 @@ function getCursorCss(
 	const dx = 1 * c - 1 * s
 	const dy = 1 * s + 1 * c
 
+	// A raw '#' in the colour (hex) would end the unencoded data url as a fragment.
 	return (
-		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${color};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
+		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${encodeURIComponent(color)};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
 			r + tr
 		} 16 16)${f ? ` scale(-1,-1) translate(0, -32)` : ''}' filter='url(%23shadow)'>` +
 		svg.replaceAll(`"`, `'`) +
@@ -43,6 +44,9 @@ const STATIC_CURSORS = [
 	'text',
 	'zoom-in',
 	'zoom-out',
+	'rotate',
+	'resize-edge',
+	'resize-corner',
 ]
 
 type CursorFunction = (rotation: number, flip: boolean, color: string) => string

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -29,8 +29,12 @@ export function useDocumentEvents() {
 			// re-dispatched, which would lead to an infinite loop.
 			if ((e as any).isSpecialRedispatchedEvent) return
 			preventDefault(e)
-			e.stopPropagation()
 			const cvs = container.querySelector('.tl-canvas')
+			// A drop on the canvas itself already reaches the canvas (and any shape's own React
+			// drop handlers) by bubbling; stopping it here would hide it from React, which
+			// delegates from the root above this container.
+			if (cvs?.contains(e.target as Node | null)) return
+			e.stopPropagation()
 			if (!cvs) return
 			const newEvent = new DragEvent(e.type, e)
 			;(newEvent as any).isSpecialRedispatchedEvent = true
@@ -277,10 +281,13 @@ export function useDocumentEvents() {
 
 		container.addEventListener('wheel', handleWheel, { passive: false })
 
+		// Not the shared `preventDefault` reference: the DOM dedupes identical listeners, so with two
+		// editors in one document the first cleanup would otherwise remove it for both.
+		const handleGesture = (e: Event) => preventDefault(e)
 		const ownerDoc = container.ownerDocument
-		ownerDoc.addEventListener('gesturestart', preventDefault)
-		ownerDoc.addEventListener('gesturechange', preventDefault)
-		ownerDoc.addEventListener('gestureend', preventDefault)
+		ownerDoc.addEventListener('gesturestart', handleGesture)
+		ownerDoc.addEventListener('gesturechange', handleGesture)
+		ownerDoc.addEventListener('gestureend', handleGesture)
 
 		container.addEventListener('keydown', handleKeyDown)
 		container.addEventListener('keyup', handleKeyUp)
@@ -290,9 +297,9 @@ export function useDocumentEvents() {
 
 			container.removeEventListener('wheel', handleWheel)
 
-			ownerDoc.removeEventListener('gesturestart', preventDefault)
-			ownerDoc.removeEventListener('gesturechange', preventDefault)
-			ownerDoc.removeEventListener('gestureend', preventDefault)
+			ownerDoc.removeEventListener('gesturestart', handleGesture)
+			ownerDoc.removeEventListener('gesturechange', handleGesture)
+			ownerDoc.removeEventListener('gestureend', handleGesture)
 
 			container.removeEventListener('keydown', handleKeyDown)
 			container.removeEventListener('keyup', handleKeyUp)

--- a/packages/editor/src/lib/hooks/useIdentity.tsx
+++ b/packages/editor/src/lib/hooks/useIdentity.tsx
@@ -1,4 +1,4 @@
-import { areArraysShallowEqual, areObjectsShallowEqual } from '@tldraw/utils'
+import { areArraysShallowEqual, areObjectsShallowEqual, isEqual } from '@tldraw/utils'
 import { useRef } from 'react'
 
 function useIdentity<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
@@ -48,4 +48,14 @@ const areNullableObjectsShallowEqual = (
 /** @internal */
 export function useShallowObjectIdentity<T extends object | null | undefined>(obj: T): T {
 	return useIdentity(obj, areNullableObjectsShallowEqual)
+}
+
+/**
+ * For small plain-data option objects that may nest (e.g. camera constraints), where a
+ * shallow comparison would still see a fresh identity on every render.
+ *
+ * @internal
+ */
+export function useDeepObjectIdentity<T extends object | null | undefined>(obj: T): T {
+	return useIdentity(obj, isEqual)
 }

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -1,5 +1,5 @@
-import { TLAsset, TLAssetStore, TLStoreSnapshot } from '@tldraw/tlschema'
-import { WeakCache } from '@tldraw/utils'
+import { TLAssetId, TLAssetStore, TLStoreSnapshot } from '@tldraw/tlschema'
+import { noop } from '@tldraw/utils'
 import { useEffect } from 'react'
 import { TLStoreOptions, createTLStore } from '../config/createTLStore'
 import { TLEditorSnapshot } from '../config/TLEditorSnapshot'
@@ -33,7 +33,9 @@ export function useLocalStore(
 
 		setState({ status: 'loading' })
 
-		const objectURLCache = new WeakCache<TLAsset, Promise<string | null>>()
+		// Keyed by asset id rather than record identity so that a record update doesn't mint
+		// another object url for the same blob; every url minted here is revoked on cleanup.
+		const objectURLCache = new Map<TLAssetId, Promise<string | null>>()
 		const assets: TLAssetStore = {
 			upload: async (asset, file) => {
 				await client.db.storeAsset(asset.id, file)
@@ -43,11 +45,14 @@ export function useLocalStore(
 				if (!asset.props.src) return null
 
 				if (asset.props.src.startsWith('asset:')) {
-					return await objectURLCache.get(asset, async () => {
-						const blob = await client.db.getAsset(asset.id)
-						if (!blob) return null
-						return URL.createObjectURL(blob)
-					})
+					let objectURL = objectURLCache.get(asset.id)
+					if (!objectURL) {
+						objectURL = client.db
+							.getAsset(asset.id)
+							.then((blob) => (blob ? URL.createObjectURL(blob) : null))
+						objectURLCache.set(asset.id, objectURL)
+					}
+					return await objectURL
 				}
 
 				return asset.props.src
@@ -78,6 +83,9 @@ export function useLocalStore(
 		return () => {
 			isClosed = true
 			client.close()
+			for (const objectURL of objectURLCache.values()) {
+				objectURL.then((url) => url && URL.revokeObjectURL(url), noop)
+			}
 		}
 	}, [options, setState])
 

--- a/packages/editor/src/lib/hooks/usePeerIds.ts
+++ b/packages/editor/src/lib/hooks/usePeerIds.ts
@@ -1,4 +1,5 @@
 import { useComputed, useValue } from '@tldraw/state-react'
+import { areArraysShallowEqual } from '@tldraw/utils'
 import { uniq } from '../utils/uniq'
 import { useEditor } from './useEditor'
 
@@ -17,7 +18,7 @@ export function usePeerIds() {
 	const $userIds = useComputed(
 		'userIds',
 		() => uniq(editor.getVisibleCollaborators().map((p) => p.userId)).sort(),
-		{ isEqual: (a, b) => a.join(',') === b.join?.(',') },
+		{ isEqual: areArraysShallowEqual },
 		[editor]
 	)
 

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -1,4 +1,5 @@
 import { atom, transact } from '@tldraw/state'
+import { noop } from '@tldraw/utils'
 import { publishDates, version } from '../../version'
 import { getDefaultCdnBaseUrl } from '../utils/assets'
 import { importPublicKey, str2ab } from '../utils/licensing'
@@ -247,8 +248,9 @@ export class LicenseManager {
 			url.searchParams.set('environment', process.env.NODE_ENV)
 		}
 
+		// best-effort: a blocked or offline request must not surface as an unhandled rejection
 		// eslint-disable-next-line no-restricted-globals
-		fetch(url.toString())
+		fetch(url.toString()).catch(noop)
 	}
 
 	private async extractLicenseKey(licenseKey: string): Promise<LicenseInfo> {

--- a/packages/editor/src/lib/license/LicenseProvider.test.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.test.tsx
@@ -1,0 +1,29 @@
+import { act, render } from '@testing-library/react'
+import { LicenseManager } from './LicenseManager'
+import { LicenseProvider, useLicenseContext } from './LicenseProvider'
+
+describe('LicenseProvider', () => {
+	it('creates a new license manager when the license key changes', async () => {
+		const managers: LicenseManager[] = []
+		function Probe() {
+			managers.push(useLicenseContext())
+			return null
+		}
+		const renderWithKey = (licenseKey: string | undefined) => (
+			<LicenseProvider licenseKey={licenseKey}>
+				<Probe />
+			</LicenseProvider>
+		)
+
+		const rendered = await act(async () => render(renderWithKey(undefined)))
+		const initial = managers.at(-1)!
+
+		await act(async () => rendered.rerender(renderWithKey('not-a-real-key')))
+		const changed = managers.at(-1)!
+		expect(changed).not.toBe(initial)
+
+		// same key again: the manager is stable
+		await act(async () => rendered.rerender(renderWithKey('not-a-real-key')))
+		expect(managers.at(-1)).toBe(changed)
+	})
+})

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import { useMaybeEditor } from '../hooks/useEditor'
 import { LicenseManager } from './LicenseManager'
 
@@ -46,21 +46,25 @@ export function LicenseProvider({
 	licenseKey?: string
 	children: ReactNode
 }) {
-	const [licenseManager] = useState(() => new LicenseManager(licenseKey))
+	// Keyed on the license key: the editor is recreated when the key changes, and must not be
+	// handed a manager that validated the old key.
+	const licenseManager = useMemo(() => new LicenseManager(licenseKey), [licenseKey])
 	const licenseState = useValue(licenseManager.state)
-	const [showEditor, setShowEditor] = useState(true)
+	// The manager whose grace period ran out, so a new key starts with the editor shown again.
+	const [gatedManager, setGatedManager] = useState<LicenseManager | null>(null)
+	const showEditor = gatedManager !== licenseManager
 
 	// When license expires or no license in production, show for 5 seconds then hide
 	useEffect(() => {
 		if (shouldHideEditorAfterDelay(licenseState) && showEditor) {
 			// eslint-disable-next-line no-restricted-globals
 			const timer = setTimeout(() => {
-				setShowEditor(false)
+				setGatedManager(licenseManager)
 			}, LICENSE_TIMEOUT)
 
 			return () => clearTimeout(timer)
 		}
-	}, [licenseState, showEditor])
+	}, [licenseManager, licenseState, showEditor])
 
 	// If license is expired or no license in production and 5 seconds have passed, don't render anything (blank screen)
 	if (shouldHideEditorAfterDelay(licenseState) && !showEditor) {

--- a/packages/editor/src/lib/primitives/Box.test.ts
+++ b/packages/editor/src/lib/primitives/Box.test.ts
@@ -1,4 +1,4 @@
-import { Box } from './Box'
+import { Box, rotateSelectionHandle } from './Box'
 import { Vec } from './Vec'
 
 describe('Box', () => {
@@ -757,5 +757,13 @@ describe('Box', () => {
 		it('returns true for zero-sized box', () => {
 			expect(new Box(0, 0, 0, 0).isValid()).toBe(true)
 		})
+	})
+})
+
+describe('rotateSelectionHandle', () => {
+	it('wraps around for negative rotations', () => {
+		expect(rotateSelectionHandle('top', Math.PI / 2)).toBe('right')
+		expect(rotateSelectionHandle('top', -Math.PI / 2)).toBe('left')
+		expect(rotateSelectionHandle('top_left', -Math.PI)).toBe('bottom_right')
 	})
 })

--- a/packages/editor/src/lib/primitives/Box.ts
+++ b/packages/editor/src/lib/primitives/Box.ts
@@ -678,7 +678,9 @@ export function rotateSelectionHandle(handle: SelectionHandle, rotation: number)
 	const numSteps = Math.round(rotation / (PI / 4))
 
 	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
+	// numSteps is negative for negative rotations, so wrap the index into range
+	const n = ORDERED_SELECTION_HANDLES.length
+	return ORDERED_SELECTION_HANDLES[(((currentIndex + numSteps) % n) + n) % n]
 }
 
 /** @public */

--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -336,6 +336,16 @@ describe('Vec.Slope', () => {
 		expect(Vec.Slope(new Vec(0, 0), new Vec(50, 100))).toEqual(2)
 		expect(Vec.Slope(new Vec(0, 0), new Vec(-50, 100))).toEqual(-2)
 		expect(Vec.Slope(new Vec(123, 456), new Vec(789, 24))).toEqual(-0.6486486486486487)
+		// A.x happened to equal B.y here, which used to trip the vertical guard
+		expect(Vec.Slope(new Vec(1, 0), new Vec(0, 1))).toEqual(-1)
+		expect(Vec.Slope(new Vec(5, 0), new Vec(5, 10))).toBeNaN()
+	})
+})
+
+describe('Vec.cross', () => {
+	it('Matches the static Vec.Cross.', () => {
+		expect(Vec.Cross(new Vec(1, 2, 3), new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
+		expect(new Vec(1, 2, 3).cross(new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
 	})
 })
 

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -164,9 +164,10 @@ export class Vec {
 	}
 
 	cross(V: VecLike) {
-		this.x = this.y * V.z! - this.z * V.y
-		this.y = this.z * V.x - this.x * V.z!
-		// this.z = this.x * V.y - this.y * V.x
+		const { x, y, z } = this
+		this.x = y * V.z! - z * V.y
+		this.y = z * V.x - x * V.z!
+		// this.z = x * V.y - y * V.x
 		return this
 	}
 
@@ -497,7 +498,7 @@ export class Vec {
 	}
 
 	static Slope(A: VecLike, B: VecLike): number {
-		if (A.x === B.y) return NaN
+		if (A.x === B.x) return NaN
 		return (A.y - B.y) / (A.x - B.x)
 	}
 

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -167,7 +167,6 @@ export class Vec {
 		const { x, y, z } = this
 		this.x = y * V.z! - z * V.y
 		this.y = z * V.x - x * V.z!
-		// this.z = x * V.y - y * V.x
 		return this
 	}
 

--- a/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
@@ -1,5 +1,35 @@
+import { Vec } from '../Vec'
+import { Arc2d } from './Arc2d'
+
 describe('Arc2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+	// quarter arc around the origin from (10,0) through (7.07,7.07) to (0,10)
+	const arc = new Arc2d({
+		center: new Vec(0, 0),
+		start: new Vec(10, 0),
+		end: new Vec(0, 10),
+		sweepFlag: 1,
+		largeArcFlag: 0,
+	})
+
+	it('hitTestLineSegment ignores circle intersections in the arc gap', () => {
+		expect(arc.hitTestLineSegment(new Vec(-12, 0), new Vec(-8, 0))).toBe(false)
+		expect(arc.hitTestLineSegment(new Vec(5, 5), new Vec(10, 10))).toBe(true)
+		// crossing exactly at an endpoint still counts
+		expect(arc.hitTestLineSegment(new Vec(0, 12), new Vec(0, 8))).toBe(true)
+	})
+
+	it('hitTestLineSegment honours the distance margin', () => {
+		const A = new Vec(8, 8)
+		const B = new Vec(12, 12)
+		expect(arc.hitTestLineSegment(A, B)).toBe(false)
+		expect(arc.hitTestLineSegment(A, B, 1)).toBe(false)
+		expect(arc.hitTestLineSegment(A, B, 2)).toBe(true)
+	})
+
+	it('nearestPoint picks the angularly nearer endpoint for points in the gap', () => {
+		// 90 degrees behind the start but 180 degrees past the end
+		expect(arc.nearestPoint(new Vec(0, -10))).toMatchObject({ x: 10, y: 0 })
+		// 180 degrees behind the start but 90 degrees past the end
+		expect(arc.nearestPoint(new Vec(-10, 0))).toMatchObject({ x: 0, y: 10 })
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Arc2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.ts
@@ -1,8 +1,11 @@
 import { intersectLineSegmentCircle } from '../intersect'
-import { getArcMeasure, getPointInArcT, getPointOnCircle } from '../utils'
+import { PI2, getArcMeasure, getPointInArcT, getPointOnCircle } from '../utils'
 import { Vec, VecLike } from '../Vec'
 import { getVerticesCountForArcLength } from './geometry-constants'
 import { Geometry2d, Geometry2dOptions } from './Geometry2d'
+
+// Angular tolerance so that intersections landing exactly on an arc's endpoint still hit
+const ARC_HIT_EPSILON = 1e-9
 
 /** @public */
 export class Arc2d extends Geometry2d {
@@ -69,20 +72,22 @@ export class Arc2d extends Geometry2d {
 		return new Vec(_center.x + dx * scale, _center.y + dy * scale)
 	}
 
-	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
-		const {
-			_center,
-			_radius: radius,
-			_measure: measure,
-			_angleStart: angleStart,
-			_angleEnd: angleEnd,
-		} = this
+	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0): boolean {
+		// The circle intersection below has no notion of a margin, so a margin
+		// falls back to the vertex-based test.
+		if (distance > 0) return super.hitTestLineSegment(A, B, distance)
+
+		const { _center, _radius: radius, _measure: measure, _angleStart: angleStart } = this
 		const intersection = intersectLineSegmentCircle(A, B, _center, radius)
 		if (intersection === null) return false
 
 		return intersection.some((p) => {
-			const result = getPointInArcT(measure, angleStart, angleEnd, _center.angle(p))
-			return result >= 0 && result <= 1
+			// Measure the sweep from the start to p along the arc's direction rather than
+			// using getPointInArcT, which clamps points in the arc's gap to t = 0 or 1 and
+			// would count them as hits.
+			let sweep = ((_center.angle(p) - angleStart) * Math.sign(measure)) % PI2
+			if (sweep < -ARC_HIT_EPSILON) sweep += PI2
+			return sweep <= Math.abs(measure) + ARC_HIT_EPSILON
 		})
 	}
 

--- a/packages/editor/src/lib/primitives/geometry/Circle2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Circle2d.test.ts
@@ -204,4 +204,17 @@ describe('Circle2d.hitTestLineSegment', () => {
 			}).hitTestLineSegment(new Vec(0, 2), new Vec(20, 2), 1)
 		).toBe(true)
 	})
+
+	it('hits a segment lying within the margin band without crossing it', () => {
+		const circle = new Circle2d({ radius: 50, isFilled: false })
+		expect(circle.hitTestLineSegment(new Vec(50, -5), new Vec(60, -5), 10)).toBe(true)
+		expect(circle.hitTestLineSegment(new Vec(50, -5), new Vec(60, -5), 2)).toBe(false)
+	})
+
+	it('hits a segment entirely inside a filled circle only', () => {
+		const A = new Vec(40, 50)
+		const B = new Vec(60, 50)
+		expect(new Circle2d({ radius: 50, isFilled: true }).hitTestLineSegment(A, B)).toBe(true)
+		expect(new Circle2d({ radius: 50, isFilled: false }).hitTestLineSegment(A, B)).toBe(false)
+	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Circle2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Circle2d.ts
@@ -1,5 +1,4 @@
 import { Box } from '../Box'
-import { intersectLineSegmentCircle } from '../intersect'
 import { PI2, getPointOnCircle } from '../utils'
 import { Vec, VecLike } from '../Vec'
 import { getVerticesCountForArcLength } from './geometry-constants'
@@ -88,8 +87,16 @@ export class Circle2d extends Geometry2d {
 	}
 
 	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0): boolean {
+		// Along the segment the distance to the center spans [nearest, furthest]
+		// (convex, so the furthest is at an endpoint). Testing for a crossing of the
+		// expanded circle instead would miss a segment lying entirely within the
+		// margin band or, when filled, entirely inside.
 		const { _center, _radius: radius } = this
-		return intersectLineSegmentCircle(A, B, _center, radius + distance) !== null
+		const nearest = Vec.DistanceToLineSegment(A, B, _center)
+		if (nearest > radius + distance) return false
+		if (this.isFilled) return true
+		const furthest = Math.sqrt(Math.max(Vec.Dist2(A, _center), Vec.Dist2(B, _center)))
+		return furthest >= radius - distance
 	}
 
 	getSvgPathData(): string {

--- a/packages/editor/src/lib/primitives/geometry/CubicSpline2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicSpline2d.ts
@@ -85,8 +85,8 @@ export class CubicSpline2d extends Geometry2d {
 		return minDist
 	}
 
-	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
-		return this.segments.some((segment) => segment.hitTestLineSegment(A, B))
+	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0): boolean {
+		return this.segments.some((segment) => segment.hitTestLineSegment(A, B, distance))
 	}
 
 	getSvgPathData() {

--- a/packages/editor/src/lib/primitives/geometry/Ellipse2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Ellipse2d.test.ts
@@ -1,5 +1,12 @@
+import { Vec } from '../Vec'
+import { Ellipse2d } from './Ellipse2d'
+
 describe('Ellipse2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+	it('hitTestLineSegment honours the distance margin', () => {
+		const ellipse = new Ellipse2d({ width: 100, height: 100, isFilled: false })
+		const A = new Vec(50, -5)
+		const B = new Vec(60, -5)
+		expect(ellipse.hitTestLineSegment(A, B)).toBe(false)
+		expect(ellipse.hitTestLineSegment(A, B, 10)).toBe(true)
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Ellipse2d.ts
@@ -102,8 +102,8 @@ export class Ellipse2d extends Geometry2d {
 		return minDist
 	}
 
-	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
-		return this.edges.some((edge) => edge.hitTestLineSegment(A, B))
+	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0): boolean {
+		return this.edges.some((edge) => edge.hitTestLineSegment(A, B, distance))
 	}
 
 	getBounds() {

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.ts
@@ -122,7 +122,7 @@ export abstract class Geometry2d {
 		const { vertices } = this
 		if (vertices.length === 0) throw Error('nearest point not found')
 		if (vertices.length === 1) return Vec.Dist(A, vertices[0])
-		let nearest: Vec | undefined
+		let nearest: VecLike | undefined
 		let dist = Infinity
 		let d: number, p: Vec, q: Vec
 		const nextLimit = this.isClosed ? vertices.length : vertices.length - 1
@@ -131,6 +131,18 @@ export abstract class Geometry2d {
 			if (i < nextLimit) {
 				const next = vertices[(i + 1) % vertices.length]
 				if (linesIntersect(A, B, p, next)) return 0
+				// Vertex-to-segment distances alone overestimate when AB runs alongside
+				// a long edge, so also measure A and B against the edge.
+				d = Vec.DistanceToLineSegment(p, next, A) ** 2
+				if (d < dist) {
+					dist = d
+					nearest = A
+				}
+				d = Vec.DistanceToLineSegment(p, next, B) ** 2
+				if (d < dist) {
+					dist = d
+					nearest = B
+				}
 			}
 			q = Vec.NearestPointOnLineSegment(A, B, p, true)
 			d = Vec.Dist2(p, q)

--- a/packages/editor/src/lib/primitives/geometry/Rectangle2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Rectangle2d.test.ts
@@ -1,5 +1,16 @@
+import { Vec } from '../Vec'
+import { Rectangle2d } from './Rectangle2d'
+
 describe('Rectangle2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+	describe('distanceToLineSegment', () => {
+		it('measures a short segment running alongside a long edge', () => {
+			const rect = new Rectangle2d({ width: 200, height: 100, isFilled: false })
+			const A = new Vec(100, -6)
+			const B = new Vec(110, -6)
+			// Measuring only vertex-to-segment distances reported ~90 here
+			expect(rect.distanceToLineSegment(A, B)).toBeCloseTo(6)
+			expect(rect.hitTestLineSegment(A, B, 8)).toBe(true)
+			expect(rect.hitTestLineSegment(A, B, 4)).toBe(false)
+		})
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
@@ -1,5 +1,14 @@
+import { Vec } from '../Vec'
+import { Stadium2d } from './Stadium2d'
+
 describe('Stadium2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+	it('hitTestLineSegment honours the distance margin', () => {
+		const stadium = new Stadium2d({ width: 200, height: 100, isFilled: false })
+		// alongside the straight top edge
+		expect(stadium.hitTestLineSegment(new Vec(80, -5), new Vec(120, -5))).toBe(false)
+		expect(stadium.hitTestLineSegment(new Vec(80, -5), new Vec(120, -5), 10)).toBe(true)
+		// alongside the left cap
+		expect(stadium.hitTestLineSegment(new Vec(-5, 40), new Vec(-5, 60))).toBe(false)
+		expect(stadium.hitTestLineSegment(new Vec(-5, 40), new Vec(-5, 60), 10)).toBe(true)
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Stadium2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Stadium2d.ts
@@ -96,9 +96,9 @@ export class Stadium2d extends Geometry2d {
 		return minDist
 	}
 
-	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
+	hitTestLineSegment(A: VecLike, B: VecLike, distance = 0): boolean {
 		const { _a: a, _b: b, _c: c, _d: d } = this
-		return [a, b, c, d].some((edge) => edge.hitTestLineSegment(A, B))
+		return [a, b, c, d].some((edge) => edge.hitTestLineSegment(A, B, distance))
 	}
 
 	getVertices() {

--- a/packages/editor/src/lib/primitives/intersect.test.ts
+++ b/packages/editor/src/lib/primitives/intersect.test.ts
@@ -147,15 +147,46 @@ describe('intersectLineSegmentLineSegment', () => {
 	})
 
 	describe('touching endpoints', () => {
-		it('should return null when segments touch at endpoints (coincident case)', () => {
+		it('should find intersection when segments touch at endpoints', () => {
 			const a1 = new Vec(0, 0)
 			const a2 = new Vec(5, 5)
 			const b1 = new Vec(5, 5)
 			const b2 = new Vec(10, 0)
 
+			// a2 === b1 is a touch, not a coincident (collinear) pair
 			const result = intersectLineSegmentLineSegment(a1, a2, b1, b2)
 
-			expect(result).toBeNull() // coincident case
+			expect(result).not.toBeNull()
+			expect(result!.x).toBeCloseTo(5, 5)
+			expect(result!.y).toBeCloseTo(5, 5)
+		})
+
+		it('should find intersection when one segment starts on the other (T-junction)', () => {
+			// Used to return null for a1/b1 touches but not a2/b2 touches
+			expect(
+				intersectLineSegmentLineSegment(
+					new Vec(0, 0),
+					new Vec(0, 10),
+					new Vec(-5, 0),
+					new Vec(5, 0)
+				)
+			).toMatchObject({ x: 0, y: 0 })
+			expect(
+				intersectLineSegmentLineSegment(
+					new Vec(-5, 0),
+					new Vec(5, 0),
+					new Vec(0, 0),
+					new Vec(0, 10)
+				)
+			).toMatchObject({ x: 0, y: 0 })
+			expect(
+				intersectLineSegmentLineSegment(
+					new Vec(0, 10),
+					new Vec(0, 0),
+					new Vec(-5, 0),
+					new Vec(5, 0)
+				)
+			).toMatchObject({ x: 0, y: 0 })
 		})
 
 		it('should return null when segments touch at one endpoint (coincident case)', () => {
@@ -483,9 +514,12 @@ describe('intersectLineSegmentPolyline', () => {
 		const points = [new Vec(0, 10), new Vec(5, 5), new Vec(5, 5), new Vec(10, 0)]
 		const result = intersectLineSegmentPolyline(a1, a2, points)
 		expect(result).not.toBeNull()
-		expect(result!.length).toBe(1)
-		expect(result![0].x).toBeCloseTo(5, 5)
-		expect(result![0].y).toBeCloseTo(5, 5)
+		// the crossing is at a shared vertex, so both non-degenerate edges report it
+		expect(result!.length).toBe(2)
+		for (const point of result!) {
+			expect(point.x).toBeCloseTo(5, 5)
+			expect(point.y).toBeCloseTo(5, 5)
+		}
 	})
 
 	it('should handle polyline with zero-length segments', () => {
@@ -494,9 +528,12 @@ describe('intersectLineSegmentPolyline', () => {
 		const points = [new Vec(0, 10), new Vec(5, 5), new Vec(5, 5), new Vec(10, 0)]
 		const result = intersectLineSegmentPolyline(a1, a2, points)
 		expect(result).not.toBeNull()
-		expect(result!.length).toBe(1)
-		expect(result![0].x).toBeCloseTo(5, 5)
-		expect(result![0].y).toBeCloseTo(5, 5)
+		// the zero-length edge contributes nothing; the two edges sharing the vertex each report it
+		expect(result!.length).toBe(2)
+		for (const point of result!) {
+			expect(point.x).toBeCloseTo(5, 5)
+			expect(point.y).toBeCloseTo(5, 5)
+		}
 	})
 
 	it('should handle polyline that touches segment endpoint', () => {
@@ -504,7 +541,11 @@ describe('intersectLineSegmentPolyline', () => {
 		const a2 = new Vec(5, 5)
 		const points = [new Vec(5, 5), new Vec(10, 0)]
 		const result = intersectLineSegmentPolyline(a1, a2, points)
-		expect(result).toBeNull() // coincident case
+		// touching at an endpoint is an intersection, not a coincident pair
+		expect(result).not.toBeNull()
+		expect(result!.length).toBe(1)
+		expect(result![0].x).toBeCloseTo(5, 5)
+		expect(result![0].y).toBeCloseTo(5, 5)
 	})
 
 	it('should handle complex polyline with multiple intersections', () => {
@@ -562,9 +603,12 @@ describe('intersectLineSegmentPolyline', () => {
 			const points = [new Vec(0, 0), new Vec(5, 5), new Vec(10, 0)] // vertex at (5,5)
 			const result = intersectLineSegmentPolyline(a1, a2, points)
 			expect(result).not.toBeNull()
-			expect(result!.length).toBe(1)
-			expect(result![0].x).toBeCloseTo(5, 5)
-			expect(result![0].y).toBeCloseTo(5, 5)
+			// both edges sharing the vertex report the crossing
+			expect(result!.length).toBe(2)
+			for (const point of result!) {
+				expect(point.x).toBeCloseTo(5, 5)
+				expect(point.y).toBeCloseTo(5, 5)
+			}
 		})
 
 		it('should detect intersection when line segment passes through a polyline vertext (floating point error case)', () => {
@@ -642,15 +686,24 @@ describe('intersectLineSegmentPolygon', () => {
 		expect(result).toBeNull()
 	})
 
-	it('should return single intersection at exit corner', () => {
+	it('should return intersections at both corners a diagonal touches', () => {
 		const a1 = new Vec(0, 0)
 		const a2 = new Vec(10, 10)
 		const points = [new Vec(0, 10), new Vec(10, 10), new Vec(10, 0), new Vec(0, 0)]
 		const result = intersectLineSegmentPolygon(a1, a2, points)
 		expect(result).not.toBeNull()
-		expect(result!.length).toBe(1)
-		expect(result![0].x).toBeCloseTo(10, 5)
-		expect(result![0].y).toBeCloseTo(10, 5)
+		// the segment starts on one corner and ends on the other; each corner is
+		// shared by two edges, so each is reported twice
+		const sorted = result!
+			.slice()
+			.sort((a, b) => a.x - b.x)
+			.map((p) => [p.x, p.y])
+		expect(sorted).toEqual([
+			[0, 0],
+			[0, 0],
+			[10, 10],
+			[10, 10],
+		])
 	})
 })
 

--- a/packages/editor/src/lib/primitives/intersect.ts
+++ b/packages/editor/src/lib/primitives/intersect.ts
@@ -32,9 +32,10 @@ export function intersectLineSegmentLineSegment(
 
 	// These comparisons inline approximately(x, 0) and approximatelyLte(x, 0/1)
 	// to avoid 7+ function calls per invocation.
-	if (Math.abs(ua_t) <= precision || Math.abs(ub_t) <= precision) return null // coincident
-
-	if (Math.abs(u_b) <= precision) return null // parallel
+	// Do not treat ua_t/ub_t of zero as coincident on their own: with a non-zero
+	// u_b they only mean a1/b1 lies on the other line (ua/ub = 0), which can be a
+	// real intersection at that endpoint.
+	if (Math.abs(u_b) <= precision) return null // parallel or coincident
 
 	const ua = ua_t / u_b
 	const ub = ub_t / u_b

--- a/packages/editor/src/lib/primitives/utils.test.ts
+++ b/packages/editor/src/lib/primitives/utils.test.ts
@@ -50,7 +50,6 @@ describe('getPointInArcT', () => {
 	})
 
 	it('should clamp a point in the gap to the angularly nearer endpoint', () => {
-		// Replaces a zero-measure case that encoded the old fixed 0.5 threshold.
 		// Quarter arc from 0 to PI/2: a point at -PI/2 is PI/2 behind the start but
 		// PI past the end, so it belongs to the start...
 		expect(getPointInArcT(Math.PI / 2, 0, Math.PI / 2, -Math.PI / 2)).toBe(0)

--- a/packages/editor/src/lib/primitives/utils.test.ts
+++ b/packages/editor/src/lib/primitives/utils.test.ts
@@ -1,4 +1,4 @@
-import { getPointInArcT } from './utils'
+import { areAnglesCompatible, getPointInArcT } from './utils'
 
 describe('getPointInArcT', () => {
 	it('should return 0 for the start of the arc', () => {
@@ -49,11 +49,21 @@ describe('getPointInArcT', () => {
 		expect(getPointInArcT(mAB, A, B, P)).toBe(0)
 	})
 
-	it('should handle edge case where measurement to center is negative but measure to points near the end are positive with other endpoint', () => {
-		const mAB = 0 // Arc measure
-		const A = 0 // Start angle
-		const B = 2.2 // End angle
-		const P = 1.1 // Point angle, should be near the end
-		expect(getPointInArcT(mAB, A, B, P)).toBe(1)
+	it('should clamp a point in the gap to the angularly nearer endpoint', () => {
+		// Replaces a zero-measure case that encoded the old fixed 0.5 threshold.
+		// Quarter arc from 0 to PI/2: a point at -PI/2 is PI/2 behind the start but
+		// PI past the end, so it belongs to the start...
+		expect(getPointInArcT(Math.PI / 2, 0, Math.PI / 2, -Math.PI / 2)).toBe(0)
+		// ...while a point at PI is PI behind the start but only PI/2 past the end
+		expect(getPointInArcT(Math.PI / 2, 0, Math.PI / 2, Math.PI)).toBe(1)
+	})
+})
+
+describe('areAnglesCompatible', () => {
+	it('treats angles a multiple of PI/2 apart as compatible regardless of sign', () => {
+		expect(areAnglesCompatible(-Math.PI / 4, Math.PI / 4)).toBe(true)
+		expect(areAnglesCompatible(Math.PI / 2 - 1e-9, 0)).toBe(true)
+		expect(areAnglesCompatible(Math.PI, -Math.PI / 2)).toBe(true)
+		expect(areAnglesCompatible(0, Math.PI / 3)).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -189,7 +189,10 @@ export function snapAngle(r: number, segments: number): number {
  * @public
  */
 export function areAnglesCompatible(a: number, b: number) {
-	return a === b || approximately((a % (Math.PI / 2)) - (b % (Math.PI / 2)), 0)
+	// Reduce the difference, not each angle: a sign-preserving % on each made
+	// -PI/4 and PI/4 incompatible. A remainder just under PI/2 is a multiple too.
+	const d = Math.abs(a - b) % (Math.PI / 2)
+	return approximately(d, 0) || approximately(d, Math.PI / 2)
 }
 
 /**
@@ -409,11 +412,11 @@ export function getPointInArcT(mAB: number, A: number, B: number, P: number): nu
 		mAP = shortAngleDist(A, P)
 		const t = mAP / mAB
 
-		// If the arc is something like -2.8 to 2.2, then we'll get a weird bug
-		// where the measurement to the center is negative but measure to points
-		// near the end are positive
+		// A sign mismatch (e.g. an arc from -2.8 to 2.2) means P is in the arc's
+		// gap, |mAP| behind A. Clamp to the angularly nearer endpoint: B is the
+		// rest of the gap away, not a fixed half of the arc.
 		if (Math.sign(mAP) !== Math.sign(mAB)) {
-			return Math.abs(t) > 0.5 ? 1 : 0
+			return Math.abs(mAP) > (PI2 - Math.abs(mAB)) / 2 ? 1 : 0
 		}
 
 		return t

--- a/packages/editor/src/lib/test/useCursor.test.tsx
+++ b/packages/editor/src/lib/test/useCursor.test.tsx
@@ -1,0 +1,29 @@
+import { act, render } from '@testing-library/react'
+import { createTLStore } from '../config/createTLStore'
+import { Editor } from '../editor/Editor'
+import { getCursor } from '../hooks/useCursor'
+import { TL_CONTAINER_CLASS, TldrawEditor } from '../TldrawEditor'
+
+describe('useCursor', () => {
+	it('maps the static schema cursor types to their css variables', async () => {
+		let editor: Editor
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} onMount={(e) => void (editor = e)} />)
+		})
+		const container = document.querySelector(`.${TL_CONTAINER_CLASS}`) as HTMLElement
+
+		for (const type of ['rotate', 'resize-edge', 'resize-corner', 'default'] as const) {
+			act(() => editor.setCursor({ type, rotation: 0 }))
+			expect(container.style.getPropertyValue('--tl-cursor')).toBe(`var(--tl-cursor-${type})`)
+		}
+	})
+})
+
+describe('getCursor', () => {
+	it('encodes the colour so a hex value does not end the data url as a fragment', () => {
+		const css = getCursor('ew-resize', 0, '#000000')
+		expect(css).toContain("style='color: %23000000;'")
+		expect(css).not.toContain('#')
+	})
+})

--- a/packages/editor/src/lib/test/useDocumentEvents.test.tsx
+++ b/packages/editor/src/lib/test/useDocumentEvents.test.tsx
@@ -1,0 +1,31 @@
+import { act, render } from '@testing-library/react'
+import { vi } from 'vitest'
+import { createTLStore } from '../config/createTLStore'
+import { TldrawEditor } from '../TldrawEditor'
+
+describe('useDocumentEvents drop handling', () => {
+	// The container's native drop listener used to stop propagation before the event reached
+	// React's root, so React onDrop handlers inside the canvas never fired.
+	it('lets a drop inside the canvas reach React drop handlers there', async () => {
+		const onDrop = vi.fn((e: React.DragEvent) => e.stopPropagation())
+		function DropTarget() {
+			return <div data-testid="drop-target" onDrop={onDrop} />
+		}
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} components={{ OnTheCanvas: DropTarget }} />)
+		})
+
+		const target = document.querySelector('[data-testid="drop-target"]')!
+		expect(target.closest('.tl-canvas')).not.toBeNull()
+		const event = new Event('drop', { bubbles: true, cancelable: true })
+		Object.defineProperty(event, 'dataTransfer', { value: { files: [], getData: () => '' } })
+		act(() => {
+			target.dispatchEvent(event)
+		})
+
+		expect(onDrop).toHaveBeenCalledTimes(1)
+		// the browser default (navigating to the dropped file) is still prevented
+		expect(event.defaultPrevented).toBe(true)
+	})
+})

--- a/packages/editor/src/lib/utils/areShapesContentEqual.ts
+++ b/packages/editor/src/lib/utils/areShapesContentEqual.ts
@@ -2,9 +2,6 @@ import { TLShape } from '@tldraw/tlschema'
 
 /**
  * Checks if two shapes are equal by comparing their props and meta.
- * @param a - The first shape.
- * @param b - The second shape.
- * @returns True if the shapes are equal, false otherwise.
  */
 export function areShapesContentEqual(a: TLShape, b: TLShape) {
 	return a.props === b.props && a.meta === b.meta

--- a/packages/editor/src/lib/utils/reorderShapes.ts
+++ b/packages/editor/src/lib/utils/reorderShapes.ts
@@ -4,11 +4,6 @@ import type { Editor } from '../editor/Editor'
 
 /**
  * Gets the changes for reordering shapes.
- * @param editor - The editor.
- * @param operation - The operation to perform.
- * @param ids - The ids of the shapes to reorder.
- * @param opts - The options.
- * @returns The changes.
  * @public
  */
 export function getReorderingShapesChanges(

--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -1,7 +1,6 @@
-import { isShapeId, TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
+import { TLShape, TLShapeId, TLShapePartial } from '@tldraw/tlschema'
 import { compact } from '@tldraw/utils'
 import type { Editor } from '../editor/Editor'
-import { Mat } from '../primitives/Mat'
 import { canonicalizeRotation } from '../primitives/utils'
 import { Vec, VecLike } from '../primitives/Vec'
 
@@ -75,18 +74,11 @@ export function applyRotationToSnapshotShapes({
 			// We need to both rotate each shape individually and rotate the shapes
 			// around the pivot point (the average center of all rotating shapes.)
 
-			const parentTransform = isShapeId(shape.parentId)
-				? editor.getShapePageTransform(shape.parentId)!
-				: Mat.Identity()
-
 			const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? initialPageCenter, delta)
 
-			const newLocalPoint = Mat.applyToPoint(
-				// use the current parent transform in case it has moved/resized since the start
-				// (e.g. if rotating a shape at the edge of a group)
-				Mat.Inverse(parentTransform),
-				newPagePoint
-			)
+			// uses the current parent transform in case it has moved/resized since the start
+			// (e.g. if rotating a shape at the edge of a group)
+			const newLocalPoint = editor.getPointInParentSpace(shape.id, newPagePoint)
 			const newRotation = canonicalizeRotation(shape.rotation + delta)
 
 			return {

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -106,6 +106,17 @@ describe('LocalIndexedDb', () => {
 		})
 	})
 
+	it('commits a write that is still in flight when the db is closed', async () => {
+		const db = new LocalIndexedDb('test-0')
+		const write = db.storeSnapshot({ schema, snapshot: { 'shape:1': { id: 'shape:1' } } })
+		await db.close()
+		await write
+
+		const reopened = new LocalIndexedDb('test-0')
+		expect((await reopened.load())?.records).toEqual([{ id: 'shape:1' }])
+		await reopened.close()
+	})
+
 	describe('#storeChanges', () => {
 		it('allows merging changes into an existing store', async () => {
 			const db = new LocalIndexedDb('test-0')

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -158,6 +158,7 @@ export class LocalIndexedDb {
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
+		// not `.finally()`: the promise it returns would re-reject with nobody observing it
 		const cleanup = () => this.pendingTransactionSet.delete(txPromise)
 		txPromise.then(cleanup, cleanup)
 		return txPromise

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -152,15 +152,14 @@ export class LocalIndexedDb {
 			try {
 				return await cb(tx)
 			} finally {
-				if (!this.isClosed) {
-					await done
-				} else {
-					tx.abort()
-				}
+				// let the transaction commit even if close() was called meanwhile, otherwise a
+				// persist racing an unmount is silently rolled back
+				await done
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise))
+		const cleanup = () => this.pendingTransactionSet.delete(txPromise)
+		txPromise.then(cleanup, cleanup)
 		return txPromise
 	}
 
@@ -208,17 +207,19 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
+			const requests: Promise<unknown>[] = []
 			for (const [id, record] of Object.entries(changes.added)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
 
 			for (const [_prev, updated] of Object.values(changes.updated)) {
-				await recordsStore.put(updated, updated.id)
+				requests.push(recordsStore.put(updated, updated.id))
 			}
 
 			for (const id of Object.keys(changes.removed)) {
-				await recordsStore.delete(id)
+				requests.push(recordsStore.delete(id))
 			}
+			await Promise.all(requests)
 
 			schemaStore.put(schema.serialize(), Table.Schema)
 			if (sessionStateSnapshot && sessionId) {
@@ -254,9 +255,9 @@ export class LocalIndexedDb {
 
 			await recordsStore.clear()
 
-			for (const [id, record] of Object.entries(snapshot)) {
-				await recordsStore.put(record, id)
-			}
+			await Promise.all(
+				Object.entries(snapshot).map(([id, record]) => recordsStore.put(record, id))
+			)
 
 			schemaStore.put(schema.serialize(), Table.Schema)
 

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -207,6 +207,14 @@ test('closing the client persists changes that are still queued', async () => {
 	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
 })
 
+test('closing the client with nothing queued does not write to the db', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.close()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
 test('closing the client before it has loaded does not write to the db', async () => {
 	const { client, tick } = testClient()
 	client.close()

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -172,3 +172,45 @@ test('writes that come in during a persist operation will get persisted afterwar
 	await tick()
 	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
 })
+
+test('diffs received while the client is still loading are applied once it has loaded', async () => {
+	const { client, channel, tick } = testClient()
+	const remotePage = PageRecordType.create({ name: 'remote', index: 'a0' as IndexKey })
+	channel.onmessage?.({
+		data: {
+			type: 'diff',
+			storeId: 'other-tab',
+			schema: client.serializedSchema,
+			changes: { added: { [remotePage.id]: remotePage }, updated: {}, removed: {} },
+		},
+	} as any)
+	expect(client.store.get(remotePage.id)).toBeUndefined()
+
+	await tick()
+	expect(client.store.get(remotePage.id)).toEqual(remotePage)
+
+	// and the first (full) db write includes them rather than overwriting them
+	client.store.put([PageRecordType.create({ name: 'local', index: 'a1' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+	expect(client.db.storeSnapshot.mock.calls[0][0].snapshot[remotePage.id]).toEqual(remotePage)
+})
+
+test('closing the client persists changes that are still queued', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'test', index: 'a0' as IndexKey })])
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+
+	// close before the throttled persist fires
+	client.close()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+})
+
+test('closing the client before it has loaded does not write to the db', async () => {
+	const { client, tick } = testClient()
+	client.close()
+	await tick()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -9,6 +9,7 @@ import {
 	extractSessionStateFromLegacySnapshot,
 	loadSessionStateSnapshotIntoStore,
 } from '../../config/TLSessionStateSnapshot'
+import { refreshPage } from '../runtime'
 import { showCantReadFromIndexDbAlert, showCantWriteToIndexDbAlert } from './alerts'
 import { LocalIndexedDb } from './LocalIndexedDb'
 
@@ -68,6 +69,7 @@ export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
 	private diffQueue: Array<RecordsDiff<UnknownRecord> | typeof UPDATE_INSTANCE_STATE> = []
 	private didDispose = false
+	private didLoad = false
 	private shouldDoFullDBWrite = true
 	private isReloading = false
 	readonly persistenceKey: string
@@ -156,6 +158,64 @@ export class TLLocalSyncClient {
 		this.debug('connecting')
 		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
 
+		const handleMessage = (msg: Message) => {
+			// if their schema is earlier than ours, we need to tell them so they can refresh
+			// if their schema is later than ours, we need to refresh
+			const res = this.store.schema.getMigrationsSince(msg.schema)
+
+			if (!res.ok) {
+				// we are older, refresh
+				// but add a safety check to make sure we don't get in an infinite loop
+				const timeSinceInit = Date.now() - this.initTime
+				if (timeSinceInit < 5000) {
+					// This tab was just reloaded, but is out of date compared to other tabs.
+					// Not expecting this to ever happen. It should only happen if we roll back a release that incremented
+					// the schema version (which we should never do)
+					// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
+					// check out an older commit. Dev server should be fine.
+					onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
+					return
+				}
+				this.debug('reloading')
+				this.isReloading = true
+				refreshPage()
+				return
+			} else if (res.value.length > 0) {
+				// they are older, tell them to refresh and not write any more data
+				this.debug('telling them to reload')
+				this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
+				// schedule a full db write in case they wrote data anyway
+				this.shouldDoFullDBWrite = true
+				this.persistIfNeeded()
+				return
+			}
+			// otherwise, all good, same version :)
+			if (msg.type === 'diff') {
+				this.debug('applying diff')
+				transact(() => {
+					this.store.mergeRemoteChanges(() => {
+						this.store.applyDiff(msg.changes as any)
+					})
+				})
+			}
+		}
+
+		// Listen from the start and buffer until we've loaded: diffs other tabs broadcast while
+		// we're still reading from IndexedDB would otherwise be dropped, then erased by our first
+		// (full) db write.
+		let bufferedMessages: Message[] | null = []
+		this.channel.onmessage = ({ data }) => {
+			this.debug('got message', data)
+			if (bufferedMessages) {
+				bufferedMessages.push(data as Message)
+			} else {
+				handleMessage(data as Message)
+			}
+		}
+		this.disposables.add(() => {
+			this.channel.close()
+		})
+
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
 		} catch (error: any) {
@@ -201,54 +261,9 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			this.didLoad = true
 
-			this.channel.onmessage = ({ data }) => {
-				this.debug('got message', data)
-				const msg = data as Message
-				// if their schema is earlier than ours, we need to tell them so they can refresh
-				// if their schema is later than ours, we need to refresh
-				const res = this.store.schema.getMigrationsSince(msg.schema)
-
-				if (!res.ok) {
-					// we are older, refresh
-					// but add a safety check to make sure we don't get in an infinite loop
-					const timeSinceInit = Date.now() - this.initTime
-					if (timeSinceInit < 5000) {
-						// This tab was just reloaded, but is out of date compared to other tabs.
-						// Not expecting this to ever happen. It should only happen if we roll back a release that incremented
-						// the schema version (which we should never do)
-						// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
-						// check out an older commit. Dev server should be fine.
-						onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
-						return
-					}
-					this.debug('reloading')
-					this.isReloading = true
-					window?.location?.reload?.()
-					return
-				} else if (res.value.length > 0) {
-					// they are older, tell them to refresh and not write any more data
-					this.debug('telling them to reload')
-					this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-					// schedule a full db write in case they wrote data anyway
-					this.shouldDoFullDBWrite = true
-					this.persistIfNeeded()
-					return
-				}
-				// otherwise, all good, same version :)
-				if (msg.type === 'diff') {
-					this.debug('applying diff')
-					transact(() => {
-						this.store.mergeRemoteChanges(() => {
-							this.store.applyDiff(msg.changes as any)
-						})
-					})
-				}
-			}
 			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-			this.disposables.add(() => {
-				this.channel.close()
-			})
 			onLoad(this)
 		} catch (e: any) {
 			this.debug('error loading data from store', e)
@@ -256,10 +271,19 @@ export class TLLocalSyncClient {
 			onLoadError(e)
 			return
 		}
+
+		// apply anything that arrived while we were loading. persists are throttled, so these
+		// changes still land before the first (full) db write
+		const messages = bufferedMessages
+		bufferedMessages = null
+		for (const msg of messages) handleMessage(msg)
 	}
 
 	close() {
 		this.debug('closing')
+		// flush queued changes so edits made in the last PERSIST_THROTTLE_MS before unmount aren't
+		// lost. never before load: a full write then would wipe the db with an empty store
+		if (this.didLoad) this.persistIfNeeded()
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
@@ -380,7 +404,7 @@ export class TLLocalSyncClient {
 			showCantWriteToIndexDbAlert()
 			if (typeof window !== 'undefined') {
 				// adios
-				window.location.reload()
+				refreshPage()
 			}
 		}
 

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -282,8 +282,10 @@ export class TLLocalSyncClient {
 	close() {
 		this.debug('closing')
 		// flush queued changes so edits made in the last PERSIST_THROTTLE_MS before unmount aren't
-		// lost. never before load: a full write then would wipe the db with an empty store
-		if (this.didLoad) this.persistIfNeeded()
+		// lost. never before load (a full write then would wipe the db with an empty store), and
+		// only when something is queued: shouldDoFullDBWrite stays true until the first persist,
+		// so an unconditional flush would rewrite the whole document on every no-op close
+		if (this.didLoad && this.diffQueue.length > 0) this.persistIfNeeded()
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -55,6 +55,24 @@ describe(TextShapeTool, () => {
 			props: { richText: toRichText('Hello') },
 		})
 	})
+
+	it('Records the deletion of an empty text shape so redo cannot resurrect it', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown(0, 0)
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+
+		// Exiting without typing deletes the empty shape (TextShapeUtil.onEditEnd)
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		// The creation and the deletion squash to nothing, so neither undo nor redo brings it back
+		editor.undo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.redo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
 })
 
 describe('When selecting the tool', () => {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -2,8 +2,6 @@ import {
 	Box,
 	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,6 +17,7 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -670,25 +669,3 @@ export class Resizing extends StateNode {
 }
 
 type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	// numSteps is negative for negative rotations, so wrap the index into range
-	const n = ORDERED_SELECTION_HANDLES.length
-	return ORDERED_SELECTION_HANDLES[(((currentIndex + numSteps) % n) + n) % n]
-}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -688,5 +688,7 @@ export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, r
 	const numSteps = Math.round(rotation / (PI / 4))
 
 	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
+	// numSteps is negative for negative rotations, so wrap the index into range
+	const n = ORDERED_SELECTION_HANDLES.length
+	return ORDERED_SELECTION_HANDLES[(((currentIndex + numSteps) % n) + n) % n]
 }

--- a/packages/tldraw/src/test/ClickManager.test.ts
+++ b/packages/tldraw/src/test/ClickManager.test.ts
@@ -263,6 +263,24 @@ it('Cancels when click moves', () => {
 	expect(event.name).toBe('pointer_up')
 })
 
+it('Does not cancel a double click on a small move when the container is offset', () => {
+	// click points are client coordinates; comparing them against the container-relative
+	// screen point used to cancel on any movement at all in an offset container
+	editor.setScreenBounds({ x: 300, y: 100, w: 1080, h: 720 })
+	const events: any[] = []
+	editor.addListener('event', (info) => events.push(info))
+
+	editor.pointerDown(500, 400).pointerMove(501, 400).pointerUp(501, 400).pointerDown(501, 400)
+
+	expect(events).toMatchObject([
+		{ name: 'pointer_down' },
+		{ name: 'pointer_move' },
+		{ name: 'pointer_up' },
+		{ name: 'pointer_down' },
+		{ name: 'double_click', type: 'click', phase: 'down' },
+	])
+})
+
 it('Resets when the focus layer changes', () => {
 	const boxId = editor.testShapeID('box')
 	const otherBoxId = editor.testShapeID('otherBox')
@@ -292,4 +310,21 @@ it('Resets when the focus layer changes', () => {
 
 	expect(events).toMatchObject([{ name: 'pointer_down' }])
 	expect(events).toHaveLength(1)
+})
+
+it('Emits double click events for an indirect pen outside pen mode', () => {
+	const events: any[] = []
+	editor.addListener('event', (info) => events.push(info))
+
+	// An indirect desktop tablet stylus reports as a pen but never enables pen mode, so
+	// its clicks still have to reach the click manager to produce double-click events.
+	const pen = { isPen: true, isPenDirect: false }
+	editor.pointerDown(0, 0, pen).pointerUp(0, 0, pen).pointerDown(0, 0, pen)
+	expect(editor.getInstanceState().isPenMode).toBe(false)
+	expect(events).toMatchObject([
+		{ name: 'pointer_down' },
+		{ name: 'pointer_up' },
+		{ name: 'pointer_down' },
+		{ name: 'double_click', type: 'click', phase: 'down' },
+	])
 })

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -913,6 +913,9 @@ describe('instance.isReadonly', () => {
 		expect(editor.getIsReadonly()).toBe(false)
 		mode.set('readonly')
 		expect(editor.getIsReadonly()).toBe(true)
+
+		// syncing the mode is not a user edit, so it must not show up in the undo history
+		expect(editor.getCanUndo()).toBe(false)
 	})
 })
 

--- a/packages/tldraw/src/test/ScribbleManager.test.ts
+++ b/packages/tldraw/src/test/ScribbleManager.test.ts
@@ -341,6 +341,16 @@ describe('ScribbleManager', () => {
 
 				expect(editor.scribbles.isSessionActive(sessionId)).toBe(false)
 			})
+
+			it('keeps a scribble that has not received its first point yet', () => {
+				// An empty starting scribble used to be spliced on the first tick, dropping
+				// the session before the tool could add a point
+				const item = editor.scribbles.addScribble({})
+
+				editor.scribbles.tick(16)
+
+				expect(() => editor.scribbles.addPoint(item.id, 0, 0)).not.toThrow()
+			})
 		})
 	})
 

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -96,6 +96,21 @@ describe('<TldrawEditor />', () => {
 		)
 	})
 
+	it('runs the teardown returned by the store onMount option when unmounted', async () => {
+		const teardown = vi.fn()
+		const storeOnMount = vi.fn(() => teardown)
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [], onMount: storeOnMount })
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor store={store} tools={defaultTools} initialState="select" />,
+			{ waitForPatterns: false }
+		)
+		expect(storeOnMount).toHaveBeenCalledTimes(1)
+		expect(teardown).not.toHaveBeenCalled()
+
+		act(() => rendered.unmount())
+		expect(teardown).toHaveBeenCalledTimes(1)
+	})
+
 	it('throws if the store has different shapes to the ones passed in', async () => {
 		const spy = vi.spyOn(console, 'error').mockImplementation(noop)
 		// expect(() =>
@@ -170,6 +185,45 @@ describe('<TldrawEditor />', () => {
 		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
 		expect(onMount).toHaveBeenCalledTimes(2)
 		expect(onMount.mock.lastCall![0].store).toBe(newStore)
+	})
+
+	it('keeps the editor when re-rendered with equal inline nested options', async () => {
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>,
+			{ waitForPatterns: false }
+		)
+		const initialEditor = onMount.mock.lastCall![0]
+		vi.spyOn(initialEditor, 'dispose')
+		// a fresh options object with fresh (but equal) nested objects, as an inline literal gives:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		expect(initialEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(1)
+		// a real change still recreates the editor:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: false }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(2)
+		expect(onMount.mock.lastCall![0].getCameraOptions().isLocked).toBe(false)
 	})
 
 	it('reflects mount state via getIsMounted and the mount/unmount events', async () => {

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -211,6 +211,44 @@ describe('<TldrawEditor />', () => {
 		)
 		expect(initialEditor.dispose).not.toHaveBeenCalled()
 		expect(onMount).toHaveBeenCalledTimes(1)
+		// deeper nesting (camera constraints, zoomSteps) is compared by value too:
+		const withConstraints = () => ({
+			camera: {
+				isLocked: true,
+				zoomSteps: [0.5, 1, 2],
+				constraints: {
+					bounds: { x: 0, y: 0, w: 100, h: 100 },
+					padding: { x: 0, y: 0 },
+					origin: { x: 0.5, y: 0.5 },
+					initialZoom: 'default' as const,
+					baseZoom: 'default' as const,
+					behavior: 'contain' as const,
+				},
+			},
+			deepLinks: { param: 'd' },
+		})
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(onMount).toHaveBeenCalledTimes(2)
+		const secondEditor = onMount.mock.lastCall![0]
+		vi.spyOn(secondEditor, 'dispose')
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		expect(secondEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(2)
 		// a real change still recreates the editor:
 		rendered.rerender(
 			<TldrawEditor
@@ -221,8 +259,8 @@ describe('<TldrawEditor />', () => {
 			/>
 		)
 		await rendered.findAllByTestId('canvas')
-		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
-		expect(onMount).toHaveBeenCalledTimes(2)
+		expect(secondEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(3)
 		expect(onMount.mock.lastCall![0].getCameraOptions().isLocked).toBe(false)
 	})
 

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -442,3 +442,30 @@ test('onAfterChangeToShape is called after the to shape is updated', () => {
 	})
 	expect.assertions(3)
 })
+
+test('a binding from a shape to itself is indexed once', () => {
+	bindShapes(ids.box1, ids.box1)
+	expect(editor.getBindingsInvolvingShape(ids.box1)).toHaveLength(1)
+
+	calls.length = 0
+	editor.updateShape({ id: ids.box1, type: 'geo', x: 10 })
+	expect(calls).toEqual([
+		'onAfterChangeFromShape: box1->box1',
+		'onAfterChangeToShape: box1->box1',
+		'onOperationComplete',
+	])
+})
+
+test('bindings cannot be created, updated, or deleted in readonly mode', () => {
+	const bindingId = bindShapes(ids.box1, ids.box2)
+	editor.updateInstanceState({ isReadonly: true })
+
+	editor.createBinding({ type: TEST_TYPE, fromId: ids.box3, toId: ids.box4 })
+	expect(editor.getBindingsInvolvingShape(ids.box3)).toHaveLength(0)
+
+	editor.updateBinding({ id: bindingId, type: TEST_TYPE, meta: { foo: 'bar' } })
+	expect(editor.getBinding(bindingId)?.meta).toEqual({})
+
+	editor.deleteBinding(bindingId)
+	expect(editor.getBinding(bindingId)).toBeDefined()
+})

--- a/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
+++ b/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
@@ -38,8 +38,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 3.141592653589793,
     "type": "geo",
     "typeName": "shape",
-    "x": 192,
-    "y": 308,
+    "x": 134,
+    "y": 250,
   },
   {
     "id": "shape:boxB",
@@ -77,8 +77,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 92,
-    "y": 92,
+    "x": 150,
+    "y": 150,
   },
   {
     "id": "shape:boxC",
@@ -116,8 +116,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 208,
-    "y": 92,
+    "x": 266,
+    "y": 150,
   },
 ]
 `;

--- a/packages/tldraw/src/test/commands/animateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/animateShapes.test.ts
@@ -1,3 +1,33 @@
-export {}
+import { createShapeId } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { TestEditor } from '../TestEditor'
 
-it.todo('Editor.animateToShape')
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+vi.useFakeTimers()
+
+it('animates a shape to its new position', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0 })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+	editor.emit('tick', 50)
+	expect(editor.getShape(id)).toMatchObject({ x: 50, y: 50 })
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 100, y: 100 })
+})
+
+it('does not move locked shapes', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, isLocked: true })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+	// the intermediate frames must respect the lock too, otherwise the shape is moved by every
+	// frame but the last and ends up stranded just short of the target
+	editor.emit('tick', 50)
+	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+})

--- a/packages/tldraw/src/test/commands/duplicatePage.test.ts
+++ b/packages/tldraw/src/test/commands/duplicatePage.test.ts
@@ -53,3 +53,22 @@ it("Doesn't duplicate the page if max pages is reached", () => {
 	}
 	expect(editor.getPages().length).toBe(editor.options.maxPages)
 })
+
+it('Keeps the duplicated shapes at their original coordinates, even when offscreen', () => {
+	editor.createShapes([{ id: createShapeId('offscreen'), type: 'geo', x: 5000, y: 5000 }])
+	// look at an empty part of the page so that no shape overlaps the viewport
+	editor.setCamera({ x: -20000, y: -20000, z: 1 })
+	const positions = editor
+		.getCurrentPageShapes()
+		.map((s) => ({ x: s.x, y: s.y }))
+		.sort((a, b) => a.x - b.x)
+
+	editor.duplicatePage(editor.getCurrentPageId())
+
+	expect(
+		editor
+			.getCurrentPageShapes()
+			.map((s) => ({ x: s.x, y: s.y }))
+			.sort((a, b) => a.x - b.x)
+	).toEqual(positions)
+})

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -1,5 +1,16 @@
-import { DefaultDashStyle, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	BaseBoxShapeUtil,
+	BaseFrameLikeShapeUtil,
+	DefaultDashStyle,
+	RecordProps,
+	T,
+	TLBaseShape,
+	createShapeId,
+	getColorValue,
+	toRichText,
+} from '@tldraw/editor'
 import { vi } from 'vitest'
+import { FrameShapeUtil } from '../../lib/shapes/frame/FrameShapeUtil'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -165,4 +176,89 @@ it('waits for required fonts to load before measuring the export', async () => {
 	const svg = await exportPromise
 	expect(resolved).toBe(true)
 	expect(svg!.svg).toMatch(/^<svg/)
+})
+
+// Not registered in TLGlobalShapePropsMap: the tldraw test project already sits at TypeScript's
+// discriminated-union limit for TLShapePartial, so one more augmentation breaks typecheck.
+const BROKEN_EXPORT_TYPE = 'my-broken-export-shape'
+const FRAME_LIKE_TYPE = 'my-frame-like-shape'
+
+type MyBrokenExportShape = TLBaseShape<typeof BROKEN_EXPORT_TYPE, { w: number; h: number }>
+type MyFrameLikeShape = TLBaseShape<typeof FRAME_LIKE_TYPE, { w: number; h: number }>
+
+class BrokenExportShapeUtil extends BaseBoxShapeUtil<any> {
+	static override type = BROKEN_EXPORT_TYPE
+	static override props: RecordProps<MyBrokenExportShape> = { w: T.number, h: T.number }
+	override getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	override component() {
+		return null as any
+	}
+	override getIndicatorPath() {
+		return undefined
+	}
+	override toSvg(): never {
+		throw new Error('toSvg failed')
+	}
+}
+
+class FrameLikeShapeUtil extends BaseFrameLikeShapeUtil<any> {
+	static override type = FRAME_LIKE_TYPE
+	static override props: RecordProps<MyFrameLikeShape> = { w: T.number, h: T.number }
+	override getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	override component() {
+		return null as any
+	}
+	override getIndicatorPath() {
+		return undefined
+	}
+}
+
+// jsdom serializes colors as rgb(), so compare against the same normalization
+function toCssColor(color: string) {
+	const el = document.createElement('div')
+	el.style.backgroundColor = color
+	return el.style.backgroundColor
+}
+
+it('rejects when a shape throws from toSvg instead of timing out with an empty export', async () => {
+	const editor = new TestEditor({ shapeUtils: [BrokenExportShapeUtil] })
+	const id = createShapeId('broken')
+	editor.createShape({ id, type: BROKEN_EXPORT_TYPE, x: 0, y: 0, props: { w: 100, h: 100 } } as any)
+
+	await expect(editor.getSvgString([id])).rejects.toThrow('toSvg failed')
+})
+
+it('takes a single frame-like export background from the shape util of that shape', async () => {
+	const editor = new TestEditor({
+		shapeUtils: [FrameShapeUtil.configure({ showColors: true }), FrameLikeShapeUtil],
+	})
+	const frameId = createShapeId('frame')
+	const frameLikeId = createShapeId('frame-like')
+	editor.createShape({
+		id: frameId,
+		type: 'frame',
+		x: 0,
+		y: 0,
+		props: { w: 100, h: 100, color: 'red' },
+	})
+	editor.createShape({
+		id: frameLikeId,
+		type: FRAME_LIKE_TYPE,
+		x: 200,
+		y: 0,
+		props: { w: 100, h: 100 },
+	} as any)
+	const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
+
+	const frameSvg = parseSvg(await editor.getSvgString([frameId], { background: true }))
+	expect(frameSvg.style.backgroundColor).toBe(toCssColor(getColorValue(colors, 'red', 'frameFill')))
+
+	// the custom frame-like shape has no color prop, so it gets the plain solid background
+	// rather than a transparent one from reading the default frame util's options
+	const frameLikeSvg = parseSvg(await editor.getSvgString([frameLikeId], { background: true }))
+	expect(frameLikeSvg.style.backgroundColor).toBe(toCssColor(colors.solid))
 })

--- a/packages/tldraw/src/test/commands/packShapes.test.ts
+++ b/packages/tldraw/src/test/commands/packShapes.test.ts
@@ -74,4 +74,24 @@ describe('editor.packShapes', () => {
 			editor.getCurrentPageShapes().map((s) => ({ ...s, parentId: 'wahtever' }))
 		).toMatchSnapshot('packed shapes')
 	})
+
+	it('packs shapes of different heights into rows, tallest first', () => {
+		// With the clusters sorted ascending by height, every shape after the first was too tall
+		// for the row's remaining space and fell into a single left-hand column.
+		editor.selectAll()
+		editor.deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{ id: ids.boxA, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.boxB, type: 'geo', x: 200, y: 0, props: { w: 100, h: 60 } },
+			{ id: ids.boxC, type: 'geo', x: 400, y: 0, props: { w: 120, h: 80 } },
+			{ id: ids.boxD, type: 'geo', x: 600, y: 0, props: { w: 100, h: 120 } },
+		])
+		editor.packShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD], 20)
+		editor.expectShapeToMatch(
+			{ id: ids.boxD, x: 110, y: 0 },
+			{ id: ids.boxA, x: 230, y: 0 },
+			{ id: ids.boxC, x: 350, y: 0 },
+			{ id: ids.boxB, x: 490, y: 0 }
+		)
+	})
 })

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -1,4 +1,4 @@
-import { TLDrawShape, Vec } from '@tldraw/editor'
+import { TLDrawShape, Vec, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -121,5 +121,34 @@ describe('forgiving palm touches when entering pen mode', () => {
 		const bounds = editor.getShapePageBounds(shape.id)!
 		expect(bounds.minX).toBeGreaterThan(200)
 		expect(bounds.minY).toBeGreaterThan(200)
+	})
+})
+
+describe('palm touches while in pen mode', () => {
+	it('ignores a palm touch without disturbing the pen drag in progress', () => {
+		const id = createShapeId('box')
+		editor.createShapes([
+			{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+		])
+		editor.updateInstanceState({ isPenMode: true })
+
+		const pen = { target: 'canvas', isPen: true } as const
+		const palm = { target: 'canvas', isPen: false } as const
+
+		editor.pointerDown(150, 150, pen)
+		editor.pointerMove(170, 170, pen)
+		editor.expectToBeIn('select.translating')
+
+		// A palm lands and lifts while the pen is still down. It must be ignored before it
+		// can reset the drag origin or clear the pen's pointing state.
+		editor.pointerDown(600, 600, palm)
+		editor.pointerUp(600, 600, palm)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+		expect(editor.inputs.getOriginPagePoint()).toMatchObject({ x: 150, y: 150 })
+
+		editor.pointerMove(200, 200, pen)
+		editor.expectShapeToMatch({ id, x: 150, y: 150 })
+		editor.pointerUp(200, 200, pen)
+		editor.expectToBeIn('select.idle')
 	})
 })

--- a/packages/tldraw/src/test/commands/putContent.test.ts
+++ b/packages/tldraw/src/test/commands/putContent.test.ts
@@ -1,4 +1,4 @@
-import { TLContent, createShapeId, structuredClone } from '@tldraw/editor'
+import { AssetRecordType, TLContent, createShapeId, structuredClone } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -36,6 +36,40 @@ describe('Migrations', () => {
 		// @ts-expect-error
 		withInvalidShapeModel.shapes[0].x = 'invalid'
 		expect(() => editor.putContentOntoCurrentPage(withInvalidShapeModel)).toThrow()
+	})
+})
+
+describe('Input content', () => {
+	it('is not mutated when it carries data url assets', () => {
+		const assetId = AssetRecordType.createId('imageAsset')
+		const imageId = createShapeId('image')
+		const src = 'data:image/png;base64,AAAA'
+		editor.createAssets([
+			{
+				type: 'image',
+				id: assetId,
+				typeName: 'asset',
+				props: { w: 100, h: 100, name: '', isAnimated: false, mimeType: 'image/png', src },
+				meta: {},
+			},
+		])
+		editor.createShape({
+			id: imageId,
+			type: 'image',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100, assetId },
+		})
+		// the content holds the live records when no migration applies, so putting it into another
+		// editor must not write through to this editor's asset
+		const content = editor.getContentFromCurrentPage([imageId])!
+		const other = new TestEditor()
+		other.putContentOntoCurrentPage(content)
+
+		expect(content.assets[0].props.src).toBe(src)
+		expect(content.rootShapeIds).toEqual([imageId])
+		expect(editor.getAsset(assetId)!.props.src).toBe(src)
+		other.dispose()
 	})
 })
 

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -315,6 +315,18 @@ describe('CameraOptions.wheelBehavior', () => {
 			.forceTick()
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 5, z: 1 })
 	})
+
+	it('When wheelBehavior is none, the input mode preference does not re-enable the wheel', () => {
+		editor.user.updateUserPreferences({ inputMode: 'trackpad' })
+		editor
+			.setCameraOptions({ ...DEFAULT_CAMERA_OPTIONS, wheelBehavior: 'none' })
+			.dispatch({
+				...wheelEvent,
+				delta: new Vec(5, 10, 0.01),
+			})
+			.forceTick()
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
+	})
 })
 
 describe('Zoom direction inversion', () => {
@@ -1255,4 +1267,94 @@ test('calling setCameraOptions will apply the new constraints', () => {
 		  "z": 1,
 		}
 	`)
+})
+
+describe('Constraint bounds away from the page origin', () => {
+	it('keeps the bounds inside the padded viewport with the inside behavior', () => {
+		editor.setCameraOptions({
+			...DEFAULT_CAMERA_OPTIONS,
+			constraints: {
+				...DEFAULT_CONSTRAINTS,
+				bounds: { x: 1000, y: 0, w: 800, h: 600 },
+				padding: { x: 100, y: 100 },
+				behavior: { x: 'inside', y: 'free' },
+			},
+		})
+		// the bounds' right edge stops at the right padding edge
+		editor.setCamera({ x: 100000, y: 0, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: -300, y: 0, z: 1 })
+		expect(editor.pageToScreen({ x: 1800, y: 0 }).x).toBe(1500)
+		// the bounds' left edge stops at the left padding edge
+		editor.setCamera({ x: -100000, y: 0, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: -900, y: 0, z: 1 })
+		expect(editor.pageToScreen({ x: 1000, y: 0 }).x).toBe(100)
+	})
+
+	it('keeps the bounds adjacent to the padded viewport with the outside behavior', () => {
+		editor.setCameraOptions({
+			...DEFAULT_CAMERA_OPTIONS,
+			constraints: {
+				...DEFAULT_CONSTRAINTS,
+				bounds: { x: 1000, y: 0, w: 800, h: 600 },
+				padding: { x: 100, y: 100 },
+				behavior: { x: 'outside', y: 'free' },
+			},
+		})
+		// the bounds' left edge stops at the right padding edge
+		editor.setCamera({ x: 100000, y: 0, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: 500, y: 0, z: 1 })
+		expect(editor.pageToScreen({ x: 1000, y: 0 }).x).toBe(1500)
+		// the bounds' right edge stops at the left padding edge
+		editor.setCamera({ x: -100000, y: 0, z: 1 })
+		expect(editor.getCamera()).toMatchObject({ x: -1700, y: 0, z: 1 })
+		expect(editor.pageToScreen({ x: 1800, y: 0 }).x).toBe(100)
+	})
+})
+
+test('clamps horizontal padding against the viewport width, not its height', () => {
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: {
+			...DEFAULT_CONSTRAINTS,
+			bounds: { x: 0, y: 0, w: 200, h: 100 },
+			padding: { x: 600, y: 0 },
+			behavior: { x: 'inside', y: 'free' },
+		},
+	})
+	// 600 is below half of the 1600px viewport width, so the padding is honoured as is
+	editor.setCamera({ x: -100000, y: 0, z: 1 })
+	expect(editor.getCamera()).toMatchObject({ x: 600, y: 0, z: 1 })
+})
+
+test('a forced animated camera move ends at the forced position', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: { ...DEFAULT_CONSTRAINTS, behavior: 'contain' },
+	})
+	editor.setCamera({ x: -5000, y: -5000, z: 1 }, { force: true, animation: { duration: 100 } })
+	editor.emit('tick', 50)
+	editor.emit('tick', 100)
+	// the final frame must not re-apply the constraints that `force` bypassed
+	expect(editor.getCamera()).toMatchObject({ x: -5000, y: -5000, z: 1 })
+})
+
+test('keeps the current zoom when setCamera is called without a finite zoom', () => {
+	editor.setCamera({ x: 0, y: 0, z: 0.5 })
+	editor.setCamera({ x: 100, y: 100 })
+	expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 0.5 })
+	editor.setCamera({ x: 0, y: 0, z: NaN })
+	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 0.5 })
+})
+
+test('slideCamera zoom momentum survives a long frame', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+	editor.setCamera({ x: 0, y: 0, z: 1 })
+	editor.slideCamera({ speed: 1, direction: { x: 0, y: 0, z: -0.01 } })
+	// a 100ms frame would have driven a linear zoom factor to zero (and the camera to NaN)
+	editor.emit('tick', 100)
+	const { x, y, z } = editor.getCamera()
+	expect(z).toBeGreaterThan(0)
+	expect(z).toBeLessThan(1)
+	expect(Number.isFinite(x) && Number.isFinite(y)).toBe(true)
 })

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -143,6 +143,60 @@ describe('distributeShapes command', () => {
 			})
 		})
 
+		it('keeps an arrow and its bound shapes together regardless of input order', () => {
+			const arrowId = createShapeId('arrow')
+			editor.updateShapes([
+				{ id: ids.boxB, type: 'geo', x: 300, y: 0 },
+				{ id: ids.boxC, type: 'geo', x: 600, y: 0 },
+			])
+			editor.createShape({ id: arrowId, type: 'arrow', x: 50, y: 50 })
+			editor.createBindings([
+				{
+					fromId: arrowId,
+					toId: ids.boxA,
+					type: 'arrow',
+					props: {
+						terminal: 'start',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+				{
+					fromId: arrowId,
+					toId: ids.boxB,
+					type: 'arrow',
+					props: {
+						terminal: 'end',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+			])
+			// the arrow comes first: seeding its cluster from bindings *to* it alone would leave
+			// it (and then A and B) in clusters of their own and pull B up against A
+			editor.stackShapes([arrowId, ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxB, x: 300 },
+				{ id: ids.boxC, x: 410 }
+			)
+		})
+
+		it('stacks in spatial order, not selection order, when a gap is given', () => {
+			// boxC sits between boxA and boxB on the page but comes after both in the input
+			editor.updateShapes([{ id: ids.boxC, type: 'geo', x: 50, y: 0 }])
+			editor.stackShapes([ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxC, x: 110 },
+				{ id: ids.boxB, x: 220 }
+			)
+		})
+
 		it('stacks the shapes based on the most common gap', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 0)

--- a/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
+++ b/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
@@ -47,6 +47,14 @@ describe('When resizing', () => {
 			h: 1,
 		})
 	})
+
+	it('updates the selection screen bounds when the container moves', () => {
+		editor.createShape({ type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } })
+		editor.selectAll()
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 100, y: 100 })
+		editor.setScreenBounds({ x: 300, y: 200, w: 1080, h: 720 })
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 400, y: 300 })
+	})
 })
 
 describe('When center is false', () => {

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -286,6 +286,17 @@ describe('When in the crop.idle state', () => {
 			.expectToBeIn('select.idle')
 	})
 
+	it('deleting the cropping shape clears the cropping shape id and leaves crop mode', () => {
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.deleteShapes([ids.imageB])
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('pointing the canvas should point canvas', () => {
 		editor
 			.expectToBeIn('select.idle')

--- a/packages/tldraw/src/test/customSnapping.test.tsx
+++ b/packages/tldraw/src/test/customSnapping.test.tsx
@@ -321,6 +321,16 @@ describe('custom handle snapping', () => {
 			expect(editor.snaps.getIndicators()).toHaveLength(0)
 			expect(handlePosition()).toMatchObject({ x: 251, y: 251 })
 		})
+
+		test("doesn't snap to a shape's label geometry", () => {
+			// a note's geometry is its body plus a label rectangle inside it; the label
+			// (50,69 100x62 in shape space here) is not an outline to snap to
+			editor.createShape({ id: createShapeId('note'), type: 'note', x: 400, y: 400 })
+			startDraggingHandle()
+			editor.pointerMove(452, 500, undefined, { ctrlKey: true })
+			expect(editor.snaps.getIndicators()).toHaveLength(0)
+			expect(handlePosition()).toMatchObject({ x: 452, y: 500 })
+		})
 	})
 
 	describe('with empty handleSnapGeometry.outline', () => {

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -41,6 +41,28 @@ it('duplicates a shape with an offset', () => {
 	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
 })
 
+it('ignores ids of shapes that do not exist', () => {
+	editor.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	editor.duplicateShapes([ids.box1, createShapeId('nope')], { x: 10, y: 10 })
+	expect(editor.getCurrentPageShapes().length).toBe(2)
+	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
+})
+
+it('offsets a duplicated descendant only once when its ancestor is also duplicated', () => {
+	editor.createShapes([
+		{ id: ids.box1, type: 'frame', x: 0, y: 0, props: { w: 500, h: 500 } },
+		{ id: ids.box2, type: 'geo', parentId: ids.box1, x: 50, y: 50, props: { w: 100, h: 100 } },
+	])
+	editor.duplicateShapes([ids.box1, ids.box2], { x: 1000, y: 0 })
+	const frameCopy = editor
+		.getCurrentPageShapes()
+		.find((s) => s.type === 'frame' && s.id !== ids.box1)!
+	const childCopy = editor.getSortedChildIdsForParent(frameCopy.id)
+	expect(childCopy).toHaveLength(1)
+	// the child follows its duplicated parent; it should not be offset a second time
+	expect(editor.getShapePageBounds(childCopy[0])).toMatchObject({ x: 1050, y: 50 })
+})
+
 it("doesn't duplicate locked shapes", () => {
 	editor
 		.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -450,6 +450,36 @@ describe('frame shapes', () => {
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(frameId)
 	})
 
+	it('restores the original index of a child that is dragged out and back in', () => {
+		const frameId = createShapeId('frame')
+		const boxA = createShapeId('A')
+		const boxB = createShapeId('B')
+		const boxC = createShapeId('C')
+		editor.createShapes([
+			{ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 200, h: 200 } },
+			// A second page-level shape, so that dragging B out lands it at page index a3: the same
+			// index as C inside the frame, which must not block restoring B to a2
+			{ id: createShapeId('X'), type: 'geo', x: 400, y: 400, props: { w: 50, h: 50 } },
+			{ id: boxA, type: 'geo', parentId: frameId, x: 10, y: 10, props: { w: 40, h: 40 } },
+			{ id: boxB, type: 'geo', parentId: frameId, x: 75, y: 75, props: { w: 50, h: 50 } },
+			{ id: boxC, type: 'geo', parentId: frameId, x: 150, y: 150, props: { w: 40, h: 40 } },
+		])
+		expect(editor.getSortedChildIdsForParent(frameId)).toEqual([boxA, boxB, boxC])
+		expect(editor.getShape(boxB)!.index).toBe('a2')
+
+		editor.setCurrentTool('select').select(boxB)
+		editor.pointerDown(100, 100).pointerMove(300, 300)
+		vi.advanceTimersByTime(300)
+		expect(editor.getShape(boxB)!.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getShape(boxB)!.index).toBe('a3')
+
+		editor.pointerMove(100, 100)
+		vi.advanceTimersByTime(300)
+		editor.pointerUp(100, 100)
+		expect(editor.getShape(boxB)!.parentId).toBe(frameId)
+		expect(editor.getSortedChildIdsForParent(frameId)).toEqual([boxA, boxB, boxC])
+	})
+
 	it('does not reparent shapes that are being dragged from within the frame', () => {
 		dragCreateFrame({ down: [0, 0], move: [200, 200], up: [200, 200] })
 		const frame = editor.getLastCreatedShape()
@@ -1716,6 +1746,27 @@ it('avoids crash when dragging into descendant', () => {
 	editor.select(frame1id)
 	editor.pointerDown(25, 25)
 	editor.pointerMove(30, 30)
+})
+
+it('unparents a frame dragged out of its parent by a point over its own nested child', () => {
+	const outer = createShapeId('outer')
+	const mid = createShapeId('mid')
+	const inner = createShapeId('inner')
+	editor.createShapes([
+		{ id: outer, type: 'frame', x: 0, y: 0, props: { w: 1000, h: 1000 } },
+		{ id: mid, type: 'frame', parentId: outer, x: 100, y: 100, props: { w: 500, h: 500 } },
+		{ id: inner, type: 'frame', parentId: mid, x: 100, y: 100, props: { w: 200, h: 200 } },
+	])
+
+	// inner travels with mid and stays under the pointer the whole drag; it must not be taken
+	// for the drop target, or outer never sees mid leave
+	editor.select(mid)
+	editor.pointerDown(250, 250)
+	editor.pointerMove(2000, 2000)
+	vi.advanceTimersByTime(300)
+
+	expect(editor.getShape(mid)!.parentId).toBe(editor.getCurrentPageId())
+	expect(editor.getShape(inner)!.parentId).toBe(mid)
 })
 
 describe('When dragging groups or shapes within a group', () => {

--- a/packages/tldraw/src/test/getShapeAtPoint.test.ts
+++ b/packages/tldraw/src/test/getShapeAtPoint.test.ts
@@ -252,8 +252,7 @@ describe('shapes bigger than the viewport', () => {
 	})
 })
 
-// Not registered in TLGlobalShapePropsMap: the tldraw test project already sits at TypeScript's
-// discriminated-union limit for TLShapePartial, so one more augmentation breaks typecheck.
+// Not registered in TLGlobalShapePropsMap; see getSvgString.test.ts.
 const PLAIN_FRAME_TYPE = 'plain-frame'
 type PlainFrameShape = TLBaseShape<typeof PLAIN_FRAME_TYPE, { w: number; h: number }>
 

--- a/packages/tldraw/src/test/getShapeAtPoint.test.ts
+++ b/packages/tldraw/src/test/getShapeAtPoint.test.ts
@@ -1,4 +1,12 @@
-import { TLShape, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	BaseFrameLikeShapeUtil,
+	RecordProps,
+	T,
+	TLBaseShape,
+	TLShape,
+	createShapeId,
+	toRichText,
+} from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -210,5 +218,72 @@ describe('frames', () => {
 
 		expect(editor.getOnlySelectedShape()).toBe(frame)
 		expect(editor.getEditingShape()).toBe(frame)
+	})
+})
+
+describe('shapes bigger than the viewport', () => {
+	beforeEach(() => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapes())
+	})
+
+	it('hits the edge of a hollow shape whose bounds contain the viewport', () => {
+		editor.createShape({
+			id: ids.box1,
+			type: 'geo',
+			x: -1000,
+			y: -1000,
+			props: { w: 5000, h: 5000 },
+		})
+		// on the left edge
+		expect(editor.getShapeAtPoint({ x: -1000, y: 500 })?.id).toBe(ids.box1)
+		// but its empty interior must still miss, since the pointer is "inside" it everywhere
+		expect(editor.getShapeAtPoint({ x: 500, y: 500 })?.id).toBe(undefined)
+	})
+
+	it('hits the body of an arrow whose bounds contain the viewport', () => {
+		editor.createShape({
+			id: ids.box1,
+			type: 'arrow',
+			x: -1000,
+			y: -1000,
+			props: { start: { x: 0, y: 0 }, end: { x: 5000, y: 5000 } },
+		})
+		expect(editor.getShapeAtPoint({ x: 0, y: 0 }, { margin: 4 })?.id).toBe(ids.box1)
+	})
+})
+
+// Not registered in TLGlobalShapePropsMap: the tldraw test project already sits at TypeScript's
+// discriminated-union limit for TLShapePartial, so one more augmentation breaks typecheck.
+const PLAIN_FRAME_TYPE = 'plain-frame'
+type PlainFrameShape = TLBaseShape<typeof PLAIN_FRAME_TYPE, { w: number; h: number }>
+
+describe('frame-like shapes with a plain geometry', () => {
+	// inherits BaseBoxShapeUtil's Rectangle2d geometry, which has no label children
+	class PlainFrameUtil extends BaseFrameLikeShapeUtil<any> {
+		static override type = PLAIN_FRAME_TYPE
+		static override props: RecordProps<PlainFrameShape> = { w: T.number, h: T.number }
+		getDefaultProps() {
+			return { w: 200, h: 200 }
+		}
+		component() {
+			return null
+		}
+		getIndicatorPath(): undefined {
+			return undefined
+		}
+	}
+
+	it('can be hit tested', () => {
+		editor = new TestEditor({ shapeUtils: [PlainFrameUtil] })
+		editor.createShape({
+			id: ids.frame1,
+			type: PLAIN_FRAME_TYPE,
+			x: 100,
+			y: 100,
+			props: { w: 200, h: 200 },
+		} as any)
+		expect(() => editor.getShapeAtPoint({ x: 150, y: 150 })).not.toThrow()
+		// just outside the edge, within the margin
+		expect(editor.getShapeAtPoint({ x: 98, y: 150 }, { margin: 4 })?.id).toBe(ids.frame1)
 	})
 })

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -294,6 +294,24 @@ describe('creating groups', () => {
 		editor.groupShapes(editor.getSelectedShapeIds())
 		expect(editor.getSelectedShapeIds().length).toBe(3)
 	})
+	it('works while a tool other than select is active', () => {
+		// e.g. importing content while drawing; the select tool gate belongs to the UI action
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.setCurrentTool('draw')
+		editor.groupShapes([ids.boxA, ids.boxB])
+		const group = editor.getShape(ids.boxA)!.parentId
+		expect(editor.getShape(group)!.type).toBe('group')
+		expect(editor.getShape(ids.boxB)!.parentId).toBe(group)
+		expect(editor.getCurrentToolId()).toBe('draw')
+	})
+	it('does nothing when every shape is locked', () => {
+		editor.createShapes([
+			{ ...box(ids.boxA, 0, 0), isLocked: true },
+			{ ...box(ids.boxB, 20, 0), isLocked: true },
+		])
+		expect(() => editor.groupShapes([ids.boxA, ids.boxB])).not.toThrow()
+		expect(editor.getCurrentPageShapes().length).toBe(2)
+	})
 	it('keeps order correct simple', () => {
 		// 0   10  20  30  40  50  60  70
 		// ┌───┐   ┌───┐   ┌───┐   ┌───┐
@@ -490,6 +508,24 @@ describe('ungrouping shapes', () => {
 		expect(editor.getSelectedShapeIds().length).toBe(2)
 		expect(editor.getShape(groupAId)).not.toBe(undefined)
 		expect(editor.getShape(groupBId)).not.toBe(undefined)
+	})
+	it('ungroups an outer group and its inner group in one call without losing the inner children', () => {
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0), box(ids.boxC, 40, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB])
+		const innerId = onlySelectedId()
+		editor.groupShapes([innerId, ids.boxC])
+		const outerId = onlySelectedId()
+
+		// outer first: its ungrouping reparents inner, so inner's children must follow the live
+		// record rather than inner's stale parentId (the about-to-be-deleted outer)
+		editor.ungroupShapes([outerId, innerId])
+
+		const pageId = editor.getCurrentPageId()
+		expect(editor.getShape(ids.boxA)?.parentId).toBe(pageId)
+		expect(editor.getShape(ids.boxB)?.parentId).toBe(pageId)
+		expect(editor.getShape(ids.boxC)?.parentId).toBe(pageId)
+		expect(editor.getShape(innerId)).toBeUndefined()
+		expect(editor.getShape(outerId)).toBeUndefined()
 	})
 	it('does not work if the scene is in readonly mode', () => {
 		// 0   10  20  30  40  50

--- a/packages/tldraw/src/test/maxShapes.test.ts
+++ b/packages/tldraw/src/test/maxShapes.test.ts
@@ -338,4 +338,24 @@ describe('Maximum shapes behavior', () => {
 			})
 		})
 	})
+
+	describe('groupShapes', () => {
+		it('does not reparent the shapes when the group itself cannot be created', () => {
+			const ids = Array.from({ length: 5 }, (_, i) => createShapeId(`shape-${i}`))
+			editor.createShapes(
+				ids.map((id, i) => ({ id, type: 'geo' as const, x: i * 50, y: 0, props: { w: 40, h: 40 } }))
+			)
+			const maxShapesHandler = vi.fn()
+			editor.addListener('max-shapes', maxShapesHandler)
+
+			editor.groupShapes([ids[0], ids[1]])
+
+			// the group record never existed, so the shapes must stay on the page rather than
+			// being parented to a missing id
+			expect(editor.getShape(ids[0])!.parentId).toBe(editor.getCurrentPageId())
+			expect(editor.getShape(ids[1])!.parentId).toBe(editor.getCurrentPageId())
+			expect(editor.getCurrentPageShapeIds().size).toBe(5)
+			expect(maxShapesHandler).toHaveBeenCalledTimes(1)
+		})
+	})
 })

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -155,3 +155,16 @@ it('keyboard events carry currently-held modifiers', () => {
 	expect(shiftDown.shiftKey).toBe(true)
 	expect(shiftDown.ctrlKey).toBe(true)
 })
+
+it('records the right-hand Shift and Alt keys under the left codes', () => {
+	// Consumers check `keys.has('ShiftLeft')`, so the right-hand keys fold into the left codes.
+	editor.keyDown('Shift', { code: 'ShiftRight' })
+	expect(editor.inputs.keys.has('ShiftLeft')).toBe(true)
+	editor.keyUp('Shift', { code: 'ShiftRight' })
+	expect(editor.inputs.keys.has('ShiftLeft')).toBe(false)
+
+	editor.keyDown('Alt', { code: 'AltRight' })
+	expect(editor.inputs.keys.has('AltLeft')).toBe(true)
+	editor.keyUp('Alt', { code: 'AltRight' })
+	expect(editor.inputs.keys.has('AltLeft')).toBe(false)
+})

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -155,16 +155,3 @@ it('keyboard events carry currently-held modifiers', () => {
 	expect(shiftDown.shiftKey).toBe(true)
 	expect(shiftDown.ctrlKey).toBe(true)
 })
-
-it('records the right-hand Shift and Alt keys under the left codes', () => {
-	// Consumers check `keys.has('ShiftLeft')`, so the right-hand keys fold into the left codes.
-	editor.keyDown('Shift', { code: 'ShiftRight' })
-	expect(editor.inputs.keys.has('ShiftLeft')).toBe(true)
-	editor.keyUp('Shift', { code: 'ShiftRight' })
-	expect(editor.inputs.keys.has('ShiftLeft')).toBe(false)
-
-	editor.keyDown('Alt', { code: 'AltRight' })
-	expect(editor.inputs.keys.has('AltLeft')).toBe(true)
-	editor.keyUp('Alt', { code: 'AltRight' })
-	expect(editor.inputs.keys.has('AltLeft')).toBe(false)
-})

--- a/packages/tldraw/src/test/navigation.test.ts
+++ b/packages/tldraw/src/test/navigation.test.ts
@@ -275,6 +275,31 @@ describe('Shape navigation', () => {
 			expect(editor.getSelectedShapeIds()).toEqual([ids.nearRight])
 		})
 
+		it('prefers an aligned shape over a nearer diagonal one', () => {
+			editor.createShapes([
+				{ id: ids.center, type: 'geo', x: 0, y: 0 },
+				{ id: ids.farRight, type: 'geo', x: 300, y: 0 },
+				{ id: ids.offAxisRight, type: 'geo', x: 200, y: 150 },
+			])
+
+			vi.spyOn(editor, 'getShapePageBounds').mockImplementation((shape: any) => {
+				if (shape?.id === ids.center) return { center: { x: 0, y: 0 } } as any
+				if (shape?.id === ids.farRight) return { center: { x: 300, y: 0 } } as any
+				if (shape?.id === ids.offAxisRight) return { center: { x: 200, y: 150 } } as any
+				return { center: { x: 0, y: 0 } } as any
+			})
+
+			editor.select(ids.center)
+			editor.selectAdjacentShape('right')
+			// the off-axis penalty must not be swamped by the (formerly squared) distance
+			expect(editor.getSelectedShapeIds()).toEqual([ids.farRight])
+
+			// and 'up' must not be biased towards up-left shapes
+			editor.select(ids.offAxisRight)
+			editor.selectAdjacentShape('up')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.farRight])
+		})
+
 		// Add this test for the 'prev' direction in directional navigation
 		it('navigates in previous/reverse directions correctly', () => {
 			// Create shapes in a pattern that tests directional navigation
@@ -994,6 +1019,36 @@ describe('Shape navigation', () => {
 
 			// Should have selected a shape rather than erroring
 			expect(editor.getSelectedShapeIds().length).toBeGreaterThan(0)
+		})
+
+		it('does nothing when there are no tabbable shapes', () => {
+			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0 }])
+			vi.spyOn(editor.getShapeUtil('geo'), 'canTabTo').mockReturnValue(false)
+			editor.select(ids.box1)
+
+			expect(() => editor.selectAdjacentShape('next')).not.toThrow()
+			expect(() => editor.selectAdjacentShape('prev')).not.toThrow()
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		it('wraps to the last shape on prev when the selected shape is not in the reading order', () => {
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0 },
+				{ id: ids.box3, type: 'geo', x: 200, y: 0 },
+				{ id: ids.box4, type: 'geo', x: 300, y: 0 },
+			])
+			vi.spyOn(editor.getShapeUtil('geo'), 'canTabTo').mockImplementation(
+				(shape) => shape.id !== ids.box1
+			)
+			editor.select(ids.box1)
+
+			editor.selectAdjacentShape('prev')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box4])
+
+			editor.select(ids.box1)
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
 		})
 
 		it('navigates in row-wise reading order with complex layouts', () => {

--- a/packages/tldraw/src/test/resizeBox.test.ts
+++ b/packages/tldraw/src/test/resizeBox.test.ts
@@ -103,4 +103,29 @@ describe('Resize box', () => {
 			},
 		})
 	})
+
+	it('Keeps the opposite edges fixed when clamping to the maximum size', () => {
+		const results = resizeBox(
+			shape,
+			{
+				newPoint: { x: -100, y: -100 },
+				handle: 'top_left',
+				mode: 'resize_bounds',
+				scaleX: 2,
+				scaleY: 2,
+				initialBounds: new Box(0, 0, 100, 100),
+				initialShape: shape,
+			},
+			{ maxWidth: 150, maxHeight: 150 }
+		)
+		// The bottom right corner stays at (100, 100), so the box spans -50..100 on each axis
+		expect(results).toMatchObject({
+			x: -50,
+			y: -50,
+			props: {
+				w: 150,
+				h: 150,
+			},
+		})
+	})
 })

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3462,6 +3462,37 @@ describe('resizing a selection of mixed rotations', () => {
 		editor.pointerDownOnHandle('bottom_right').pointerMove(100, 25)
 		expect(roundedPageBounds(ids.boxA, 0.5)).toMatchObject({ x: 0, y: 0, w: 20, h: 20 })
 	})
+
+	it('mirrors an unaligned shape across the rotated selection axis when flipping', () => {
+		// C is rotated 0.3 inside a group that is then rotated by 0.5, so C's page rotation (0.8)
+		// is out of alignment with the selection axes and takes the unaligned resize path
+		const alignedId = createShapeId('aligned')
+		const unalignedId = createShapeId('unaligned')
+		editor.createShapes([
+			box(alignedId, 0, 0, 100, 50),
+			{ ...box(unalignedId, 200, 0, 100, 50), rotation: 0.3 },
+		])
+		editor.groupShapes([alignedId, unalignedId])
+		const groupId = editor.getOnlySelectedShapeId()!
+		editor.rotateShapesBy([groupId], 0.5)
+		editor.select(groupId)
+
+		const selectionBounds = editor.getSelectionRotatedPageBounds()!
+		const centerBefore = editor.getShapePageBounds(unalignedId)!.center
+		// mirror across the selection's left edge, which is where the right handle ends up
+		const expectedCenter = Vec.RotWith(centerBefore, selectionBounds.point, -0.5)
+		expectedCenter.x = selectionBounds.point.x - (expectedCenter.x - selectionBounds.point.x)
+		expectedCenter.rotWith(selectionBounds.point, 0.5)
+
+		editor.resizeSelection({ scaleX: -1 }, 'right')
+
+		// a flip across an axis at angle θ maps a page rotation r to 2θ - r; negating the rotation
+		// (as if θ were 0) leaves the shape off by 2θ
+		expect(editor.getShapePageTransform(unalignedId).rotation()).toBeCloseTo(2 * 0.5 - 0.8)
+		const centerAfter = editor.getShapePageBounds(unalignedId)!.center
+		expect(centerAfter.x).toBeCloseTo(expectedCenter.x)
+		expect(centerAfter.y).toBeCloseTo(expectedCenter.y)
+	})
 })
 
 // describe('Icons', () => {

--- a/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
+++ b/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
@@ -72,4 +72,25 @@ describe('shapeIdsInCurrentPage', () => {
 			new Set([ids.box1, ids.box2, ids.box3])
 		)
 	})
+
+	it('updates the descendants of a shape that is reparented to another page', () => {
+		const frameId = createShapeId('frame')
+		editor.createShapes([
+			{ type: 'frame', id: frameId },
+			{ type: 'geo', id: ids.box1, parentId: frameId },
+		])
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box1]))
+
+		const page2Id = PageRecordType.createId('page2')
+		editor.createPage({ name: 'New Page 2', id: page2Id })
+		editor.reparentShapes([frameId], page2Id)
+
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([]))
+
+		editor.setCurrentPage(page2Id)
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box1]))
+
+		editor.reparentShapes([frameId], editor.getPages()[0].id)
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([]))
+	})
 })

--- a/packages/tldraw/src/test/spacebarPanning.test.ts
+++ b/packages/tldraw/src/test/spacebarPanning.test.ts
@@ -80,3 +80,13 @@ it('When holding spacebar, pressing the arrow keys moves over by one viewport', 
 	expect(editor.getViewportPageBounds()).toEqual({ x: 1080, y: 720, w: 1080, h: 720 })
 	editor.keyUp(' ')
 })
+
+it('When the camera is locked, spacebar + arrow keys do not move the camera', () => {
+	editor.setCameraOptions({ isLocked: true })
+	editor.user.updateUserPreferences({ animationSpeed: 0 })
+	editor.keyDown(' ')
+	editor.keyDown('ArrowRight')
+	editor.keyUp('ArrowRight')
+	expect(editor.getViewportPageBounds()).toEqual({ x: -0, y: -0, w: 1080, h: 720 })
+	editor.keyUp(' ')
+})

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -1,5 +1,6 @@
 import { Box, PageRecordType, createShapeId, react } from '@tldraw/editor'
 import { vi } from 'vitest'
+import { DefaultFontFaces } from '../lib/shapes/shared/defaultFonts'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -143,6 +144,20 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		const page2 = PageRecordType.createId('page2-switch')
 		editor.createPage({ name: 'page2-switch', id: page2 })
 		editor.setCurrentPage(page2)
+
+		expect(tracker.delta).toBe(1)
+		tracker.stop()
+	})
+
+	it('ticks when a font finishes loading (text bounds depend on font metrics)', async () => {
+		// The index reads bounds without capture, so a font swap that resizes measured
+		// text would otherwise leave the stale fallback-font bounds in the tree.
+		editor.createShapes([{ id: createShapeId('text'), type: 'text', x: 100, y: 100 }])
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		await editor.fonts.ensureFontIsLoaded(DefaultFontFaces.tldraw_draw.normal.normal)
 
 		expect(tracker.delta).toBe(1)
 		tracker.stop()

--- a/packages/tldraw/src/test/viewport-following.test.ts
+++ b/packages/tldraw/src/test/viewport-following.test.ts
@@ -1,6 +1,6 @@
+import { InstancePresenceRecordType, TLUserId, createUserId } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let editor: TestEditor
 
 beforeEach(() => {
@@ -8,6 +8,34 @@ beforeEach(() => {
 })
 
 describe('When following a user', () => {
+	it('keeps following a leader whose own leader is missing', () => {
+		const pageId = editor.getCurrentPageId()
+		const leaderId = createUserId('leader')
+		const leadersLeaderId = createUserId('leaders-leader')
+		const presence = (userId: TLUserId, followingUserId: TLUserId | null) =>
+			InstancePresenceRecordType.create({
+				id: InstancePresenceRecordType.createId(userId),
+				userId,
+				userName: userId,
+				currentPageId: pageId,
+				followingUserId,
+				camera: { x: 0, y: 0, z: 1 },
+				screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
+				lastActivityTimestamp: Date.now(),
+			})
+
+		// the leader follows someone whose presence we don't have
+		editor.store.put([presence(leaderId, leadersLeaderId)])
+		editor.startFollowingUser(leaderId)
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+
+		// the leader's leader shows up, then leaves again
+		editor.store.put([presence(leadersLeaderId, null)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+		editor.store.remove([InstancePresenceRecordType.createId(leadersLeaderId)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+	})
+
 	it.todo('starts following a user')
 	it.todo('stops following a user')
 	it.todo('stops following a user when the camera changes due to user action')

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -274,6 +274,8 @@ export function lns(str: string): string;
 export class LruCache<K, V> {
     constructor(maxSize: number);
     // (undocumented)
+    delete(key: K): boolean;
+    // (undocumented)
     get(key: K): undefined | V;
     // (undocumented)
     has(key: K): boolean;

--- a/packages/utils/src/lib/LruCache.ts
+++ b/packages/utils/src/lib/LruCache.ts
@@ -25,6 +25,10 @@ export class LruCache<K, V> {
 		return this.map.has(key)
 	}
 
+	delete(key: K): boolean {
+		return this.map.delete(key)
+	}
+
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get size(): number {
 		return this.map.size


### PR DESCRIPTION
> Superseded by the per-bug split tracked in #10363; this PR stays open only as the index and full write-up until the splits land.

**Risk: high · Importance: medium**

In order to clear out a backlog of long-standing correctness bugs in the core editor before they get copied into more custom shapes and apps, this PR applies the results of a full-package review of `packages/editor`. Each fix is small and self-contained and nearly all of them come with a focused regression test; the diff is large because there are many of them, not because any one change is deep.

The most visible fixes, grouped by area:

- **Hit testing and geometry.** `getShapeAtPoint` no longer assumes every frame-like shape has a `Group2d` geometry (custom `BaseFrameLikeShapeUtil` subclasses threw on every pointer move); very large arrows and hollow shapes whose bbox contains the viewport are hittable again; `getDraggingOverShape` excludes descendants of the dragged shapes (dragging a frame over its own child frame no longer hides it); line-segment distance/hit tests on `Geometry2d`, `Arc2d`, `Circle2d`, `Ellipse2d`, `Stadium2d` and `CubicSpline2d` honour the margin and alongside-edge cases; `Vec.Slope`/`Vec.cross` typos.
- **Camera.** Constraint math for `inside`/`outside` behaviors omitted `bounds.x/y`, so offset bounds could be panned off-screen; the padding clamp used swapped axes; `setCamera({ x, y })` reset zoom to 100% and a `NaN` z crashed the store; forced animated moves snapped back on the last frame; `slideCamera` zoom momentum could hit zero; `wheelBehavior: 'none'` is no longer overridden by the user's input-mode preference; space+arrow panning and `pinch_end` honour `isLocked`.
- **Grouping, layout and history.** `ungroupShapes([outer, inner])` deleted the inner group's children; `groupShapes` at `maxShapesPerPage` reparented shapes into a group it never created; `packShapes` sorted ascending and stacked everything in one column; `_resizeUnalignedShape` used the wrong flip rotation for rotated selections; `onEditEnd` ran under `history: 'ignore'`, leaving phantom undo entries after editing an empty text shape; `setErasingShapes` sorted the caller's array in place.
- **Input handling.** Indirect desktop styluses never reached the `ClickManager` (no double-click to edit text since #9316); `ClickManager` compared client and container-relative coordinates, so any container offset cancelled double-clicks, and its timers were never actually cleared; the stylus-eraser button crashed a bare editor without an `EraserTool`; palm rejection in pen mode now runs before input state is updated; `MenuClickCapture` no longer sticks after a right-click pan; drop events inside `.tl-canvas` reach React handlers.
- **Component and lifecycle.** Inline nested `options` (`camera`, `deepLinks`) no longer recreate the `Editor` on every parent render; corrupt user-preferences in localStorage no longer prevent mount; `LicenseProvider` reacts to `licenseKey` changes; `createTLStore` returns the `onMount` teardown; spatial index rebuilds when fonts load.
- **Persistence and export.** `TLLocalSyncClient` buffers cross-tab diffs that arrive during load and flushes queued changes on close; `LocalIndexedDb` no longer aborts in-flight writes on close; export rejects (instead of a blank image after 5 s) when `toSvg` throws; single frame-like exports use the shape's own util instead of reaching for `'frame'`; `fetchCache` no longer caches failures; `StyleEmbedder` handles multi-url values; `parseCss` matches bare `@import url(...)`.

Two behavior changes worth calling out: `createBindings`/`updateBindings`/`deleteBindings` and `updateDocumentSettings` now no-op in readonly mode like the other mutators (copy/duplicate still work in readonly via an internal unguarded path), and `animateShapes`, `deleteShapes`, `duplicateShapes` and `groupShapes` now share `updateShapes`' lock semantics.

The right-shift/alt normalization fix found in the same review is already in #10192 and was left out here. Follow-up issues are filed for the findings that were confirmed but not fixed (API additions, device-only behavior, larger refactors).

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix hit testing for custom frame-like shapes, large arrows and hollow shapes, and shapes dragged over their own descendants.
- Fix camera constraints with offset bounds, padding clamping, `setCamera` without `z`, forced animated moves and `wheelBehavior: 'none'`.
- Fix `ungroupShapes` deleting nested group children, `packShapes` stacking in one column, and undo history after editing an empty text shape.
- Fix double-click with desktop styluses and in offset containers, and a crash when a stylus eraser is used without an eraser tool.
- Stop recreating the editor when inline nested `options` are passed to `TldrawEditor`.
- Make binding mutations and `updateDocumentSettings` respect readonly mode.

### API changes

- Added an optional `distance` parameter to `Arc2d`, `CubicSpline2d`, `Ellipse2d` and `Stadium2d` `hitTestLineSegment()` (matching `Geometry2d`)
- Added `LruCache.delete()`
- Added `@internal` `Editor._deleteBindings()` and `FontManager.getFontLoadEpoch()`

### Code changes

| Section         | LOC change    |
| --------------- | ------------- |
| Core code       | +915 / -823   |
| Tests           | +1628 / -41   |
| Automated files | +18 / -10     |
| Documentation   | +1 / -1       |