### PR TITLE
fix(dotcom): store the migrated records under the server schema in createRoomSnapshot

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
@@ -1,11 +1,10 @@
 import { CreateSnapshotRequestBody } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { createTLSchema } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { getR2KeyForSnapshot } from '../r2'
 import { Environment } from '../types'
-import { validateSnapshot } from '../utils/validateSnapshot'
+import { snapshotSchema, validateSnapshot } from '../utils/validateSnapshot'
 
 export interface R2Snapshot {
 	parent_slug: CreateSnapshotRequestBody['parent_slug']
@@ -25,10 +24,8 @@ export async function createRoomSnapshot(request: IRequest, env: Environment): P
 	const persistedRoomSnapshot = {
 		parent_slug: data.parent_slug,
 		drawing: {
-			// The validated store and the schema it was migrated to, not the raw body: when the
-			// client's schema needed migrating, session-scoped records were only stripped from the
-			// migrated copy, and storing it under the old schema would re-run migrations on load.
-			schema: createTLSchema().serialize(),
+			// Session-scoped records are only stripped from the migrated copy, so persist that, not the raw body.
+			schema: snapshotSchema.serialize(),
 			clock: 0,
 			documents: Object.values(snapshotResult.value).map((r) => ({
 				state: r,

--- a/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/createRoomSnapshot.ts
@@ -1,5 +1,6 @@
 import { CreateSnapshotRequestBody } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
+import { createTLSchema } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { getR2KeyForSnapshot } from '../r2'
@@ -24,9 +25,12 @@ export async function createRoomSnapshot(request: IRequest, env: Environment): P
 	const persistedRoomSnapshot = {
 		parent_slug: data.parent_slug,
 		drawing: {
-			schema: data.schema,
+			// The validated store and the schema it was migrated to, not the raw body: when the
+			// client's schema needed migrating, session-scoped records were only stripped from the
+			// migrated copy, and storing it under the old schema would re-run migrations on load.
+			schema: createTLSchema().serialize(),
 			clock: 0,
-			documents: Object.values(data.snapshot).map((r) => ({
+			documents: Object.values(snapshotResult.value).map((r) => ({
 				state: r,
 				lastChangedClock: 0,
 			})),

--- a/apps/dotcom/sync-worker/src/routes/tla/createFiles.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/createFiles.ts
@@ -1,12 +1,11 @@
 import { CreateFilesRequestBody } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { createTLSchema } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../../r2'
 import { Environment } from '../../types'
 import { getUserIdFromRequest } from '../../utils/tla/permissions'
-import { validateSnapshot } from '../../utils/validateSnapshot'
+import { snapshotSchema, validateSnapshot } from '../../utils/validateSnapshot'
 
 // Create new files based on snapshots. This is used when dropping .tldr files onto the app.
 export async function createFiles(request: IRequest, env: Environment): Promise<Response> {
@@ -30,7 +29,7 @@ export async function createFiles(request: IRequest, env: Environment): Promise<
 
 		// Create the new snapshot
 		const snapshot: RoomSnapshot = {
-			schema: createTLSchema().serialize(),
+			schema: snapshotSchema.serialize(),
 			clock: 0,
 			documents: Object.values(snapshotResult.value).map((r) => ({
 				state: r,

--- a/apps/dotcom/sync-worker/src/utils/validateSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/utils/validateSnapshot.ts
@@ -7,12 +7,16 @@ interface SnapshotRequestBody {
 	snapshot: SerializedStore<TLRecord>
 }
 
-const schema = createTLSchema()
+// Exported so callers persist the exact schema the records were migrated to.
+export const snapshotSchema = createTLSchema()
 export function validateSnapshot(
 	body: SnapshotRequestBody
 ): Result<SerializedStore<TLRecord>, string> {
 	// Migrate the snapshot using the provided schema
-	const migrationResult = schema.migrateStoreSnapshot({ store: body.snapshot, schema: body.schema })
+	const migrationResult = snapshotSchema.migrateStoreSnapshot({
+		store: body.snapshot,
+		schema: body.schema,
+	})
 
 	if (migrationResult.type === 'error') {
 		console.error('Migration error:', migrationResult.reason)
@@ -27,7 +31,7 @@ export function validateSnapshot(
 			}
 
 			// Get the corresponding record type from the provided schema
-			const recordType = schema.types[record.typeName]
+			const recordType = snapshotSchema.types[record.typeName]
 
 			// Throw if any records have missing record type definitions
 			if (!recordType) {


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where `createRoomSnapshot` persisted the raw request body instead of the validated store.

### Before

`validateSnapshot` migrated the client's records with the server schema and stripped session-scoped records from the migrated copy, but the handler wrote `data.snapshot` (unmigrated, unstripped) under `data.schema`.

### After

The handler persists `snapshotResult.value` under `createTLSchema().serialize()`, matching `createFiles`. Storing the migrated records under the old schema would have re-run the migrations on load.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix snapshot links persisting unvalidated records

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +6 / -2    |