### PR TITLE
docs(dotcom): describe the outbox instead of the deleted replicator and user DO

### DIFF
--- a/apps/dotcom/browser-run-thumbnails.md
+++ b/apps/dotcom/browser-run-thumbnails.md
@@ -56,7 +56,7 @@ A board with no usable cached image is sent to the site-wide default (`/social-o
 
 Nothing renders on crawler demand any more, so a board's thumbnail has to exist before its first share. Two triggers make that happen, both enqueueing onto the same queue and consumer, and both subject to the same re-resolve and version check at render time. Every queue message carries a `reason` (`publish`, `edit`) that rides through to telemetry; `crawler` survives in the union only as the fallback for messages enqueued before the field existed.
 
-- **Publish.** The `publish` effect in `TLPostgresReplicator` enqueues a render right after `publishSnapshot` writes the frozen R2 snapshot, so a published board's image is being made before its link is pasted anywhere. `unpublish` deletes the cached image and pending marker instead — the one replicator effect that touches a thumbnail. **Unsharing has no effect of its own**: every board renders whether shared or not, and the share gate is applied at serve time, so there is nothing derived from a board's public state to tear down when it goes private.
+- **Publish.** `publishSnapshot` (the outbox publish effect in `utils/publishSnapshots.ts`, run by `TLFileEffectProcessor`) enqueues a render right after it writes the frozen R2 snapshot, so a published board's image is being made before its link is pasted anywhere. `unpublishSnapshot` deletes the cached image and pending marker instead — the one outbox effect that touches a thumbnail. **Unsharing has no effect of its own**: every board renders whether shared or not, and the share gate is applied at serve time, so there is nothing derived from a board's public state to tear down when it goes private.
 - **On edit.** `TLFileDurableObject.persistToDatabase` schedules a render on a persist that actually advanced the document clock. The only states that skip are `legacy` and `deleted` (see "Rendering every board"); shared and private boards both render. There is no sampling and no staleness window — a persist means the board's saved content genuinely differs from what the cached thumbnail shows, which is exactly when a re-render is warranted.
 
   **The ask is debounced, not throttled.** Each persist pushes the render deadline out by `OG_RENDER_DEBOUNCE_MS` (60s), so a board renders once its editing _settles_ rather than on a cadence while it is still being drawn on — which is what a thumbnail is for. `OG_RENDER_MAX_WAIT_MS` (5 minutes), measured from the first persist since the last render, stops a board that is never left alone from never rendering. The arithmetic lives in `utils/ogRenderDebounce.ts` so it is testable without standing up a durable object; the object supplies the clock and the alarm.
@@ -523,7 +523,7 @@ flowchart TB
     end
 
     subgraph warm ["Refresh triggers (ahead of the first crawler)"]
-        PUB["publish effect<br/>(TLPostgresReplicator)"]
+        PUB["publish effect<br/>(publishSnapshots.ts via TLFileEffectProcessor)"]
         SPEC["persist on edit<br/>(TLFileDurableObject,<br/>debounced 60s, 5min max wait)"]
     end
 
@@ -641,7 +641,7 @@ There are two constants to tune, both in `config.ts`, and the measurement in "Wh
 ### Explicitly not doing
 
 - Synchronous wait in `getOgImage` — the queue's ~5s default batch linger means a short wait mostly misses, and the phases above remove the need. Revisit only with data showing otherwise.
-- An `isEmpty`-based trigger — the `file.isEmpty` column is vestigial (written `true` at creation, never flipped by client or server), so there is no replicator-visible first-content transition.
+- An `isEmpty`-based trigger — the `file.isEmpty` column is vestigial (written `true` at creation, never flipped by client or server), so there is no outbox-visible first-content transition.
 - A DO-owned render single-flight — the advisory pending marker plus the consumer's version check is the accepted model and stays adequate at these volumes.
 - A cap on thumbnail rendering — see "Request limits". Capping our own derived artifact only buys staler thumbnails; the caps belong on the MCP endpoint, which is the surface an outside caller can actually drive.
 

--- a/apps/dotcom/workspaces-feature.md
+++ b/apps/dotcom/workspaces-feature.md
@@ -111,7 +111,7 @@ The client hook named `useHasFileAdminRights` currently returns true for any mem
 
 ## Data sync model
 
-The user durable object syncs:
+The client's Zero queries (see `TldrawApp.preload`) sync:
 
 - The current user.
 - The user's `file_state` rows and related files.
@@ -123,7 +123,7 @@ The user durable object syncs:
 
 The sidebar is built from the workspace graph. For migrated users, `getFile(fileId)` only returns a file if it can be found through one of the user's workspace memberships. A shared file may still be openable through the file durable object even when it is not returned by `getFile`.
 
-When membership or workspace file subscriptions change, the user durable object may do a hard reboot and refetch the graph. That keeps the sidebar consistent after other users move files, delete files, add files, remove members, or delete workspaces.
+Zero replicates membership and workspace file changes incrementally, which keeps the sidebar consistent after other users move files, delete files, add files, remove members, or delete workspaces. Server-side effects of file changes (room notifications, publish/unpublish) run through the `effect_outbox` drained by `TLFileEffectProcessor`.
 
 The live canvas connection is checked separately by the file durable object:
 
@@ -262,7 +262,7 @@ The active workspace then changes because the open file belongs to that workspac
 
 The user presses the sidebar new-file button. The app creates the file in the active workspace, navigates to it, and starts rename on desktop.
 
-Other members of the workspace receive the new file through sync. Depending on subscription state, their user durable object may refetch the workspace graph before the file appears.
+Other members of the workspace receive the new file through Zero sync.
 
 ### Sharing a workspace
 
@@ -294,7 +294,7 @@ If the file is only a home guest link, removal removes that home link. The file 
 
 ### Another member creates a file in the active workspace
 
-The user's workspace graph gains a `group_file` row and the new file. The sidebar eventually shows it in the active workspace's unpinned list. The file may appear after a user durable object refetch if the new file creates a new subscription.
+The user's workspace graph gains a `group_file` row and the new file. The sidebar shows it in the active workspace's unpinned list once Zero has replicated the rows.
 
 The user is not navigated away from their current file.
 
@@ -352,7 +352,7 @@ The deleting user's client navigates to another file or creates a new one. Other
 
 ### An owner removes the current user from a workspace
 
-The current user's `group_user` row is deleted. Their user durable object loses the workspace subscription and refetches the graph. The workspace disappears from the sidebar.
+The current user's `group_user` row is deleted. Zero drops the workspace from the user's query results and the workspace disappears from the sidebar.
 
 For files owned by that workspace:
 
@@ -484,8 +484,8 @@ Main files reviewed:
 - `apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts`
 - `apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx`
 - `apps/dotcom/sync-worker/src/TLFileDurableObject.ts`
-- `apps/dotcom/sync-worker/src/UserDataSyncer.ts`
-- `apps/dotcom/sync-worker/src/fetchEverythingSql.snap.ts`
+- `apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts`
+- `apps/dotcom/sync-worker/src/fileEffects.ts`
 - `apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts`
 - `apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts`
 - `apps/dotcom/sync-worker/src/utils/tla/getJoinableWorkspaceFromInvite.ts`


### PR DESCRIPTION
**Risk: low · Importance: low**

In order to stop `apps/dotcom/workspaces-feature.md` and `browser-run-thumbnails.md` describing the user durable object and `TLPostgresReplicator` that #9899 deleted, this PR rewrites those passages in terms of Zero queries and the `effect_outbox` drained by `TLFileEffectProcessor`.

### Change type

- [x] `other`

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +10 / -10  |