### PR TITLE
fix(editor): respect shape locks in animateShapes and ancestor locks in delete/duplicate/group

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8848,6 +8848,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const animations: ShapeAnimation[] = []
 
+		// Snapshot the lock override now: when this animation is started inside
+		// editor.run(..., { ignoreShapeLock: true }), run() restores the flag before any tick
+		// fires, so the final updateShapes below would refuse the locked shape and strand it
+		const ignoreShapeLock = this._shouldIgnoreShapeLock
+
 		let partial: TLShapePartial | null | undefined, result: ShapeAnimation
 		for (let i = 0, n = partials.length; i < n; i++) {
 			partial = partials[i]
@@ -8860,7 +8865,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// _updateShapes, which doesn't check locks, so a locked shape would otherwise be moved by
 			// every frame but the last and end up stranded at the penultimate one
 			const unlocks = shape.isLocked && Object.hasOwn(partial, 'isLocked') && !partial.isLocked
-			if (!this._shouldIgnoreShapeLock && !unlocks && this.isShapeOrAncestorLocked(shape)) {
+			if (!ignoreShapeLock && !unlocks && this.isShapeOrAncestorLocked(shape)) {
 				continue
 			}
 
@@ -8884,7 +8889,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				if (partialsToUpdate.length) {
 					// the regular update shapes also removes the shape from
 					// the animating shapes set
-					this.updateShapes(partialsToUpdate)
+					this.run(() => this.updateShapes(partialsToUpdate), { ignoreShapeLock })
 				}
 
 				this.off('tick', handleTick)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8856,6 +8856,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shape = this.getShape(partial.id)!
 			if (!shape) continue
 
+			// Apply the same lock rule as updateShapes up front: the intermediate frames go through
+			// _updateShapes, which doesn't check locks, so a locked shape would otherwise be moved by
+			// every frame but the last and end up stranded at the penultimate one
+			const unlocks = shape.isLocked && Object.hasOwn(partial, 'isLocked') && !partial.isLocked
+			if (!this._shouldIgnoreShapeLock && !unlocks && this.isShapeOrAncestorLocked(shape)) {
+				continue
+			}
+
 			result = {
 				start: structuredClone(shape),
 				end: applyPartialToRecordWithProps(structuredClone(shape), partial),
@@ -9193,7 +9201,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/** @internal */
 	private _getUnlockedShapeIds(ids: TLShapeId[]): TLShapeId[] {
-		return ids.filter((id) => !this.getShape(id)?.isLocked)
+		// Match updateShapes, which also refuses shapes under a locked ancestor; otherwise a child
+		// of a locked frame can't be moved but can still be deleted or duplicated
+		return ids.filter((id) => !this.isShapeOrAncestorLocked(id))
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2241,10 +2241,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			parentToSelectWithinId = this.getCurrentPageId()
 		}
 
-		// Select all the unlocked shapes within the parent
+		// Select all the unlocked shapes within the parent. Only the shape's own lock matters here:
+		// selecting inside a locked frame or group is allowed, mutating is not.
 		const ids = this.getSortedChildIdsForParent(parentToSelectWithinId)
 		if (ids.length <= 0) return this
-		this.setSelectedShapes(this._getUnlockedShapeIds(ids))
+		this.setSelectedShapes(ids.filter((id) => !this.getShape(id)?.isLocked))
 		return this
 	}
 
@@ -8968,6 +8969,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 				this.getShape(id)
 			)
 		)
+		// Re-check after the lock filter: Box.Common of nothing is not a valid box and would throw
+		if (shapesToGroup.length <= 1) return this
+
 		const sortedShapeIds = shapesToGroup.sort(sortByIndex).map((s) => s.id)
 		const childBounds = compact(shapesToGroup.map((shape) => this.getShapePageBounds(shape)))
 		const pageBounds = Box.Common(childBounds)

--- a/packages/tldraw/src/test/commands/animateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/animateShapes.test.ts
@@ -1,3 +1,33 @@
-export {}
+import { createShapeId } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { TestEditor } from '../TestEditor'
 
-it.todo('Editor.animateToShape')
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+vi.useFakeTimers()
+
+it('animates a shape to its new position', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0 })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+	editor.emit('tick', 50)
+	expect(editor.getShape(id)).toMatchObject({ x: 50, y: 50 })
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 100, y: 100 })
+})
+
+it('does not move locked shapes', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, isLocked: true })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+	// the intermediate frames must respect the lock too, otherwise the shape is moved by every
+	// frame but the last and ends up stranded just short of the target
+	editor.emit('tick', 50)
+	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+})

--- a/packages/tldraw/src/test/commands/animateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/animateShapes.test.ts
@@ -31,3 +31,20 @@ it('does not move locked shapes', () => {
 	editor.emit('tick', 60)
 	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
 })
+
+it('moves a locked shape all the way when the lock is ignored', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, isLocked: true })
+	editor.run(
+		() => {
+			editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+		},
+		{ ignoreShapeLock: true }
+	)
+	editor.emit('tick', 50)
+	expect(editor.getShape(id)).toMatchObject({ x: 50, y: 50 })
+	// run() has restored the lock setting by the time the final frame lands, so the final update
+	// must remember that this animation was allowed to move the locked shape
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 100, y: 100, isLocked: true })
+})

--- a/packages/tldraw/src/test/commands/animateShapes.test.ts
+++ b/packages/tldraw/src/test/commands/animateShapes.test.ts
@@ -48,3 +48,25 @@ it('moves a locked shape all the way when the lock is ignored', () => {
 	editor.emit('tick', 60)
 	expect(editor.getShape(id)).toMatchObject({ x: 100, y: 100, isLocked: true })
 })
+
+it('does not move a child of a locked frame', () => {
+	const frameId = createShapeId('frame')
+	const id = createShapeId('box')
+	editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, isLocked: true })
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, parentId: frameId })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100 }], { animation: { duration: 100 } })
+	editor.emit('tick', 50)
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+})
+
+it('moves a locked shape when the animation unlocks it', () => {
+	const id = createShapeId('box')
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, isLocked: true })
+	editor.animateShapes([{ id, type: 'geo', x: 100, y: 100, isLocked: false }], {
+		animation: { duration: 100 },
+	})
+	editor.emit('tick', 50)
+	editor.emit('tick', 60)
+	expect(editor.getShape(id)).toMatchObject({ x: 100, y: 100, isLocked: false })
+})

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -153,6 +153,22 @@ describe('Locked shapes', () => {
 	})
 })
 
+describe('Children of locked shapes', () => {
+	it('Can be selected with select all', () => {
+		editor.select(ids.groupedBoxA)
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.groupedBoxA, ids.groupedBoxB])
+	})
+
+	it('Cannot be grouped, without throwing', () => {
+		const shapeCount = editor.getCurrentPageShapes().length
+
+		expect(() => editor.groupShapes([ids.groupedBoxA, ids.groupedBoxB])).not.toThrow()
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
+		expect(editor.getShape(ids.groupedBoxA)!.parentId).toBe(ids.lockedGroup)
+	})
+})
+
 describe('Unlocking', () => {
 	it('Can unlock shapes', () => {
 		editor.setSelectedShapes([ids.lockedShapeA, ids.lockedShapeB])

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -167,6 +167,50 @@ describe('Children of locked shapes', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
 		expect(editor.getShape(ids.groupedBoxA)!.parentId).toBe(ids.lockedGroup)
 	})
+
+	it('Cannot be deleted', () => {
+		const shapeCount = editor.getCurrentPageShapes().length
+		editor.deleteShapes([ids.groupedBoxA])
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
+		expect(editor.getShape(ids.groupedBoxA)).toBeDefined()
+	})
+
+	it('Cannot be duplicated', () => {
+		const shapeCount = editor.getCurrentPageShapes().length
+		editor.duplicateShapes([ids.groupedBoxA])
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
+	})
+
+	it('Cannot be ungrouped', () => {
+		const innerGroup = createShapeId('innerGroup')
+		editor.createShapes([
+			{ id: innerGroup, type: 'group', parentId: ids.lockedGroup },
+			{ id: createShapeId('innerBox'), type: 'geo', parentId: innerGroup, x: 1000, y: 1000 },
+		])
+		expect(editor.getShape(innerGroup)).toBeDefined()
+
+		editor.ungroupShapes([innerGroup])
+		expect(editor.getShape(innerGroup)).toBeDefined()
+		expect(editor.getShape(createShapeId('innerBox'))!.parentId).toBe(innerGroup)
+	})
+
+	it('Can be deleted, duplicated and grouped when forced', () => {
+		editor.run(
+			() => {
+				const shapeCount = editor.getCurrentPageShapes().length
+				editor.duplicateShapes([ids.groupedBoxA])
+				expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
+
+				editor.groupShapes([ids.groupedBoxA, ids.groupedBoxB])
+				expect(editor.getShape(ids.groupedBoxA)!.parentId).not.toBe(ids.lockedGroup)
+				expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 2)
+
+				editor.deleteShapes([ids.groupedBoxA])
+				expect(editor.getShape(ids.groupedBoxA)).toBeUndefined()
+			},
+			{ ignoreShapeLock: true }
+		)
+	})
 })
 
 describe('Unlocking', () => {


### PR DESCRIPTION
This PR fixes a bug where `animateShapes` moved a locked shape, dragging it along every frame and leaving it stranded just short of the target. It also fixes a bug where a child of a locked frame could not be moved but could still be deleted, duplicated, grouped or ungrouped.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`animateShapes` pushed every intermediate frame through `_updateShapes`, which has no lock check, and only the final frame through `updateShapes`, which refused the locked shape — so the shape was moved by every frame but the last and stranded at the penultimate one.

`_getUnlockedShapeIds` (used by delete, duplicate, group and ungroup) only looked at a shape's own `isLocked`, while `updateShapes` also refuses shapes under a locked ancestor, so the two disagreed for children of locked frames.

### After

`animateShapes` filters out locked and ancestor-locked shapes before the animation starts, applying the same rule as `updateShapes` (including the "unlocking" exception and `_shouldIgnoreShapeLock`).

`_getUnlockedShapeIds` uses `isShapeOrAncestorLocked`, so delete, duplicate, group and ungroup share `updateShapes`' ancestor-lock semantics.

### Implementation notes

The ancestor-lock change is a behaviour change for API callers that relied on being able to delete or duplicate children of locked frames.

### Change type

- [x] `bugfix`

### Test plan

**`animateShapes` moves locked shapes**

1. Run `yarn dev` and open http://localhost:5420/shape-animation.
2. Select one of the shapes and press Shift+L to lock it.
3. Click "Animate multiple shapes" (it animates every shape on the page).
4. On `main` the locked shape scatters along with the others. With this PR the locked shape stays where it is while the unlocked shapes move.

**Children of locked frames can be deleted or duplicated**

1. On http://localhost:5420, press `F` and draw a frame, then press `R` and draw a rectangle inside it.
2. Click the frame's title to select the frame and press Shift+L to lock it.
3. Click the rectangle inside the frame to select it (it can't be dragged), then press Delete; also try Cmd+D.
4. On `main` the rectangle is deleted (or duplicated) even though its parent frame is locked. With this PR Delete and Cmd+D do nothing to the child of a locked frame.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Stop animateShapes from moving locked shapes and apply ancestor-lock semantics to delete, duplicate, group and ungroup.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -1   |
| Tests     | +32 / -2   |
