### PR TITLE
fix(dotcom): keep the feedback dialog open when submission fails

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -257,6 +257,12 @@
       "value": " commented on your board"
     }
   ],
+  "28b2464e1f": [
+    {
+      "type": 0,
+      "value": "Could not submit feedback"
+    }
+  ],
   "299cb00a7a": [
     {
       "type": 0,
@@ -273,6 +279,12 @@
     {
       "type": 0,
       "value": "Search..."
+    }
+  ],
+  "2d3cdcfdd4": [
+    {
+      "type": 0,
+      "value": "Please try again."
     }
   ],
   "2de510be71": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -95,6 +95,9 @@
   "2755e3ab39": {
     "translation": "<name>{author}</name> commented on your board"
   },
+  "28b2464e1f": {
+    "translation": "Could not submit feedback"
+  },
   "299cb00a7a": {
     "translation": "Upload failed"
   },
@@ -103,6 +106,9 @@
   },
   "2a37324bb4": {
     "translation": "Search..."
+  },
+  "2d3cdcfdd4": {
+    "translation": "Please try again."
   },
   "2de510be71": {
     "translation": "Regenerating replaces the current invite link with a new one. Anyone using the old link will need the new one to join."

--- a/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@clerk/clerk-react'
-import { addBreadcrumb, withScope } from '@sentry/react'
+import { addBreadcrumb, captureException, withScope } from '@sentry/react'
 import { SubmitFeedbackRequestBody } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -24,6 +24,8 @@ import styles from './dialogs.module.css'
 const messages = defineMessages({
 	submitted: { defaultMessage: 'Feedback submitted' },
 	thanks: { defaultMessage: 'Thanks for helping us improve tldraw!' },
+	failed: { defaultMessage: 'Could not submit feedback' },
+	tryAgain: { defaultMessage: 'Please try again.' },
 })
 
 const descriptionKey = 'tldraw-feedback-description'
@@ -78,30 +80,40 @@ function SignedInSubmitFeedbackDialog({ onClose }: { onClose(): void }) {
 	const [includeFileLink, setIncludeFileLink] = useState(true)
 	const toasts = useToasts()
 	const intl = useIntl()
+	const [isSubmitting, setIsSubmitting] = useState(false)
 	const onSubmit = useCallback(async () => {
-		if (!rInput.current?.value?.trim()) return
-		fetch('/api/app/submit-feedback', {
-			method: 'POST',
-			body: JSON.stringify({
-				allowContact: true,
-				description: rInput.current.value.trim(),
-				url: includeFileLink
-					? window.location.href.replace('https', 'https-please-be-mindful')
-					: '',
-			} satisfies SubmitFeedbackRequestBody),
-		})
-			.then((r) => {
-				if (!r.ok) {
-					throw new Error('Failed to submit feedback ' + r.status)
-				}
+		const description = rInput.current?.value?.trim()
+		if (!description || isSubmitting) return
+		setIsSubmitting(true)
+		try {
+			const r = await fetch('/api/app/submit-feedback', {
+				method: 'POST',
+				body: JSON.stringify({
+					allowContact: true,
+					description,
+					url: includeFileLink
+						? window.location.href.replace('https', 'https-please-be-mindful')
+						: '',
+				} satisfies SubmitFeedbackRequestBody),
 			})
-			.catch((e) => {
-				addBreadcrumb({ message: 'Failed to submit feedback' })
-				withScope((scope) => {
-					console.error(e)
-					scope.setExtra('description', rInput.current?.value?.trim())
-				})
+			if (!r.ok) {
+				throw new Error('Failed to submit feedback ' + r.status)
+			}
+		} catch (e) {
+			// Keep the dialog (and the saved draft) so the text isn't lost on a failed send.
+			addBreadcrumb({ message: 'Failed to submit feedback' })
+			withScope((scope) => {
+				scope.setExtra('description', description)
+				captureException(e)
 			})
+			toasts.addToast({
+				severity: 'error',
+				title: intl.formatMessage(messages.failed),
+				description: intl.formatMessage(messages.tryAgain),
+			})
+			setIsSubmitting(false)
+			return
+		}
 		deleteFromLocalStorage(descriptionKey)
 		onClose()
 		toasts.addToast({
@@ -109,7 +121,7 @@ function SignedInSubmitFeedbackDialog({ onClose }: { onClose(): void }) {
 			title: intl.formatMessage(messages.submitted),
 			description: intl.formatMessage(messages.thanks),
 		})
-	}, [includeFileLink, intl, onClose, toasts])
+	}, [includeFileLink, intl, isSubmitting, onClose, toasts])
 
 	// Focus the input when the dialog opens, select all text
 	useEffect(() => {
@@ -184,7 +196,7 @@ function SignedInSubmitFeedbackDialog({ onClose }: { onClose(): void }) {
 						<F defaultMessage="Cancel" />
 					</TldrawUiButtonLabel>
 				</TldrawUiButton>
-				<TldrawUiButton type="primary" onClick={onSubmit}>
+				<TldrawUiButton type="primary" onClick={onSubmit} disabled={isSubmitting}>
 					<TldrawUiButtonLabel>
 						<F defaultMessage="Submit" />
 					</TldrawUiButtonLabel>

--- a/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/SubmitFeedbackDialog.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@clerk/clerk-react'
-import { addBreadcrumb, captureException, withScope } from '@sentry/react'
+import { addBreadcrumb, captureException } from '@sentry/react'
 import { SubmitFeedbackRequestBody } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -101,11 +101,9 @@ function SignedInSubmitFeedbackDialog({ onClose }: { onClose(): void }) {
 			}
 		} catch (e) {
 			// Keep the dialog (and the saved draft) so the text isn't lost on a failed send.
+			// Don't attach the draft to the report: it's unsent user text and shouldn't reach Sentry.
 			addBreadcrumb({ message: 'Failed to submit feedback' })
-			withScope((scope) => {
-				scope.setExtra('description', description)
-				captureException(e)
-			})
+			captureException(e)
 			toasts.addToast({
 				severity: 'error',
 				title: intl.formatMessage(messages.failed),


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where a failed feedback submission looked like success and lost the draft.

### Before

`SignedInSubmitFeedbackDialog.onSubmit` fired the request without awaiting it, then deleted the saved draft, closed the dialog, and showed the "Feedback submitted" toast regardless; the catch only logged to the console.

### After

The submit is awaited with a disabled button; on failure the dialog and draft stay, the error is captured to Sentry, and an error toast is shown.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app`, open http://localhost:3000 and sign in.
2. Open devtools, Network tab, and add a request-blocking rule for `/api/app/submit-feedback` (or tick "Offline").
3. Click "Send feedback" in the sidebar (or the help menu), type a message, and click Submit.
4. On `main` the dialog closes, a "Feedback submitted" toast appears, and reopening the dialog shows an empty draft. With this PR the dialog stays open with the text intact, the Submit button is disabled while the request is in flight, and a "Could not submit feedback" error toast appears.

- [x] Unit tests

### Release notes

- Fix feedback submission reporting success when the request failed

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Automated files | +18 / -0   |
| Apps            | +36 / -24  |
