### PR TITLE
fix(dotcom): fix the export preview race, QR code caching, and last-published time in the share menu

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/QrCode.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useRef } from 'react'
-import { FileHelpers, useLocalStorageState, useValue } from 'tldraw'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { FileHelpers, useValue } from 'tldraw'
 import { useGlobalEditor } from '../../../utils/globalEditor'
 import { getLocalSessionState } from '../../utils/local-session-state'
 import { createQRCodeImageDataString } from '../../utils/qrcode'
@@ -8,8 +8,9 @@ import styles from './file-share-menu.module.css'
 export function QrCode({ url }: { url: string }) {
 	const ref = useRef<HTMLImageElement>(null)
 
-	// Save the QR codes in local storage
-	const [qrCode, setQrCode] = useLocalStorageState<string | null>(url, null)
+	// Not cached in localStorage: the url carries the viewport, so every camera move would add a
+	// new data-url entry that nothing ever evicts.
+	const [qrCode, setQrCode] = useState<string | null>(null)
 
 	const theme = useValue('is dark mode', () => getLocalSessionState().theme, [])
 	const editor = useGlobalEditor()

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -260,11 +260,14 @@ function ExportPreviewImage() {
 	const ref = useRef<HTMLImageElement>(null)
 
 	const rImagePreviewSize = useRef<HTMLDivElement>(null)
+	// useReactor discards the effect's return value, so there is no cleanup closure: without a
+	// sequence a slow earlier export lands after a quick later one.
+	const rRenderSeq = useRef(0)
 
 	useReactor(
 		'update preview',
 		() => {
-			let cancelled = false
+			const seq = ++rRenderSeq.current
 
 			const editor = globalEditor.get()
 			if (!editor) return
@@ -294,7 +297,7 @@ function ExportPreviewImage() {
 			const fn = shapes.length > 20 ? getEditorImageSlowly : getEditorImage
 
 			fn(editor, shapes, preferences, ({ src, width, height }) => {
-				if (cancelled) return
+				if (seq !== rRenderSeq.current) return
 				const elm = ref.current
 				if (!elm) return
 				// We want to use an image element here so that a user can right click and copy / save / drag the qr code
@@ -302,10 +305,6 @@ function ExportPreviewImage() {
 				const sizeElm = rImagePreviewSize.current
 				if (sizeElm) sizeElm.textContent = `${width.toFixed()}×${height.toFixed()}`
 			})
-
-			return () => {
-				cancelled = true
-			}
 		},
 		[]
 	)

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
 	Box,
 	Editor,
@@ -300,7 +300,7 @@ function ExportPreviewImage() {
 				if (seq !== rRenderSeq.current) return
 				const elm = ref.current
 				if (!elm) return
-				// We want to use an image element here so that a user can right click and copy / save / drag the qr code
+				// We want to use an image element here so that a user can right click and copy / save / drag the preview
 				elm.setAttribute('src', src)
 				const sizeElm = rImagePreviewSize.current
 				if (sizeElm) sizeElm.textContent = `${width.toFixed()}×${height.toFixed()}`
@@ -308,6 +308,9 @@ function ExportPreviewImage() {
 		},
 		[]
 	)
+
+	// A debounced export still pending at unmount would otherwise run against a gone element
+	useEffect(() => () => getEditorImageSlowly.cancel(), [])
 
 	return (
 		<div className={styles.fileShareMenuExportPreview}>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
@@ -69,7 +69,7 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 
 	const publishShareUrl = publishedSlug ? routes.tlaPublish(publishedSlug, { asUrl: true }) : null
 
-	const secondsSince = Math.min(0, Math.floor((Date.now() - file.lastPublished) / 1000))
+	const secondsSince = Math.min(0, Math.floor((file.lastPublished - Date.now()) / 1000))
 	const learnMoreUrl = 'https://tldraw.notion.site/Publishing-1283e4c324c08059a1a1d9ba9833ddc9'
 	return (
 		<TlaMenuTabsPage id="publish">
@@ -112,7 +112,6 @@ export function TlaPublishTab({ file }: { file: TlaFile }) {
 								<F defaultMessage="Publish changes" />
 							</TlaButton>
 						)}
-						{/* todo: make this data actually true based on file.lastPublished */}
 						<TlaMenuDetail>
 							<F
 								defaultMessage="Last published <date></date>"

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -77,7 +77,8 @@ export function TlaMenuControlInfoTooltip({
 					<a
 						onClick={onClick}
 						href={href}
-						target="_blank nofollow noreferrer"
+						target="_blank"
+						rel="noopener noreferrer nofollow"
 						className={styles.menuInfoTrigger}
 					>
 						<TldrawUiIcon label={helpMsg} icon="help-circle" small />


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes four small share-menu bugs.

### Before

`ExportPreviewImage` returned a cleanup closure from `useReactor`, which discards it, so a slow earlier export could overwrite a quicker later one. `QrCode` cached its data URL in `localStorage` keyed by the full URL, which carries the viewport, so every camera move added an entry nothing evicted. `TlaPublishTab`'s `secondsSince` had its subtraction reversed. `TlaMenuControlInfoTooltip` put `nofollow noreferrer` in `target`.

### After

The preview uses a render sequence counter; the QR code uses component state; the sign is fixed; the link uses `target="_blank" rel="noopener noreferrer nofollow"`.

### Change type

- [x] `bugfix`

### Test plan

**Last published time**

1. Run `yarn dev-app`, open a file, open the Share menu and go to the Publish tab.
2. Publish the file, close the menu, wait a couple of minutes, then reopen the Publish tab.
3. On `main` the detail always reads "Last published now" (the subtraction was reversed and clamped to 0). With this PR it reads "Last published 2 minutes ago" and keeps counting.

**QR code cache**

1. Run `yarn dev-app`, open a shared file, open the Share menu's Invite tab so the QR code renders.
2. Close the menu, pan or zoom the canvas, and reopen the Invite tab; repeat a few times.
3. Open devtools → Application → Local Storage for localhost. On `main` a new entry keyed by the full deep link (with the viewport in the query) is added on every reopen and never removed. With this PR no QR code entries are written.

**Help link target**

1. In the Share menu's Publish tab, click the help icon next to "Publish this file" twice.
2. On `main` the second click navigates the first tab again (the `target` value was a made-up window name). With this PR each click opens a new tab with `rel="noopener noreferrer nofollow"`.

- [x] Unit tests

### Release notes

- Fix the last-published time in the share menu and the export preview race

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +13 / -13  |