### PR TITLE
Remove comment tool from develop toolbar

### DIFF
--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -8,14 +8,11 @@ import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useMemo } from 'react'
 import {
 	commentSchemaRecords,
-	CommentToolbarItem,
 	createTLSchema,
 	DefaultContextMenu,
 	DefaultContextMenuContent,
 	DefaultDebugMenu,
 	DefaultDebugMenuContent,
-	DefaultToolbar,
-	DefaultToolbarContent,
 	Editor,
 	ExampleDialog,
 	PerformanceApiAdapter,
@@ -118,13 +115,6 @@ const components: TLComponents = {
 		</DefaultDebugMenu>
 	),
 	InFrontOfTheCanvas: Comments,
-	// The default toolbar doesn't include the comment tool, so add it here.
-	Toolbar: () => (
-		<DefaultToolbar>
-			<CommentToolbarItem />
-			<DefaultToolbarContent />
-		</DefaultToolbar>
-	),
 }
 
 // Dragging the comment tool out anchors a comment to a rectangular region; a click anchors a pin.


### PR DESCRIPTION
This PR removes the extra comment button from the toolbar in the develop page of the examples app.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

1. Create a shape...
2.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Removed comment button from toolbar in examples/develop