### PR TITLE
fix(dotcom): stop the image resize worker matching unparseable etags

### DIFF
--- a/apps/dotcom/image-resize-worker/src/worker.ts
+++ b/apps/dotcom/image-resize-worker/src/worker.ts
@@ -68,7 +68,9 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 					const etag = cachedResponse.headers.get('etag')
 					if (ifNoneMatch && etag) {
 						const parsedEtag = parseEtag(etag)
-						for (const tag of ifNoneMatch.split(', ')) {
+						// An unparseable etag matches nothing; without this, two unparseable tags
+						// compare equal as `null === null` and every request gets a 304.
+						for (const tag of parsedEtag === null ? [] : ifNoneMatch.split(', ')) {
 							if (parseEtag(tag) === parsedEtag) {
 								return new Response(null, { status: 304 })
 							}
@@ -134,6 +136,6 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 }
 
 function parseEtag(etag: string) {
-	const match = etag.match(/^(?:W\/)"(.*)"$/)
+	const match = etag.match(/^(?:W\/)?"(.*)"$/)
 	return match ? match[1] : null
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the image resize worker returned 304 for every request when etags were unparseable.

### Before

`parseEtag` only matched strong etags and returned `null` otherwise; two unparseable tags then compared equal as `null === null`.

### After

`parseEtag` accepts weak (`W/"…"`) etags, and an unparseable cached etag matches nothing.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix the image resize worker returning stale 304s for unparseable etags

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +4 / -2    |