### PR TITLE
fix(editor): snapping ignores hidden shapes and label geometry, and gap-snap axis drift

### DIFF
--- a/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/BoundsSnaps.ts
@@ -159,6 +159,22 @@ function findAdjacentGaps(
 	return matches
 }
 
+// Adjacent evenly spaced items produce many center snaps whose gaps cover the
+// same breadth; only the smallest such gap needs showing, so find the one a new
+// gap would be redundant with. Touching breadths don't count as overlapping.
+function findOverlappingCenterSnap(snaps: NearestSnap[], gap: Gap) {
+	return snaps.find(
+		(snap): snap is Extract<NearestSnap, { type: 'gap_center' }> =>
+			snap.type === 'gap_center' &&
+			rangesOverlap(
+				gap.breadthIntersection[0],
+				gap.breadthIntersection[1],
+				snap.gap.breadthIntersection[0],
+				snap.gap.breadthIntersection[1]
+			)
+	)
+}
+
 function dedupeGapSnaps(snaps: Array<Extract<SnapIndicator, { type: 'gaps' }>>) {
 	// sort by descending order of number of gaps
 	snaps.sort((a, b) => b.gaps.length - a.gaps.length)
@@ -597,9 +613,8 @@ export class BoundsSnaps {
 		// which are closest to it in each axis
 		for (const thisSnapPoint of selectionSnapPoints) {
 			for (const otherSnapPoint of otherNodeSnapPoints) {
-				const offset = Vec.Sub(thisSnapPoint, otherSnapPoint)
-				const offsetX = Math.abs(offset.x)
-				const offsetY = Math.abs(offset.y)
+				const offsetX = Math.abs(thisSnapPoint.x - otherSnapPoint.x)
+				const offsetY = Math.abs(thisSnapPoint.y - otherSnapPoint.y)
 
 				if (round(offsetX) <= round(minOffset.x)) {
 					if (round(offsetX) < round(minOffset.x)) {
@@ -718,23 +733,14 @@ export class BoundsSnaps {
 				//              │         │
 				//              └─────────┘
 
-				const otherCenterSnap = nearestSnapsX.find(({ type }) => type === 'gap_center') as
-					| Extract<NearestSnap, { type: 'gap_center' }>
-					| undefined
+				const overlappingCenterSnap = findOverlappingCenterSnap(nearestSnapsX, gap)
 
-				const gapBreadthsOverlap =
-					otherCenterSnap &&
-					rangeIntersection(
-						gap.breadthIntersection[0],
-						gap.breadthIntersection[1],
-						otherCenterSnap.gap.breadthIntersection[0],
-						otherCenterSnap.gap.breadthIntersection[1]
-					)
-
-				// if there is another center snap and it's bigger than this one, and it overlaps with this one, replace it
-				if (otherCenterSnap && otherCenterSnap.gap.length > gap.length && gapBreadthsOverlap) {
-					nearestSnapsX[nearestSnapsX.indexOf(otherCenterSnap)] = snap
-				} else if (!otherCenterSnap || !gapBreadthsOverlap) {
+				// if there is another center snap that overlaps with this one, keep only the smaller gap
+				if (overlappingCenterSnap) {
+					if (overlappingCenterSnap.gap.length > gap.length) {
+						nearestSnapsX[nearestSnapsX.indexOf(overlappingCenterSnap)] = snap
+					}
+				} else {
 					nearestSnapsX.push(snap)
 				}
 			}
@@ -853,26 +859,16 @@ export class BoundsSnaps {
 				//              │         │
 				//              └─────────┘
 
-				const otherCenterSnap = nearestSnapsY.find(({ type }) => type === 'gap_center') as
-					| Extract<NearestSnap, { type: 'gap_center' }>
-					| undefined
+				const overlappingCenterSnap = findOverlappingCenterSnap(nearestSnapsY, gap)
 
-				const gapBreadthsOverlap =
-					otherCenterSnap &&
-					rangesOverlap(
-						otherCenterSnap.gap.breadthIntersection[0],
-						otherCenterSnap.gap.breadthIntersection[1],
-						gap.breadthIntersection[0],
-						gap.breadthIntersection[1]
-					)
-
-				// if there is another center snap and it's bigger than this one, and it overlaps with this one, replace it
-				if (otherCenterSnap && otherCenterSnap.gap.length > gap.length && gapBreadthsOverlap) {
-					nearestSnapsY[nearestSnapsY.indexOf(otherCenterSnap)] = snap
-				} else if (!otherCenterSnap || !gapBreadthsOverlap) {
+				// if there is another center snap that overlaps with this one, keep only the smaller gap
+				if (overlappingCenterSnap) {
+					if (overlappingCenterSnap.gap.length > gap.length) {
+						nearestSnapsY[nearestSnapsY.indexOf(overlappingCenterSnap)] = snap
+					}
+				} else {
 					nearestSnapsY.push(snap)
 				}
-				continue
 			}
 
 			// check for duplication top match

--- a/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/HandleSnaps.ts
@@ -1,7 +1,8 @@
 import { computed } from '@tldraw/state'
 import { TLHandle, TLShape, TLShapeId, VecModel } from '@tldraw/tlschema'
 import { assertExists, uniqueId } from '@tldraw/utils'
-import { Geometry2d } from '../../../primitives/geometry/Geometry2d'
+import { Geometry2d, Geometry2dFilters } from '../../../primitives/geometry/Geometry2d'
+import { Group2d } from '../../../primitives/geometry/Group2d'
 import { Vec } from '../../../primitives/Vec'
 import type { Editor } from '../../Editor'
 import type { PointsSnapIndicator, SnapData, SnapManager } from './SnapManager'
@@ -156,11 +157,21 @@ export class HandleSnaps {
 		let minDistanceForOutline = snapThreshold
 		let nearestPointOnOutline: Vec | null = null
 
+		// Labels and internal detail (a note's label, a geo check mark) are not outlines
+		// to snap to. Group2d.nearestPoint throws when the filter leaves no child, so
+		// skip those groups.
+		const filters = Geometry2dFilters.EXCLUDE_NON_STANDARD
 		for (const { shapeId, outline } of this.iterateSnapOutlines(currentShapeId, handle)) {
+			if (
+				outline instanceof Group2d &&
+				outline.children.every((child) => child.isExcludedByFilter(filters))
+			) {
+				continue
+			}
 			const shapePageTransform = assertExists(this.editor.getShapePageTransform(shapeId))
 			const pointInShapeSpace = this.editor.getPointInShapeSpace(shapeId, handleInPageSpace)
 
-			const nearestShapePointInShapeSpace = outline.nearestPoint(pointInShapeSpace)
+			const nearestShapePointInShapeSpace = outline.nearestPoint(pointInShapeSpace, filters)
 			const nearestInPageSpace = shapePageTransform.applyToPoint(nearestShapePointInShapeSpace)
 
 			if (Vec.DistMin(handleInPageSpace, nearestInPageSpace, minDistanceForOutline)) {

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.test.ts
@@ -78,6 +78,7 @@ describe('SnapManager', () => {
 			getShapePageBounds: vi.fn(),
 			isShapeOfType: vi.fn(),
 			isShapeFrameLike: vi.fn(() => false),
+			isShapeHidden: vi.fn(() => false),
 		} as any
 
 		editor.getShapeUtil.mockReturnValue({
@@ -332,6 +333,18 @@ describe('SnapManager', () => {
 			editor.getShapeUtil.mockReturnValue({
 				canSnap: vi.fn(() => false),
 			} as any)
+
+			const result = snapManager.getSnappableShapes()
+			expect(result.has(shapeId)).toBe(false)
+		})
+
+		it('should exclude hidden shapes', () => {
+			const shapeId = createShapeId('shape1')
+
+			editor.getSortedChildIdsForParent.mockReturnValue([shapeId])
+			editor.getShape.mockReturnValue(createMockShape(shapeId) as any)
+			editor.getShapePageBounds.mockReturnValue(new Box(10, 10, 50, 50))
+			editor.isShapeHidden.mockReturnValue(true)
 
 			const result = snapManager.getSnappableShapes()
 			expect(result.has(shapeId)).toBe(false)

--- a/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
+++ b/packages/editor/src/lib/editor/managers/SnapManager/SnapManager.ts
@@ -65,21 +65,21 @@ export class SnapManager {
 	@computed getSnappableShapes(): Set<TLShapeId> {
 		const { editor } = this
 		const renderingBounds = editor.getViewportPageBounds()
-		const selectedShapeIds = editor.getSelectedShapeIds()
+		const selectedShapeIds = new Set(editor.getSelectedShapeIds())
 
 		const snappableShapes: Set<TLShapeId> = new Set()
 
 		const collectSnappableShapesFromParent = (parentId: TLParentId) => {
 			if (isShapeId(parentId)) {
 				const parent = editor.getShape(parentId)
-				if (parent && editor.isShapeFrameLike(parent)) {
+				if (parent && editor.isShapeFrameLike(parent) && !editor.isShapeHidden(parent)) {
 					snappableShapes.add(parentId)
 				}
 			}
 			const sortedChildIds = editor.getSortedChildIdsForParent(parentId)
 			for (const childId of sortedChildIds) {
 				// Skip any selected ids
-				if (selectedShapeIds.includes(childId)) continue
+				if (selectedShapeIds.has(childId)) continue
 				const childShape = editor.getShape(childId)
 				if (!childShape) continue
 				const util = editor.getShapeUtil(childShape)
@@ -88,11 +88,13 @@ export class SnapManager {
 				// Only consider shapes if they're inside of the viewport page bounds
 				const pageBounds = editor.getShapePageBounds(childId)
 				if (!(pageBounds && renderingBounds.includes(pageBounds))) continue
-				// Snap to children of groups but not group itself
+				// Snap to children of groups but not group itself. A hidden group's
+				// children may still override to visible, so recurse before the check.
 				if (editor.isShapeOfType(childShape, 'group')) {
 					collectSnappableShapesFromParent(childId)
 					continue
 				}
+				if (editor.isShapeHidden(childShape)) continue
 				snappableShapes.add(childId)
 			}
 		}

--- a/packages/tldraw/src/test/customSnapping.test.tsx
+++ b/packages/tldraw/src/test/customSnapping.test.tsx
@@ -353,6 +353,16 @@ describe('custom handle snapping', () => {
 			expect(pagePoint.x).toBeCloseTo(10)
 			expect(pagePoint.y).toBeCloseTo(110)
 		})
+
+		test("doesn't snap to a shape's label geometry", () => {
+			// a note's geometry is its body plus a label rectangle inside it; the label
+			// (50,69 100x62 in shape space here) is not an outline to snap to
+			editor.createShape({ id: createShapeId('note'), type: 'note', x: 400, y: 400 })
+			startDraggingHandle()
+			editor.pointerMove(452, 500, undefined, { ctrlKey: true })
+			expect(editor.snaps.getIndicators()).toHaveLength(0)
+			expect(handlePosition()).toMatchObject({ x: 452, y: 500 })
+		})
 	})
 
 	describe('with empty handleSnapGeometry.outline', () => {

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -1099,6 +1099,63 @@ describe('Snap-between behavior', () => {
 		expect(pointLines[1].points).toHaveLength(6)
 	})
 
+	it('shows both horizontal snap-betweens when their breadths only touch', () => {
+		// ┌───┐       ┌───┐
+		// │ A ├──┼──┤ B │  ┌───┐
+		// ├───┤       ├───┤  │ X │ ◄─── drag
+		// │ C ├──┼──┤ D │  └───┘
+		// └───┘       └───┘
+		// the A-B and C-D gaps share the same span but their breadths only meet at
+		// y=10, which is not an overlap, so neither center snap hides the other
+		editor.createShapes([
+			box(ids.box1, 0, 0),
+			box(ids.box2, 20, 0),
+			box(ids.line1, 0, 10),
+			box(ids.boxD, 20, 10),
+			box(ids.boxX, 50, 0, 4, 20),
+		])
+
+		editor.pointerDown(52, 10, ids.boxX).pointerMove(16, 10, { ctrlKey: true })
+		expect(editor.getShape(ids.boxX)).toMatchObject({ x: 13, y: 0 })
+
+		const { gapLines } = getGapAndPointLines(editor.snaps.getIndicators()!)
+		expect(gapLines).toHaveLength(2)
+		expect(gapLines.map((line) => line.direction)).toEqual(['horizontal', 'horizontal'])
+		expect(gapLines[0].gaps).toHaveLength(2)
+		expect(gapLines[1].gaps).toHaveLength(2)
+	})
+
+	it('shows both vertical snap-betweens when their breadths only touch', () => {
+		// ┌───┬───┐
+		// │ A │ B │
+		// └─┬─┴─┬─┘
+		//   ┼   ┼
+		// ┌─┴─┬─┴─┐
+		// │ C │ D │
+		// └───┴───┘
+		//
+		// ┌───────┐
+		// │   X   │ ◄─── drag
+		// └───────┘
+		// vertical mirror of the horizontal case above; both axes must agree
+		editor.createShapes([
+			box(ids.box1, 0, 0),
+			box(ids.box2, 10, 0),
+			box(ids.line1, 0, 20),
+			box(ids.boxD, 10, 20),
+			box(ids.boxX, 0, 50, 20, 4),
+		])
+
+		editor.pointerDown(10, 52, ids.boxX).pointerMove(10, 16, { ctrlKey: true })
+		expect(editor.getShape(ids.boxX)).toMatchObject({ x: 0, y: 13 })
+
+		const { gapLines } = getGapAndPointLines(editor.snaps.getIndicators()!)
+		expect(gapLines).toHaveLength(2)
+		expect(gapLines.map((line) => line.direction)).toEqual(['vertical', 'vertical'])
+		expect(gapLines[0].gaps).toHaveLength(2)
+		expect(gapLines[1].gaps).toHaveLength(2)
+	})
+
 	it('should not snap horizontally if the shape is larger than the gap', () => {
 		//        ┌─────┐             ┌─────┐
 		//        │     │             │     │


### PR DESCRIPTION
This PR fixes a bug where shapes snapped to hidden shapes and to the label geometry of shapes such as notes, neither of which the user can see or reasonably target. It also fixes gap snapping behaving differently on the horizontal and vertical axes.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`SnapManager.getSnappableShapes` never consulted `isShapeHidden`, so hidden shapes (and hidden frame-like parents) were snap targets. `HandleSnaps` called `outline.nearestPoint` with no geometry filter, so a note's label rectangle counted as an outline to snap a handle to.

In `BoundsSnaps`, the horizontal and vertical center-snap loops had drifted apart: the horizontal loop tested breadth overlap with `rangeIntersection` (touching counts) while the vertical one used `rangesOverlap` (strict); both de-duplicated against only the first existing `gap_center` snap rather than the one that actually overlaps; and the vertical loop ended with a `continue` that skipped the top/bottom duplication checks below it.

### After

`getSnappableShapes` skips hidden shapes and hidden frame-like parents, recursing into groups before the check so a hidden group's visible children still count. `HandleSnaps` passes `Geometry2dFilters.EXCLUDE_NON_STANDARD` to `nearestPoint` and skips groups left with no children by that filter (`Group2d.nearestPoint` throws otherwise).

Both axes share a `findOverlappingCenterSnap` helper with strict breadth overlap, which finds the existing overlapping center snap and keeps only the smaller gap; the stray `continue` is gone so the vertical loop runs the same duplication checks as the horizontal one.

### Implementation notes

Along the way the snap-point distance loop no longer allocates a `Vec` per point pair, and the selected-id check uses a `Set`.

### Change type

- [x] `bugfix`

### Test plan

**Snapping to hidden shapes**

1. Run `yarn dev` and open http://localhost:5420/layer-panel.
2. Draw two rectangles side by side, then click the eye icon next to one of them in the layer panel to hide it.
3. Hold Ctrl (Cmd on Mac) or turn on "Always snap" in the preferences, and drag the visible rectangle slowly past where the hidden one was.
4. On `main` snap guide lines appear aligned with the invisible rectangle and the dragged shape sticks to its edges. With this PR nothing snaps there.

**Handle snapping to label geometry**

1. On http://localhost:5420/develop draw a note, then draw a line shape next to it and select the line.
2. Hold Ctrl (Cmd on Mac) and drag one of the line's vertex handles slowly across the middle of the note.
3. On `main` the handle jumps to an invisible rectangle in the middle of the note (the note's label box) and a snap indicator appears there. With this PR the handle snaps only at the note's outer edge.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Stop snapping to hidden shapes and label geometry, and make gap snapping behave the same on both axes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +51 / -42  |
| Tests     | +23 / -0   |

