### PR TITLE
fix(editor): keep edges of oversized hollow shapes hittable and use the shared margin for selected shapes

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5844,14 +5844,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getSelectedShapeAtPoint(point: VecLike): TLShape | undefined {
 		const selectedShapeIds = this.getSelectedShapeIds()
-		const margin = this.options.hitTestMargin / this.getZoomLevel()
+		if (selectedShapeIds.length === 0) return undefined
+		const selectedShapeIdSet = new Set(selectedShapeIds)
+		const margin = this.getHitTestMargin()
 		const sortedShapes = this.getCurrentPageShapesSorted()
 
 		// iterate from the top (highest z-index) to find the top-most matching shape
 		for (let i = sortedShapes.length - 1; i >= 0; i--) {
 			const shape = sortedShapes[i]
 			if (shape.type === 'group') continue
-			if (!selectedShapeIds.includes(shape.id)) continue
+			if (!selectedShapeIdSet.has(shape.id)) continue
 			if (
 				this.getShapeGeometry(shape).hitTestPoint(
 					this.getPointInShapeSpace(shape, point),
@@ -6022,9 +6024,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// other hits would be occluded by the shape.
 						return inMarginClosestToEdgeHit || shape
 					} else {
-						// If the shape is bigger than the viewport, then skip it.
-						if (this.getShapePageBounds(shape)!.contains(viewportPageBounds)) continue
-
 						// If we're close to the edge of the shape, and if it's the closest edge among
 						// all the edges that we've gotten close to so far, then we will want to hit the
 						// shape unless we hit something else or closer in later iterations.
@@ -6045,6 +6044,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 								inMarginClosestToEdgeHit = shape
 							}
 						} else if (!inMarginClosestToEdgeHit) {
+							// If the shape is bigger than the viewport, then skip it. (Only here: its
+							// edges should still be hittable within the margin.)
+							if (this.getShapePageBounds(shape)!.contains(viewportPageBounds)) continue
+
 							// If we're not within margin distance to any edge, and if the
 							// shape is hollow, then we want to hit the shape with the
 							// smallest area. (There's a bug here with self-intersecting
@@ -6063,6 +6066,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// If the distance is less than the margin, return the shape as the hit.
 				// Use the editor's configurable hit test margin.
 				if (distance < this.getHitTestMargin()) {
+					// An edge we already hit (above this shape) that is at least as close still wins,
+					// matching the closest-edge rule used for hollow shapes
+					if (inMarginClosestToEdgeHit && inMarginClosestToEdgeDistance <= distance) {
+						return inMarginClosestToEdgeHit
+					}
 					return shape
 				}
 			}

--- a/packages/tldraw/src/test/getShapeAtPoint.test.ts
+++ b/packages/tldraw/src/test/getShapeAtPoint.test.ts
@@ -255,3 +255,34 @@ describe('frame-like shapes with a plain geometry', () => {
 		expect(editor.getShapeAtPoint({ x: 98, y: 150 }, { margin: 4 })?.id).toBe(ids.frame1)
 	})
 })
+
+describe('shapes bigger than the viewport', () => {
+	beforeEach(() => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapes())
+	})
+
+	it('hits the edge of a hollow shape whose bounds contain the viewport', () => {
+		editor.createShape({
+			id: ids.box1,
+			type: 'geo',
+			x: -1000,
+			y: -1000,
+			props: { w: 5000, h: 5000 },
+		})
+		// on the left edge
+		expect(editor.getShapeAtPoint({ x: -1000, y: 500 })?.id).toBe(ids.box1)
+		// but its empty interior must still miss, since the pointer is "inside" it everywhere
+		expect(editor.getShapeAtPoint({ x: 500, y: 500 })?.id).toBe(undefined)
+	})
+
+	it('hits the body of an arrow whose bounds contain the viewport', () => {
+		editor.createShape({
+			id: ids.box1,
+			type: 'arrow',
+			x: -1000,
+			y: -1000,
+			props: { start: { x: 0, y: 0 }, end: { x: 5000, y: 5000 } },
+		})
+		expect(editor.getShapeAtPoint({ x: 0, y: 0 }, { margin: 4 })?.id).toBe(ids.box1)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where clicking the stroke of an arrow or the edge of a hollow shape did nothing while zoomed in far enough that the shape's bounds contained the viewport. It also makes `getSelectedShapeAtPoint` use the shared hit-test margin.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`getShapeAtPoint` skipped any hollow closed geometry whose page bounds contained the viewport before testing its edges, so an oversized arrow or hollow geo could not be hit at all. An open shape within the margin was also returned immediately, beating a higher-z hollow edge that had already been hit at least as close.

`getSelectedShapeAtPoint` computed its own margin from `options.hitTestMargin / zoom` (ignoring the coarse-pointer adjustment) and checked membership with `selectedShapeIds.includes` inside the z-order loop.

### After

The bigger-than-viewport skip applies only to the hollow-interior fallback, so edges stay hittable within the margin while the empty interior still misses. An open shape within the margin now loses to an already-hit hollow edge that is at least as close, matching the closest-edge rule used for hollow shapes.

`getSelectedShapeAtPoint` uses `getHitTestMargin()` and a `Set` of selected ids, returning early when nothing is selected.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420.
2. Press `R` and draw a rectangle that fills most of the screen (the default geo fill is hollow), then press Escape to deselect it.
3. Zoom in (Cmd+scroll or pinch) with the pointer over the rectangle's left edge until the other three edges are off-screen, so the shape's bounds contain the viewport, and click the left edge.
4. On `main` nothing is selected: the rectangle is skipped entirely once it is bigger than the viewport. With this PR clicking the edge selects it, while clicking the empty interior still selects nothing.
5. Repeat with a long diagonal arrow: draw it, zoom in on its middle until both ends are off-screen, and click the stroke. On `main` nothing is selected; with this PR the arrow is selected.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix selecting arrows and hollow shapes that are larger than the viewport by clicking their edges.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -5   |
| Tests     | +31 / -0   |
