### PR TITLE
fix(dotcom): seed a late-found app file from its createSource

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1298,6 +1298,20 @@ export class TLFileDurableObject extends DurableObject {
 					throw new RoomNotFoundError(slug)
 				}
 
+				// The cache can still have been empty at the check above when the row only became
+				// visible on this second lookup (a connect that raced the createFile mutation).
+				// Seeding a from-source file with the empty default would persist an empty room,
+				// and the R2 blob then means `createSource` is never consulted again.
+				if (file.createSource) {
+					const res = await this.handleFileCreateFromSource()
+					if (commentsPromise) {
+						const snapshot: RoomSnapshot = { ...res.snapshot }
+						mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+						res.snapshot = snapshot
+					}
+					return res
+				}
+
 				// Comments can exist in Postgres before the first throttled R2 persist ever runs
 				// (e.g. DO SQLite lost right after commenting on a fresh file), so rehydrate them
 				// here too. Clone the shared DEFAULT_INITIAL_SNAPSHOT constant — the merge reassigns

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1174,6 +1174,31 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	/**
+	 * Seed the room from its `createSource` and merge in Postgres comments. `createSource` is
+	 * never cleared from the file record, so this re-runs whenever the R2 blob is missing,
+	 * including a from-source file that gained comments and then lost its DO SQLite before the
+	 * first throttled R2 persist; without the merge those comments would be orphaned (visible in
+	 * /comments, absent from the room). A fresh duplicate has zero rows and the merge is a no-op.
+	 */
+	private async loadFromCreateSource(
+		commentsPromise: Promise<CommentLoadResult> | null
+	): Promise<DBLoadResult> {
+		const createFromSourceTimer = this.timer()
+		const res = await this.handleFileCreateFromSource()
+		createFromSourceTimer.report('db_load_create_from_source')
+
+		if (commentsPromise) {
+			// Clone: loadCreateSourceData can return the shared DEFAULT_INITIAL_SNAPSHOT constant
+			// and the merge mutates top-level snapshot fields.
+			const snapshot: RoomSnapshot = { ...res.snapshot }
+			mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+			res.snapshot = snapshot
+		}
+
+		return res
+	}
+
+	/**
 	 * Resolve the seed content for a file's `createSource`, as a RoomSnapshot or its serialized
 	 * string. Returns undefined for an unknown source, which the caller turns into RoomNotFoundError.
 	 */
@@ -1265,27 +1290,8 @@ export class TLFileDurableObject extends DurableObject {
 			}
 
 			if (this._fileRecordCache?.createSource) {
-				const createFromSourceTimer = this.timer()
-				const res = await this.handleFileCreateFromSource()
-				createFromSourceTimer.report('db_load_create_from_source')
-
-				// `createSource` is never cleared from the file record, so this branch re-enters
-				// whenever the R2 blob is missing — including a from-source file that gained
-				// comments and then lost its DO SQLite before the first throttled R2 persist.
-				// Merge the Postgres comments back in like the other branches, or they'd be
-				// orphaned: visible in the app-level /comments view but absent from the room, and
-				// resurrected inconsistently later. For a genuinely fresh duplicate the query
-				// returns zero rows and the merge is a no-op. Clone the snapshot before merging:
-				// loadCreateSourceData can return the shared DEFAULT_INITIAL_SNAPSHOT module
-				// constant, and the merge mutates top-level snapshot fields.
-				if (commentsPromise) {
-					const snapshot: RoomSnapshot = { ...res.snapshot }
-					mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
-					res.snapshot = snapshot
-				}
-
+				const res = await this.loadFromCreateSource(commentsPromise)
 				loadTimer.report('db_load_total')
-
 				return res
 			}
 
@@ -1293,8 +1299,8 @@ export class TLFileDurableObject extends DurableObject {
 				// finally check whether the file exists in the DB but not in R2 yet
 				const file = await this.getAppFileRecord()
 
-				loadTimer.report('db_load_total')
 				if (!file) {
+					loadTimer.report('db_load_total')
 					throw new RoomNotFoundError(slug)
 				}
 
@@ -1303,14 +1309,12 @@ export class TLFileDurableObject extends DurableObject {
 				// Seeding a from-source file with the empty default would persist an empty room,
 				// and the R2 blob then means `createSource` is never consulted again.
 				if (file.createSource) {
-					const res = await this.handleFileCreateFromSource()
-					if (commentsPromise) {
-						const snapshot: RoomSnapshot = { ...res.snapshot }
-						mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
-						res.snapshot = snapshot
-					}
+					const res = await this.loadFromCreateSource(commentsPromise)
+					loadTimer.report('db_load_total')
 					return res
 				}
+
+				loadTimer.report('db_load_total')
 
 				// Comments can exist in Postgres before the first throttled R2 persist ever runs
 				// (e.g. DO SQLite lost right after commenting on a fresh file), so rehydrate them


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where a duplicated or imported file could be permanently seeded with the empty default snapshot.

### Before

When a client connected before the `createFile` insert was visible, `onRequest`'s lookup returned null and the cache stayed null. `loadFromDatabase` then missed R2, skipped the `createSource` branch (the cached row was null), and only on its last lookup found the row — at which point it loaded `DEFAULT_INITIAL_SNAPSHOT` and persisted it. The R2 blob now existed, so `createSource` was never consulted again.

### After

The late-row branch checks the freshly fetched row's `createSource` and seeds from it, merging comments the same way the R2 path does.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix duplicated or imported files occasionally opening empty

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +14 / -0   |