### PR TITLE
fix(editor): rebuild the spatial index when fonts load and keep page shape ids correct across cross-page reparents

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1821,6 +1821,8 @@ export class FontManager {
     dispose(): void;
     // (undocumented)
     ensureFontIsLoaded(font: TLFontFace): Promise<void>;
+    // @internal (undocumented)
+    getFontLoadEpoch(): number;
     // (undocumented)
     getShapeFontFaces(shape: TLShape | TLShapeId): TLFontFace[];
     // (undocumented)

--- a/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
+++ b/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
@@ -75,9 +75,15 @@ export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: ()
 				}
 			}
 
-			for (const [_from, to] of Object.values(changes.updated)) {
+			for (const [from, to] of Object.values(changes.updated)) {
 				if (isShape(to)) {
-					if (isShapeInPage(store, currentPageId, to)) {
+					const inPage = isShapeInPage(store, currentPageId, to)
+					// A reparent that moves a shape onto or off this page takes its descendants
+					// with it, but they are not in the diff; rebuild so they don't keep stale membership
+					if (isShape(from) && from.parentId !== to.parentId && inPage !== prevValue.has(to.id)) {
+						return fromScratch()
+					}
+					if (inPage) {
 						builder.add(to.id)
 					} else {
 						builder.remove(to.id)

--- a/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
+++ b/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
@@ -68,9 +68,13 @@ export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: ()
 			prevValue
 		) as IncrementalSetConstructor<TLShapeId>
 
+		const addedIds = new Set<TLShapeId>()
+
 		for (const changes of diff) {
 			for (const record of Object.values(changes.added)) {
-				if (isShape(record) && isShapeInPage(store, currentPageId, record)) {
+				if (!isShape(record)) continue
+				addedIds.add(record.id)
+				if (isShapeInPage(store, currentPageId, record)) {
 					builder.add(record.id)
 				}
 			}
@@ -79,8 +83,14 @@ export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: ()
 				if (isShape(to)) {
 					const inPage = isShapeInPage(store, currentPageId, to)
 					// A reparent that moves a shape onto or off this page takes its descendants
-					// with it, but they are not in the diff; rebuild so they don't keep stale membership
-					if (isShape(from) && from.parentId !== to.parentId && inPage !== prevValue.has(to.id)) {
+					// with it, but they are not in the diff; rebuild so they don't keep stale membership.
+					// A shape created in this diff has no pre-existing descendants, so it can't go stale.
+					if (
+						isShape(from) &&
+						from.parentId !== to.parentId &&
+						!addedIds.has(to.id) &&
+						inPage !== prevValue.has(to.id)
+					) {
 						return fromScratch()
 					}
 					if (inPage) {

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -1,4 +1,4 @@
-import { computed, EMPTY_ARRAY, transact } from '@tldraw/state'
+import { atom, computed, EMPTY_ARRAY, transact } from '@tldraw/state'
 import { AtomMap } from '@tldraw/store'
 import { TLFontFace, TLShape, TLShapeId } from '@tldraw/tlschema'
 import {
@@ -101,6 +101,22 @@ export class FontManager {
 		return this.fontStates.get(font) ?? null
 	}
 
+	// One signal for consumers that deliberately avoid per-shape font tracking (the
+	// spatial index); otherwise their cached text bounds stay at the fallback-font size.
+	private readonly fontLoadEpoch = atom('font load epoch', 0)
+
+	/** @internal */
+	getFontLoadEpoch(): number {
+		return this.fontLoadEpoch.get()
+	}
+
+	private setFontState(font: TLFontFace, state: FontState['state']) {
+		transact(() => {
+			this.fontStates.update(font, (s) => ({ ...s, state }))
+			this.fontLoadEpoch.update((n) => n + 1)
+		})
+	}
+
 	ensureFontIsLoaded(font: TLFontFace): Promise<void> {
 		const existingState = this.getFontState(font)
 		if (existingState) return existingState.loadingPromise
@@ -122,7 +138,7 @@ export class FontManager {
 						return
 					}
 					this.editor.getContainerDocument().fonts.add(instance)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'ready' }))
+					this.setFontState(font, 'ready')
 				})
 				.catch((err) => {
 					if (isStale()) {
@@ -131,7 +147,7 @@ export class FontManager {
 						return
 					}
 					console.error(err)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'error' }))
+					this.setFontState(font, 'error')
 				}),
 		}
 

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -41,6 +41,7 @@ export class SpatialIndexManager {
 	private rbush: RBushIndex
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
+	private lastFontLoadEpoch = -1
 
 	// Bumps only when the rbush content may have changed. Consumers subscribe
 	// via the computed; a stable epoch lets prop-only diffs skip downstream
@@ -66,21 +67,27 @@ export class SpatialIndexManager {
 		const bindingHistory = this.editor.store.query.filterHistory('binding')
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
-			// These three reads are the computed's only tracked dependencies.
-			// Every input to a shape's page bounds is a shape or binding record,
-			// so the two histories cover all invalidation; the rebuild/update
-			// paths below run without capture to avoid registering a dependency
-			// per checked shape on every update (and ~page-size dependencies on
-			// every rebuild).
+			// These four reads are the computed's only tracked dependencies. A
+			// shape's page bounds derive from shape and binding records plus, for
+			// text, the font load state (measured text resizes when its font swaps
+			// in), so the histories and the font load epoch cover all invalidation.
+			// The rebuild/update paths below run without capture to avoid
+			// registering a dependency per checked shape on every update (and
+			// ~page-size dependencies on every rebuild).
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
 			const bindingDiff = bindingHistory.getDiffSince(lastComputedEpoch)
 			const currentPageId = this.editor.getCurrentPageId()
+			const fontLoadEpoch = this.editor.fonts.getFontLoadEpoch()
 
 			if (
 				isUninitialized(_prevValue) ||
 				shapeDiff === RESET_VALUE ||
 				bindingDiff === RESET_VALUE ||
-				this.lastPageId !== currentPageId
+				this.lastPageId !== currentPageId ||
+				// Which shapes a font load resizes isn't known without visiting
+				// every shape, so rebuild; loads are rare and bounded by the
+				// number of distinct fonts.
+				this.lastFontLoadEpoch !== fontLoadEpoch
 			) {
 				return unsafe__withoutCapture(() => this.rebuildAndBumpEpoch())
 			}
@@ -97,6 +104,7 @@ export class SpatialIndexManager {
 	private buildFromScratch(): void {
 		this.rbush.clear()
 		this.lastPageId = this.editor.getCurrentPageId()
+		this.lastFontLoadEpoch = this.editor.fonts.getFontLoadEpoch()
 
 		const elements: SpatialElement[] = []
 		for (const shape of this.editor.getCurrentPageShapes()) {

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -67,10 +67,11 @@ export class SpatialIndexManager {
 		const bindingHistory = this.editor.store.query.filterHistory('binding')
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
-			// These four reads are the computed's only tracked dependencies. A
-			// shape's page bounds derive from shape and binding records plus, for
-			// text, the font load state (measured text resizes when its font swaps
-			// in), so the histories and the font load epoch cover all invalidation.
+			// These four reads are the computed's only tracked dependencies: shape
+			// and binding record changes, plus font loads (measured text resizes
+			// when its font swaps in). Theme changes that resize shapes without a
+			// record diff (e.g. `updateTheme({ fontSize })`) are not tracked, so
+			// the index stays stale for those until the next rebuild.
 			// The rebuild/update paths below run without capture to avoid
 			// registering a dependency per checked shape on every update (and
 			// ~page-size dependencies on every rebuild).

--- a/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
+++ b/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
@@ -72,4 +72,25 @@ describe('shapeIdsInCurrentPage', () => {
 			new Set([ids.box1, ids.box2, ids.box3])
 		)
 	})
+
+	it('updates the descendants of a shape that is reparented to another page', () => {
+		const frameId = createShapeId('frame')
+		editor.createShapes([
+			{ type: 'frame', id: frameId },
+			{ type: 'geo', id: ids.box1, parentId: frameId },
+		])
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box1]))
+
+		const page2Id = PageRecordType.createId('page2')
+		editor.createPage({ name: 'New Page 2', id: page2Id })
+		editor.reparentShapes([frameId], page2Id)
+
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([]))
+
+		editor.setCurrentPage(page2Id)
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box1]))
+
+		editor.reparentShapes([frameId], editor.getPages()[0].id)
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([]))
+	})
 })

--- a/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
+++ b/packages/tldraw/src/test/shapeIdsInCurrentPage.test.ts
@@ -93,4 +93,20 @@ describe('shapeIdsInCurrentPage', () => {
 		editor.reparentShapes([frameId], editor.getPages()[0].id)
 		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([]))
 	})
+
+	it('includes a shape created and then reparented into an on-page frame before the next read', () => {
+		const frameId = createShapeId('frame')
+		editor.createShapes([
+			{ type: 'frame', id: frameId },
+			{ type: 'geo', id: ids.box2 },
+		])
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box2]))
+
+		// separate puts give separate history entries, so the create and the reparent land in
+		// different diffs of the same recompute
+		const template = editor.getShape(ids.box2)!
+		editor.store.put([{ ...template, id: ids.box1 }])
+		editor.store.put([{ ...template, id: ids.box1, parentId: frameId }])
+		expect(new Set(editor.getCurrentPageShapeIds())).toEqual(new Set([frameId, ids.box1, ids.box2]))
+	})
 })

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -1,5 +1,6 @@
 import { Box, PageRecordType, createShapeId, react } from '@tldraw/editor'
 import { vi } from 'vitest'
+import { DefaultFontFaces } from '../lib/shapes/shared/defaultFonts'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -143,6 +144,20 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		const page2 = PageRecordType.createId('page2-switch')
 		editor.createPage({ name: 'page2-switch', id: page2 })
 		editor.setCurrentPage(page2)
+
+		expect(tracker.delta).toBe(1)
+		tracker.stop()
+	})
+
+	it('ticks when a font finishes loading (text bounds depend on font metrics)', async () => {
+		// The index reads bounds without capture, so a font swap that resizes measured
+		// text would otherwise leave the stale fallback-font bounds in the tree.
+		editor.createShapes([{ id: createShapeId('text'), type: 'text', x: 100, y: 100 }])
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		await editor.fonts.ensureFontIsLoaded(DefaultFontFaces.tldraw_draw.normal.normal)
 
 		expect(tracker.delta).toBe(1)
 		tracker.stop()


### PR DESCRIPTION
This PR fixes a bug where hit testing and culling used stale bounds for text shapes whose font finished loading after the shape was measured. It also fixes descendants of a container keeping stale current-page membership when the container was reparented to another page.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The spatial index computed tracked only the shape and binding record histories and the current page id, and read shape bounds without capture. A text shape measured with the fallback font kept that size in the R-tree after the real font swapped in, because nothing it depended on changed.

`deriveShapeIdsInCurrentPage` only re-evaluated records present in the diff. Reparenting a frame to another page moves its children with it, but the children are not in the diff, so they kept their old page membership.

### After

`FontManager` has an `@internal` font-load epoch that bumps whenever a font becomes ready or errors, and the spatial index computed depends on it; an epoch change triggers a rebuild with the real font's bounds. `deriveShapeIdsInCurrentPage` falls back to a full rebuild when an updated shape's `parentId` changed and that moved it onto or off the current page.

### Implementation notes

Which shapes a font load resizes is not known without visiting every shape, so the spatial index rebuilds rather than updating incrementally; font loads are rare and bounded by the number of distinct fonts.

### Change type

- [x] `bugfix`

### Test plan

**Stale hit-test bounds for text after its font loads**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Create a text shape with a long single line (40+ characters) in the default draw font at size XL, then reload the page so the text is measured with the fallback font before the real font swaps in.
3. Without touching the shape, hover and click near the last characters of the line.
4. On `main` the hover outline and click target use the fallback-font width, so the trailing end of the rendered text misses (or empty space past it hits) until something rebuilds the index, such as switching pages. With this PR the hit area matches the rendered text as soon as the font loads.

**Descendants keep stale page membership after a cross-page reparent**

1. On http://localhost:5420/develop, draw a frame and a rectangle inside it, then select only the frame.
2. In the console, run `editor.createPage({ name: 'Page 2' })`, then `editor.reparentShapes(editor.getSelectedShapeIds(), editor.getPages()[1].id)`.
3. On `main` the frame disappears from the current page but the rectangle stays on the canvas and is still listed in `editor.getCurrentPageShapeIds()`. With this PR both the frame and the rectangle leave the current page.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Refresh the spatial index when fonts finish loading and keep current-page shape ids correct when a container moves to another page.

### API changes

- Adds `@internal` `FontManager.getFontLoadEpoch()`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +42 / -12  |
| Tests           | +36 / -0   |
| Automated files | +2 / -0    |

