### PR TITLE
fix(editor): prefer aligned shapes over nearer diagonal ones in keyboard navigation

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2459,8 +2459,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// Ok, now score that subset of shapes.
 		const lowestScoringShape = minBy(shapesInDirection, ({ center }) => {
-			// Distance is the primary weighting factor.
-			const distance = Vec.Dist2(currentCenter, center)
+			// Linear, not squared: the off-axis and diagonal penalties below are page units too, and
+			// squared distance swamps them, so a nearer diagonal shape beats an aligned one.
+			const distance = Vec.Dist(currentCenter, center)
 
 			// Distance along the primary axis.
 			const dirProp = ['left', 'right'].includes(direction) ? 'x' : 'y'
@@ -2470,9 +2471,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const offProp = ['left', 'right'].includes(direction) ? 'y' : 'x'
 			const offAxisDeviation = Math.abs(center[offProp] - currentCenter[offProp])
 
-			// Angle in degrees
-			const angle = Math.abs(Vec.Angle(currentCenter, center) * (180 / Math.PI))
-			const angleDeviation = Math.abs(angle - directionToAngle[direction])
+			// atan2 gives -180..180, so 'up' is -90; normalize to 0..360 to match 270, and wrap the
+			// deviation so that 350 is 10 away from 'right' (0), not 350.
+			const angle = (Vec.Angle(currentCenter, center) * (180 / Math.PI) + 360) % 360
+			const rawAngleDeviation = Math.abs(angle - directionToAngle[direction])
+			const angleDeviation = Math.min(rawAngleDeviation, 360 - rawAngleDeviation)
 
 			// Calculate final score (lower is better).
 			// Weight factors to prioritize:

--- a/packages/tldraw/src/test/navigation.test.ts
+++ b/packages/tldraw/src/test/navigation.test.ts
@@ -30,6 +30,8 @@ const ids = {
 	nearRight: createShapeId('nearRight'),
 	farRight: createShapeId('farRight'),
 	offAxisRight: createShapeId('offAxisRight'),
+	upLeft: createShapeId('upLeft'),
+	upRight: createShapeId('upRight'),
 	row1Shape1: createShapeId('row1Shape1'),
 	row1Shape2: createShapeId('row1Shape2'),
 	row1Shape3: createShapeId('row1Shape3'),
@@ -280,6 +282,66 @@ describe('Shape navigation', () => {
 			// Navigate right - should select nearRight as it's closest
 			editor.selectAdjacentShape('right')
 			expect(editor.getSelectedShapeIds()).toEqual([ids.nearRight])
+		})
+
+		it('prefers an aligned shape over a nearer diagonal one', () => {
+			editor.createShapes([
+				{ id: ids.center, type: 'geo', x: 0, y: 0 },
+				{ id: ids.farRight, type: 'geo', x: 300, y: 0 },
+				{ id: ids.offAxisRight, type: 'geo', x: 200, y: 150 },
+			])
+
+			vi.spyOn(editor, 'getShapePageBounds').mockImplementation((shape: any) => {
+				if (shape?.id === ids.center) return boundsAtCenter({ x: 0, y: 0 })
+				if (shape?.id === ids.farRight) return boundsAtCenter({ x: 300, y: 0 })
+				if (shape?.id === ids.offAxisRight) return boundsAtCenter({ x: 200, y: 150 })
+				return boundsAtCenter({ x: 0, y: 0 })
+			})
+
+			editor.select(ids.center)
+			editor.selectAdjacentShape('right')
+			// squared distance would let the nearer off-axis shape beat the aligned one
+			expect(editor.getSelectedShapeIds()).toEqual([ids.farRight])
+		})
+
+		it('prefers the more vertically aligned shape when navigating up', () => {
+			// Both are 50 away. atan2 (y down) gives up-left -143 and up-right -53; |angle| would
+			// put them 127 and 217 from 270 and pick upLeft.
+			editor.createShapes([
+				{ id: ids.center, type: 'geo', x: 0, y: 0 },
+				{ id: ids.upLeft, type: 'geo', x: -40, y: -30 },
+				{ id: ids.upRight, type: 'geo', x: 30, y: -40 },
+			])
+
+			vi.spyOn(editor, 'getShapePageBounds').mockImplementation((shape: any) => {
+				if (shape?.id === ids.upLeft) return boundsAtCenter({ x: -40, y: -30 })
+				if (shape?.id === ids.upRight) return boundsAtCenter({ x: 30, y: -40 })
+				return boundsAtCenter({ x: 0, y: 0 })
+			})
+
+			editor.select(ids.center)
+			editor.selectAdjacentShape('up')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.upRight])
+		})
+
+		it('measures the angle deviation across the 0/360 seam', () => {
+			// aboveRight is at -3 degrees (357 once normalised). Without wrapping, its deviation from
+			// 'right' (0) reads as 357 and the lower shape wins.
+			editor.createShapes([
+				{ id: ids.center, type: 'geo', x: 0, y: 0 },
+				{ id: ids.upRight, type: 'geo', x: 100, y: -5 },
+				{ id: ids.offAxisRight, type: 'geo', x: 160, y: 20 },
+			])
+
+			vi.spyOn(editor, 'getShapePageBounds').mockImplementation((shape: any) => {
+				if (shape?.id === ids.upRight) return boundsAtCenter({ x: 100, y: -5 })
+				if (shape?.id === ids.offAxisRight) return boundsAtCenter({ x: 160, y: 20 })
+				return boundsAtCenter({ x: 0, y: 0 })
+			})
+
+			editor.select(ids.center)
+			editor.selectAdjacentShape('right')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.upRight])
 		})
 
 		// Add this test for the 'prev' direction in directional navigation


### PR DESCRIPTION
This PR fixes Cmd+arrow shape navigation picking a nearer diagonal shape over one aligned with the direction, and being biased towards up-left shapes when navigating `up`.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`getNearestAdjacentShape` scored candidates with squared distance plus linear off-axis and angle penalties, so distance swamped the penalties and diagonal shapes beat aligned ones. It also took `Math.abs` of the raw angle before comparing it against 270 for `up`, so shapes to the upper left scored as if they were to the upper right.

### After

Directional scoring uses linear distance so the penalties are in the same units, and normalises the angle to 0..360 (taking the smaller of the two arc deviations) before comparing it against the direction's angle.

The Tab-with-no-tabbable-shapes crash and Shift+Tab wrap this PR originally also fixed already landed on `main` via #10482 and #10559, so they were dropped here.

### Change type

- [x] `bugfix`

### Test plan

1. On an empty page in http://localhost:5420/develop, run `editor.createShapes([{ type: 'geo', x: 0, y: 0 }, { type: 'geo', x: 300, y: 0 }, { type: 'geo', x: 200, y: 150 }])` in the devtools console.
2. Click the rectangle at the origin to select it.
3. Press Cmd+ArrowRight (Ctrl+ArrowRight on Windows/Linux).
4. On `main` the selection jumps to the lower rectangle at (200, 150), which is nearer but diagonal. With this PR it jumps to the rectangle at (300, 0), which is in line with the selected one.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix Cmd+arrow shape navigation preferring diagonal shapes over aligned ones.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -5    |
| Tests     | +62 / -0   |
