### PR TITLE
fix(dotcom): fix sidebar file link deps and simplify the sidebar toggles and admin-rights hook

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -6,8 +6,8 @@ import { useTldrFileDrop } from '../../hooks/useTldrFileDrop'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import {
 	getIsSidebarOpen,
+	toggleMobileSidebar,
 	toggleSidebar,
-	updateLocalSessionState,
 	useIsSidebarOpen,
 	useIsSidebarOpenMobile,
 } from '../../utils/local-session-state'
@@ -54,7 +54,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 		// thinking nothing is open.
 		if (editor) tlmenus.clearOpenMenus(editor.contextId)
 		tlmenus.deleteOpenMenu('sidebar-workspace-switcher')
-		updateLocalSessionState(() => ({ isSidebarOpenMobile: false }))
+		toggleMobileSidebar(false)
 	}, [editor])
 
 	const { onDrop, onDragOver, onDragEnter, onDragLeave } = useTldrFileDrop()

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -16,7 +16,6 @@ import {
 import { routes } from '../../../../routeDefs'
 import { useApp } from '../../../hooks/useAppState'
 import { useHasFileAdminRights } from '../../../hooks/useIsFileOwner'
-import { useIsFilePinned } from '../../../hooks/useIsFilePinned'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { getIsCoarsePointer } from '../../../utils/getIsCoarsePointer'
 import { F, defineMessages, useIntl } from '../../../utils/i18n'
@@ -79,10 +78,12 @@ export function TlaSidebarFileLink({
 	const isRenaming = useValue(
 		'shouldRename',
 		() => isEqual(app.sidebarState.get().renameState, { fileId, workspaceId }),
-		[fileId, app]
+		[fileId, workspaceId, app]
 	)
 
-	const isPinned = useIsFilePinned(fileId, workspaceId)
+	// The parent's single getWorkspaceFilesSorted pass already decided this; recomputing it per
+	// link (useIsFilePinned) repeats that whole sort for every row on each membership change.
+	const isPinned = item.isPinned
 
 	const handleRenameAction = () => {
 		if (isMobile) {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarToggleMobile.tsx
@@ -2,7 +2,7 @@ import { TldrawUiButton, useValue } from 'tldraw'
 import { useGlobalEditor } from '../../../../utils/globalEditor'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { useMsg } from '../../../utils/i18n'
-import { getLocalSessionState, updateLocalSessionState } from '../../../utils/local-session-state'
+import { getIsSidebarOpenMobile, toggleMobileSidebar } from '../../../utils/local-session-state'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import { messages } from './sidebar-shared'
 import styles from '../sidebar.module.css'
@@ -28,9 +28,9 @@ export function TlaSidebarToggleMobile() {
 			tooltip={toggleSidebarLbl}
 			title={toggleSidebarLbl}
 			onClick={() => {
-				updateLocalSessionState((s) => ({ isSidebarOpenMobile: !s.isSidebarOpenMobile }))
+				toggleMobileSidebar()
 				trackEvent('sidebar-toggle', {
-					value: getLocalSessionState().isSidebarOpenMobile,
+					value: getIsSidebarOpenMobile(),
 					source: 'sidebar',
 				})
 			}}

--- a/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
@@ -1,22 +1,10 @@
-import { can } from '@tldraw/dotcom-shared'
 import { useValue } from 'tldraw'
 import { useMaybeApp } from './useAppState'
 
 export function useHasFileAdminRights(fileId?: string): boolean {
 	const app = useMaybeApp()
-	return useValue(
-		'isOwner',
-		() => {
-			if (!app) return false
-			if (!fileId) return false
-			const file = app?.getFile(fileId)
-			if (!file) return false
-			if (file.owningGroupId) {
-				const role = app.getWorkspaceMembership(file.owningGroupId)?.role
-				return can(role, 'accessFiles')
-			}
-			return false
-		},
-		[app, fileId]
-	)
+	return useValue('hasFileAdminRights', () => !!(app && fileId) && app.canUpdateFile(fileId), [
+		app,
+		fileId,
+	])
 }


### PR DESCRIPTION
**Risk: low · Importance: medium**

This PR fixes a missing `useValue` dependency in the sidebar file link and simplifies three sidebar helpers.

### Before

`TlaSidebarFileLink`'s `isRenaming` omitted `workspaceId` from its deps, and it recomputed `isPinned` per row via `useIsFilePinned` (a full sort per link per membership change) even though the parent's `getWorkspaceFilesSorted` pass already carried it. The sidebar and mobile toggle duplicated `toggleMobileSidebar`; `useHasFileAdminRights` duplicated `app.canUpdateFile`.

### After

Deps are complete, `isPinned` comes from `item.isPinned`, and the helpers delegate.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev-app`, sign in, and make sure you have at least one workspace besides your home workspace.
2. Open one of your home-workspace files; it is listed under "Today" in the sidebar.
3. From the file name menu choose "Move to" and pick the other workspace. The sidebar switches to that workspace and the same file is still listed under "Today" (the link component is reused with the new workspace id).
4. Double-click the file in the sidebar (or right-click → Rename).
5. On `main` the inline rename input never appears, because `isRenaming` still compares against the old workspace id. With this PR the rename input opens.

- [x] Unit tests

### Release notes

- Fix the sidebar rename state not updating when a file moves workspace

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +13 / -25  |