### PR TITLE
fix(dotcom): show an error page when app bootstrap fails instead of a blank page

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -1,0 +1,85 @@
+import { atom, promiseWithResolve } from 'tldraw'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TldrawApp } from './TldrawApp'
+
+function createAppStub({
+	queryComplete = Promise.resolve(),
+	changesFlushed = Promise.resolve(),
+	user = undefined as { id: string } | undefined,
+} = {}) {
+	return Object.assign(Object.create(TldrawApp.prototype), {
+		userId: 'user:test',
+		getToken: async () => 'token',
+		z: { preload: () => ({ complete: queryComplete }) },
+		changesFlushed,
+		user$: atom('user', user),
+	}) as TldrawApp
+}
+
+describe('TldrawApp.preload', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.unstubAllGlobals()
+	})
+
+	it.each([undefined, { id: 'user:test' }])(
+		'times out a stalled Zero query with user %j',
+		async (user) => {
+			const app = createAppStub({ queryComplete: promiseWithResolve<void>(), user })
+			const rejected = vi.fn()
+			void app.preload().catch(rejected)
+
+			await vi.advanceTimersByTimeAsync(10_000)
+
+			expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+			expect(vi.getTimerCount()).toBe(0)
+		}
+	)
+
+	it('times out pending state updates', async () => {
+		const app = createAppStub({ changesFlushed: promiseWithResolve<void>() })
+		const rejected = vi.fn()
+		void app.preload().catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+	})
+
+	it('shares the deadline between the query and user-record waits', async () => {
+		const queryComplete = promiseWithResolve<void>()
+		const rejected = vi.fn()
+		void createAppStub({ queryComplete }).preload().catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(9_000)
+		queryComplete.resolve()
+		await vi.advanceTimersByTimeAsync(999)
+		expect(rejected).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(1)
+
+		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+		expect(vi.getTimerCount()).toBe(0)
+	})
+
+	it('times out a missing user after a successful init', async () => {
+		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+		const rejected = vi.fn()
+		void createAppStub().preload().catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(rejected).toHaveBeenCalledWith(
+			new Error('Timed out waiting for the user record after init')
+		)
+	})
+
+	it('loads an existing user after an init error and clears the deadline', async () => {
+		await expect(createAppStub({ user: { id: 'user:test' } }).preload()).resolves.toBeUndefined()
+		expect(vi.getTimerCount()).toBe(0)
+	})
+})

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -73,6 +73,8 @@ import { updateLocalSessionState } from '../utils/local-session-state'
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
 
+const USER_PRELOAD_TIMEOUT_MS = 10_000
+
 let appId = 0
 
 /**
@@ -398,6 +400,7 @@ export class TldrawApp {
 	async preload() {
 		// Ensure user exists in DB before Zero can query
 		const token = await this.getToken()
+		let initError: Error | undefined
 		if (!token) {
 			throw new Error('No auth token available for init')
 		} else {
@@ -405,14 +408,31 @@ export class TldrawApp {
 				method: 'POST',
 				headers: { Authorization: `Bearer ${token}` },
 			})
-			if (!res.ok) console.error(`Init failed: ${res.status}`)
+			// A failed init only matters if the user row never shows up: returning users whose row
+			// already exists should still load through a transient worker error.
+			if (!res.ok) initError = new Error(`Init failed: ${res.status}`)
 		}
 		await this.z.preload(this.userQuery()).complete
 		await this.changesFlushed
-		await new Promise((resolve) => {
-			let unlisten = () => {}
-			unlisten = react('wait for user', () => this.user$.get() && resolve(unlisten()))
+		// Without a deadline, a user row that never arrives (failed init, stalled replication)
+		// hangs `create()` forever and the page stays blank for the whole session.
+		const userLoaded = promiseWithResolve<void>()
+		const stopWaiting = react('wait for user', () => {
+			if (this.user$.get()) userLoaded.resolve()
 		})
+		const timeout = setTimeout(
+			() =>
+				userLoaded.reject(
+					initError ?? new Error('Timed out waiting for the user record after init')
+				),
+			USER_PRELOAD_TIMEOUT_MS
+		)
+		try {
+			await userLoaded
+		} finally {
+			clearTimeout(timeout)
+			stopWaiting()
+		}
 		await Promise.all([
 			this.z.preload(this.fileStateQuery()).complete,
 			this.z.preload(this.workspaceMembershipsQuery()).complete,
@@ -1051,7 +1071,14 @@ export class TldrawApp {
 		)
 		// @ts-expect-error
 		window.app = app
-		await app.preload()
+		try {
+			await app.preload()
+		} catch (e) {
+			// Don't leave the half-built app's Zero connection and timers running behind the
+			// error page the caller shows for this.
+			app.dispose()
+			throw e
+		}
 		const user = app.getUser()
 		if (user.color === '___INIT___') {
 			app.updateUser({

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -412,26 +412,25 @@ export class TldrawApp {
 			// already exists should still load through a transient worker error.
 			if (!res.ok) initError = new Error(`Init failed: ${res.status}`)
 		}
-		await this.z.preload(this.userQuery()).complete
-		await this.changesFlushed
-		// Without a deadline, a user row that never arrives (failed init, stalled replication)
-		// hangs `create()` forever and the page stays blank for the whole session.
-		const userLoaded = promiseWithResolve<void>()
-		const stopWaiting = react('wait for user', () => {
-			if (this.user$.get()) userLoaded.resolve()
-		})
+		// Zero's query can itself stall, so the deadline must cover it as well as the user row.
+		const timedOut = promiseWithResolve<never>()
+		let stopWaiting: (() => void) | undefined
 		const timeout = setTimeout(
 			() =>
-				userLoaded.reject(
-					initError ?? new Error('Timed out waiting for the user record after init')
-				),
+				timedOut.reject(initError ?? new Error('Timed out waiting for the user record after init')),
 			USER_PRELOAD_TIMEOUT_MS
 		)
 		try {
-			await userLoaded
+			await Promise.race([this.z.preload(this.userQuery()).complete, timedOut])
+			await Promise.race([this.changesFlushed, timedOut])
+			const userLoaded = promiseWithResolve<void>()
+			stopWaiting = react('wait for user', () => {
+				if (this.user$.get()) userLoaded.resolve()
+			})
+			await Promise.race([userLoaded, timedOut])
 		} finally {
 			clearTimeout(timeout)
-			stopWaiting()
+			stopWaiting?.()
 		}
 		await Promise.all([
 			this.z.preload(this.fileStateQuery()).complete,

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -1,7 +1,9 @@
 import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
+import { captureException } from '@sentry/react'
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { assertExists, atom } from 'tldraw'
+import { ErrorPage } from '../../components/ErrorPage/ErrorPage'
 import { TldrawApp } from '../app/TldrawApp'
 import { useTldrawAppUiEvents } from '../utils/app-ui-events'
 import {
@@ -15,8 +17,15 @@ const appContext = createContext<TldrawApp | null>(null)
 
 export const isClientTooOld$ = atom('isClientTooOld', false)
 
+const APP_LOAD_ERROR_MESSAGES = {
+	header: 'Something went wrong',
+	para1: 'Please try refreshing the page. Still having trouble? Let us know at hello@tldraw.com.',
+	cta: 'Refresh',
+}
+
 export function AppStateProvider({ children }: { children: ReactNode }) {
 	const [app, setApp] = useState(null as TldrawApp | null)
+	const [error, setError] = useState<unknown>(null)
 	const auth = useAuth()
 	const { user, isLoaded } = useClerkUser()
 
@@ -35,6 +44,7 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		let _app: TldrawApp
 		let didCancel = false
+		setError(null)
 
 		const FETCH_TIMEOUT = 5000
 		function fetchFlagsWithTimeout(): Promise<FeatureFlags> {
@@ -83,7 +93,10 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 			_app = app
 			setApp(app)
 		})().catch((err) => {
+			if (didCancel) return
 			console.error('[AppState] Failed to initialize:', err)
+			captureException(err)
+			setError(err)
 		})
 
 		return () => {
@@ -94,6 +107,21 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [auth.userId, user])
+
+	if (error) {
+		// A swallowed bootstrap failure would leave the blank loading state below up for the
+		// whole session.
+		return (
+			<ErrorPage
+				messages={APP_LOAD_ERROR_MESSAGES}
+				cta={
+					<button type="button" onClick={() => window.location.reload()}>
+						{APP_LOAD_ERROR_MESSAGES.cta}
+					</button>
+				}
+			/>
+		)
+	}
 
 	if (!app) {
 		// We used to show a Loading... here but it was causing too much flickering.


### PR DESCRIPTION
**Risk: medium · Importance: high**

This PR fixes a bug where a failed sign-in bootstrap left a blank page for the whole session.

### Before

`TldrawApp.preload` only logged a non-2xx `/init` and then waited for the user row forever, so `TldrawApp.create` never resolved; `useAppState` swallowed every bootstrap error and rendered null.

### After

`preload` bounds the user-row wait (10s) and rejects with the init error if there was one — a returning user whose row already exists still loads through a transient worker error. `create` disposes the half-built app on failure, and `AppStateProvider` renders the error page with a refresh action and captures the error to Sentry.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app`, open http://localhost:3000 and sign in.
2. In devtools, open Network > Network request blocking and add the pattern `*/api/app/*/init`, then enable blocking.
3. Reload the page so the app bootstraps with `/init` blocked.
4. On `main` the page stays blank for the whole session (only a `[AppState] Failed to initialize` console error). With this PR, a "Something went wrong" error page appears with a Refresh button; clearing the block and clicking Refresh loads the app.

- [x] Unit tests

### Release notes

- Fix a blank page when first-time sign-in fails

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +60 / -5   |
