### PR TITLE
fix(editor): react to licenseKey changes and don't surface watermark tracking failures

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2445,6 +2445,7 @@ export class LicenseManager {
     constructor(licenseKey: string | undefined, testPublicKey?: string);
     // (undocumented)
     static className: string;
+    dispose(): void;
     // (undocumented)
     featureFlags: Atom<Record<LicenseFeatureName, boolean>, unknown>;
     // (undocumented)

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -1,4 +1,5 @@
 import { atom, transact } from '@tldraw/state'
+import { noop } from '@tldraw/utils'
 import { publishDates, version } from '../../version'
 import { getDefaultCdnBaseUrl } from '../utils/assets'
 import { importPublicKey, str2ab } from '../utils/licensing'
@@ -247,8 +248,9 @@ export class LicenseManager {
 			url.searchParams.set('environment', process.env.NODE_ENV)
 		}
 
+		// best-effort: a blocked or offline request must not surface as an unhandled rejection
 		// eslint-disable-next-line no-restricted-globals
-		fetch(url.toString())
+		fetch(url.toString()).catch(noop)
 	}
 
 	private async extractLicenseKey(licenseKey: string): Promise<LicenseInfo> {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -128,6 +128,7 @@ export class LicenseManager {
 		...NO_FEATURES,
 	})
 	public verbose = true
+	private isDisposed = false
 
 	constructor(licenseKey: string | undefined, testPublicKey?: string) {
 		this.isTest = process.env.NODE_ENV === 'test'
@@ -145,6 +146,9 @@ export class LicenseManager {
 
 		this.getLicenseFromKey(licenseKey)
 			.then((result) => {
+				// replaced by a manager for a newer key: this one's messages, tracking ping and state
+				// would describe a key the app no longer uses
+				if (this.isDisposed) return
 				const licenseState = getLicenseState(
 					result,
 					(messages: string[]) => this.outputMessages(messages),
@@ -161,9 +165,15 @@ export class LicenseManager {
 				})
 			})
 			.catch((error) => {
+				if (this.isDisposed) return
 				console.error('License validation failed:', error)
 				this.state.set('unlicensed')
 			})
+	}
+
+	/** Ignore the pending validation: nothing is logged, tracked or set once the manager is replaced. */
+	dispose() {
+		this.isDisposed = true
 	}
 
 	/**

--- a/packages/editor/src/lib/license/LicenseProvider.test.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.test.tsx
@@ -1,0 +1,29 @@
+import { act, render } from '@testing-library/react'
+import { LicenseManager } from './LicenseManager'
+import { LicenseProvider, useLicenseContext } from './LicenseProvider'
+
+describe('LicenseProvider', () => {
+	it('creates a new license manager when the license key changes', async () => {
+		const managers: LicenseManager[] = []
+		function Probe() {
+			managers.push(useLicenseContext())
+			return null
+		}
+		const renderWithKey = (licenseKey: string | undefined) => (
+			<LicenseProvider licenseKey={licenseKey}>
+				<Probe />
+			</LicenseProvider>
+		)
+
+		const rendered = await act(async () => render(renderWithKey(undefined)))
+		const initial = managers.at(-1)!
+
+		await act(async () => rendered.rerender(renderWithKey('not-a-real-key')))
+		const changed = managers.at(-1)!
+		expect(changed).not.toBe(initial)
+
+		// same key again: the manager is stable
+		await act(async () => rendered.rerender(renderWithKey('not-a-real-key')))
+		expect(managers.at(-1)).toBe(changed)
+	})
+})

--- a/packages/editor/src/lib/license/LicenseProvider.test.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.test.tsx
@@ -1,20 +1,31 @@
 import { act, render } from '@testing-library/react'
-import { LicenseManager } from './LicenseManager'
-import { LicenseProvider, useLicenseContext } from './LicenseProvider'
+import { vi } from 'vitest'
+import { LicenseFromKeyResult, LicenseManager } from './LicenseManager'
+import { LICENSE_TIMEOUT, LicenseProvider, useLicenseContext } from './LicenseProvider'
+
+const NO_KEY: LicenseFromKeyResult = { isLicenseParseable: false, reason: 'no-key-provided' }
 
 describe('LicenseProvider', () => {
-	it('creates a new license manager when the license key changes', async () => {
-		const managers: LicenseManager[] = []
-		function Probe() {
-			managers.push(useLicenseContext())
-			return null
-		}
-		const renderWithKey = (licenseKey: string | undefined) => (
-			<LicenseProvider licenseKey={licenseKey}>
-				<Probe />
-			</LicenseProvider>
-		)
+	const managers: LicenseManager[] = []
+	function Probe() {
+		managers.push(useLicenseContext())
+		return null
+	}
+	const renderWithKey = (licenseKey: string | undefined) => (
+		<LicenseProvider licenseKey={licenseKey}>
+			<Probe />
+		</LicenseProvider>
+	)
 
+	beforeEach(() => {
+		managers.length = 0
+	})
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.useRealTimers()
+	})
+
+	it('creates a new license manager when the license key changes', async () => {
 		const rendered = await act(async () => render(renderWithKey(undefined)))
 		const initial = managers.at(-1)!
 
@@ -25,5 +36,41 @@ describe('LicenseProvider', () => {
 		// same key again: the manager is stable
 		await act(async () => rendered.rerender(renderWithKey('not-a-real-key')))
 		expect(managers.at(-1)).toBe(changed)
+	})
+
+	it('shows the editor again when a new key arrives after the gate closed', async () => {
+		// validation never settles so the test drives the state by hand
+		vi.spyOn(LicenseManager.prototype, 'getLicenseFromKey').mockReturnValue(new Promise(() => {}))
+		vi.useFakeTimers()
+
+		const rendered = await act(async () => render(renderWithKey('expired-key')))
+		const expired = managers.at(-1)!
+		act(() => expired.state.set('expired'))
+		act(() => vi.advanceTimersByTime(LICENSE_TIMEOUT))
+		expect(rendered.queryByTestId('tl-license-expired')).not.toBeNull()
+
+		await act(async () => rendered.rerender(renderWithKey('fresh-key')))
+		expect(rendered.queryByTestId('tl-license-expired')).toBeNull()
+		expect(managers.at(-1)).not.toBe(expired)
+	})
+
+	it('ignores the validation result of a manager replaced by a new key', async () => {
+		const resolvers: ((result: LicenseFromKeyResult) => void)[] = []
+		vi.spyOn(LicenseManager.prototype, 'getLicenseFromKey').mockImplementation(
+			() => new Promise((resolve) => resolvers.push(resolve))
+		)
+		const track = vi.spyOn(LicenseManager.prototype as any, 'maybeTrack')
+
+		const rendered = await act(async () => render(renderWithKey(undefined)))
+		const orphan = managers.at(-1)!
+		await act(async () => rendered.rerender(renderWithKey('real-key')))
+		expect(managers.at(-1)).not.toBe(orphan)
+
+		await act(async () => resolvers[0](NO_KEY))
+		expect(orphan.state.get()).toBe('pending')
+		expect(track).not.toHaveBeenCalled()
+
+		await act(async () => resolvers[1](NO_KEY))
+		expect(managers.at(-1)!.state.get()).toBe('unlicensed')
 	})
 })

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import { useMaybeEditor } from '../hooks/useEditor'
 import { LicenseManager } from './LicenseManager'
 
@@ -46,21 +46,25 @@ export function LicenseProvider({
 	licenseKey?: string
 	children: ReactNode
 }) {
-	const [licenseManager] = useState(() => new LicenseManager(licenseKey))
+	// Keyed on the license key: the editor is recreated when the key changes, and must not be
+	// handed a manager that validated the old key.
+	const licenseManager = useMemo(() => new LicenseManager(licenseKey), [licenseKey])
 	const licenseState = useValue(licenseManager.state)
-	const [showEditor, setShowEditor] = useState(true)
+	// The manager whose grace period ran out, so a new key starts with the editor shown again.
+	const [gatedManager, setGatedManager] = useState<LicenseManager | null>(null)
+	const showEditor = gatedManager !== licenseManager
 
 	// When license expires or no license in production, show for 5 seconds then hide
 	useEffect(() => {
 		if (shouldHideEditorAfterDelay(licenseState) && showEditor) {
 			// eslint-disable-next-line no-restricted-globals
 			const timer = setTimeout(() => {
-				setShowEditor(false)
+				setGatedManager(licenseManager)
 			}, LICENSE_TIMEOUT)
 
 			return () => clearTimeout(timer)
 		}
-	}, [licenseState, showEditor])
+	}, [licenseManager, licenseState, showEditor])
 
 	// If license is expired or no license in production and 5 seconds have passed, don't render anything (blank screen)
 	if (shouldHideEditorAfterDelay(licenseState) && !showEditor) {

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useMaybeEditor } from '../hooks/useEditor'
 import { LicenseManager } from './LicenseManager'
 
@@ -50,9 +50,19 @@ export function LicenseProvider({
 	// handed a manager that validated the old key.
 	const licenseManager = useMemo(() => new LicenseManager(licenseKey), [licenseKey])
 	const licenseState = useValue(licenseManager.state)
-	// The manager whose grace period ran out, so a new key starts with the editor shown again.
+	// The manager whose LICENSE_TIMEOUT elapsed; compared by identity so a new key un-gates the editor.
 	const [gatedManager, setGatedManager] = useState<LicenseManager | null>(null)
 	const showEditor = gatedManager !== licenseManager
+
+	// Dispose only the replaced manager, never on cleanup: strict mode re-runs effects with the
+	// same manager, and disposing it there would silence the live one.
+	const previousManager = useRef<LicenseManager | null>(null)
+	useEffect(() => {
+		if (previousManager.current && previousManager.current !== licenseManager) {
+			previousManager.current.dispose()
+		}
+		previousManager.current = licenseManager
+	}, [licenseManager])
 
 	// When license expires or no license in production, show for 5 seconds then hide
 	useEffect(() => {


### PR DESCRIPTION
This PR fixes a bug where an app that mounted `TldrawEditor` without a license key and received one later stayed unlicensed, and was blanked out once the grace period ran out. It also fixes a bug where a blocked or offline watermark tracking request surfaced as an unhandled promise rejection.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`LicenseProvider` created its `LicenseManager` once in `useState` from the initial `licenseKey` and never looked at the prop again, so when the key arrived `TldrawEditor` recreated the editor with the stale manager that had validated `undefined`. The gating flag was a single `showEditor` boolean, so once the grace period had elapsed nothing could show the editor again.

`LicenseManager.maybeTrack` called `fetch` without a catch, so a failed tracking request rejected unhandled.

### After

The manager is memoised on `licenseKey`, so a changed key produces a fresh manager and the same key keeps the same instance. The gating state records which manager was gated, so a new manager starts with the editor shown and the grace period runs again.

A manager replaced before its validation settled is disposed, so it no longer prints the "no license key" console block, sends a tracking ping for a key the app no longer uses, or sets its state. The provider disposes only the replaced manager, not on effect cleanup, because strict mode re-runs effects with the same manager.

`maybeTrack` swallows fetch failures: tracking is best-effort.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/basic. In `apps/examples/src/examples/getting-started/basic/BasicExample.tsx`, hold the key in state and pass it through: `const [key, setKey] = useState<string>()` and `<Tldraw licenseKey={key} />`, plus a button that calls `setKey('<a valid tldraw license key>')`.
2. Load the page: the editor mounts without a key, so the "made with tldraw" watermark shows.
3. Click the button to hand the editor the license key.
4. On `main` the watermark stays (the provider keeps the manager that validated `undefined`). With this PR the editor remounts with a fresh manager and the watermark disappears.

- [x] Unit tests — the new tests fail on `main` and pass with this change: a changed key creates a new manager, a new key reopens the gate after `LICENSE_TIMEOUT`, and a replaced manager ignores its validation result

### Release notes

- Pick up a license key that arrives after the first render and stop watermark tracking failures surfacing as unhandled rejections.

### API changes

- Added `LicenseManager.dispose()` (internal class) so a manager replaced by a new key ignores its pending validation

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +32 / -6   |
| Tests           | +76 / -0   |
| Automated files | +1 / -0    |
