### PR TITLE
fix(dotcom): build copy-to-workspace sources from route params and fix file-name fallbacks

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -182,7 +182,9 @@ function usePrefix() {
 }
 
 export function useRoomInfo() {
-	const id = useParams()['roomId'] as string
+	// Legacy routes name the param roomId; the publish route (/p/:fileSlug) names it fileSlug.
+	const { roomId, fileSlug } = useParams()
+	const id = roomId ?? fileSlug
 	const prefix = usePrefix()
 	if (!id || !prefix) return null
 	return { prefix, id }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacyModal.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyLegacyModal.tsx
@@ -16,7 +16,7 @@ import { routes } from '../../../../routeDefs'
 import { trackEvent } from '../../../../utils/analytics'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { F } from '../../../utils/i18n'
-import { useGetFileName } from '../TlaEditorTopRightPanel'
+import { useGetFileName, useRoomInfo } from '../TlaEditorTopRightPanel'
 import styles from './sneaky-legacy-modal.module.css'
 
 function LegacyChangesModal({ onClose }: { onClose(): void }) {
@@ -24,12 +24,14 @@ function LegacyChangesModal({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const navigate = useNavigate()
 	const name = useGetFileName()
+	// From the route params, not the raw pathname: see useFileEditorOverrides.
+	const roomInfo = useRoomInfo()
 
 	const handleCopy = async () => {
-		if (!app) return
+		if (!app || !roomInfo) return
 		const res = await app.createFile({
 			name,
-			createSource: window.location.pathname.slice(1),
+			createSource: `${roomInfo.prefix}/${roomInfo.id}`,
 		})
 		onClose()
 		if (res?.ok) {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakySetDocumentTitle.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakySetDocumentTitle.tsx
@@ -14,8 +14,10 @@ export function SneakySetDocumentTitle() {
 	const title = useValue(
 		'title',
 		() =>
-			((fileSlug ? app?.getFileName(fileSlug, false) : null) ??
-				editor?.getDocumentSettings().name) ||
+			// `||` not `??`: getFileName returns '' for a file the app doesn't know yet (first visit to
+			// a shared link), which must fall through to the document name like the top-left panel does.
+			(fileSlug ? app?.getFileName(fileSlug, false)?.trim() : null) ||
+			editor?.getDocumentSettings().name ||
 			// rather than displaying the date for the project here, display Untitled project
 			untitledProject,
 		[app, editor, fileSlug, untitledProject]

--- a/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
@@ -13,6 +13,7 @@ import { useHandleUiEvents } from '../../../utils/analytics'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { useIntl, useMsg } from '../../utils/i18n'
 import { editorMessages as messages } from './editor-messages'
+import { useRoomInfo } from './TlaEditorTopRightPanel'
 
 /** Triggers a GET to the app file download endpoint; browser shows download immediately with progress. */
 export function downloadAppFile(fileId: string) {
@@ -36,12 +37,17 @@ export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 	const intl = useIntl()
 	const navigate = useNavigate()
 	const trackEvent = useHandleUiEvents()
+	// Built from the route params rather than the raw pathname: a trailing slash (`/r/abc/`, which
+	// the router still matches) would otherwise produce a createSource the room can never resolve.
+	const roomInfo = useRoomInfo()
+	const copySource = roomInfo ? `${roomInfo.prefix}/${roomInfo.id}` : null
 
 	const getFileName = useCallback(
 		(editor: Editor) => {
 			const documentName =
-				((fileSlug ? app?.getFileName(fileSlug, false) : null) ??
-					editor?.getDocumentSettings().name) ||
+				// `||` not `??`: see SneakySetDocumentTitle
+				(fileSlug ? app?.getFileName(fileSlug, false)?.trim() : null) ||
+				editor?.getDocumentSettings().name ||
 				// rather than displaying the date for the project here, display Untitled project
 				untitledProject
 			const defaultName = saveFileNames.get(editor.store) || documentName
@@ -89,10 +95,11 @@ export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 					label: intl.formatMessage(messages.copyToMyfiles),
 					readonlyOk: true,
 					async onSelect() {
+						if (!copySource) return
 						const defaultName = getFileName(editor)
 						const res = await app?.createFile({
 							name: defaultName,
-							createSource: window.location.pathname.slice(1),
+							createSource: copySource,
 						})
 						if (res?.ok) {
 							const { fileId } = res.value
@@ -105,7 +112,7 @@ export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 				return actions
 			},
 		}
-	}, [app, fileSlug, getFileName, intl, navigate, trackEvent])
+	}, [app, copySource, fileSlug, getFileName, intl, navigate, trackEvent])
 
 	return overrides
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where "Copy to my workspace" was unreachable on published boards, one where a trailing-slash URL created an unopenable copy, and one where the document title fell back to the wrong name.

### Before

`useRoomInfo` read `useParams().roomId`, but the publish route is `/p/:fileSlug`, so it returned null and the action was never offered (regression from #5385). `SneakyLegacyModal` and `useFileEditorOverrides` built `createSource` from `window.location.pathname.slice(1)`, so `/r/abc/` (which the router still matches) produced a source the room could never resolve. `SneakySetDocumentTitle` and `useFileEditorOverrides.getFileName` used `??` on `getFileName`, which returns `''` for a file the app doesn't know yet, so the document-name fallback was unreachable.

### After

`useRoomInfo` reads `roomId ?? fileSlug`; `createSource` is built from route params; the name chains use `||`.

### Change type

- [x] `bugfix`

### Test plan

**Copy to my workspace missing on published boards**

1. Run `yarn dev-app`, sign in at http://localhost:3000, open a board and publish it from the share menu, then open its `/p/<slug>` link while still signed in.
2. Open the top-left "..." menu next to the tldraw logo.
3. On `main` there is no "Copy to my workspace" item (`useRoomInfo` read `roomId`, which the `/p/:fileSlug` route doesn't set). With this PR the item is listed, and selecting it creates a copy in your workspace and navigates to it.

**Trailing slash produces an unopenable copy**

1. Run `yarn dev-app` and seed a legacy room: `curl -X POST http://localhost:3000/api/app/__test__/legacy-room -H 'content-type: application/json' -d '{"slug":"legacy-test"}'`.
2. Sign in and open http://localhost:3000/r/legacy-test/ (with the trailing slash).
3. In the "This file is now read-only" dialog click "Copy to personal workspace".
4. On `main` the new file's `createSource` is `r/legacy-test/`, which the worker can't resolve, so the copy opens to the "Not found" error. With this PR the copy opens with the room's content.

- [x] Unit tests

### Release notes

- Fix "Copy to my workspace" missing on published boards

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +23 / -10  |
