### PR TITLE
fix(dotcom): await the resolved slug's room before reading legacy room data

### DIFF
--- a/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getLegacyRoomData.ts
@@ -27,6 +27,7 @@ export async function getLegacyRoomData(
 
 	const slug = await getSlug(env, id, type)
 	if (!slug) return null
-	await getRoomDurableObject(env, id).awaitPersist()
+	// The room lives under the resolved slug; a readonly id would address a different, empty object.
+	await getRoomDurableObject(env, slug).awaitPersist()
 	return await env.ROOMS.get(getR2KeyForRoom({ slug, isApp: false })).then((r) => r?.text())
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where `getLegacyRoomData` could read a stale snapshot.

### Before

The helper resolved the readonly id to its slug but awaited persistence on the durable object for the unresolved id — a different, empty object — so the room's latest changes might not be in R2 yet.

### After

It awaits persistence on the resolved slug's object before reading R2.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix legacy room snapshots occasionally lagging behind the live room

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +2 / -1    |