### PR TITLE
fix(editor): editing-shape history, cropping cleanup, erasing ids and the collaboration-mode reaction

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -72,6 +72,7 @@ import {
 	Result,
 	ZERO_INDEX_KEY,
 	annotateError,
+	areArraysShallowEqual,
 	assert,
 	assertExists,
 	bind,
@@ -545,6 +546,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				nextPageState.editingShapeId = null
 			}
 
+			if (
+				prevPageState.croppingShapeId &&
+				shapesNoLongerInPage.has(prevPageState.croppingShapeId)
+			) {
+				if (!nextPageState) nextPageState = { ...prevPageState }
+				nextPageState.croppingShapeId = null
+			}
+
 			const hintingShapeIds = prevPageState.hintingShapeIds.filter(
 				(id) => !shapesNoLongerInPage.has(id)
 			)
@@ -938,7 +947,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const mode = this.store.props.collaboration.mode
 			this.disposables.add(
 				react('update collaboration mode', () => {
-					this.store.put([{ ...this.getInstanceState(), isReadonly: mode.get() === 'readonly' }])
+					const isReadonly = mode.get() === 'readonly'
+					// only track `mode`, and keep the sync out of the user's undo history
+					unsafe__withoutCapture(() =>
+						this._updateInstanceState({ isReadonly }, { history: 'ignore' })
+					)
 				})
 			)
 		}
@@ -2796,57 +2809,38 @@ export class Editor extends EventEmitter<TLEventMap> {
 	setEditingShape(shape: TLShapeId | TLShape | null): this {
 		const id = typeof shape === 'string' ? shape : (shape?.id ?? null)
 
-		if (!id) {
-			// setting the editing shape to null
+		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
+		if (id && !this.canEditShape(id)) return this
+
+		this.run(() => {
+			// Clean up the previous editing shape. This runs outside the history-ignored batch below,
+			// otherwise document changes made by onEditEnd (e.g. deleting an empty text shape) are
+			// never recorded and leave a phantom undo entry whose redo resurrects the shape.
+			const prevEditingShapeId = this.getEditingShapeId()
+			if (prevEditingShapeId) {
+				const prevEditingShape = this.getShape(prevEditingShapeId)
+				if (prevEditingShape) {
+					this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
+				}
+			}
+
 			this.run(
 				() => {
-					// Clean up the previous editing shape
-					const prevEditingShapeId = this.getEditingShapeId()
-					if (prevEditingShapeId) {
-						const prevEditingShape = this.getShape(prevEditingShapeId)
-						if (prevEditingShape) {
-							this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-						}
-					}
-
 					// Clean up the editing shape state and rich text editor
 					this._updateCurrentPageState({ editingShapeId: null })
 					this._currentRichTextEditor.set(null)
+
+					if (!id) return
+
+					this.select(id)
+					this._updateCurrentPageState({ editingShapeId: id })
+
+					const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
+					this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
 				},
 				{ history: 'ignore' }
 			)
-
-			return this
-		}
-
-		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
-		if (!this.canEditShape(id)) return this
-
-		// id was provided and the next editing shape is editable, so set the rich text editor to null
-		this.run(
-			() => {
-				// Clean up the previous editing shape
-				const prevEditingShapeId = this.getEditingShapeId()
-				if (prevEditingShapeId) {
-					const prevEditingShape = this.getShape(prevEditingShapeId)
-					if (prevEditingShape) {
-						this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-					}
-				}
-
-				// Clean up the editing shape state and rich text editor
-				this._updateCurrentPageState({ editingShapeId: null })
-				this._currentRichTextEditor.set(null)
-
-				// Set the new editing shape
-				this.select(id)
-				this._updateCurrentPageState({ editingShapeId: id })
-
-				const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
-				this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
-			},
-			{ history: 'ignore' }
-		)
+		})
 
 		return this
 	}
@@ -3011,26 +3005,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setErasingShapes(shapes: TLShapeId[] | TLShape[]): this {
+		// copy before sorting: the caller may pass a store-owned (frozen) array
 		const ids =
 			typeof shapes[0] === 'string'
-				? (shapes as TLShapeId[])
+				? (shapes as TLShapeId[]).slice()
 				: (shapes as TLShape[]).map((shape) => shape.id)
 		ids.sort() // sort the incoming ids
 		const erasingShapeIds = this.getErasingShapeIds()
 		this.run(
 			() => {
-				if (ids.length === erasingShapeIds.length) {
-					// if the new ids are the same length as the current ids, they might be the same.
-					// presuming the current ids are also sorted, check each item to see if it's the same;
-					// if we find any unequal, then we know the new ids are different.
-					for (let i = 0; i < ids.length; i++) {
-						if (ids[i] !== erasingShapeIds[i]) {
-							this._updateCurrentPageState({ erasingShapeIds: ids })
-							break
-						}
-					}
-				} else {
-					// if the ids are a different length, then we know they're different.
+				// the current ids are also sorted, so a shallow comparison tells us whether they changed
+				if (!areArraysShallowEqual(ids, erasingShapeIds)) {
 					this._updateCurrentPageState({ erasingShapeIds: ids })
 				}
 			},

--- a/packages/editor/src/lib/hooks/usePeerIds.ts
+++ b/packages/editor/src/lib/hooks/usePeerIds.ts
@@ -1,4 +1,5 @@
 import { useComputed, useValue } from '@tldraw/state-react'
+import { areArraysShallowEqual } from '@tldraw/utils'
 import { uniq } from '../utils/uniq'
 import { useEditor } from './useEditor'
 
@@ -17,7 +18,7 @@ export function usePeerIds() {
 	const $userIds = useComputed(
 		'userIds',
 		() => uniq(editor.getVisibleCollaborators().map((p) => p.userId)).sort(),
-		{ isEqual: (a, b) => a.join(',') === b.join?.(',') },
+		{ isEqual: areArraysShallowEqual },
 		[editor]
 	)
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -55,6 +55,24 @@ describe(TextShapeTool, () => {
 			props: { richText: toRichText('Hello') },
 		})
 	})
+
+	it('Records the deletion of an empty text shape so redo cannot resurrect it', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown(0, 0)
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+
+		// Exiting without typing deletes the empty shape (TextShapeUtil.onEditEnd)
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		// The creation and the deletion squash to nothing, so neither undo nor redo brings it back
+		editor.undo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.redo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
 })
 
 describe('When selecting the tool', () => {

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -913,6 +913,9 @@ describe('instance.isReadonly', () => {
 		expect(editor.getIsReadonly()).toBe(false)
 		mode.set('readonly')
 		expect(editor.getIsReadonly()).toBe(true)
+
+		// syncing the mode is not a user edit, so it must not show up in the undo history
+		expect(editor.getCanUndo()).toBe(false)
 	})
 })
 

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -286,6 +286,17 @@ describe('When in the crop.idle state', () => {
 			.expectToBeIn('select.idle')
 	})
 
+	it('deleting the cropping shape clears the cropping shape id and leaves crop mode', () => {
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.deleteShapes([ids.imageB])
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('pointing the canvas should point canvas', () => {
 		editor
 			.expectToBeIn('select.idle')


### PR DESCRIPTION
This PR fixes a bug where exiting an empty text shape left a phantom undo entry whose redo resurrected the deleted shape. It also fixes the editor staying in crop mode pointing at a shape that had been deleted, `setErasingShapes` throwing when passed a store-owned (frozen) array, and the collaboration-mode readonly sync polluting the user's undo history.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `setEditingShape` called the previous editing shape's `onEditEnd` inside a `history: 'ignore'` batch, so the deletion `TextShapeUtil.onEditEnd` performs on an empty shape was never recorded; the creation stayed in history on its own.
- `cleanupInstancePageState` cleared `editingShapeId`, hinting and erasing ids for deleted shapes but not `croppingShapeId`, so deleting the cropping shape left the editor in crop mode with a missing shape.
- `setErasingShapes` sorted its input array in place, which throws on a frozen store-owned array, and compared it to the current ids with a hand-rolled loop.
- The `update collaboration mode` reaction did `store.put` on the whole instance state, tracking every instance-state field and recording the write in history.

### After

- `setEditingShape` runs `onEditEnd` in an outer `run` before the history-ignored batch, so the deletion is recorded and squashes with the creation; neither undo nor redo brings the shape back.
- `cleanupInstancePageState` also clears `croppingShapeId` when the cropping shape leaves the page, so the editor returns to `select.idle`.
- `setErasingShapes` copies the ids before sorting and compares with `areArraysShallowEqual`; `usePeerIds` uses the same helper for its `isEqual`.
- The reaction calls `_updateInstanceState({ isReadonly }, { history: 'ignore' })` inside `unsafe__withoutCapture`, so it tracks only `mode` and leaves undo history untouched.

### Change type

- [x] `bugfix`

### Test plan

**Phantom undo entry for an empty text shape**

1. Run `yarn dev` and open http://localhost:5420.
2. Press `T` for the text tool and click once on the canvas, then press Escape without typing anything. The empty text shape is deleted.
3. Press Cmd+Z, then Cmd+Shift+Z (redo).
4. On `main` redo resurrects the empty text shape: `editor.getCurrentPageShapes().length` in the devtools console is `1` and Cmd+A shows a selection box around an invisible shape. With this PR the page stays empty after both undo and redo.

**Deleting the cropping shape leaves the editor in crop mode**

1. On http://localhost:5420, drop or paste an image onto the canvas and double-click it to enter crop mode.
2. Press Delete to delete the image while cropping.
3. On `main` `editor.getPath()` in the devtools console still reports `select.crop.idle` and `editor.getCroppingShapeId()` returns the deleted id, so clicking another image drops straight into crop mode on it. With this PR the editor returns to `select.idle` and the cropping id is cleared.

**`setErasingShapes` throws on a store-owned array**

1. On http://localhost:5420, draw a shape and select it.
2. In the devtools console run `editor.setErasingShapes(editor.getSelectedShapeIds())` (the selected ids array is frozen in dev builds).
3. On `main` the call throws `TypeError: Cannot assign to read only property '0'` from the in-place sort. With this PR it succeeds and the shape is marked as erasing.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Record onEditEnd changes in history, leave crop mode when the cropping shape is deleted, stop setErasingShapes mutating its input, and keep collaboration-mode syncs out of undo history.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +44 / -58  |
| Tests     | +32 / -0   |
