### PR TITLE
fix(editor): keep new scribbles alive until their first point and stop allocating an idle timer per frame

### DIFF
--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -52,6 +52,7 @@ interface Session {
 	state: 'active' | 'stopping' | 'complete'
 	options: Required<Omit<ScribbleSessionOptions, 'id'>>
 	idleTimeoutHandle?: number
+	idleDeadline: number
 	fadeElapsed: number
 	totalPointsAtFadeStart: number
 }
@@ -86,6 +87,7 @@ export class ScribbleManager {
 				fadeEasing: options.fadeEasing ?? (options.fadeMode === 'grouped' ? 'ease-in' : 'linear'),
 				fadeDurationMs: options.fadeDurationMs ?? this.editor.options.laserFadeoutMs,
 			},
+			idleDeadline: 0,
 			fadeElapsed: 0,
 			totalPointsAtFadeStart: 0,
 		}
@@ -400,11 +402,26 @@ export class ScribbleManager {
 
 	// ==================== PRIVATE HELPERS ====================
 
+	// Called on every pointer move and laser tick, so keep one pending timer per
+	// session and re-arm it only when it fires early. Otherwise every call leaves a
+	// timer id behind in editor.timers for the editor's lifetime.
 	private resetIdleTimeout(session: Session): void {
-		this.clearIdleTimeout(session)
+		session.idleDeadline = Date.now() + session.options.idleTimeoutMs
+		if (session.idleTimeoutHandle === undefined) {
+			this.armIdleTimeout(session, session.options.idleTimeoutMs)
+		}
+	}
+
+	private armIdleTimeout(session: Session, delay: number): void {
 		session.idleTimeoutHandle = this.editor.timers.setTimeout(() => {
-			this.stopSession(session.id)
-		}, session.options.idleTimeoutMs)
+			session.idleTimeoutHandle = undefined
+			const remaining = session.idleDeadline - Date.now()
+			if (remaining > 0) {
+				this.armIdleTimeout(session, remaining)
+			} else {
+				this.stopSession(session.id)
+			}
+		}, delay)
 	}
 
 	private clearIdleTimeout(session: Session): void {
@@ -444,10 +461,13 @@ export class ScribbleManager {
 			}
 		}
 
-		// Remove completed items in individual fade mode
+		// Remove faded-out items in individual fade mode. A scribble that has not
+		// received its first point yet is also empty but must stay, otherwise the
+		// session is dropped before the tool gets to add a point.
 		if (session.options.fadeMode === 'individual') {
 			for (let i = session.items.length - 1; i >= 0; i--) {
-				if (session.items[i].scribble.points.length === 0) {
+				const { scribble } = session.items[i]
+				if (scribble.points.length === 0 && scribble.state === 'stopping') {
 					session.items.splice(i, 1)
 				}
 			}

--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -461,13 +461,15 @@ export class ScribbleManager {
 			}
 		}
 
-		// Remove faded-out items in individual fade mode. A scribble that has not
-		// received its first point yet is also empty but must stay, otherwise the
-		// session is dropped before the tool gets to add a point.
+		// Remove empty items in individual fade mode. A starting scribble that has
+		// not received its first point yet is also empty but must stay, otherwise
+		// the session is dropped before the tool gets to add a point. Empty items in
+		// any other state (completed or stopped before drawing) would keep the
+		// session alive forever, since the tick handlers never touch them again.
 		if (session.options.fadeMode === 'individual') {
 			for (let i = session.items.length - 1; i >= 0; i--) {
 				const { scribble } = session.items[i]
-				if (scribble.points.length === 0 && scribble.state === 'stopping') {
+				if (scribble.points.length === 0 && scribble.state !== 'starting') {
 					session.items.splice(i, 1)
 				}
 			}

--- a/packages/tldraw/src/test/ScribbleManager.test.ts
+++ b/packages/tldraw/src/test/ScribbleManager.test.ts
@@ -360,6 +360,16 @@ describe('ScribbleManager', () => {
 				expect(editor.getInstanceState().scribbles).toEqual([])
 				expect(editor.scribbles.isSessionActive(sessionId)).toBe(false)
 			})
+
+			it('keeps a scribble that has not received its first point yet', () => {
+				// An empty starting scribble used to be spliced on the first tick, dropping
+				// the session before the tool could add a point
+				const item = editor.scribbles.addScribble({})
+
+				editor.scribbles.tick(16)
+
+				expect(() => editor.scribbles.addPoint(item.id, 0, 0)).not.toThrow()
+			})
 		})
 	})
 

--- a/packages/tldraw/src/test/ScribbleManager.test.ts
+++ b/packages/tldraw/src/test/ScribbleManager.test.ts
@@ -370,6 +370,17 @@ describe('ScribbleManager', () => {
 
 				expect(() => editor.scribbles.addPoint(item.id, 0, 0)).not.toThrow()
 			})
+
+			it('removes a scribble that is completed before its first point', () => {
+				const sessionId = editor.scribbles.startSession({ selfConsume: false })
+				const item = editor.scribbles.addScribbleToSession(sessionId, {})
+
+				editor.scribbles.complete(item.id)
+				editor.scribbles.tick(16)
+
+				expect(editor.scribbles.isSessionActive(sessionId)).toBe(false)
+				expect(() => editor.scribbles.addPoint(item.id, 0, 0)).toThrow()
+			})
 		})
 	})
 


### PR DESCRIPTION
This PR fixes a bug where a scribble added in a tool's `onEnter` disappeared after one idle frame if the tool only fed it points on pointer move, so later `addPoint`/`stop` calls threw. It also fixes the laser tool leaking an editor timer per frame.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`tickSessionItems` in individual fade mode removed every item with no points, which included a freshly added scribble that had not received its first point yet, so the session was dropped before the tool could draw.

`resetIdleTimeout` cleared and created a new `editor.timers.setTimeout` on every call; the laser tool calls it once per frame, so the timers registry grew for the editor's lifetime.

### After

`tickSessionItems` keeps empty items whose scribble is still `starting`, so a new scribble stays alive until its first point. Empty items in any other state (completed or stopped before drawing) are still removed, so they cannot keep a session alive forever.

`resetIdleTimeout` records an `idleDeadline` per session and keeps a single pending timer; when the timer fires early it re-arms for the remaining time, otherwise it stops the session.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420 and open the browser devtools console (the examples app exposes `window.editor`).
2. Run `const s = editor.scribbles.addScribble({})` to start a scribble without giving it a point yet, as a custom tool's `onEnter` would.
3. Wait a moment (at least one animation frame), then run `editor.scribbles.addPoint(s.id, 100, 100)`.
4. On `main` the call throws `Scribble with id … not found` because the empty scribble was dropped on the first tick. With this PR the call returns the scribble item and the point is added.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix scribbles being dropped before their first point and the laser pointer leaking a timer per frame.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -5   |
| Tests     | +21 / -0   |

