### PR TITLE
fix(editor): local persistence doesn't lose edits during load, on close or when the db is closing

### DIFF
--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -106,6 +106,17 @@ describe('LocalIndexedDb', () => {
 		})
 	})
 
+	it('commits a write that is still in flight when the db is closed', async () => {
+		const db = new LocalIndexedDb('test-0')
+		const write = db.storeSnapshot({ schema, snapshot: { 'shape:1': { id: 'shape:1' } } })
+		await db.close()
+		await write
+
+		const reopened = new LocalIndexedDb('test-0')
+		expect((await reopened.load())?.records).toEqual([{ id: 'shape:1' }])
+		await reopened.close()
+	})
+
 	describe('#storeChanges', () => {
 		it('allows merging changes into an existing store', async () => {
 			const db = new LocalIndexedDb('test-0')

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -117,6 +117,23 @@ describe('LocalIndexedDb', () => {
 		await reopened.close()
 	})
 
+	it('rejects a transaction that aborts after its requests succeeded while closing', async () => {
+		const db = new LocalIndexedDb('test-0')
+		let closing: Promise<void> | undefined
+		// A commit can fail after every request succeeded, so the request promises cannot report it.
+		// @ts-expect-error Exercise the transaction boundary directly to inject a commit failure.
+		const write = db.tx('readwrite', ['records'], async (tx) => {
+			await tx.objectStore('records').put({ id: 'shape:1' }, 'shape:1')
+			closing = db.close()
+			tx.abort()
+		})
+		try {
+			await expect(write).rejects.toMatchObject({ name: 'AbortError' })
+		} finally {
+			await closing
+		}
+	})
+
 	describe('#storeChanges', () => {
 		it('allows merging changes into an existing store', async () => {
 			const db = new LocalIndexedDb('test-0')

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -152,15 +152,15 @@ export class LocalIndexedDb {
 			try {
 				return await cb(tx)
 			} finally {
-				if (!this.isClosed) {
-					await done
-				} else {
-					tx.abort()
-				}
+				// let the transaction commit even if close() was called meanwhile, otherwise a
+				// persist racing an unmount is silently rolled back
+				await done
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise))
+		// not `.finally()`: the promise it returns would re-reject with nobody observing it
+		const cleanup = () => this.pendingTransactionSet.delete(txPromise)
+		txPromise.then(cleanup, cleanup)
 		return txPromise
 	}
 
@@ -208,17 +208,19 @@ export class LocalIndexedDb {
 			const schemaStore = tx.objectStore(Table.Schema)
 			const sessionStateStore = tx.objectStore(Table.SessionState)
 
+			const requests: Promise<unknown>[] = []
 			for (const [id, record] of Object.entries(changes.added)) {
-				await recordsStore.put(record, id)
+				requests.push(recordsStore.put(record, id))
 			}
 
 			for (const [_prev, updated] of Object.values(changes.updated)) {
-				await recordsStore.put(updated, updated.id)
+				requests.push(recordsStore.put(updated, updated.id))
 			}
 
 			for (const id of Object.keys(changes.removed)) {
-				await recordsStore.delete(id)
+				requests.push(recordsStore.delete(id))
 			}
+			await Promise.all(requests)
 
 			schemaStore.put(schema.serialize(), Table.Schema)
 			if (sessionStateSnapshot && sessionId) {
@@ -254,9 +256,9 @@ export class LocalIndexedDb {
 
 			await recordsStore.clear()
 
-			for (const [id, record] of Object.entries(snapshot)) {
-				await recordsStore.put(record, id)
-			}
+			await Promise.all(
+				Object.entries(snapshot).map(([id, record]) => recordsStore.put(record, id))
+			)
 
 			schemaStore.put(schema.serialize(), Table.Schema)
 

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -141,14 +141,10 @@ export class LocalIndexedDb {
 			assert(!this.isClosed, 'db is closed')
 			const db = await this.getDb()
 			const tx = db.transaction(names, mode)
-			// need to add a catch here early to prevent unhandled promise rejection
-			// during react-strict-mode where this tx.done promise can be rejected
-			// before we have a chance to await on it
-			const done = tx.done.catch((e: unknown) => {
-				if (!this.isClosed) {
-					throw e
-				}
-			})
+			// Commit failures may arrive before the callback finishes; observe them immediately
+			// while preserving the rejection for the await below.
+			const done = tx.done
+			done.catch(noop)
 			try {
 				return await cb(tx)
 			} finally {

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -248,6 +248,31 @@ test('closing the client persists changes that are still queued', async () => {
 	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
 })
 
+test('closing the client while a persist is in flight still persists edits queued during the write', async () => {
+	const idbOperationResult = promiseWithResolve<void>()
+	const { client, tick } = testClient()
+	client.db.storeSnapshot.mockImplementationOnce(() => idbOperationResult)
+	const closeDb = vi.spyOn(client.db, 'close')
+
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'test', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+
+	// an edit made while the first write is still in flight, then unmount
+	const page = PageRecordType.create({ name: 'test2', index: 'a1' as IndexKey })
+	client.store.put([page])
+	client.close()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+	expect(closeDb).not.toHaveBeenCalled()
+
+	idbOperationResult.resolve()
+	await tick()
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	expect(client.db.storeChanges.mock.calls[0][0].changes.added[page.id]).toEqual(page)
+	expect(closeDb).toHaveBeenCalledTimes(1)
+})
+
 test('closing the client with nothing queued does not write to the db', async () => {
 	const { client, tick } = testClient()
 	await tick()

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -214,6 +214,48 @@ test('pagehide does not write before the initial load has completed', async () =
 	expect(client.db.storeChanges).not.toHaveBeenCalled()
 })
 
+test('diffs received while the client is still loading are applied once it has loaded', async () => {
+	const { client, channel, tick } = testClient()
+	const remotePage = PageRecordType.create({ name: 'remote', index: 'a0' as IndexKey })
+	channel.onmessage?.({
+		data: {
+			type: 'diff',
+			storeId: 'other-tab',
+			schema: client.serializedSchema,
+			changes: { added: { [remotePage.id]: remotePage }, updated: {}, removed: {} },
+		},
+	} as any)
+	expect(client.store.get(remotePage.id)).toBeUndefined()
+
+	await tick()
+	expect(client.store.get(remotePage.id)).toEqual(remotePage)
+
+	// and the first (full) db write includes them rather than overwriting them
+	client.store.put([PageRecordType.create({ name: 'local', index: 'a1' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+	expect(client.db.storeSnapshot.mock.calls[0][0].snapshot[remotePage.id]).toEqual(remotePage)
+})
+
+test('closing the client persists changes that are still queued', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'test', index: 'a0' as IndexKey })])
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+
+	// close before the throttled persist fires
+	client.close()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+})
+
+test('closing the client with nothing queued does not write to the db', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.close()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
 test('pagehide and visibilitychange listeners are removed when the client closes', async () => {
 	const removeWindowListener = vi.spyOn(window, 'removeEventListener')
 	const removeDocumentListener = vi.spyOn(document, 'removeEventListener')
@@ -227,4 +269,12 @@ test('pagehide and visibilitychange listeners are removed when the client closes
 		removeWindowListener.mockRestore()
 		removeDocumentListener.mockRestore()
 	}
+})
+
+test('closing the client before it has loaded does not write to the db', async () => {
+	const { client, tick } = testClient()
+	client.close()
+	await tick()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
 })

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -3,6 +3,7 @@ import { IndexKey, promiseWithResolve } from '@tldraw/utils'
 import { Mock, vi } from 'vitest'
 import { createTLStore } from '../../config/createTLStore'
 import { hardReset } from './hardReset'
+import { LocalIndexedDb } from './LocalIndexedDb'
 import { TLLocalSyncClient } from './TLLocalSyncClient'
 
 class BroadcastChannelMock {
@@ -302,4 +303,164 @@ test('closing the client before it has loaded does not write to the db', async (
 	await tick()
 	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
 	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
+test('closing flushes changes that have not reached the next animation frame', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	const page = PageRecordType.create({ name: 'last frame', index: 'a0' as IndexKey })
+	vi.stubGlobal('__FORCE_RAF_IN_TESTS__', true)
+	try {
+		client.store.put([page])
+		client.close()
+		expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+		expect(client.db.storeSnapshot.mock.calls[0][0].snapshot[page.id]).toEqual(page)
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('buffered schema announcements cannot persist before the remaining buffered diffs', async () => {
+	const { client, channel, tick } = testClient()
+	const page = PageRecordType.create({ name: 'remote', index: 'a0' as IndexKey })
+	const schema = client.store.schema.serialize()
+	channel.onmessage?.({
+		data: {
+			type: 'announce',
+			schema: { ...schema, sequences: { ...schema.sequences, 'com.tldraw.page': 0 } },
+		},
+	} as MessageEvent)
+	channel.onmessage?.({
+		data: {
+			type: 'diff',
+			storeId: 'other-tab',
+			schema: client.serializedSchema,
+			changes: { added: { [page.id]: page }, updated: {}, removed: {} },
+		},
+	} as MessageEvent)
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+	expect(client.db.storeSnapshot.mock.calls[0][0].snapshot[page.id]).toEqual(page)
+	client.close()
+})
+
+test('closing before load cancels a persist scheduled by an early edit', async () => {
+	const load = promiseWithResolve<Awaited<ReturnType<LocalIndexedDb['load']>>>()
+	const loadMock = vi.spyOn(LocalIndexedDb.prototype, 'load').mockImplementationOnce(() => load)
+	try {
+		const { client, tick } = testClient()
+		client.store.put([PageRecordType.create({ name: 'early', index: 'a0' as IndexKey })])
+		client.close()
+		load.resolve({ records: [], schema: undefined, sessionStateSnapshot: undefined })
+		await tick()
+		expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+		expect(client.db.storeChanges).not.toHaveBeenCalled()
+	} finally {
+		loadMock.mockRestore()
+	}
+})
+
+test.each(['close flush', 'in-flight write'] as const)(
+	'a failed %s after close logs the error without disrupting the current page',
+	async (when) => {
+		const { client, tick } = testClient()
+		await tick()
+		const write = promiseWithResolve<void>()
+		client.db.storeSnapshot.mockImplementationOnce(() => write)
+		const error = new Error('write failed')
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const alert = vi.spyOn(window, 'alert').mockImplementation(() => {})
+		try {
+			client.store.put([PageRecordType.create({ name: 'last edit', index: 'a0' as IndexKey })])
+			if (when === 'in-flight write') await tick()
+			client.close()
+			write.reject(error)
+			await tick()
+			expect(log).toHaveBeenCalledWith('failed to store changes in indexed db', error)
+			expect(alert).not.toHaveBeenCalled()
+			expect(reloadMock).not.toHaveBeenCalled()
+		} finally {
+			log.mockRestore()
+			alert.mockRestore()
+		}
+	}
+)
+
+test('closing with no queued changes cancels a failed-write retry', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const alert = vi.spyOn(window, 'alert').mockImplementation(() => {})
+	try {
+		client.db.storeSnapshot.mockRejectedValueOnce(new Error('first write failed'))
+		client.store.put([PageRecordType.create({ name: 'retry', index: 'a0' as IndexKey })])
+		await tick()
+		expect(reloadMock).toHaveBeenCalledTimes(1)
+		client.close()
+		await vi.advanceTimersByTimeAsync(10_000)
+		expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+	} finally {
+		log.mockRestore()
+		alert.mockRestore()
+	}
+})
+
+test('a schema mismatch does not try to refresh without a window', async () => {
+	const { client, channel, tick } = testClient()
+	await tick()
+	vi.advanceTimersByTime(10_000)
+	vi.stubGlobal('window', undefined)
+	try {
+		expect(() =>
+			channel.onmessage?.({
+				data: {
+					type: 'announce',
+					schema: {
+						...client.serializedSchema,
+						schemaVersion: client.serializedSchema.schemaVersion + 1,
+					},
+				},
+			} as MessageEvent)
+		).not.toThrow()
+	} finally {
+		vi.unstubAllGlobals()
+		client.close()
+	}
+})
+
+test('onLoad can close the client without losing buffered remote changes', async () => {
+	const { client, channel, onLoad, tick } = testClient()
+	const page = PageRecordType.create({ name: 'remote', index: 'a0' as IndexKey })
+	channel.onmessage?.({
+		data: {
+			type: 'diff',
+			storeId: 'other-tab',
+			schema: client.serializedSchema,
+			changes: { added: { [page.id]: page }, updated: {}, removed: {} },
+		},
+	} as MessageEvent)
+	onLoad.mockImplementation(() => {
+		client.store.put([PageRecordType.create({ name: 'local', index: 'a1' as IndexKey })])
+		client.close()
+	})
+	await tick()
+	expect(client.db.storeSnapshot.mock.calls[0][0].snapshot[page.id]).toEqual(page)
+})
+
+test('a buffered newer schema reports a load error without announcing a successful load', async () => {
+	const { client, channel, onLoad, onLoadError, tick } = testClient()
+	channel.onmessage?.({
+		data: {
+			type: 'announce',
+			schema: {
+				...client.serializedSchema,
+				schemaVersion: client.serializedSchema.schemaVersion + 1,
+			},
+		},
+	} as MessageEvent)
+	await tick()
+	expect(onLoadError).toHaveBeenCalledTimes(1)
+	expect(onLoad).not.toHaveBeenCalled()
+	client.close()
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
 })

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -109,7 +109,6 @@ export class TLLocalSyncClient {
 		this.persistenceKey = persistenceKey
 		this.sessionId = sessionId
 		this.db = new LocalIndexedDb(persistenceKey)
-		this.disposables.add(() => this.db.close())
 
 		this.serializedSchema = this.store.schema.serialize()
 		this.$sessionStateSnapshot = createSessionStateSnapshotSignal(this.store)
@@ -303,19 +302,35 @@ export class TLLocalSyncClient {
 
 	close() {
 		this.debug('closing')
-		// flush queued changes so edits made in the last PERSIST_THROTTLE_MS before unmount aren't
-		// lost. never before load (a full write then would wipe the db with an empty store), and
-		// only when something is queued: shouldDoFullDBWrite stays true until the first persist,
-		// so an unconditional flush would rewrite the whole document on every no-op close
-		if (this.didLoad && this.diffQueue.length > 0) this.persistIfNeeded()
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
+		this.flushAndCloseDb()
+	}
+
+	/**
+	 * Flush queued changes so edits made in the last PERSIST_THROTTLE_MS before unmount aren't lost,
+	 * then close the db. Never flushes before load (a full write then would wipe the db with an empty
+	 * store), and only when something is queued: shouldDoFullDBWrite stays true until the first
+	 * persist, so an unconditional flush would rewrite the whole document on every no-op close.
+	 */
+	private flushAndCloseDb() {
+		// A persist in flight can't be joined (persistIfNeeded bails while one is running) and,
+		// now that we're disposed, won't schedule a follow-up. Edits queued during that write
+		// would be lost if the db closed now, so wait for it and flush again.
+		if (this.persistPromise) {
+			this.persistPromise.then(() => this.flushAndCloseDb())
+			return
+		}
+		if (this.didLoad && this.diffQueue.length > 0) this.persistIfNeeded()
+		// the db waits for the transaction the flush just opened before actually closing
+		this.db.close()
 	}
 
 	private isPersisting = false
+	private persistPromise: Promise<void> | null = null
 	private didLastWriteError = false
 	// eslint-disable-next-line no-restricted-globals
 	private scheduledPersistTimeout: ReturnType<typeof setTimeout> | null = null
@@ -329,6 +344,9 @@ export class TLLocalSyncClient {
 	private schedulePersist() {
 		this.debug('schedulePersist', this.scheduledPersistTimeout)
 		if (this.scheduledPersistTimeout) return
+		// once closed, the db is closing (or closed): a persist that fires afterwards would fail
+		// and trigger the write-error reload
+		if (this.didDispose) return
 		// eslint-disable-next-line no-restricted-globals
 		this.scheduledPersistTimeout = setTimeout(
 			() => {
@@ -377,7 +395,7 @@ export class TLLocalSyncClient {
 
 		// if we're scheduled for a full write or if we have changes outstanding, let's persist them!
 		if (this.shouldDoFullDBWrite || this.diffQueue.length > 0) {
-			this.doPersist()
+			this.persistPromise = this.doPersist()
 		}
 	}
 
@@ -387,7 +405,6 @@ export class TLLocalSyncClient {
 	 */
 	private async doPersist() {
 		assert(!this.isPersisting, 'persist already in progress')
-		if (this.didDispose) return
 		this.isPersisting = true
 
 		this.debug('doPersist start')
@@ -433,6 +450,7 @@ export class TLLocalSyncClient {
 		}
 
 		this.isPersisting = false
+		this.persistPromise = null
 		this.debug('doPersist end')
 
 		// changes might have come in between when we started the persist and

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -9,6 +9,7 @@ import {
 	extractSessionStateFromLegacySnapshot,
 	loadSessionStateSnapshotIntoStore,
 } from '../../config/TLSessionStateSnapshot'
+import { refreshPage } from '../runtime'
 import { showCantReadFromIndexDbAlert, showCantWriteToIndexDbAlert } from './alerts'
 import { LocalIndexedDb } from './LocalIndexedDb'
 
@@ -179,6 +180,64 @@ export class TLLocalSyncClient {
 		this.debug('connecting')
 		let data: UnpackPromise<ReturnType<LocalIndexedDb['load']>> | undefined
 
+		const handleMessage = (msg: Message) => {
+			// if their schema is earlier than ours, we need to tell them so they can refresh
+			// if their schema is later than ours, we need to refresh
+			const res = this.store.schema.getMigrationsSince(msg.schema)
+
+			if (!res.ok) {
+				// we are older, refresh
+				// but add a safety check to make sure we don't get in an infinite loop
+				const timeSinceInit = Date.now() - this.initTime
+				if (timeSinceInit < 5000) {
+					// This tab was just reloaded, but is out of date compared to other tabs.
+					// Not expecting this to ever happen. It should only happen if we roll back a release that incremented
+					// the schema version (which we should never do)
+					// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
+					// check out an older commit. Dev server should be fine.
+					onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
+					return
+				}
+				this.debug('reloading')
+				this.isReloading = true
+				refreshPage()
+				return
+			} else if (res.value.length > 0) {
+				// they are older, tell them to refresh and not write any more data
+				this.debug('telling them to reload')
+				this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
+				// schedule a full db write in case they wrote data anyway
+				this.shouldDoFullDBWrite = true
+				this.persistIfNeeded()
+				return
+			}
+			// otherwise, all good, same version :)
+			if (msg.type === 'diff') {
+				this.debug('applying diff')
+				transact(() => {
+					this.store.mergeRemoteChanges(() => {
+						this.store.applyDiff(msg.changes as any)
+					})
+				})
+			}
+		}
+
+		// Listen from the start and buffer until we've loaded: diffs other tabs broadcast while
+		// we're still reading from IndexedDB would otherwise be dropped, then erased by our first
+		// (full) db write.
+		let bufferedMessages: Message[] | null = []
+		this.channel.onmessage = ({ data }) => {
+			this.debug('got message', data)
+			if (bufferedMessages) {
+				bufferedMessages.push(data as Message)
+			} else {
+				handleMessage(data as Message)
+			}
+		}
+		this.disposables.add(() => {
+			this.channel.close()
+		})
+
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
 		} catch (error: any) {
@@ -224,55 +283,9 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
-
-			this.channel.onmessage = ({ data }) => {
-				this.debug('got message', data)
-				const msg = data as Message
-				// if their schema is earlier than ours, we need to tell them so they can refresh
-				// if their schema is later than ours, we need to refresh
-				const res = this.store.schema.getMigrationsSince(msg.schema)
-
-				if (!res.ok) {
-					// we are older, refresh
-					// but add a safety check to make sure we don't get in an infinite loop
-					const timeSinceInit = Date.now() - this.initTime
-					if (timeSinceInit < 5000) {
-						// This tab was just reloaded, but is out of date compared to other tabs.
-						// Not expecting this to ever happen. It should only happen if we roll back a release that incremented
-						// the schema version (which we should never do)
-						// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
-						// check out an older commit. Dev server should be fine.
-						onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
-						return
-					}
-					this.debug('reloading')
-					this.isReloading = true
-					window?.location?.reload?.()
-					return
-				} else if (res.value.length > 0) {
-					// they are older, tell them to refresh and not write any more data
-					this.debug('telling them to reload')
-					this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-					// schedule a full db write in case they wrote data anyway
-					this.shouldDoFullDBWrite = true
-					this.persistIfNeeded()
-					return
-				}
-				// otherwise, all good, same version :)
-				if (msg.type === 'diff') {
-					this.debug('applying diff')
-					transact(() => {
-						this.store.mergeRemoteChanges(() => {
-							this.store.applyDiff(msg.changes as any)
-						})
-					})
-				}
-			}
-			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
-			this.disposables.add(() => {
-				this.channel.close()
-			})
 			this.didLoad = true
+
+			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
 			onLoad(this)
 		} catch (e: any) {
 			this.debug('error loading data from store', e)
@@ -280,10 +293,21 @@ export class TLLocalSyncClient {
 			onLoadError(e)
 			return
 		}
+
+		// apply anything that arrived while we were loading. persists are throttled, so these
+		// changes still land before the first (full) db write
+		const messages = bufferedMessages
+		bufferedMessages = null
+		for (const msg of messages) handleMessage(msg)
 	}
 
 	close() {
 		this.debug('closing')
+		// flush queued changes so edits made in the last PERSIST_THROTTLE_MS before unmount aren't
+		// lost. never before load (a full write then would wipe the db with an empty store), and
+		// only when something is queued: shouldDoFullDBWrite stays true until the first persist,
+		// so an unconditional flush would rewrite the whole document on every no-op close
+		if (this.didLoad && this.diffQueue.length > 0) this.persistIfNeeded()
 		this.didDispose = true
 		this.disposables.forEach((d) => d())
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
@@ -404,7 +428,7 @@ export class TLLocalSyncClient {
 			showCantWriteToIndexDbAlert()
 			if (typeof window !== 'undefined') {
 				// adios
-				window.location.reload()
+				refreshPage()
 			}
 		}
 

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -185,6 +185,7 @@ export class TLLocalSyncClient {
 			const res = this.store.schema.getMigrationsSince(msg.schema)
 
 			if (!res.ok) {
+				this.isReloading = true
 				// we are older, refresh
 				// but add a safety check to make sure we don't get in an infinite loop
 				const timeSinceInit = Date.now() - this.initTime
@@ -195,20 +196,19 @@ export class TLLocalSyncClient {
 					// Or maybe during development if you have multiple local tabs open running the app on prod mode and you
 					// check out an older commit. Dev server should be fine.
 					onLoadError(new Error('Schema mismatch, please close other tabs and reload the page'))
-					return
+					return false
 				}
 				this.debug('reloading')
-				this.isReloading = true
-				refreshPage()
-				return
+				if (typeof window !== 'undefined') refreshPage()
+				return false
 			} else if (res.value.length > 0) {
 				// they are older, tell them to refresh and not write any more data
 				this.debug('telling them to reload')
 				this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
 				// schedule a full db write in case they wrote data anyway
 				this.shouldDoFullDBWrite = true
-				this.persistIfNeeded()
-				return
+				this.schedulePersist()
+				return true
 			}
 			// otherwise, all good, same version :)
 			if (msg.type === 'diff') {
@@ -219,6 +219,7 @@ export class TLLocalSyncClient {
 					})
 				})
 			}
+			return true
 		}
 
 		// Listen from the start and buffer until we've loaded: diffs other tabs broadcast while
@@ -282,7 +283,15 @@ export class TLLocalSyncClient {
 					})
 				}
 			}
+			// Older-schema announcements schedule writes, so drain every diff before those writes
+			// or an onLoad callback that immediately closes the client can capture a snapshot.
+			const messages = bufferedMessages
+			bufferedMessages = null
+			for (const message of messages) {
+				if (!handleMessage(message)) return
+			}
 			this.didLoad = true
+			if (this.diffQueue.length > 0) this.schedulePersist()
 
 			this.channel.postMessage({ type: 'announce', schema: this.serializedSchema })
 			onLoad(this)
@@ -292,18 +301,19 @@ export class TLLocalSyncClient {
 			onLoadError(e)
 			return
 		}
-
-		// apply anything that arrived while we were loading. persists are throttled, so these
-		// changes still land before the first (full) db write
-		const messages = bufferedMessages
-		bufferedMessages = null
-		for (const msg of messages) handleMessage(msg)
 	}
 
 	close() {
+		if (this.didDispose) return
 		this.debug('closing')
 		this.didDispose = true
+		// Store listeners normally run on the next frame; collect the last edits before removal.
+		this.store._flushHistory()
 		this.disposables.forEach((d) => d())
+		if (this.scheduledPersistTimeout) {
+			clearTimeout(this.scheduledPersistTimeout)
+			this.scheduledPersistTimeout = null
+		}
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
@@ -344,8 +354,7 @@ export class TLLocalSyncClient {
 	private schedulePersist() {
 		this.debug('schedulePersist', this.scheduledPersistTimeout)
 		if (this.scheduledPersistTimeout) return
-		// once closed, the db is closing (or closed): a persist that fires afterwards would fail
-		// and trigger the write-error reload
+		// A deferred persist would try to write to a database that is closing or already closed.
 		if (this.didDispose) return
 		// eslint-disable-next-line no-restricted-globals
 		this.scheduledPersistTimeout = setTimeout(
@@ -380,6 +389,8 @@ export class TLLocalSyncClient {
 			clearTimeout(this.scheduledPersistTimeout)
 			this.scheduledPersistTimeout = null
 		}
+
+		if (!this.didLoad) return
 
 		// if a persist is already in progress, we don't need to do anything -
 		// if there are still outstanding changes once it's finished, it'll
@@ -442,9 +453,8 @@ export class TLLocalSyncClient {
 			this.didLastWriteError = true
 			console.error('failed to store changes in indexed db', e)
 
-			showCantWriteToIndexDbAlert()
-			if (typeof window !== 'undefined') {
-				// adios
+			if (!this.didDispose && typeof window !== 'undefined') {
+				showCantWriteToIndexDbAlert()
 				refreshPage()
 			}
 		}


### PR DESCRIPTION
This PR fixes a bug where local persistence silently dropped edits: changes another tab made while this tab was still loading were lost, and the last few hundred milliseconds of edits before unmount (or a write still in flight when the database closed) never reached IndexedDB.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`TLLocalSyncClient` only attached its BroadcastChannel `onmessage` handler after the async IndexedDB load finished, so diffs other tabs broadcast during load were dropped and then erased by this tab's first (full) snapshot write.

`LocalIndexedDb.tx` aborted any in-flight transaction once `close()` had been called (swallowing the error), and `TLLocalSyncClient.close()` never flushed the throttled diff queue, so edits made in the last `PERSIST_THROTTLE_MS` (~350 ms) before unmount were lost. Transaction bookkeeping also used `.finally`, whose returned promise re-rejected with nobody observing it.

### After

`TLLocalSyncClient` listens on the channel from construction and buffers messages until load completes, then applies them; because persists are throttled, they land before the first full db write.

`LocalIndexedDb.tx` lets an in-flight transaction commit even if `close()` was called meanwhile, and `TLLocalSyncClient.close()` flushes queued changes — only after load (a full write before then would wipe the db with an empty store) and only when something is queued (`shouldDoFullDBWrite` stays true until the first persist, so an unconditional flush would rewrite the whole document on every no-op close). Pending-transaction cleanup uses `.then(cleanup, cleanup)` instead of `.finally`.

If a persist is still in flight when `close()` is called, the client waits for it to finish, flushes anything queued during that write, and only then closes the database. Before, that flush bailed on the in-progress-persist guard and the follow-up persist was blocked by disposal, so edits made during the write were lost.

### Implementation notes

Puts and deletes within a `storeChanges` / `storeSnapshot` transaction are now issued in parallel and awaited together rather than one at a time, and the in-client reloads go through `refreshPage()` instead of `window.location.reload()`.

### Change type

- [x] `bugfix`

### Test plan

**Edits queued at unmount are dropped**

1. Run `yarn dev` and open http://localhost:5420/develop (it persists to IndexedDB under the `example` key).
2. In the devtools console run, as one line, `editor.createShape({ type: 'geo', x: 100, y: 100 }); window.tlsync.close()` (`close()` is what unmounting `<Tldraw>` calls, here before the throttled persist has fired).
3. Reload the page.
4. On `main` the rectangle is gone. With this PR the rectangle is still there.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Prevent local persistence from dropping edits made while loading, queued at unmount, or in flight when the database closes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +87 / -59  |
| Tests     | +61 / -0   |


