### PR TITLE
fix(dotcom): check Zero mutator results instead of catching promises that never reject

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -1074,6 +1074,12 @@
       "value": "Delete file"
     }
   ],
+  "9c228b6834": [
+    {
+      "type": 0,
+      "value": "You appear to be offline. Check your connection and try again."
+    }
+  ],
   "9ccb565b86": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -434,6 +434,9 @@
   "9bef626805": {
     "translation": "Delete file"
   },
+  "9c228b6834": {
+    "translation": "You appear to be offline. Check your connection and try again."
+  },
   "9ccb565b86": {
     "translation": "We're having trouble connecting to our authentication service. This is usually temporary. Please try refreshing the page."
   },

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1,4 +1,4 @@
-import { QueryResultType, Zero } from '@rocicorp/zero'
+import { MutatorResultErrorDetails, QueryResultType, Zero } from '@rocicorp/zero'
 import { captureException } from '@sentry/react'
 import {
 	AcceptInviteResponseBody,
@@ -441,6 +441,9 @@ export class TldrawApp {
 		unknown_error: {
 			defaultMessage: 'An unexpected error occurred.',
 		},
+		offline_error: {
+			defaultMessage: 'You appear to be offline. Check your connection and try again.',
+		},
 		forbidden: {
 			defaultMessage: 'You do not have the necessary permissions to perform this action.',
 		},
@@ -480,8 +483,10 @@ export class TldrawApp {
 		return msg
 	}
 
-	showMutationRejectionToast = throttle((errorCode: ZErrorCode) => {
-		const descriptor = this.getMessage(errorCode)
+	// Zero-level errors (socket down, client closed) carry prose, not a ZErrorCode.
+	showMutationRejectionToast = throttle((error: MutatorResultErrorDetails['error']) => {
+		const descriptor =
+			error.type === 'zero' ? this.messages.offline_error : this.getMessage(error.message as ZErrorCode)
 		this.toasts?.addToast({
 			title: this.getIntl().formatMessage(this.messages.mutation_error_toast_title),
 			description: this.getIntl().formatMessage(descriptor),
@@ -773,7 +778,7 @@ export class TldrawApp {
 			time: Date.now(),
 		}).client
 		if (res.type === 'error') {
-			this.showMutationRejectionToast(res.error.message as ZErrorCode)
+			this.showMutationRejectionToast(res.error)
 			return Result.err('mutation rejected')
 		}
 
@@ -950,7 +955,7 @@ export class TldrawApp {
 		// failures resolve with {type: 'error'} — so the result has to be checked, not caught.
 		const res = await this.z.mutate.removeFileFromWorkspace({ fileId, workspaceId }).client
 		if (res.type === 'error') {
-			this.showMutationRejectionToast(res.error.message as ZErrorCode)
+			this.showMutationRejectionToast(res.error)
 			return false
 		}
 		return true

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -485,8 +485,8 @@ export class TldrawApp {
 
 	// Zero-level errors (socket down, client closed) carry prose, not a ZErrorCode.
 	showMutationRejectionToast = throttle((error: MutatorResultErrorDetails['error']) => {
-		const descriptor =
-			error.type === 'zero' ? this.messages.offline_error : this.getMessage(error.message as ZErrorCode)
+		const code = error.type === 'zero' ? ZErrorCode.offline_error : (error.message as ZErrorCode)
+		const descriptor = this.getMessage(code)
 		this.toasts?.addToast({
 			title: this.getIntl().formatMessage(this.messages.mutation_error_toast_title),
 			description: this.getIntl().formatMessage(descriptor),

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -942,9 +942,18 @@ export class TldrawApp {
 	/**
 	 * Remove a user's file states for a file and delete the file if the user is the owner of the file.
 	 */
-	async deleteOrForgetFile(fileId: string, workspaceId: string = this.getHomeWorkspaceId()) {
-		// Optimistic update, remove file and file states
-		await this.z.mutate.removeFileFromWorkspace({ fileId, workspaceId }).client
+	async deleteOrForgetFile(
+		fileId: string,
+		workspaceId: string = this.getHomeWorkspaceId()
+	): Promise<boolean> {
+		// Optimistic update, remove file and file states. Zero mutator promises never reject —
+		// failures resolve with {type: 'error'} — so the result has to be checked, not caught.
+		const res = await this.z.mutate.removeFileFromWorkspace({ fileId, workspaceId }).client
+		if (res.type === 'error') {
+			this.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return false
+		}
+		return true
 	}
 
 	setFileSharedLinkType(fileId: string, sharedLinkType: TlaFile['sharedLinkType'] | 'no-access') {

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -298,19 +298,19 @@ export function FileItems({
 												onClose={onClose}
 												onCreate={async (name) => {
 													const id = uniqueId()
-													try {
-														await app.z.mutate.createWorkspace({ id, name }).client
-													} catch (e) {
-														app.showMutationRejectionToast((e as Error).message as ZErrorCode)
+													const createRes = await app.z.mutate.createWorkspace({ id, name }).client
+													if (createRes.type === 'error') {
+														app.showMutationRejectionToast(createRes.error.message as ZErrorCode)
 														return
 													}
 													trackEvent('create-workspace', { source })
-													try {
-														await app.z.mutate.moveFileToWorkspace({ fileId, workspaceId: id })
-															.client
-													} catch (e) {
+													const moveRes = await app.z.mutate.moveFileToWorkspace({
+														fileId,
+														workspaceId: id,
+													}).client
+													if (moveRes.type === 'error') {
 														// the workspace was created; only the move failed
-														app.showMutationRejectionToast((e as Error).message as ZErrorCode)
+														app.showMutationRejectionToast(moveRes.error.message as ZErrorCode)
 													}
 												}}
 											/>

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -1,6 +1,6 @@
 /* ---------------------- Menu ---------------------- */
 
-import { FILE_PREFIX, TlaFile, ZErrorCode } from '@tldraw/dotcom-shared'
+import { FILE_PREFIX, TlaFile } from '@tldraw/dotcom-shared'
 import { Fragment, ReactNode, useCallback, useId } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -300,7 +300,7 @@ export function FileItems({
 													const id = uniqueId()
 													const createRes = await app.z.mutate.createWorkspace({ id, name }).client
 													if (createRes.type === 'error') {
-														app.showMutationRejectionToast(createRes.error.message as ZErrorCode)
+														app.showMutationRejectionToast(createRes.error)
 														return
 													}
 													trackEvent('create-workspace', { source })
@@ -310,7 +310,7 @@ export function FileItems({
 													}).client
 													if (moveRes.type === 'error') {
 														// the workspace was created; only the move failed
-														app.showMutationRejectionToast(moveRes.error.message as ZErrorCode)
+														app.showMutationRejectionToast(moveRes.error)
 													}
 												}}
 											/>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -249,10 +249,9 @@ function useCreateWorkspaceDialog() {
 					onClose={onClose}
 					onCreate={async (name) => {
 						const id = uniqueId()
-						try {
-							await app.z.mutate.createWorkspace({ id, name }).client
-						} catch (e) {
-							app.showMutationRejectionToast((e as Error).message as ZErrorCode)
+						const createRes = await app.z.mutate.createWorkspace({ id, name }).client
+						if (createRes.type === 'error') {
+							app.showMutationRejectionToast(createRes.error.message as ZErrorCode)
 							return
 						}
 						trackEvent('create-workspace', { source: 'sidebar' })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -1,4 +1,3 @@
-import { ZErrorCode } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
 import { ReactNode, useCallback } from 'react'
@@ -251,7 +250,7 @@ function useCreateWorkspaceDialog() {
 						const id = uniqueId()
 						const createRes = await app.z.mutate.createWorkspace({ id, name }).client
 						if (createRes.type === 'error') {
-							app.showMutationRejectionToast(createRes.error.message as ZErrorCode)
+							app.showMutationRejectionToast(createRes.error)
 							return
 						}
 						trackEvent('create-workspace', { source: 'sidebar' })

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -36,7 +36,8 @@ export function TlaDeleteFileDialog({
 	const handleDelete = async () => {
 		const token = await auth.getToken()
 		if (!token) throw new Error('No token')
-		if (!(await app.deleteOrForgetFile(fileId, workspaceId))) {
+		const deleted = await app.deleteOrForgetFile(fileId, workspaceId)
+		if (!deleted) {
 			onClose()
 			return
 		}

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -36,8 +36,11 @@ export function TlaDeleteFileDialog({
 	const handleDelete = async () => {
 		const token = await auth.getToken()
 		if (!token) throw new Error('No token')
+		if (!(await app.deleteOrForgetFile(fileId, workspaceId))) {
+			onClose()
+			return
+		}
 		trackEvent('delete-file', { source: 'file-menu' })
-		await app.deleteOrForgetFile(fileId, workspaceId)
 
 		// Stay in the workspace the file was deleted from: go to its most recent remaining
 		// file, or — if that was its last file — create a fresh blank file in it, the same

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -173,65 +173,61 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	}
 
 	const handleToggleInviteLink = async (enabled: boolean) => {
-		try {
-			await app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled }).client
-			trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
-		} catch (error) {
-			console.error('Error toggling invite link:', error)
-			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		const res = await app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled })
+			.client
+		if (res.type === 'error') {
+			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return
 		}
+		trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
 	}
 
 	const handleRegenerateInviteLink = async () => {
-		try {
-			await app.z.mutate.regenerateWorkspaceInviteSecret({ id: workspaceId }).server
-			trackEvent('regenerate-workspace-invite-secret', { source: 'workspace-settings' })
-		} catch (error) {
-			console.error('Error regenerating invite link:', error)
-			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		const res = await app.z.mutate.regenerateWorkspaceInviteSecret({ id: workspaceId }).server
+		if (res.type === 'error') {
+			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return
 		}
+		trackEvent('regenerate-workspace-invite-secret', { source: 'workspace-settings' })
 	}
 
 	const handleLeaveWorkspace = async () => {
-		try {
-			const isCurrentlyOnAFileInThisWorkspace =
-				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
-			await app.z.mutate.leaveWorkspace({ workspaceId }).client
-			trackEvent('leave-workspace', { source: 'workspace-settings' })
-			onClose()
-			if (isCurrentlyOnAFileInThisWorkspace) {
-				navigate('/')
-			}
-		} catch (error) {
-			console.error('Error leaving workspace:', error)
-			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		const isCurrentlyOnAFileInThisWorkspace =
+			currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
+		const res = await app.z.mutate.leaveWorkspace({ workspaceId }).client
+		if (res.type === 'error') {
+			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return
+		}
+		trackEvent('leave-workspace', { source: 'workspace-settings' })
+		onClose()
+		if (isCurrentlyOnAFileInThisWorkspace) {
+			navigate('/')
 		}
 	}
 
 	const handleDeleteWorkspace = async () => {
-		try {
-			const isCurrentlyOnAFileInThisWorkspace =
-				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
-			await app.z.mutate.deleteWorkspace({ id: workspaceId }).client
-			trackEvent('delete-workspace', { source: 'workspace-settings' })
-			onClose()
-			if (isCurrentlyOnAFileInThisWorkspace) {
-				navigate('/')
-			}
-		} catch (error) {
-			console.error('Error deleting workspace:', error)
-			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		const isCurrentlyOnAFileInThisWorkspace =
+			currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
+		const res = await app.z.mutate.deleteWorkspace({ id: workspaceId }).client
+		if (res.type === 'error') {
+			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return
+		}
+		trackEvent('delete-workspace', { source: 'workspace-settings' })
+		onClose()
+		if (isCurrentlyOnAFileInThisWorkspace) {
+			navigate('/')
 		}
 	}
 
 	const handleRemoveMember = async (targetUserId: string) => {
-		try {
-			await app.z.mutate.removeWorkspaceMember({ workspaceId, targetUserId }).client
-			trackEvent('remove-workspace-member', { source: 'workspace-settings' })
-		} catch (error) {
-			console.error('Error removing member:', error)
-			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		const res = await app.z.mutate.removeWorkspaceMember({ workspaceId, targetUserId }).client
+		if (res.type === 'error') {
+			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			return
 		}
+		trackEvent('remove-workspace-member', { source: 'workspace-settings' })
 	}
 
 	const openRegenerateConfirmDialog = () => {
@@ -470,22 +466,19 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 															]}
 															onChange={async (value) => {
 																if (value === member.role) return
-																try {
-																	await app.z.mutate.setWorkspaceMemberRole({
-																		workspaceId,
-																		targetUserId: member.userId,
-																		role: value,
-																	}).client
-																	trackEvent('set-workspace-member-role', {
-																		source: 'workspace-settings',
-																		role: value,
-																	})
-																} catch (err) {
-																	console.error('Failed to change member role', err)
-																	app.showMutationRejectionToast(
-																		(err as Error).message as ZErrorCode
-																	)
+																const res = await app.z.mutate.setWorkspaceMemberRole({
+																	workspaceId,
+																	targetUserId: member.userId,
+																	role: value,
+																}).client
+																if (res.type === 'error') {
+																	app.showMutationRejectionToast(res.error.message as ZErrorCode)
+																	return
 																}
+																trackEvent('set-workspace-member-role', {
+																	source: 'workspace-settings',
+																	role: value,
+																})
 															}}
 														/>
 													) : memberIsOwner ? (

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { MAX_WORKSPACE_NAME_LENGTH, Role, ZErrorCode, can } from '@tldraw/dotcom-shared'
+import { MAX_WORKSPACE_NAME_LENGTH, Role, can } from '@tldraw/dotcom-shared'
 import { Tooltip as _Tooltip } from 'radix-ui'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -176,7 +176,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 		const res = await app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled })
 			.client
 		if (res.type === 'error') {
-			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			app.showMutationRejectionToast(res.error)
 			return
 		}
 		trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
@@ -185,7 +185,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleRegenerateInviteLink = async () => {
 		const res = await app.z.mutate.regenerateWorkspaceInviteSecret({ id: workspaceId }).server
 		if (res.type === 'error') {
-			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			app.showMutationRejectionToast(res.error)
 			return
 		}
 		trackEvent('regenerate-workspace-invite-secret', { source: 'workspace-settings' })
@@ -194,9 +194,17 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleLeaveWorkspace = async () => {
 		const isCurrentlyOnAFileInThisWorkspace =
 			currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
-		const res = await app.z.mutate.leaveWorkspace({ workspaceId }).client
-		if (res.type === 'error') {
-			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+		const mutation = app.z.mutate.leaveWorkspace({ workspaceId })
+		const clientRes = await mutation.client
+		if (clientRes.type === 'error') {
+			app.showMutationRejectionToast(clientRes.error)
+			return
+		}
+		// The last-owner check runs against local rows, so two owners leaving at once both pass
+		// locally and the server rejects one. Wait for it before navigating away.
+		const serverRes = await mutation.server
+		if (serverRes.type === 'error') {
+			app.showMutationRejectionToast(serverRes.error)
 			return
 		}
 		trackEvent('leave-workspace', { source: 'workspace-settings' })
@@ -211,7 +219,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 			currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
 		const res = await app.z.mutate.deleteWorkspace({ id: workspaceId }).client
 		if (res.type === 'error') {
-			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			app.showMutationRejectionToast(res.error)
 			return
 		}
 		trackEvent('delete-workspace', { source: 'workspace-settings' })
@@ -224,7 +232,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleRemoveMember = async (targetUserId: string) => {
 		const res = await app.z.mutate.removeWorkspaceMember({ workspaceId, targetUserId }).client
 		if (res.type === 'error') {
-			app.showMutationRejectionToast(res.error.message as ZErrorCode)
+			app.showMutationRejectionToast(res.error)
 			return
 		}
 		trackEvent('remove-workspace-member', { source: 'workspace-settings' })
@@ -472,7 +480,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 																	role: value,
 																}).client
 																if (res.type === 'error') {
-																	app.showMutationRejectionToast(res.error.message as ZErrorCode)
+																	app.showMutationRejectionToast(res.error)
 																	return
 																}
 																trackEvent('set-workspace-member-role', {

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -189,6 +189,7 @@ export const ZErrorCode = stringEnum(
 	'unpublish_failed',
 	'republish_failed',
 	'unknown_error',
+	'offline_error',
 	'client_too_old',
 	'forbidden',
 	'bad_request',


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where workspace and file actions proceeded as if they had succeeded when the server rejected them.

### Before

Zero 1.9 mutator `.client` / `.server` promises never reject — failures resolve with `{type: 'error'}` — so every `try/catch` around `createWorkspace`, `moveFileToWorkspace`, `leaveWorkspace`, `deleteWorkspace`, member role and invite changes, and `deleteOrForgetFile` was dead. A user at the workspace limit clicking New workspace got no toast, a tracked `create-workspace` event, and a welcome file created in a phantom workspace; a rejected Leave/Delete still closed the dialog and navigated to `/`.

### After

Each call checks `res.type === 'error'`, shows the rejection toast, and stops. `deleteOrForgetFile` returns whether it succeeded and `TlaDeleteFileDialog` stops on failure.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app`, open http://localhost:3000 and sign in. To hit the workspace limit quickly, temporarily set `MAX_NUMBER_OF_WORKSPACES` in `packages/dotcom-shared/src/constants.ts` to `2` before starting (or create 20 workspaces).
2. Open the sidebar workspace switcher, choose New workspace and create workspaces until you have reached the limit.
3. Choose New workspace once more, enter a name and confirm.
4. On `main` no "You have reached the maximum number of workspaces" toast shows, a `create-workspace` event is tracked and the app tries to seed and open a welcome file in a workspace that was never created. With this PR, the toast shows and nothing else happens.

- [x] Unit tests

### Release notes

- Fix workspace and file actions reporting success when the server rejected them

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +78 / -74  |
