### PR TITLE
fix(dotcom): step room history by UTC calendar month and guard invalid offsets

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
@@ -57,20 +57,20 @@ describe('getRoomHistory', () => {
 			hasMore: false,
 		})
 	})
+	it.each(['!', 'not-a-date'])(
+		'uses now for scanning and filtering invalid offset %s',
+		async (offset) => {
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-03-31T12:00:00Z'))
+			const timestamps = [
+				'2026-03-31T13:00:00.000Z',
+				'2026-03-30T10:00:00.000Z',
+				'2026-02-28T10:00:00.000Z',
+			]
+			await expect(listHistory(timestamps, offset)).resolves.toEqual({
+				timestamps: timestamps.slice(1),
+				hasMore: false,
+			})
+		}
+	)
 })
-it.each(['!', 'not-a-date'])(
-	'uses now for scanning and filtering invalid offset %s',
-	async (offset) => {
-		vi.useFakeTimers()
-		vi.setSystemTime(new Date('2026-03-31T12:00:00Z'))
-		const timestamps = [
-			'2026-03-31T13:00:00.000Z',
-			'2026-03-30T10:00:00.000Z',
-			'2026-02-28T10:00:00.000Z',
-		]
-		await expect(listHistory(timestamps, offset)).resolves.toEqual({
-			timestamps: timestamps.slice(1),
-			hasMore: false,
-		})
-	}
-)

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
@@ -1,5 +1,5 @@
 import { IRequest } from 'itty-router'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Environment } from '../types'
 import { getMonthPrefix, getPreviousMonth, getRoomHistory } from './getRoomHistory'
 
@@ -44,6 +44,8 @@ async function listHistory(timestamps: string[], offset: string) {
 }
 
 describe('getRoomHistory', () => {
+	afterEach(() => vi.useRealTimers())
+
 	it('collects consecutive months once and excludes the pagination offset', async () => {
 		const timestamps = [
 			'2026-03-31T12:00:00.000Z',
@@ -56,3 +58,19 @@ describe('getRoomHistory', () => {
 		})
 	})
 })
+it.each(['!', 'not-a-date'])(
+	'uses now for scanning and filtering invalid offset %s',
+	async (offset) => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-03-31T12:00:00Z'))
+		const timestamps = [
+			'2026-03-31T13:00:00.000Z',
+			'2026-03-30T10:00:00.000Z',
+			'2026-02-28T10:00:00.000Z',
+		]
+		await expect(listHistory(timestamps, offset)).resolves.toEqual({
+			timestamps: timestamps.slice(1),
+			hasMore: false,
+		})
+	}
+)

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
@@ -1,0 +1,58 @@
+import { IRequest } from 'itty-router'
+import { describe, expect, it, vi } from 'vitest'
+import { Environment } from '../types'
+import { getMonthPrefix, getPreviousMonth, getRoomHistory } from './getRoomHistory'
+
+vi.mock('../utils/tla/getAuth', () => ({ requireAdminAccessToRequest: vi.fn() }))
+
+describe('getMonthPrefix', () => {
+	it('uses the UTC month at a local month boundary', () => {
+		expect(getMonthPrefix(new Date('2026-03-01T00:30:00+02:00'))).toBe('2026-02')
+	})
+})
+
+describe('getPreviousMonth', () => {
+	it.each([
+		['2026-03-29T12:00:00Z', '2026-02-01T00:00:00.000Z'],
+		['2026-03-30T12:00:00Z', '2026-02-01T00:00:00.000Z'],
+		['2026-03-31T12:00:00Z', '2026-02-01T00:00:00.000Z'],
+		['2024-03-31T12:00:00Z', '2024-02-01T00:00:00.000Z'],
+		['2026-01-31T12:00:00Z', '2025-12-01T00:00:00.000Z'],
+		['2026-03-01T00:30:00+02:00', '2026-01-01T00:00:00.000Z'],
+	])('steps from %s to %s without changing the input', (input, expected) => {
+		const date = new Date(input)
+		const originalTime = date.getTime()
+		expect(getPreviousMonth(date).toISOString()).toBe(expected)
+		expect(date.getTime()).toBe(originalTime)
+	})
+})
+
+async function listHistory(timestamps: string[], offset: string) {
+	const list = vi.fn(async ({ prefix }: { prefix: string }) => ({
+		objects: timestamps
+			.map((timestamp) => ({ key: `app_rooms/board/${timestamp}` }))
+			.filter(({ key }) => key.startsWith(prefix)),
+		truncated: false,
+	}))
+	const response = await getRoomHistory(
+		{ params: { roomId: 'board' }, query: { offset } } as unknown as IRequest,
+		{ ROOMS_HISTORY_EPHEMERAL: { list } } as unknown as Environment,
+		true
+	)
+	expect(response.status).toBe(200)
+	return response.json()
+}
+
+describe('getRoomHistory', () => {
+	it('collects consecutive months once and excludes the pagination offset', async () => {
+		const timestamps = [
+			'2026-03-31T12:00:00.000Z',
+			'2026-03-30T10:00:00.000Z',
+			'2026-02-28T10:00:00.000Z',
+		]
+		await expect(listHistory(timestamps, timestamps[0])).resolves.toEqual({
+			timestamps: timestamps.slice(1),
+			hasMore: false,
+		})
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -12,9 +12,9 @@ function getMonthPrefix(date: Date): string {
 }
 
 function getPreviousMonth(date: Date): Date {
-	const prev = new Date(date)
-	prev.setMonth(prev.getMonth() - 1)
-	return prev
+	// Step by calendar month from the 1st: `setMonth(m - 1)` on the 29th–31st lands in the same
+	// month again (Mar 31 → "Feb 31" → Mar 3), so the month scan would fetch it twice.
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))
 }
 
 async function fetchTimestampsFromBatch(
@@ -97,11 +97,10 @@ export async function getRoomHistory(
 	const targetEntryCount = 1000
 
 	if (offset) {
-		try {
-			currentMonth = new Date(offset)
-		} catch (_e) {
-			currentMonth = new Date()
-		}
+		// `new Date` never throws; an unparseable offset is an Invalid Date that would blow up in
+		// toISOString further down.
+		const parsed = new Date(offset)
+		currentMonth = Number.isNaN(parsed.getTime()) ? new Date() : parsed
 	} else {
 		// If we don't have an offset we can check if the room doesn't have too many entries
 		const allTimestampsForRoom = await fetchTimestampsForPrefix(

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -7,11 +7,11 @@ import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
 
-function getMonthPrefix(date: Date): string {
+export function getMonthPrefix(date: Date): string {
 	return date.toISOString().split('T')[0].substring(0, 7)
 }
 
-function getPreviousMonth(date: Date): Date {
+export function getPreviousMonth(date: Date): Date {
 	// Use day 1 to avoid overflowing shorter months and scanning the same month twice.
 	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))
 }

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -83,7 +83,7 @@ export async function getRoomHistory(
 		return new Response('Not found', { status: 404 })
 	}
 
-	const offset = request.query?.offset as string // offset is the earliest timestamp from the previous page
+	let offset = request.query?.offset as string // offset is the earliest timestamp from the previous page
 
 	const versionCacheBucket = env.ROOMS_HISTORY_EPHEMERAL
 	const bucketKey = getR2KeyForRoom({ slug: roomId, isApp })
@@ -99,6 +99,7 @@ export async function getRoomHistory(
 		// Invalid dates would throw in toISOString when building the month prefix.
 		const parsed = new Date(offset)
 		currentMonth = Number.isNaN(parsed.getTime()) ? new Date() : parsed
+		offset = currentMonth.toISOString()
 	} else {
 		// If we don't have an offset we can check if the room doesn't have too many entries
 		const allTimestampsForRoom = await fetchTimestampsForPrefix(

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -12,8 +12,7 @@ function getMonthPrefix(date: Date): string {
 }
 
 function getPreviousMonth(date: Date): Date {
-	// Step by calendar month from the 1st: `setMonth(m - 1)` on the 29th–31st lands in the same
-	// month again (Mar 31 → "Feb 31" → Mar 3), so the month scan would fetch it twice.
+	// Use day 1 to avoid overflowing shorter months and scanning the same month twice.
 	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))
 }
 
@@ -97,8 +96,7 @@ export async function getRoomHistory(
 	const targetEntryCount = 1000
 
 	if (offset) {
-		// `new Date` never throws; an unparseable offset is an Invalid Date that would blow up in
-		// toISOString further down.
+		// Invalid dates would throw in toISOString when building the month prefix.
 		const parsed = new Date(offset)
 		currentMonth = Number.isNaN(parsed.getTime()) ? new Date() : parsed
 	} else {


### PR DESCRIPTION
**Risk: low · Importance: low**

This PR fixes a bug where room history double-fetched a month on the 29th–31st, and one where an unparseable `offset` threw.

### Before

`getPreviousMonth` used `setMonth(m - 1)` on the local date: Mar 31 → "Feb 31" → Mar 3, so the month scan fetched March twice. `new Date(offset)` never throws, so a bad offset became an Invalid Date that blew up in `toISOString` further down.

### After

Months step from the 1st in UTC (matching `getMonthPrefix`'s `toISOString`), and an Invalid Date offset falls back to now.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix room history listing a month twice at the end of long months

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +7 / -8    |