### PR TITLE
fix(editor): export embedding of multi-url styles, font lists, failed fetches and bare @import rules

### DIFF
--- a/packages/editor/src/lib/exports/FontEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.test.ts
@@ -1,0 +1,30 @@
+import { FontEmbedder } from './FontEmbedder'
+
+describe('FontEmbedder', () => {
+	let style: HTMLStyleElement
+
+	beforeEach(() => {
+		style = document.createElement('style')
+		style.textContent = `
+			@font-face { font-family: 'Font A'; src: url('/font-a.woff2'); }
+			@font-face { font-family: 'Font B'; src: url('/font-b.woff2'); }
+		`
+		document.head.appendChild(style)
+	})
+
+	afterEach(() => {
+		style.remove()
+	})
+
+	it('embeds every family in a font-family list, even when an earlier one was already seen', async () => {
+		const embedder = new FontEmbedder()
+		embedder.startFindingDocumentFontFaces(document)
+
+		embedder.onFontFamilyValue(`'Font A'`)
+		embedder.onFontFamilyValue(`'Font A', 'Font B'`)
+
+		const css = await embedder.createCss()
+		expect(css).toContain('Font A')
+		expect(css).toContain('Font B')
+	})
+})

--- a/packages/editor/src/lib/exports/FontEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.test.ts
@@ -1,4 +1,6 @@
-import { FontEmbedder } from './FontEmbedder'
+import { vi } from 'vitest'
+import { fetchCssFontFaces, FontEmbedder } from './FontEmbedder'
+import { parseCssFontFaces } from './parseCss'
 
 describe('FontEmbedder', () => {
 	let style: HTMLStyleElement
@@ -26,5 +28,49 @@ describe('FontEmbedder', () => {
 		const css = await embedder.createCss()
 		expect(css).toContain('Font A')
 		expect(css).toContain('Font B')
+	})
+
+	it('retries a failed font fetch on the next export', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		// the parsed sheet is shared across exports through the fetch cache
+		const fontFaces = parseCssFontFaces(
+			`@font-face { font-family: 'Font A'; src: url(a.woff2); }`,
+			'https://example.com/fonts.css'
+		)
+		const blob = new Blob(['font'], { type: 'font/woff2' })
+		vi.spyOn(window, 'fetch')
+			.mockResolvedValueOnce({ ok: false } as Response)
+			.mockResolvedValue({ ok: true, blob: async () => blob } as Response)
+
+		const exportCss = async () => {
+			const embedder = new FontEmbedder()
+			embedder.startFindingDocumentFontFaces(document)
+			;(embedder as any).fontFacesPromise = Promise.resolve(fontFaces)
+			embedder.onFontFamilyValue(`'Font A'`)
+			return embedder.createCss()
+		}
+
+		expect(await exportCss()).toContain('url(a.woff2)')
+		expect(await exportCss()).toContain('data:font/woff2;base64,')
+	})
+})
+
+describe('fetchCssFontFaces', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('resolves when stylesheets @import each other', async () => {
+		const sheets: Record<string, string> = {
+			'https://example.com/a.css': `@import url(b.css); @font-face { font-family: 'Font A'; src: url(a.woff2); }`,
+			'https://example.com/b.css': `@import url(a.css); @font-face { font-family: 'Font B'; src: url(b.woff2); }`,
+		}
+		vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
+			const url = String(input)
+			return { ok: true, url, text: async () => sheets[url] } as Response
+		})
+
+		const fontFaces = await fetchCssFontFaces('https://example.com/a.css')
+		expect(fontFaces.map((f) => [...f.fontFamilies])).toEqual([['font a'], ['font b']])
 	})
 })

--- a/packages/editor/src/lib/exports/FontEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.test.ts
@@ -73,4 +73,27 @@ describe('fetchCssFontFaces', () => {
 		const fontFaces = await fetchCssFontFaces('https://example.com/a.css')
 		expect(fontFaces.map((f) => [...f.fontFamilies])).toEqual([['font a'], ['font b']])
 	})
+
+	it('keeps font order in source order when siblings import the same sheet', async () => {
+		const sheets: Record<string, string> = {
+			'https://example.com/root.css': `@import url(c.css); @import url(d.css);`,
+			'https://example.com/c.css': `@import url(e.css); @font-face { font-family: 'Font C'; src: url(c.woff2); }`,
+			'https://example.com/d.css': `@import url(e.css); @font-face { font-family: 'Font D'; src: url(d.woff2); }`,
+			'https://example.com/e.css': `@font-face { font-family: 'Font E'; src: url(e.woff2); }`,
+		}
+		vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
+			const url = String(input)
+			// the first sibling resolves last, so the shared sheet is reached through the second first
+			if (url.endsWith('c.css')) await new Promise((resolve) => setTimeout(resolve, 20))
+			return { ok: true, url, text: async () => sheets[url] } as Response
+		})
+
+		const fontFaces = await fetchCssFontFaces('https://example.com/root.css')
+		expect(fontFaces.map((f) => [...f.fontFamilies][0])).toEqual([
+			'font c',
+			'font e',
+			'font d',
+			'font e',
+		])
+	})
 })

--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -36,7 +36,7 @@ export class FontEmbedder {
 
 		const fonts = parseCssFontFamilyValue(fontFamilyValue)
 		for (const font of fonts) {
-			if (this.foundFontNames.has(font)) return
+			if (this.foundFontNames.has(font)) continue
 			this.foundFontNames.add(font)
 
 			this.pendingPromises.push(

--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -133,7 +133,9 @@ const fetchParsedCss = fetchCache(async (response: Response) => {
 /** @internal */
 export async function fetchCssFontFaces(
 	url: string,
-	// sheets that @import each other would otherwise await their own in-flight fetch forever
+	// the chain of sheets that imported this one: sheets that @import each other would otherwise
+	// await their own in-flight fetch forever. Each branch gets its own copy so a sheet imported by
+	// two siblings lands under both in source order, not under whichever fetch resolved first.
 	seen = new Set<string>()
 ): Promise<ParsedFontFace[]> {
 	if (seen.has(url)) return []
@@ -143,7 +145,7 @@ export async function fetchCssFontFaces(
 	if (!parsed) return []
 
 	const importedFontFaces = await Promise.all(
-		parsed.importUrls.map((importUrl) => fetchCssFontFaces(importUrl, seen))
+		parsed.importUrls.map((importUrl) => fetchCssFontFaces(importUrl, new Set(seen)))
 	)
 	return [...parsed.fontFaces, ...importedFontFaces.flat()]
 }

--- a/packages/editor/src/lib/exports/FontEmbedder.ts
+++ b/packages/editor/src/lib/exports/FontEmbedder.ts
@@ -24,6 +24,9 @@ export class FontEmbedder {
 	private fontFacesPromise: Promise<ParsedFontFace[]> | null = null
 	private readonly foundFontNames = new Set<string>()
 	private readonly fontFacesToEmbed = new Set<ParsedFontFace>()
+	// per export, keyed by resolved url: parsed font faces are shared across exports through the
+	// fetch cache, so a failed fetch stored on them would never be retried
+	private readonly embeddedUrls = new Map<string, Promise<string | null>>()
 	private readonly pendingPromises: Promise<void>[] = []
 
 	startFindingDocumentFontFaces(doc: Document) {
@@ -47,9 +50,9 @@ export class FontEmbedder {
 
 						this.fontFacesToEmbed.add(fontFace)
 						for (const url of fontFace.urls) {
-							if (!url.resolved || url.embedded) continue
+							if (!url.resolved || this.embeddedUrls.has(url.resolved)) continue
 							// kick off fetching this font
-							url.embedded = resourceToDataUrl(url.resolved)
+							this.embeddedUrls.set(url.resolved, resourceToDataUrl(url.resolved))
 						}
 					}
 				})
@@ -66,11 +69,11 @@ export class FontEmbedder {
 			let fontFaceString = `@font-face {${fontFace.fontFace}}`
 
 			for (const url of fontFace.urls) {
-				if (!url.embedded) continue
-				const dataUrl = await url.embedded
+				if (!url.resolved) continue
+				const dataUrl = await this.embeddedUrls.get(url.resolved)
 				if (!dataUrl) continue
 
-				fontFaceString = fontFaceString.replace(url.original, dataUrl)
+				fontFaceString = fontFaceString.replace(url.original, () => dataUrl)
 			}
 
 			css += fontFaceString
@@ -119,12 +122,28 @@ async function getDocumentFontFaces(doc: Document) {
 	return compact(await Promise.all(fontFaces)).flat()
 }
 
-const fetchCssFontFaces = fetchCache(async (response: Response): Promise<ParsedFontFace[]> => {
+const fetchParsedCss = fetchCache(async (response: Response) => {
 	const parsed = parseCss(await response.text(), response.url)
+	return {
+		fontFaces: parsed.fontFaces,
+		importUrls: parsed.imports.map(({ url }) => new URL(url, response.url).href),
+	}
+})
+
+/** @internal */
+export async function fetchCssFontFaces(
+	url: string,
+	// sheets that @import each other would otherwise await their own in-flight fetch forever
+	seen = new Set<string>()
+): Promise<ParsedFontFace[]> {
+	if (seen.has(url)) return []
+	seen.add(url)
+
+	const parsed = await fetchParsedCss(url)
+	if (!parsed) return []
 
 	const importedFontFaces = await Promise.all(
-		parsed.imports.map(({ url }) => fetchCssFontFaces(new URL(url, response.url).href))
+		parsed.importUrls.map((importUrl) => fetchCssFontFaces(importUrl, seen))
 	)
-
-	return [...parsed.fontFaces, ...compact(importedFontFaces).flat()]
-})
+	return [...parsed.fontFaces, ...importedFontFaces.flat()]
+}

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -92,10 +92,18 @@ export class StyleEmbedder {
 					if (urlMatches.length === 0) continue
 
 					promises.push(
-						...urlMatches.map(async ({ url, original }) => {
-							const dataUrl = (await resourceToDataUrl(url)) ?? 'data:'
-							styles[property] = value.replace(original, `url("${dataUrl}")`)
-						})
+						(async () => {
+							// resolve every url first, then rewrite the value in one pass - replacing
+							// per-url from the original value would keep only the last replacement
+							const dataUrls = await Promise.all(
+								urlMatches.map(({ url }) => resourceToDataUrl(url))
+							)
+							styles[property] = urlMatches.reduce(
+								(result, { original }, i) =>
+									result.replace(original, `url("${dataUrls[i] ?? 'data:'}")`),
+								value
+							)
+						})()
 					)
 				}
 			}

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -94,13 +94,14 @@ export class StyleEmbedder {
 					promises.push(
 						(async () => {
 							// resolve every url first, then rewrite the value in one pass - replacing
-							// per-url from the original value would keep only the last replacement
+							// per-url from the original value would keep only whichever resolved last.
+							// The replacer callback keeps `$` in a data url's mime segment literal.
 							const dataUrls = await Promise.all(
 								urlMatches.map(({ url }) => resourceToDataUrl(url))
 							)
 							styles[property] = urlMatches.reduce(
 								(result, { original }, i) =>
-									result.replace(original, `url("${dataUrls[i] ?? 'data:'}")`),
+									result.replace(original, () => `url("${dataUrls[i] ?? 'data:'}")`),
 								value
 							)
 						})()

--- a/packages/editor/src/lib/exports/fetchCache.test.ts
+++ b/packages/editor/src/lib/exports/fetchCache.test.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest'
+import { fetchCache } from './fetchCache'
+
+describe('fetchCache', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('caches successes but retries after a failure', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		const fetchSpy = vi
+			.spyOn(window, 'fetch')
+			.mockResolvedValueOnce({ ok: false } as Response)
+			.mockResolvedValue({ ok: true, text: async () => 'hello' } as Response)
+		const fetchText = fetchCache((response) => response.text())
+
+		expect(await fetchText('https://example.com/a')).toBe(null)
+		expect(await fetchText('https://example.com/a')).toBe('hello')
+		expect(await fetchText('https://example.com/a')).toBe('hello')
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+	})
+})

--- a/packages/editor/src/lib/exports/fetchCache.ts
+++ b/packages/editor/src/lib/exports/fetchCache.ts
@@ -18,6 +18,10 @@ export function fetchCache<T>(cb: (response: Response) => Promise<T>, init?: Req
 			}
 		})()
 		cache.set(url, promise)
+		// only keep successes, otherwise a transient failure poisons this url for the whole session
+		promise.then((result) => {
+			if (result === null && cache.get(url) === promise) cache.delete(url)
+		})
 		return promise
 	}
 }

--- a/packages/editor/src/lib/exports/parseCss.test.ts
+++ b/packages/editor/src/lib/exports/parseCss.test.ts
@@ -120,6 +120,10 @@ test('parseCss', () => {
 		  ],
 		  "imports": [
 		    {
+		      "extras": "",
+		      "url": "https://example.com/font.css",
+		    },
+		    {
 		      "extras": " screen and (min-width: 900px)",
 		      "url": "thing.css",
 		    },

--- a/packages/editor/src/lib/exports/parseCss.ts
+++ b/packages/editor/src/lib/exports/parseCss.ts
@@ -18,7 +18,7 @@ export interface ParsedFontFace {
 // Parse @import declarations:
 // https://developer.mozilla.org/en-US/docs/Web/CSS/@import#formal_syntax
 const importsRegex =
-	/@import\s+(?:"([^"]+)"|'([^']+)'|url\s*\(\s*(?:"([^"]+)"|'([^']+)'|([^'")]+))\s*\))([^;]+);/gi
+	/@import\s+(?:"([^"]+)"|'([^']+)'|url\s*\(\s*(?:"([^"]+)"|'([^']+)'|([^'")]+))\s*\))([^;]*);/gi
 
 // Locate @font-face declarations:
 const fontFaceRegex = /@font-face\s*{([^}]+)}/gi

--- a/packages/editor/src/lib/exports/parseCss.ts
+++ b/packages/editor/src/lib/exports/parseCss.ts
@@ -2,7 +2,7 @@ import { safeParseUrl } from '@tldraw/utils'
 
 export interface ParsedFontFace {
 	fontFace: string
-	urls: { original: string; resolved: string | null; embedded?: Promise<string | null> }[]
+	urls: { original: string; resolved: string | null }[]
 	fontFamilies: Set<string>
 }
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -274,6 +274,8 @@ export function lns(str: string): string;
 export class LruCache<K, V> {
     constructor(maxSize: number);
     // (undocumented)
+    delete(key: K): boolean;
+    // (undocumented)
     get(key: K): undefined | V;
     // (undocumented)
     has(key: K): boolean;

--- a/packages/utils/src/lib/LruCache.test.ts
+++ b/packages/utils/src/lib/LruCache.test.ts
@@ -19,6 +19,18 @@ describe('LruCache', () => {
 		expect(cache.size).toBe(2)
 	})
 
+	it('delete() removes an entry and frees its slot', () => {
+		const cache = new LruCache<string, number>(2)
+		cache.set('a', 1)
+		cache.set('b', 2)
+		expect(cache.delete('a')).toBe(true)
+		expect(cache.delete('a')).toBe(false)
+		expect(cache.has('a')).toBe(false)
+		cache.set('c', 3)
+		expect(cache.get('b')).toBe(2)
+		expect(cache.size).toBe(2)
+	})
+
 	it('has() checks existence without promoting', () => {
 		const cache = new LruCache<string, number>(2)
 		cache.set('a', 1)

--- a/packages/utils/src/lib/LruCache.ts
+++ b/packages/utils/src/lib/LruCache.ts
@@ -25,6 +25,10 @@ export class LruCache<K, V> {
 		return this.map.has(key)
 	}
 
+	delete(key: K): boolean {
+		return this.map.delete(key)
+	}
+
 	// eslint-disable-next-line tldraw/no-setter-getter
 	get size(): number {
 		return this.map.size


### PR DESCRIPTION
This PR fixes a bug where exported SVGs and PNGs could be missing resources and fonts they referenced. It also fixes a transient fetch failure permanently blocking that resource from later exports, `@import` rules without a media list never being followed, and stylesheets that `@import` each other hanging the export.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `StyleEmbedder` resolved each `url()` in a CSS value independently and replaced it into the original string, so when a value had several URLs only the one that resolved last survived.
- `FontEmbedder.onFontFamilyValue` used `return` instead of `continue` when a family had already been seen, so every later family in a `font-family` list was skipped.
- `fetchCache` cached `null` results, so one failed fetch poisoned that URL for the rest of the session.
- `FontEmbedder` stored each font file's embedding promise on the `ParsedFontFace` objects that the fetch cache shares across exports, so a failed font fetch was never retried on a later export even once the fetch cache had let go of it.
- `parseCss`'s `@import` regex required a media list after the URL, so bare `@import url(...)` rules never matched.
- `fetchCssFontFaces` recursed through imports with no cycle guard. With bare imports followed, `a.css` → `b.css` → `a.css` made the cached promises await each other and the export never finished.

### After

- `StyleEmbedder` resolves every URL first and rewrites the value in one pass, through a replacer callback so a `$` in a data URL is not read as a replacement pattern.
- `FontEmbedder` skips only the already-seen family and continues through the list.
- `fetchCache` evicts a `null` result so the next call retries; this adds `LruCache.delete` in `@tldraw/utils`.
- `FontEmbedder` keeps font embedding promises per export, so the next export retries a failed font file.
- The `@import` regex accepts an empty media list.
- Imports are walked over a cached fetch-and-parse step, each branch tracking only its own import chain, so cyclic stylesheets resolve and a sheet imported by two siblings lands under both in source order rather than under whichever fetch resolved first.

### Change type

- [x] `bugfix`

### Test plan

**Failed font fetch permanently breaking later exports**

1. Run `yarn dev`, open http://localhost:5420/develop and create a text shape.
2. In devtools, open the Network request blocking panel, add the pattern `*.woff2` and enable blocking.
3. Right-click the text shape, choose Export as > SVG. The font fetch fails, so the downloaded SVG renders the text in a fallback font.
4. Remove the blocking pattern (or disable blocking), then export the text shape as SVG again and open the new file.
5. On `main` the second SVG still uses the fallback font because the failed fetch result was cached. With this PR the font is fetched again and the text renders in the tldraw draw font.

- [x] Unit tests — the new tests fail on `main` and pass with this change (the import cycle test times out without the guard; the two-export retry test fails without per-export embedding; the sibling-import ordering test fails with a shared seen set)

### Release notes

- Embed every referenced resource and font in exports, retry failed resource and font fetches, follow bare @import rules, and don't hang on stylesheets that import each other.

### API changes

- Added `LruCache.delete(key)` in `@tldraw/utils`

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +57 / -19  |
| Tests           | +137 / -0  |
| Automated files | +2 / -0    |
