### PR TITLE
fix(editor): frame drag targets exclude the dragged shapes' descendants and restore child indices

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6669,6 +6669,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const draggingShapes = compact(droppingShapes.map((s) => this.getShape(s))).filter(
 			(s) => !s.isLocked && !this.isShapeHidden(s)
 		)
+		// Descendants of the dragged shapes can't be the target, otherwise dragging a frame out of
+		// its parent reports a nested child as the target and the parent never sees the drag leave
+		const excludedIds = this.getShapeAndDescendantIds(draggingShapes.map((s) => s.id))
 
 		const maybeDraggingOverShapes = this.getShapesAtPoint(point, {
 			hitInside: true,
@@ -6678,7 +6681,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				!droppingShapes.includes(s) &&
 				!s.isLocked &&
 				!this.isShapeHidden(s) &&
-				!draggingShapes.includes(s)
+				!excludedIds.has(s.id)
 		)
 
 		for (const maybeDraggingOverShape of maybeDraggingOverShapes) {

--- a/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/BaseFrameLikeShapeUtil.tsx
@@ -93,7 +93,11 @@ export abstract class BaseFrameLikeShapeUtil<
 			const currentChildren = compact(
 				editor.getSortedChildIdsForParent(shape).map((id) => editor.getShape(id))
 			)
-			if (previousChildren.every((s) => !currentChildren.find((c) => c.index === s.index))) {
+			if (
+				previousChildren.every(
+					(s) => !currentChildren.find((c) => c.index === initialIndices.get(s.id))
+				)
+			) {
 				canRestoreOriginalIndices = true
 			}
 		}

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -450,6 +450,36 @@ describe('frame shapes', () => {
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(frameId)
 	})
 
+	it('restores the original index of a child that is dragged out and back in', () => {
+		const frameId = createShapeId('frame')
+		const boxA = createShapeId('A')
+		const boxB = createShapeId('B')
+		const boxC = createShapeId('C')
+		editor.createShapes([
+			{ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 200, h: 200 } },
+			// A second page-level shape, so that dragging B out lands it at page index a3: the same
+			// index as C inside the frame, which must not block restoring B to a2
+			{ id: createShapeId('X'), type: 'geo', x: 400, y: 400, props: { w: 50, h: 50 } },
+			{ id: boxA, type: 'geo', parentId: frameId, x: 10, y: 10, props: { w: 40, h: 40 } },
+			{ id: boxB, type: 'geo', parentId: frameId, x: 75, y: 75, props: { w: 50, h: 50 } },
+			{ id: boxC, type: 'geo', parentId: frameId, x: 150, y: 150, props: { w: 40, h: 40 } },
+		])
+		expect(editor.getSortedChildIdsForParent(frameId)).toEqual([boxA, boxB, boxC])
+		expect(editor.getShape(boxB)!.index).toBe('a2')
+
+		editor.setCurrentTool('select').select(boxB)
+		editor.pointerDown(100, 100).pointerMove(300, 300)
+		vi.advanceTimersByTime(300)
+		expect(editor.getShape(boxB)!.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getShape(boxB)!.index).toBe('a3')
+
+		editor.pointerMove(100, 100)
+		vi.advanceTimersByTime(300)
+		editor.pointerUp(100, 100)
+		expect(editor.getShape(boxB)!.parentId).toBe(frameId)
+		expect(editor.getSortedChildIdsForParent(frameId)).toEqual([boxA, boxB, boxC])
+	})
+
 	it('does not reparent shapes that are being dragged from within the frame', () => {
 		dragCreateFrame({ down: [0, 0], move: [200, 200], up: [200, 200] })
 		const frame = editor.getLastCreatedShape()
@@ -1716,6 +1746,27 @@ it('avoids crash when dragging into descendant', () => {
 	editor.select(frame1id)
 	editor.pointerDown(25, 25)
 	editor.pointerMove(30, 30)
+})
+
+it('unparents a frame dragged out of its parent by a point over its own nested child', () => {
+	const outer = createShapeId('outer')
+	const mid = createShapeId('mid')
+	const inner = createShapeId('inner')
+	editor.createShapes([
+		{ id: outer, type: 'frame', x: 0, y: 0, props: { w: 1000, h: 1000 } },
+		{ id: mid, type: 'frame', parentId: outer, x: 100, y: 100, props: { w: 500, h: 500 } },
+		{ id: inner, type: 'frame', parentId: mid, x: 100, y: 100, props: { w: 200, h: 200 } },
+	])
+
+	// inner travels with mid and stays under the pointer the whole drag; it must not be taken
+	// for the drop target, or outer never sees mid leave
+	editor.select(mid)
+	editor.pointerDown(250, 250)
+	editor.pointerMove(2000, 2000)
+	vi.advanceTimersByTime(300)
+
+	expect(editor.getShape(mid)!.parentId).toBe(editor.getCurrentPageId())
+	expect(editor.getShape(inner)!.parentId).toBe(mid)
 })
 
 describe('When dragging groups or shapes within a group', () => {


### PR DESCRIPTION
This PR fixes a bug where a frame dragged out of its parent frame, grabbed over one of its own nested children, stayed clipped inside the parent until drop. It also fixes a bug where a child dragged out of a frame and back in did not return to its original z-order.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`getDraggingOverShape` excluded only the dragged shapes themselves from the candidate targets, so a nested child travelling under the pointer was reported as the drop target and the parent frame never saw the drag leave.

`BaseFrameLikeShapeUtil.onDragShapesIn` decided whether the original child indices could be restored by comparing each dragged shape's current page-level index against the frame's remaining children; a shape whose page index happened to collide with a sibling's index blocked the restore.

### After

`getDraggingOverShape` excludes the dragged shapes and all their descendants (via `getShapeAndDescendantIds`), so the parent frame sees the drag leave and unparents the frame.

`onDragShapesIn` compares the stored initial index instead, so a child dragged out and back in lands at its original position among its siblings.

### Change type

- [x] `bugfix`

### Test plan

**Frame dragged out of its parent while grabbed over a nested child**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Draw a large frame, draw a second frame inside it, then draw a third frame inside the second one.
3. Click the middle frame's label to select it, then press in the empty area of the innermost frame (inside the middle frame's selection) and drag the middle frame out past the outer frame's edge.
4. On `main` the middle frame stays clipped inside the outer frame for the whole drag and only pops out on drop. With this PR it leaves the outer frame as soon as the pointer moves outside it.

**Child dragged out of a frame and back in loses its z-order**

1. On http://localhost:5420/develop draw a frame, then draw a rectangle outside the frame.
2. Inside the frame draw three overlapping filled rectangles A, B and C in that order, so B sits between A and C.
3. Drag B out of the frame onto the page and, without releasing, drag it back into the frame over A and C, then release.
4. On `main` B comes back on top of C. With this PR B returns to its original position between A and C.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix dragging a frame out of its parent when grabbed over a nested child, and restore a child's original z-order when dragged back into a frame.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -2    |
| Tests     | +51 / -0   |

