### PR TITLE
fix(editor): groupShapes and ungroupShapes edge cases

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8948,13 +8948,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 				? (shapes as TLShapeId[])
 				: (shapes.map((s) => (s as TLShape).id) as TLShapeId[])
 
-		if (ids.length <= 1) return this
-
 		const shapesToGroup = compact(
 			(this._shouldIgnoreShapeLock ? ids : this._getUnlockedShapeIds(ids)).map((id) =>
 				this.getShape(id)
 			)
 		)
+		// Check the count after dropping locked / missing shapes, otherwise two locked ids get
+		// past this and Box.Common([]) throws below
+		if (shapesToGroup.length <= 1) return this
+
 		const sortedShapeIds = shapesToGroup.sort(sortByIndex).map((s) => s.id)
 		const childBounds = compact(shapesToGroup.map((shape) => this.getShapePageBounds(shape)))
 		const pageBounds = Box.Common(childBounds)
@@ -8967,11 +8969,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const parentId = this.findCommonAncestor(shapesToGroup) ?? this.getCurrentPageId()
 
-		// Only group when the select tool is active
-		if (this.getCurrentToolId() !== 'select') return this
-
-		// If not already in idle, cancel the current interaction (get back to idle)
-		if (!this.isIn('select.idle')) {
+		// If the select tool is mid-interaction, cancel it (get back to idle) before grouping
+		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
 
@@ -8981,6 +8980,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			.sort(sortByIndex)
 
 		const highestIndex = shapesWithRootParent[shapesWithRootParent.length - 1]?.index
+
+		// createShapes bails out when the page is full, so check first; otherwise the shapes get
+		// reparented into a group that was never created and vanish from the page
+		if (!this.canCreateShapes([groupId])) {
+			alertMaxShapes(this)
+			return this
+		}
 
 		this.run(() => {
 			this.createShapes([
@@ -9038,9 +9044,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapesToUngroup.length === 0) return this
 
-		// todo: the editor shouldn't know about the select tool, move to group / ungroup actions
-		if (this.getCurrentToolId() !== 'select') return this
-		if (!this.isIn('select.idle')) {
+		// If the select tool is mid-interaction, cancel it (get back to idle) before ungrouping
+		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
 		}
 
@@ -9063,10 +9068,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (groups.length === 0) return this
 
 		this.run(() => {
-			let group: TLGroupShape
-
 			for (let i = 0, n = groups.length; i < n; i++) {
-				group = groups[i]
+				// Re-read the group: ungrouping an outer group earlier in this loop reparents the
+				// inner ones, and the stale parentId would send their children into a group that's
+				// about to be deleted
+				const group = this.getShape<TLGroupShape>(groups[i].id)
+				if (!group) continue
 				const childIds = this.getSortedChildIdsForParent(group.id)
 
 				for (let j = 0, n = childIds.length; j < n; j++) {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8953,8 +8953,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				this.getShape(id)
 			)
 		)
-		// Check the count after dropping locked / missing shapes, otherwise two locked ids get
-		// past this and Box.Common([]) throws below
+		// Re-check after the lock filter: Box.Common of nothing is not a valid box and would throw
 		if (shapesToGroup.length <= 1) return this
 
 		const sortedShapeIds = shapesToGroup.sort(sortByIndex).map((s) => s.id)
@@ -8969,6 +8968,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const parentId = this.findCommonAncestor(shapesToGroup) ?? this.getCurrentPageId()
 
+		// createShapes bails out when the page is full, so check first; otherwise the shapes get
+		// reparented into a group that was never created and vanish from the page
+		if (!this.canCreateShapes([groupId])) {
+			alertMaxShapes(this)
+			return this
+		}
+
 		// If the select tool is mid-interaction, cancel it (get back to idle) before grouping
 		if (this.isIn('select') && !this.isIn('select.idle')) {
 			this.cancel()
@@ -8980,13 +8986,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			.sort(sortByIndex)
 
 		const highestIndex = shapesWithRootParent[shapesWithRootParent.length - 1]?.index
-
-		// createShapes bails out when the page is full, so check first; otherwise the shapes get
-		// reparented into a group that was never created and vanish from the page
-		if (!this.canCreateShapes([groupId])) {
-			alertMaxShapes(this)
-			return this
-		}
 
 		this.run(() => {
 			this.createShapes([

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -294,6 +294,24 @@ describe('creating groups', () => {
 		editor.groupShapes(editor.getSelectedShapeIds())
 		expect(editor.getSelectedShapeIds().length).toBe(3)
 	})
+	it('works while a tool other than select is active', () => {
+		// e.g. importing content while drawing; the select tool gate belongs to the UI action
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.setCurrentTool('draw')
+		editor.groupShapes([ids.boxA, ids.boxB])
+		const group = editor.getShape(ids.boxA)!.parentId
+		expect(editor.getShape(group)!.type).toBe('group')
+		expect(editor.getShape(ids.boxB)!.parentId).toBe(group)
+		expect(editor.getCurrentToolId()).toBe('draw')
+	})
+	it('does nothing when every shape is locked', () => {
+		editor.createShapes([
+			{ ...box(ids.boxA, 0, 0), isLocked: true },
+			{ ...box(ids.boxB, 20, 0), isLocked: true },
+		])
+		expect(() => editor.groupShapes([ids.boxA, ids.boxB])).not.toThrow()
+		expect(editor.getCurrentPageShapes().length).toBe(2)
+	})
 	it('keeps order correct simple', () => {
 		// 0   10  20  30  40  50  60  70
 		// ┌───┐   ┌───┐   ┌───┐   ┌───┐
@@ -490,6 +508,24 @@ describe('ungrouping shapes', () => {
 		expect(editor.getSelectedShapeIds().length).toBe(2)
 		expect(editor.getShape(groupAId)).not.toBe(undefined)
 		expect(editor.getShape(groupBId)).not.toBe(undefined)
+	})
+	it('ungroups an outer group and its inner group in one call without losing the inner children', () => {
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0), box(ids.boxC, 40, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB])
+		const innerId = onlySelectedId()
+		editor.groupShapes([innerId, ids.boxC])
+		const outerId = onlySelectedId()
+
+		// outer first: its ungrouping reparents inner, so inner's children must follow the live
+		// record rather than inner's stale parentId (the about-to-be-deleted outer)
+		editor.ungroupShapes([outerId, innerId])
+
+		const pageId = editor.getCurrentPageId()
+		expect(editor.getShape(ids.boxA)?.parentId).toBe(pageId)
+		expect(editor.getShape(ids.boxB)?.parentId).toBe(pageId)
+		expect(editor.getShape(ids.boxC)?.parentId).toBe(pageId)
+		expect(editor.getShape(innerId)).toBeUndefined()
+		expect(editor.getShape(outerId)).toBeUndefined()
 	})
 	it('does not work if the scene is in readonly mode', () => {
 		// 0   10  20  30  40  50

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -298,11 +298,15 @@ describe('creating groups', () => {
 		// e.g. importing content while drawing; the select tool gate belongs to the UI action
 		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
 		editor.setCurrentTool('draw')
+		editor.pointerDown(100, 100)
+		editor.pointerMove(120, 120)
+		editor.expectToBeIn('draw.drawing')
 		editor.groupShapes([ids.boxA, ids.boxB])
 		const group = editor.getShape(ids.boxA)!.parentId
 		expect(editor.getShape(group)!.type).toBe('group')
 		expect(editor.getShape(ids.boxB)!.parentId).toBe(group)
-		expect(editor.getCurrentToolId()).toBe('draw')
+		// the in-progress interaction of a non-select tool is left alone
+		editor.expectToBeIn('draw.drawing')
 	})
 	it('does nothing when every shape is locked', () => {
 		editor.createShapes([

--- a/packages/tldraw/src/test/maxShapes.test.ts
+++ b/packages/tldraw/src/test/maxShapes.test.ts
@@ -338,4 +338,24 @@ describe('Maximum shapes behavior', () => {
 			})
 		})
 	})
+
+	describe('groupShapes', () => {
+		it('does not reparent the shapes when the group itself cannot be created', () => {
+			const ids = Array.from({ length: 5 }, (_, i) => createShapeId(`shape-${i}`))
+			editor.createShapes(
+				ids.map((id, i) => ({ id, type: 'geo' as const, x: i * 50, y: 0, props: { w: 40, h: 40 } }))
+			)
+			const maxShapesHandler = vi.fn()
+			editor.addListener('max-shapes', maxShapesHandler)
+
+			editor.groupShapes([ids[0], ids[1]])
+
+			// the group record never existed, so the shapes must stay on the page rather than
+			// being parented to a missing id
+			expect(editor.getShape(ids[0])!.parentId).toBe(editor.getCurrentPageId())
+			expect(editor.getShape(ids[1])!.parentId).toBe(editor.getCurrentPageId())
+			expect(editor.getCurrentPageShapeIds().size).toBe(5)
+			expect(maxShapesHandler).toHaveBeenCalledTimes(1)
+		})
+	})
 })


### PR DESCRIPTION
This PR fixes a bug where `groupShapes` threw when every shape in the selection was locked. It also fixes `groupShapes` orphaning shapes when the page is at its shape limit, `ungroupShapes` deleting the children of a nested group when the outer group is ungrouped first in the same call, and both commands silently doing nothing unless the select tool was active.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `groupShapes` checked the id count before filtering out locked and missing shapes, so two locked ids got through and `Box.Common([])` threw on the empty bounds list.
- `groupShapes` did not check `canCreateShapes`, so at the page shape limit `createShapes` bailed out but the shapes were still reparented into the group that was never created, and vanished from the page.
- `ungroupShapes` reparented each group's children using the group record captured before the loop, so ungrouping an outer group first moved the inner group but its stale `parentId` still pointed at the outer group, which was then deleted along with the inner children.
- Both commands returned early unless `getCurrentToolId()` was `'select'`, so a call made from another tool was ignored.

### After

- The count check runs after filtering, so an all-locked selection is a no-op.
- The max-shapes check runs before anything is written and fires the usual `max-shapes` alert.
- The loop re-reads the live group record, so inner children follow the group to its new parent.
- Both commands work from any tool; if the select tool is mid-interaction it is cancelled back to idle first, as before.

### Implementation notes

Callers that relied on `groupShapes`/`ungroupShapes` being a no-op outside the select tool will now see them take effect; the select-tool gate belongs to the UI actions, not the editor commands.

### Change type

- [x] `bugfix`

### Test plan

**Grouping an all-locked selection throws**

1. Run `yarn dev` and open http://localhost:5420/develop, draw two rectangles and lock both (right-click → Lock).
2. In the devtools console run `editor.groupShapes([...editor.getCurrentPageShapeIds()])`.
3. On `main` this throws `Editor.groupShapes: group bounds are invalid (NaN).`. With this PR it is a no-op and the two shapes stay as they were.

**Grouping at the page shape limit orphans the shapes**

1. On http://localhost:5420/develop draw three rectangles, then in the console run `editor.options.maxShapesPerPage = 3`.
2. Select two of the rectangles and press Ctrl+G / Cmd+G.
3. On `main` the "max shapes" toast appears and the two rectangles vanish from the canvas. With this PR the toast appears and the rectangles stay where they are.

**Ungrouping an outer and inner group in one call deletes the inner children**

1. On http://localhost:5420/develop draw three rectangles A, B and C. Select A and B and press Ctrl+G / Cmd+G, then select that group together with C and press Ctrl+G / Cmd+G again.
2. With the outer group selected, in the console run `const outer = editor.getOnlySelectedShape().id; const inner = editor.getSortedChildIdsForParent(outer).find((id) => editor.getShape(id).type === 'group'); editor.ungroupShapes([outer, inner])`.
3. On `main` A and B are deleted along with the groups. With this PR all three rectangles remain on the page as top-level shapes.

**Group and ungroup do nothing outside the select tool**

1. On http://localhost:5420/develop draw two rectangles and switch to the draw tool (press D).
2. In the console run `editor.groupShapes([...editor.getCurrentPageShapeIds()])`.
3. On `main` nothing happens. With this PR the two rectangles are grouped and the draw tool stays active.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix groupShapes throwing for locked selections or orphaning shapes at the page limit, ungroupShapes deleting nested children, and both commands ignoring calls made outside the select tool.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +20 / -13  |
| Tests     | +56 / -0   |

