### PR TITLE
fix(editor): readonly guards for bindings and document settings, and self-bindings indexed once

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1212,6 +1212,10 @@ export class Editor extends EventEmitter<TLEventMap> {
     deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
         isolateShapes?: boolean | undefined;
     }): this;
+    // @internal (undocumented)
+    _deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
+        isolateShapes?: boolean | undefined;
+    }): this;
     deletePage(page: TLPage | TLPageId): this;
     deleteShape(id: TLShapeId): this;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1212,7 +1212,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
         isolateShapes?: boolean | undefined;
     }): this;
-    // @internal (undocumented)
+    // @internal
     _deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes }?: {
         isolateShapes?: boolean | undefined;
     }): this;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -736,7 +736,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 						}
 
 						if (deleteBindingIds.length) {
-							this.deleteBindings(deleteBindingIds)
+							// straight to the store: this cleanup must run even when deleteBindings would
+							// refuse (readonly), e.g. for a deletion that arrived from a remote peer
+							this.store.remove(deleteBindingIds)
 						}
 					},
 				},
@@ -1947,6 +1949,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 **/
 	updateDocumentSettings(settings: Partial<TLDocument>): this {
+		if (this.getIsReadonly()) return this
 		this.run(
 			() => {
 				this.store.put([{ ...this.getDocumentSettings(), ...settings }])
@@ -6829,6 +6832,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * binding, but the `type`, `toId`, and `fromId` must all be provided.
 	 */
 	createBindings<B extends TLBinding = TLBinding>(partials: TLBindingCreate<B>[]) {
+		if (this.getIsReadonly()) return this
+
 		const bindings: TLBinding[] = []
 		for (const partial of partials) {
 			const fromShape = this.getShape(partial.fromId)
@@ -6868,6 +6873,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * binding is skipped. The changes from the partial are merged into the existing record.
 	 */
 	updateBindings(partials: (TLBindingUpdate | null | undefined)[]) {
+		if (this.getIsReadonly()) return this
+
 		const updated: TLBinding[] = []
 
 		for (const partial of partials) {
@@ -6905,6 +6912,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Delete several bindings by their IDs. If a binding ID doesn't exist, it's ignored.
 	 */
 	deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
+		if (this.getIsReadonly()) return this
+		return this._deleteBindings(bindings, { isolateShapes })
+	}
+
+	// Unguarded so that withIsolatedShapes can transiently isolate shapes (copy, duplicate)
+	// in readonly mode; the public deleteBindings is what readonly blocks.
+	/** @internal */
+	_deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
 		const ids = bindings.map((binding) => (typeof binding === 'string' ? binding : binding.id))
 		if (isolateShapes) {
 			this.store.atomic(() => {
@@ -11864,7 +11879,7 @@ function withIsolatedShapes<T>(
 					}
 				}
 
-				editor.deleteBindings([...bindingsToRemove], { isolateShapes: true })
+				editor._deleteBindings([...bindingsToRemove], { isolateShapes: true })
 
 				try {
 					result = Result.ok(callback(bindingsWithBoth))

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6916,9 +6916,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this._deleteBindings(bindings, { isolateShapes })
 	}
 
-	// Unguarded so that withIsolatedShapes can transiently isolate shapes (copy, duplicate)
-	// in readonly mode; the public deleteBindings is what readonly blocks.
-	/** @internal */
+	/**
+	 * Unguarded so that withIsolatedShapes can transiently isolate shapes for copy and export in
+	 * readonly mode; the public deleteBindings is what readonly blocks.
+	 *
+	 * @internal
+	 */
 	_deleteBindings(bindings: (TLBinding | TLBindingId)[], { isolateShapes = false } = {}) {
 		const ids = bindings.map((binding) => (typeof binding === 'string' ? binding : binding.id))
 		if (isolateShapes) {

--- a/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
+++ b/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
@@ -18,6 +18,8 @@ function fromScratch(bindingsQuery: Computed<TLBinding[], unknown>) {
 		} else {
 			bindingsForFromShape.push(binding)
 		}
+		// A binding from a shape to itself belongs in that shape's array once, not twice
+		if (toId === fromId) continue
 		const bindingsForToShape = shapesToBindings.get(toId)
 		if (!bindingsForToShape) {
 			shapesToBindings.set(toId, [binding])
@@ -83,6 +85,7 @@ export function bindingsIndex(editor: Editor): Computed<TLBindingsIndex> {
 
 		function addBinding(binding: TLBinding) {
 			ensureNewArray(binding.fromId).push(binding)
+			if (binding.toId === binding.fromId) return
 			ensureNewArray(binding.toId).push(binding)
 		}
 

--- a/packages/tldraw/src/test/bindings.test.tsx
+++ b/packages/tldraw/src/test/bindings.test.tsx
@@ -442,3 +442,30 @@ test('onAfterChangeToShape is called after the to shape is updated', () => {
 	})
 	expect.assertions(3)
 })
+
+test('a binding from a shape to itself is indexed once', () => {
+	bindShapes(ids.box1, ids.box1)
+	expect(editor.getBindingsInvolvingShape(ids.box1)).toHaveLength(1)
+
+	calls.length = 0
+	editor.updateShape({ id: ids.box1, type: 'geo', x: 10 })
+	expect(calls).toEqual([
+		'onAfterChangeFromShape: box1->box1',
+		'onAfterChangeToShape: box1->box1',
+		'onOperationComplete',
+	])
+})
+
+test('bindings cannot be created, updated, or deleted in readonly mode', () => {
+	const bindingId = bindShapes(ids.box1, ids.box2)
+	editor.updateInstanceState({ isReadonly: true })
+
+	editor.createBinding({ type: TEST_TYPE, fromId: ids.box3, toId: ids.box4 })
+	expect(editor.getBindingsInvolvingShape(ids.box3)).toHaveLength(0)
+
+	editor.updateBinding({ id: bindingId, type: TEST_TYPE, meta: { foo: 'bar' } })
+	expect(editor.getBinding(bindingId)?.meta).toEqual({})
+
+	editor.deleteBinding(bindingId)
+	expect(editor.getBinding(bindingId)).toBeDefined()
+})


### PR DESCRIPTION
This PR fixes a bug where a readonly editor could still create, update and delete bindings and change document settings. It also fixes a binding from a shape to itself being indexed twice for that shape.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`createBindings`, `updateBindings`, `deleteBindings` and `updateDocumentSettings` wrote straight to the store with no `getIsReadonly()` check, unlike the shape mutation methods.

`bindingsIndex` pushed every binding into both its `fromId` array and its `toId` array, so a binding with `fromId === toId` appeared twice in the same shape's array and its change callbacks fired twice.

### After

All four methods return early in readonly mode. `bindingsIndex` indexes a self-binding once, in both the from-scratch and incremental paths.

### Implementation notes

Two internal paths must still remove bindings in readonly mode: the shape `beforeDelete` side effect that cleans up orphaned bindings (a deletion can arrive from a remote peer) now calls `store.remove` directly, and `withIsolatedShapes` (used by copy and duplicate) goes through a new unguarded `@internal` `Editor._deleteBindings`. The public `deleteBindings` is the readonly gate and delegates to it.

### Change type

- [x] `bugfix`

### Test plan

**Readonly binding and document settings mutations**

1. Run `yarn dev`, open http://localhost:5420/develop, draw two rectangles and an arrow from inside one to inside the other so the arrow is bound at both ends, then select the arrow.
2. In the devtools console run `editor.updateInstanceState({ isReadonly: true })`.
3. Run `editor.deleteBindings(editor.getBindingsFromShape(editor.getOnlySelectedShape(), 'arrow'))`, then `editor.getBindingsFromShape(editor.getOnlySelectedShape(), 'arrow').length`.
4. Run `editor.updateDocumentSettings({ gridSize: 100 })`, then `editor.getDocumentSettings().gridSize`.
5. On `main` the readonly editor still applies both: the length is `0` and `gridSize` is `100`. With this PR both calls are no-ops: the arrow keeps its `2` bindings and `gridSize` stays `10`.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Block binding and document-settings mutations in readonly mode and index self-referential bindings once.

### API changes

- Adds `@internal` `Editor._deleteBindings`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +20 / -2   |
| Tests           | +27 / -0   |
| Automated files | +4 / -0    |

