### PR TITLE
fix(dotcom-shared): require workspace access to pin and unpin files

### DIFF
--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -409,6 +409,9 @@ export function createMutators(userId: string) {
 			assert(fileId, ZErrorCode.bad_request)
 			assert(typeof index === 'string' || index == null, ZErrorCode.bad_request)
 			assert(workspaceId, ZErrorCode.bad_request)
+			// Without this any signed-in user who knows a (fileId, workspaceId) pair — a guest who
+			// opened a shared link, a removed member — could rewrite that workspace's pin order.
+			assert(can(await getRole(tx, userId, workspaceId), 'accessFiles'), ZErrorCode.forbidden)
 
 			// Pinned files are group_file rows with a non-null index.
 			// New pins go above the workspace's current top pinned file.
@@ -430,6 +433,9 @@ export function createMutators(userId: string) {
 
 		unpinFile: async (tx: Tx, { fileId, workspaceId }: { fileId: string; workspaceId: string }) => {
 			assert(fileId, ZErrorCode.bad_request)
+			assert(workspaceId, ZErrorCode.bad_request)
+			// See pinFile.
+			assert(can(await getRole(tx, userId, workspaceId), 'accessFiles'), ZErrorCode.forbidden)
 
 			await tx.mutate.group_file.update({
 				fileId,


### PR DESCRIPTION
**Risk: low · Importance: urgent**

This PR fixes a bug where any signed-in user could rewrite a workspace's pin order.

### Before

`pinFile` and `unpinFile` asserted their arguments but, unlike every sibling workspace mutator, never checked the caller's role. Anyone who knew a `(fileId, workspaceId)` pair — a guest who had opened a shared link, a removed member — could `UPDATE group_file SET index` for that workspace.

### After

Both require `can(role, 'accessFiles')` for the workspace; `unpinFile` also asserts `workspaceId`. Home-workspace pins are unaffected (`getRole` treats the home workspace as owner).

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix pin and unpin being allowed for users without access to the workspace

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -0    |