### PR TITLE
fix(dotcom): don't render file-bound menu actions on legacy routes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -219,7 +219,8 @@ export function TlaEditorTopLeftPanelSignedIn() {
 	const isOwner = useHasFileAdminRights(fileSlug)
 
 	const app = useApp()
-	const fileId = useCurrentFileId()!
+	// Undefined on legacy routes (/r, /ro, /v, /s): the file-bound actions have nothing to act on.
+	const fileId = useCurrentFileId()
 	const fileName = useValue(
 		'fileName',
 		// TODO(david): This is a temporary fix for allowing guests to see the file name.
@@ -229,7 +230,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 		() => {
 			// we need that backup file name for empty file names (the initial value for the name is empty)
 			return (
-				app.getFileName(fileId, false)?.trim() ||
+				app.getFileName(fileId ?? null, false)?.trim() ||
 				editor.getDocumentSettings().name ||
 				// rather than displaying the date for the project here, display Untitled project
 				intl.formatMessage(messages.untitledProject)
@@ -239,7 +240,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 	)
 	const handleFileNameChange = useCallback(
 		(name: string) => {
-			if (isOwner) {
+			if (isOwner && fileId) {
 				setIsRenaming(false)
 				// only actually update the name if name is a value, otherwise keep the previous name
 				if (name) {
@@ -255,7 +256,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 	const handleRenameAction = () => {
 		if (getIsCoarsePointer()) {
 			const newName = prompt(intl.formatMessage(sidebarMessages.renameFile), fileName)?.trim()
-			if (newName) {
+			if (newName && fileId) {
 				app.updateFile(fileId, { name: newName })
 			}
 		} else {
@@ -279,7 +280,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 			<span className={styles.topLeftPanelSeparator}>{separator}</span>
 			<DefaultPageMenu />
 			<TlaFileMenu
-				fileId={fileId}
+				fileId={fileId ?? ''}
 				workspaceId={null}
 				source="file-header"
 				onRenameAction={handleRenameAction}
@@ -296,15 +297,17 @@ export function TlaEditorTopLeftPanelSignedIn() {
 				}
 			>
 				<TldrawUiMenuGroup id="regular-stuff">
-					<TldrawUiMenuSubmenu id="file" label={fileSubmenuMsg}>
-						<FileItems
-							source="file-header"
-							fileId={fileId}
-							onRenameAction={handleRenameAction}
-							workspaceId={null}
-						/>
-						<ImportFileActionItem />
-					</TldrawUiMenuSubmenu>
+					{fileId && (
+						<TldrawUiMenuSubmenu id="file" label={fileSubmenuMsg}>
+							<FileItems
+								source="file-header"
+								fileId={fileId}
+								onRenameAction={handleRenameAction}
+								workspaceId={null}
+							/>
+							<ImportFileActionItem />
+						</TldrawUiMenuSubmenu>
+					)}
 					<EditSubmenu />
 					<TlaViewSubmenu />
 					<ExportFileContentSubMenu />


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where the signed-in file menu on legacy routes ran its file-bound actions with an undefined file id.

### Before

`TlaEditorTopLeftPanelSignedIn` is mounted on `/r`, `/ro`, `/v`, and `/s`, where there is no `fileSlug`. Copy link built `routes.tlaFile(undefined)` (TypeError, nothing copied), Download requested `/api/app/file/undefined/download`, Duplicate no-op'd.

### After

The `File` submenu is only rendered when there is a file id, and the rename handlers no-op without one. The rest of the panel (sidebar spacer, page menu, edit/view/export) is unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app` and seed a legacy room: `curl -X POST http://localhost:3000/api/app/__test__/legacy-room -H 'content-type: application/json' -d '{"slug":"legacy-test"}'`.
2. Sign in, open http://localhost:3000/r/legacy-test and close the read-only dialog.
3. Open the top-left "..." menu next to the file name.
4. On `main` the menu has a "File" submenu whose actions have no file id: "Copy link" throws a TypeError and copies nothing, "Download" requests `/api/app/file/undefined/download`, and "Duplicate" does nothing. With this PR the "File" submenu is not shown on `/r`, `/ro`, `/v` and `/s` routes; Edit, View and Export are unchanged.

- [x] Unit tests

### Release notes

- Fix broken file actions in the menu on legacy room routes

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +17 / -14  |
