### PR TITLE
fix(dotcom): cancel stale async work in /new and the locale loader

### DIFF
--- a/apps/dotcom/client/src/pages/tla-new.tsx
+++ b/apps/dotcom/client/src/pages/tla-new.tsx
@@ -9,12 +9,15 @@ export function Component() {
 	const navigate = useNavigate()
 	const trackEvent = useTldrawAppUiEvents()
 	useEffect(() => {
+		// A user who leaves /new before the mutation settles must not be yanked to the new file.
+		let cancelled = false
 		const createFile = async () => {
 			if (!app) {
 				navigate(routes.tlaRoot(), { replace: true })
 				return
 			}
 			const res = await app.createFile()
+			if (cancelled) return
 			if (res.ok) {
 				const { fileId } = res.value
 				navigate(routes.tlaFile(fileId), { replace: true })
@@ -24,6 +27,9 @@ export function Component() {
 			}
 		}
 		createFile()
+		return () => {
+			cancelled = true
+		}
 	}, [app, navigate, trackEvent])
 	return null
 }

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -1,5 +1,4 @@
 import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
-import { getAssetUrlsByImport } from '@tldraw/assets/imports.vite'
 import classNames from 'classnames'
 import { Tooltip as _Tooltip } from 'radix-ui'
 import { ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
@@ -26,6 +25,7 @@ import {
 import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
 import { ErrorPage, RefreshErrorBoundary } from '../../components/ErrorPage/ErrorPage'
 import { SignedInAnalytics, SignedOutAnalytics, trackEvent } from '../../utils/analytics'
+import { assetUrls } from '../../utils/assetUrls'
 import { globalEditor } from '../../utils/globalEditor'
 import { TlaCookieConsent } from '../components/dialogs/TlaCookieConsent'
 import { TlaLegalAcceptance } from '../components/dialogs/TlaLegalAcceptance'
@@ -44,8 +44,6 @@ import {
 	resetLocalSessionStateButKeepTheme,
 	updateLocalSessionState,
 } from '../utils/local-session-state'
-
-const assetUrls = getAssetUrlsByImport()
 
 function getTextDirection(locale: string): 'ltr' | 'rtl' {
 	const [language] = locale.toLowerCase().split('-')
@@ -166,6 +164,9 @@ function IntlWrapper({ children, locale }: { children: ReactNode; locale: string
 	const [messages, setMessages] = useState(translationsEnJson)
 
 	useEffect(() => {
+		// Guard against a slower fetch for a previous locale landing after this one's and
+		// overwriting it, and against a missing/invalid locale file becoming an unhandled rejection.
+		let cancelled = false
 		async function fetchMessages() {
 			if (locale === 'en') {
 				setMessages(translationsEnJson)
@@ -173,13 +174,21 @@ function IntlWrapper({ children, locale }: { children: ReactNode; locale: string
 			}
 
 			const res = await fetch(`/tla/locales-compiled/${locale}.json`)
+			if (!res.ok) throw new Error(`Failed to load locale ${locale}: ${res.status}`)
 			const messages = await res.json()
+			if (cancelled) return
 			setMessages({
 				...translationsEnJson,
 				...messages,
 			})
 		}
-		fetchMessages()
+		fetchMessages().catch((e) => {
+			console.error(e)
+			if (!cancelled) setMessages(translationsEnJson)
+		})
+		return () => {
+			cancelled = true
+		}
 	}, [locale])
 
 	const defaultLocale = 'en'

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -26,6 +26,7 @@ import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
 import { ErrorPage, RefreshErrorBoundary } from '../../components/ErrorPage/ErrorPage'
 import { SignedInAnalytics, SignedOutAnalytics, trackEvent } from '../../utils/analytics'
 import { assetUrls } from '../../utils/assetUrls'
+import { reportError } from '../../utils/errorReporting'
 import { globalEditor } from '../../utils/globalEditor'
 import { TlaCookieConsent } from '../components/dialogs/TlaCookieConsent'
 import { TlaLegalAcceptance } from '../components/dialogs/TlaLegalAcceptance'
@@ -183,7 +184,7 @@ function IntlWrapper({ children, locale }: { children: ReactNode; locale: string
 			})
 		}
 		fetchMessages().catch((e) => {
-			console.error(e)
+			reportError(e)
 			if (!cancelled) setMessages(translationsEnJson)
 		})
 		return () => {


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a bug where leaving `/new` before the file was created still navigated to it, and one where a slow locale fetch could overwrite a newer one.

### Before

`tla-new`'s effect had no cancel guard. `IntlWrapper`'s `fetchMessages` had no cancel guard or error handling, so a missing locale file was an unhandled rejection. `TlaRootProviders` also called `getAssetUrlsByImport()` itself instead of reusing the shared `assetUrls`.

### After

Both effects set a `cancelled` flag on cleanup; the locale loader falls back to English on failure; the shared `assetUrls` is reused.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Fix navigating away from /new still opening the new file

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +19 / -4   |