### PR TITLE
fix(dotcom): honour a stored analytics opt-out after a reload

### DIFF
--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -213,9 +213,17 @@ function configurePosthog(options: AnalyticsOptions) {
 			})
 		}
 		posthog.opt_in_capturing()
-	} else if (currentOptionsPosthog?.optedIn) {
-		posthog.setPersonProperties({ analytics_consent: false })
-		posthog.opt_out_capturing()
+	} else if (cookieConsent.get()?.analytics === false) {
+		// Keyed on stored consent, not the previous options: a persisted PostHog opt-in would
+		// otherwise survive a reload with consent already off, and a first reject never engages
+		// cookieless_mode.
+		if (currentOptionsPosthog?.optedIn) {
+			posthog.setPersonProperties({ analytics_consent: false })
+		}
+		// An explicit opt-out is already persisted and opt_out_capturing emits its own $pageview.
+		if (posthog.get_explicit_consent_status() !== 'denied') {
+			posthog.opt_out_capturing()
+		}
 	}
 
 	currentOptionsPosthog = options


### PR DESCRIPTION
**Risk: low · Importance: high**

This PR fixes a bug where a stored analytics opt-out never reached PostHog after a reload.

### Before

`configurePosthog` only called `opt_out_capturing` when an earlier call in the same page lifetime had opted in. A user who accepted on device A and later turned analytics off elsewhere came back to A with PostHog's persisted opt-in restored and consent already `false`, so the opt-out branch was skipped and cookie-based capture continued; a first Reject from pending likewise never engaged `cookieless_mode`.

### After

The branch keys on the stored consent being `false` and calls `opt_out_capturing` unless PostHog already reports `denied` (it persists the opt-out and emits its own `$pageview`, so repeating it every load would double-count).

### Change type

- [x] `bugfix`

### Test plan

**Stored opt-out ignored after a reload**

1. Open this PR's preview deploy in a fresh browser profile (PostHog only runs when `VITE_POSTHOG_KEY` is set, so local `yarn dev-app` doesn't exercise it). Open devtools → Network and filter on `analytics.tldraw.com`.
2. Sign in and accept analytics in the cookie banner ("Accept all"), or confirm the Analytics toggle is on under the sidebar user menu → "Manage cookies".
3. In a second browser profile, sign in as the same user and turn Analytics off in "Manage cookies".
4. Reload the first profile.
5. On `main` PostHog keeps its persisted opt-in: new requests carry the user's `distinct_id` and no `$cookieless_mode`. With this PR the stored opt-out is applied on load: requests carry `distinct_id: "$posthog_cookieless"` and `$cookieless_mode: true`.

**First reject never engages cookieless mode**

1. Open the preview deploy in a fresh browser profile with the same Network filter, and click "Opt out" in the cookie banner.
2. Navigate between a few pages.
3. On `main` no PostHog requests are sent at all (consent stays pending, so nothing is captured). With this PR page views are sent in cookieless mode (`distinct_id: "$posthog_cookieless"`).

- [x] Unit tests

### Release notes

- Fix analytics opt-out not being honoured after a reload

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +11 / -3   |
