### PR TITLE
fix(dotcom): fix .tldr drop and upload edge cases

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1104,6 +1104,13 @@ export class TldrawApp {
 		const totalFiles = files.length
 		let uploadedFiles = 0
 		if (totalFiles === 0) return
+		// createFile runs this check too, but only after the snapshot and its assets are already
+		// uploaded — which would orphan a room in R2 and stack a generic error on the limit toast.
+		if (!this.canCreateNewFile(workspaceId ?? this.getHomeWorkspaceId())) {
+			this.showMaxFilesToast()
+			onUploadError?.()
+			return
+		}
 
 		// this is only approx since we upload the files in pieces and they are base64 encoded
 		// in the json blob, so this will usually be a big overestimate. But that's fine because
@@ -1267,10 +1274,14 @@ export class TldrawApp {
 			throw Error(response.message)
 		}
 		const fileId = response.slugs[0]
+		// `||` not `??`: File.name is never nullish, so the document-name fallback was unreachable
+		// and a file called `.tldr` would reach createFile with an empty name (bad_request).
 		const name =
-			file.name?.replace(/\.tldr$/, '') ??
-			Object.values(snapshot.store).find((d): d is TLDocument => d.typeName === 'document')?.name ??
-			''
+			file.name.replace(/\.tldr$/, '').trim() ||
+			Object.values(snapshot.store)
+				.find((d): d is TLDocument => d.typeName === 'document')
+				?.name?.trim() ||
+			undefined
 
 		return this.createFile({ fileId, name, workspaceId })
 	}

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -671,7 +671,7 @@ export class TldrawApp {
 		return mostRecent?.fileId ?? scopedFiles[0]?.fileId ?? null
 	}
 
-	private canCreateNewFile(workspaceId: string) {
+	private canCreateNewFile(workspaceId: string, count = 1) {
 		// Count only files the workspace actually owns — not guest files (shared files the
 		// user opened) or mislinked rows that getWorkspaceFilesSorted hides. Counting those
 		// would let the limit fire on files the user can neither see nor remove. createFile
@@ -682,7 +682,7 @@ export class TldrawApp {
 		const nonDeletedCount = membership.groupFiles.filter(
 			(gf) => gf.file && !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
 		).length
-		return nonDeletedCount < this.config.maxNumberOfFiles
+		return nonDeletedCount + count <= this.config.maxNumberOfFiles
 	}
 
 	private showMaxFilesToast() {
@@ -1089,6 +1089,8 @@ export class TldrawApp {
 		return createIntl()!
 	}
 
+	// Explicit return type: inferring it (via createFile → getWorkspaceFilesSorted) is circular when
+	// uploadTldrFiles.test.ts is checked first, which turns getWorkspaceFilesSorted's result into any.
 	async uploadTldrFiles(
 		files: File[],
 		opts: {
@@ -1098,7 +1100,7 @@ export class TldrawApp {
 			workspaceId?: string
 			onUploadError?(): void
 		}
-	) {
+	): Promise<void> {
 		let { onFirstFileUploaded } = opts
 		const { source, workspaceId, onUploadError } = opts
 		const totalFiles = files.length
@@ -1106,7 +1108,9 @@ export class TldrawApp {
 		if (totalFiles === 0) return
 		// createFile runs this check too, but only after the snapshot and its assets are already
 		// uploaded — which would orphan a room in R2 and stack a generic error on the limit toast.
-		if (!this.canCreateNewFile(workspaceId ?? this.getHomeWorkspaceId())) {
+		// Check the whole batch: with one slot left, a two-file import would otherwise create the
+		// first file and then upload the second before createFile rejects it.
+		if (!this.canCreateNewFile(workspaceId ?? this.getHomeWorkspaceId(), totalFiles)) {
 			this.showMaxFilesToast()
 			onUploadError?.()
 			return

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1089,8 +1089,6 @@ export class TldrawApp {
 		return createIntl()!
 	}
 
-	// Explicit return type: inferring it (via createFile → getWorkspaceFilesSorted) is circular when
-	// uploadTldrFiles.test.ts is checked first, which turns getWorkspaceFilesSorted's result into any.
 	async uploadTldrFiles(
 		files: File[],
 		opts: {

--- a/apps/dotcom/client/src/tla/app/uploadTldrFiles.test.ts
+++ b/apps/dotcom/client/src/tla/app/uploadTldrFiles.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TldrawApp } from './TldrawApp'
+
+// Drive the real `uploadTldrFiles` on a bare prototype instance with the members it reads stubbed,
+// avoiding a full TldrawApp (Zero/Clerk/router). Same approach as getWorkspaceFilesSorted.test.ts.
+function createAppStub({
+	ownedFileCount,
+	maxNumberOfFiles,
+}: {
+	ownedFileCount: number
+	maxNumberOfFiles: number
+}) {
+	const homeId = 'user:home'
+	const groupFiles = Array.from({ length: ownedFileCount }, (_, i) => ({
+		fileId: `file:${i}`,
+		groupId: homeId,
+		file: { id: `file:${i}`, owningGroupId: homeId, isDeleted: false },
+	}))
+	const uploadTldrFile = vi.fn(async (file: File) => ({ ok: true, value: { fileId: file.name } }))
+	const addToast = vi.fn(() => 'toast:1')
+	const app = Object.create(TldrawApp.prototype)
+	Object.assign(app, {
+		userId: homeId,
+		config: { maxNumberOfFiles },
+		workspaceMemberships$: { get: () => [{ groupId: homeId, groupFiles }] },
+		abortController: new AbortController(),
+		toasts: { addToast, removeToast: vi.fn(), toasts: { update: vi.fn() } },
+		messages: {},
+		getIntl: () => ({ formatMessage: () => '' }),
+		trackEvent: vi.fn(),
+		uploadTldrFile,
+	})
+	return { app: app as TldrawApp, uploadTldrFile, addToast }
+}
+
+function makeFiles(count: number) {
+	return Array.from({ length: count }, (_, i) => new File(['{}'], `board-${i}.tldr`))
+}
+
+describe('uploadTldrFiles', () => {
+	it('uploads a batch that fits in the remaining capacity', async () => {
+		const { app, uploadTldrFile, addToast } = createAppStub({
+			ownedFileCount: 198,
+			maxNumberOfFiles: 200,
+		})
+		const onUploadError = vi.fn()
+
+		await app.uploadTldrFiles(makeFiles(2), { source: 'file-drop', onUploadError })
+
+		expect(uploadTldrFile).toHaveBeenCalledTimes(2)
+		expect(onUploadError).not.toHaveBeenCalled()
+		expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }))
+	})
+
+	it('refuses the whole batch before uploading when it exceeds the remaining capacity', async () => {
+		// One slot left: a single-file preflight would pass, create the first file, then upload the
+		// second before createFile rejects it — orphaning the second room and stacking two errors.
+		const { app, uploadTldrFile, addToast } = createAppStub({
+			ownedFileCount: 199,
+			maxNumberOfFiles: 200,
+		})
+		const onUploadError = vi.fn()
+
+		await app.uploadTldrFiles(makeFiles(2), { source: 'file-drop', onUploadError })
+
+		expect(uploadTldrFile).not.toHaveBeenCalled()
+		expect(onUploadError).toHaveBeenCalledTimes(1)
+		expect(addToast).toHaveBeenCalledTimes(1)
+		expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ keepOpen: true }))
+	})
+
+	it('still allows a single file into the last remaining slot', async () => {
+		const { app, uploadTldrFile } = createAppStub({ ownedFileCount: 199, maxNumberOfFiles: 200 })
+
+		await app.uploadTldrFiles(makeFiles(1), { source: 'file-drop' })
+
+		expect(uploadTldrFile).toHaveBeenCalledTimes(1)
+	})
+
+	it('refuses a single file when the workspace is full', async () => {
+		const { app, uploadTldrFile } = createAppStub({ ownedFileCount: 200, maxNumberOfFiles: 200 })
+		const onUploadError = vi.fn()
+
+		await app.uploadTldrFiles(makeFiles(1), { source: 'file-drop', onUploadError })
+
+		expect(uploadTldrFile).not.toHaveBeenCalled()
+		expect(onUploadError).toHaveBeenCalledTimes(1)
+	})
+})

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@clerk/clerk-react'
+import { can } from '@tldraw/dotcom-shared'
 import { memo, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { defaultHandleExternalFileContent, useEditor, useToasts, useTranslation } from 'tldraw'
@@ -23,8 +24,13 @@ export const SneakyTldrawFileDropHandler = memo(function SneakyTldrawFileDropHan
 			const files = rejectTldrawOfflineFiles(content.files)
 			const tldrawFiles = files.filter((file) => file.name.endsWith('.tldr'))
 			if (tldrawFiles.length > 0) {
-				const currentFile = fileId ? app.getFile(fileId) : null
-				const workspaceId = currentFile?.owningGroupId ?? undefined
+				// Drop into the open file's workspace only if the user can add files there; a guest on
+				// a shared board would otherwise upload the snapshot and then have createFile refused.
+				const owningGroupId = fileId ? app.getFile(fileId)?.owningGroupId : null
+				const workspaceId =
+					owningGroupId && can(app.getWorkspaceMembership(owningGroupId)?.role, 'addFiles')
+						? owningGroupId
+						: undefined
 				await app.uploadTldrFiles(tldrawFiles, {
 					source: 'file-drop',
 					onFirstFileUploaded: (fileId) => {

--- a/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
+++ b/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
@@ -15,13 +15,17 @@ export function useTldrFileDrop() {
 
 	const onDrop = useCallback(
 		async (e: DragEvent) => {
+			// Read the file list before any await: the DataTransfer is neutered once the drop event
+			// finishes dispatching, so reading it after the token fetch finds it empty.
+			const droppedFiles = e.dataTransfer?.files ? Array.from(e.dataTransfer.files) : []
+			if (!droppedFiles.length) return
+
 			const token = await auth.getToken()
 			if (!token) {
 				return
 			}
 
-			if (!e.dataTransfer?.files?.length) return
-			const files = rejectTldrawOfflineFiles(Array.from(e.dataTransfer.files))
+			const files = rejectTldrawOfflineFiles(droppedFiles)
 			const tldrawFiles = files.filter((file) => file.name.endsWith('.tldr'))
 			if (!tldrawFiles.length) {
 				return


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes four edge cases in `.tldr` drop and upload.

### Before

`useTldrFileDrop.onDrop` awaited `auth.getToken()` before reading `e.dataTransfer.files`, and the `DataTransfer` is neutered once the drop dispatch completes, so a token refresh meant the drop was silently ignored. `SneakyFileDropHandler` targeted the open file's workspace even when the user couldn't add files there (guest on a shared board: upload then `createFile` refused). `uploadTldrFiles` checked the file limit only in `createFile`, after the snapshot and assets were uploaded. The file-name derivation used `??` on `File.name` (never nullish), so the document-name fallback was unreachable and a file called `.tldr` reached `createFile` with an empty name.

### After

Files are captured before the first `await`; the drop targets the owning workspace only when the user can add files there; the limit is checked before uploading; the name chain uses `||`.

### Change type

- [x] `bugfix`

### Test plan

**File named only `.tldr`**

1. Export any board as a `.tldr` file and rename it to exactly `.tldr` (for example `cp board.tldr .tldr` in a terminal; press Cmd+Shift+. in Finder to see it).
2. Run `yarn dev-app`, open http://localhost:3000, sign in, and open any board.
3. Drag the `.tldr` file onto the canvas.
4. On `main` the upload is followed by a mutation-rejected toast and an "unknown error" toast, and no file is created. With this PR a new file opens, named after the document name inside the file (or the default new-file name).

**Dropping a `.tldr` on a shared board you can't add files to**

1. As user A, create a board in a workspace and copy its share link (edit access).
2. In another browser profile, sign in as user B (not a member of that workspace) and open the share link.
3. Drag a `.tldr` file onto user B's canvas.
4. On `main` the snapshot uploads and then the create is refused with an error toast. With this PR the file is created in user B's home workspace and opens.

- [x] Unit tests

### Release notes

- Fix `.tldr` drops being ignored after a session token refresh

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +28 / -7   |
