### PR TITLE
chore(dotcom): declare missing dependencies

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"@clerk/clerk-react": "^5.53.3",
 		"@clerk/elements": "^0.23.74",
+		"@clerk/types": "^4.95.1",
 		"@rocicorp/zero": "1.9.0",
 		"@sentry/integrations": "^7.120.3",
 		"@sentry/react": "^7.120.3",
@@ -70,6 +71,7 @@
 		"@clerk/testing": "^1.4.15",
 		"@formatjs/cli": "^6.5.1",
 		"@formatjs/unplugin": "^1.1.0",
+		"@peculiar/webcrypto": "^1.5.0",
 		"@playwright/test": "^1.61.0",
 		"@sentry/cli": "^2.41.1",
 		"@tldraw/validate": "workspace:*",

--- a/apps/dotcom/client/src/tla/utils/importFromUrl.ts
+++ b/apps/dotcom/client/src/tla/utils/importFromUrl.ts
@@ -1,4 +1,4 @@
-import { createTLSchema, fetch, parseTldrawJsonFile } from 'tldraw'
+import { createTLSchema, fetch, parseTldrawJsonFile, TLDocument } from 'tldraw'
 import type { TldrawApp } from '../app/TldrawApp'
 
 export async function importFromUrl(
@@ -22,7 +22,7 @@ export async function importFromUrl(
 		}
 		const snapshot = parseResult.value.getStoreSnapshot()
 		const documentRecord = Object.values(snapshot.store).find(
-			(r): r is import('@tldraw/tlschema').TLDocument => r.typeName === 'document'
+			(r): r is TLDocument => r.typeName === 'document'
 		)
 		const rawName = documentRecord?.name?.trim()
 		const sanitized = rawName?.replace(/[/\\:*?"<>|]/g, '_').slice(0, 200) || 'import'

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -27,6 +27,7 @@
 		"concurrently": "^9.1.2",
 		"dotenv": "^16.4.7",
 		"lazyrepo": "0.0.0-alpha.27",
-		"tsx": "^4.19.2"
+		"tsx": "^4.19.2",
+		"vitest": "^4.1.7"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12565,6 +12565,7 @@ __metadata:
     lazyrepo: "npm:0.0.0-alpha.27"
     pg: "npm:^8.16.3"
     tsx: "npm:^4.19.2"
+    vitest: "npm:^4.1.7"
   languageName: unknown
   linkType: soft
 
@@ -18937,8 +18938,10 @@ __metadata:
     "@clerk/clerk-react": "npm:^5.53.3"
     "@clerk/elements": "npm:^0.23.74"
     "@clerk/testing": "npm:^1.4.15"
+    "@clerk/types": "npm:^4.95.1"
     "@formatjs/cli": "npm:^6.5.1"
     "@formatjs/unplugin": "npm:^1.1.0"
+    "@peculiar/webcrypto": "npm:^1.5.0"
     "@playwright/test": "npm:^1.61.0"
     "@rocicorp/zero": "npm:1.9.0"
     "@sentry/cli": "npm:^2.41.1"


### PR DESCRIPTION
**Risk: low · Importance: low**

In order to keep every import declared by the workspace that uses it, this PR declares `@clerk/types` and `@peculiar/webcrypto` in the dotcom client (already imported by `auth.ts`, `useUser.tsx`, and the test setup), declares `vitest` in zero-cache (which has `test` scripts and four test files), and makes `importFromUrl` take `TLDocument` from `tldraw` instead of a dynamic `import('@tldraw/tlschema')` type.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +2 / -2    |
| Config/tooling | +7 / -1    |