### PR TITLE
fix(dotcom): render loader error pages instead of throwing out of the error boundary

### DIFF
--- a/apps/dotcom/client/src/tla/pages/file-history-snapshot.tsx
+++ b/apps/dotcom/client/src/tla/pages/file-history-snapshot.tsx
@@ -19,7 +19,7 @@ export function ErrorBoundary() {
 	return <Component error={error} />
 }
 
-const { loader, useData } = defineLoader(async (args) => {
+const { loader, useMaybeData } = defineLoader(async (args) => {
 	const fileSlug = args.params.fileSlug
 	const timestamp = args.params.timestamp
 
@@ -39,7 +39,7 @@ export { loader }
 export function Component({ error: _error }: { error?: unknown }) {
 	const userId = useMaybeApp()?.userId
 
-	const result = useData()
+	const result = useMaybeData()
 
 	const snapshot = useMemo(() => {
 		if (!result) {

--- a/apps/dotcom/client/src/tla/pages/file-history.tsx
+++ b/apps/dotcom/client/src/tla/pages/file-history.tsx
@@ -10,7 +10,7 @@ import { useMaybeApp } from '../hooks/useAppState'
 import { TlaAnonLayout } from '../layouts/TlaAnonLayout/TlaAnonLayout'
 import { toggleSidebar } from '../utils/local-session-state'
 
-const { loader, useData } = defineLoader(async (args) => {
+const { loader, useMaybeData } = defineLoader(async (args) => {
 	const fileSlug = args.params.fileSlug
 
 	if (!fileSlug) return null
@@ -32,7 +32,7 @@ export function ErrorBoundary() {
 }
 
 export function Component({ error: _error }: { error?: unknown }) {
-	const data = useData()
+	const data = useMaybeData()
 	const [allTimestamps, setAllTimestamps] = useState<string[]>([])
 	const [hasMore, setHasMore] = useState(false)
 	const [isLoading, setIsLoading] = useState(false)

--- a/apps/dotcom/client/src/tla/pages/legacy-history-snapshot.tsx
+++ b/apps/dotcom/client/src/tla/pages/legacy-history-snapshot.tsx
@@ -19,7 +19,7 @@ export function ErrorBoundary() {
 	return <Component error={error} />
 }
 
-const { loader, useData } = defineLoader(async (args) => {
+const { loader, useMaybeData } = defineLoader(async (args) => {
 	const roomId = args.params.boardId
 	const timestamp = args.params.timestamp
 
@@ -39,7 +39,7 @@ export { loader }
 export function Component({ error: _error }: { error?: unknown }) {
 	const userId = useMaybeApp()?.userId
 
-	const result = useData()
+	const result = useMaybeData()
 
 	const snapshot = useMemo(() => {
 		if (!result) {

--- a/apps/dotcom/client/src/tla/pages/legacy-history.tsx
+++ b/apps/dotcom/client/src/tla/pages/legacy-history.tsx
@@ -16,7 +16,7 @@ History here should work in an identical way to its previous implementation.
 
 // todo: Add top bar for anon users (branding, sign in, etc)
 
-const { loader, useData } = defineLoader(async (args) => {
+const { loader, useMaybeData } = defineLoader(async (args) => {
 	const boardId = args.params.boardId
 
 	if (!boardId) return null
@@ -41,7 +41,7 @@ export function ErrorBoundary() {
 }
 
 export function Component({ error: _error }: { error?: unknown }) {
-	const data = useData()
+	const data = useMaybeData()
 
 	const userId = useMaybeApp()?.userId
 

--- a/apps/dotcom/client/src/tla/pages/legacy-snapshot.tsx
+++ b/apps/dotcom/client/src/tla/pages/legacy-snapshot.tsx
@@ -24,7 +24,7 @@ relationship to the previous room, and the user should be able to edit it just
 like any other file.
 */
 
-const { loader, useData } = defineLoader(async (args) => {
+const { loader, useMaybeData } = defineLoader(async (args) => {
 	const roomId = args.params.roomId
 	const result = await fetch(`/api/snapshot/${roomId}`)
 	if (!result.ok) throw new Error('Room not found')
@@ -54,7 +54,7 @@ export function Component({ error: _error }: { error?: unknown }) {
 
 	const userId = useMaybeApp()?.userId
 
-	const result = useData()
+	const result = useMaybeData()
 
 	const snapshot = useMemo(() => {
 		if (!result) {

--- a/apps/dotcom/client/src/utils/defineLoader.test.tsx
+++ b/apps/dotcom/client/src/utils/defineLoader.test.tsx
@@ -1,0 +1,77 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineLoader } from './defineLoader'
+
+beforeEach(() => {
+	vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+async function renderLoader(run: () => Promise<unknown>) {
+	const { loader, useMaybeData } = defineLoader(run)
+	function Page() {
+		const data = useMaybeData()
+		return <div>data:{JSON.stringify(data)}</div>
+	}
+
+	const router = createMemoryRouter(
+		[
+			{
+				path: '/',
+				element: <Outlet />,
+				errorElement: <div>root error</div>,
+				children: [
+					{
+						path: 'test',
+						loader,
+						element: <Page />,
+						errorElement: (
+							<div>
+								local error
+								<Page />
+							</div>
+						),
+					},
+				],
+			},
+		],
+		{ initialEntries: ['/test'] }
+	)
+	const container = document.createElement('div')
+	const root = createRoot(container)
+	try {
+		await act(async () => {
+			root.render(<RouterProvider router={router} future={{ v7_startTransition: true }} />)
+		})
+		return container.textContent
+	} finally {
+		await act(async () => root.unmount())
+		router.dispose()
+	}
+}
+
+describe('useMaybeData', () => {
+	it('preserves successful loader data when there is no route error', async () => {
+		expect(await renderLoader(async () => ({ value: 42 }))).toBe('data:{"value":42}')
+	})
+
+	it('preserves a successful null result', async () => {
+		expect(await renderLoader(async () => null)).toBe('data:null')
+	})
+
+	it.each([new Error('Room not found'), new Response('Missing', { status: 404 })])(
+		'renders the local error boundary without loader data after throwing %s',
+		async (error) => {
+			expect(
+				await renderLoader(async () => {
+					throw error
+				})
+			).toBe('local errordata:')
+		}
+	)
+})

--- a/apps/dotcom/client/src/utils/defineLoader.tsx
+++ b/apps/dotcom/client/src/utils/defineLoader.tsx
@@ -1,8 +1,14 @@
-import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom'
+import { LoaderFunctionArgs, useLoaderData, useRouteError } from 'react-router-dom'
 
 export function defineLoader<T>(_loader: (args: LoaderFunctionArgs) => Promise<T>): {
 	loader(args: LoaderFunctionArgs): Promise<{ [specialSymbol]: T }>
 	useData(): Exclude<T, Response>
+	/**
+	 * Like `useData`, but returns undefined when the route's loader rejected. For components the
+	 * route's ErrorBoundary renders too: there is no loader data in that render, so `useData`
+	 * would throw a second error out of the boundary and the intended error UI never shows.
+	 */
+	useMaybeData(): Exclude<T, Response> | undefined
 } {
 	const specialSymbol = Symbol('loader')
 	const loader = async (params: any) => {
@@ -15,12 +21,21 @@ export function defineLoader<T>(_loader: (args: LoaderFunctionArgs) => Promise<T
 		} as any
 	}
 
+	function unwrap(raw: unknown) {
+		if (typeof raw === 'object' && raw && specialSymbol in raw) return (raw as any)[specialSymbol]
+		throw new Error('Loader data not found')
+	}
+
 	return {
 		loader,
 		useData() {
+			return unwrap(useLoaderData())
+		},
+		useMaybeData() {
+			const routeError = useRouteError()
 			const raw = useLoaderData()
-			if (typeof raw === 'object' && raw && specialSymbol in raw) return raw[specialSymbol] as any
-			throw new Error('Loader data not found')
+			if (routeError !== undefined) return undefined
+			return unwrap(raw)
 		},
 	}
 }

--- a/apps/dotcom/client/src/utils/defineLoader.tsx
+++ b/apps/dotcom/client/src/utils/defineLoader.tsx
@@ -34,7 +34,7 @@ export function defineLoader<T>(_loader: (args: LoaderFunctionArgs) => Promise<T
 		useMaybeData() {
 			const routeError = useRouteError()
 			const raw = useLoaderData()
-			if (routeError !== undefined) return undefined
+			if (routeError != null) return undefined
 			return unwrap(raw)
 		},
 	}


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where missing-snapshot and history pages showed the generic error page instead of their own not-found UI.

### Before

The route `ErrorBoundary` rendered `<Component error />`, but `Component` called `useData()`, and react-router has no loader data inside an `errorElement`, so `useData` threw a second error out of the boundary and the root boundary took over (no sidebar, wrong error in Sentry).

### After

`defineLoader` gains `useMaybeData()`, which returns `undefined` when the route's loader rejected; the five loader-error pages use it.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app` and sign in at http://localhost:3000.
2. Open http://localhost:3000/s/does-not-exist (a snapshot id that doesn't exist, so the route loader rejects).
3. On `main` the root error boundary takes over: a full-page "Something went wrong" screen with no sidebar, and the error reported is "Loader data not found" rather than the loader's own error. With this PR the page renders its own error view inside the app layout, with the sidebar open next to it.

- [x] Unit tests

### Release notes

- Fix missing-snapshot pages showing a generic error

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +28 / -13  |
