### PR TITLE
fix(dotcom): gate social preview names on anonymous viewability

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/getSocialPreview.ts
+++ b/apps/dotcom/sync-worker/src/routes/getSocialPreview.ts
@@ -23,6 +23,7 @@ import { getSlug } from '../utils/roomOpenMode'
 import { R2Snapshot } from './createRoomSnapshot'
 import { cleanName, getDocumentNameFromSnapshot } from './getDocumentNameFromSnapshot'
 import { getPublishedRoomSnapshot } from './tla/getPublishedFile'
+import { isFileAnonymouslyViewable } from './tla/getSharedFile'
 import { resolveThumbnailBoard } from './tla/thumbnailRender'
 
 // These mirror the static social preview metadata in apps/dotcom/client/index.html. They are used
@@ -119,13 +120,15 @@ async function getTlaFileName(env: Environment, slug: string): Promise<string | 
 	try {
 		file = await db
 			.selectFrom('file')
-			.select(['name', 'shared'])
+			.select(['id', 'name', 'shared', 'isDeleted'])
 			.where('id', '=', slug)
 			.executeTakeFirst()
 	} finally {
 		await db.destroy()
 	}
-	if (!file || !file.shared) return null
+	// The same gate the OG image on this card goes through, so a trashed (or test) board can't keep
+	// unfurling its name after the room itself started answering not-found.
+	if (!file || !isFileAnonymouslyViewable(file)) return null
 
 	const name = cleanName(file.name)
 	if (name) return name


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a trashed or test board's name kept unfurling in link previews.

### Before

`getTlaFileName` in `getSocialPreview.ts` returned the file's name whenever a row existed, even after the room itself had started answering not-found.

### After

The name goes through `isFileAnonymouslyViewable`, the same gate the OG image on the card uses.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix link previews showing the name of a deleted board

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +5 / -2    |