### PR TITLE
fix(editor): exports reject when a shape's toSvg throws and frame-like backgrounds don't require the frame util

### DIFF
--- a/packages/editor/src/lib/exports/ExportDelay.tsx
+++ b/packages/editor/src/lib/exports/ExportDelay.tsx
@@ -1,4 +1,4 @@
-import { bind, sleep } from '@tldraw/utils'
+import { bind, noop, promiseWithResolve, sleep } from '@tldraw/utils'
 
 /**
  * Export delay is a helper class that allows you to wait for a set of promises to resolve before
@@ -11,8 +11,20 @@ import { bind, sleep } from '@tldraw/utils'
 export class ExportDelay {
 	private isResolved = false
 	private readonly promisesToWaitFor: Promise<void>[] = []
+	private readonly failure = promiseWithResolve<never>()
 
-	constructor(private readonly maxDelayTimeMs: number) {}
+	constructor(private readonly maxDelayTimeMs: number) {
+		// only observed inside `resolve`, so a `fail` before then would otherwise be an unhandled rejection
+		this.failure.catch(noop)
+	}
+
+	/**
+	 * Abort the export: `resolve` rejects with this error instead of waiting out the delay and
+	 * snapshotting a broken svg.
+	 */
+	@bind fail(error: unknown): void {
+		this.failure.reject(error)
+	}
 
 	@bind waitUntil(promise: Promise<void>): void {
 		if (this.isResolved) {
@@ -40,9 +52,9 @@ export class ExportDelay {
 		const timeoutPromise = sleep(this.maxDelayTimeMs).then(() => 'timeout' as const)
 		const resolvePromise = this.resolvePromises().then(() => 'resolved' as const)
 
-		const result = await Promise.race([timeoutPromise, resolvePromise])
+		const result = await Promise.race([timeoutPromise, resolvePromise, this.failure])
 		if (result === 'timeout') {
-			console.warn('[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms')
+			console.warn(`[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms`)
 		}
 
 		this.isResolved = true

--- a/packages/editor/src/lib/exports/getSvgAsImage.ts
+++ b/packages/editor/src/lib/exports/getSvgAsImage.ts
@@ -145,7 +145,13 @@ function measureContentBounds(
 	// (extraPx * 2 >= w means declaredRight <= declaredLeft, producing zero/negative crop)
 	if (extraPx <= 0 || extraPx * 2 >= w || extraPx * 2 >= h) return null
 
-	const imageData = ctx.getImageData(0, 0, w, h)
+	let imageData: ImageData
+	try {
+		imageData = ctx.getImageData(0, 0, w, h)
+	} catch {
+		// a tainted or unallocatable canvas can't be measured; export untrimmed rather than fail
+		return null
+	}
 	const data = imageData.data
 
 	// Determine how to detect "empty" pixels.
@@ -302,9 +308,11 @@ export async function trimSvgToContent(
 
 	if (trimPadding <= 0) return null
 
-	// Render SVG to a temporary canvas at 1:1 pixel ratio
-	const canvasWidth = Math.floor(width)
-	const canvasHeight = Math.floor(height)
+	// Render SVG to a temporary canvas at 1:1 pixel ratio, clamped like the raster path so a
+	// large export doesn't exceed the browser's canvas limits
+	let [canvasWidth, canvasHeight] = clampToBrowserMaxCanvasSize(width, height)
+	canvasWidth = Math.floor(canvasWidth)
+	canvasHeight = Math.floor(canvasHeight)
 
 	if (canvasWidth <= 0 || canvasHeight <= 0) return null
 
@@ -313,7 +321,7 @@ export async function trimSvgToContent(
 	if (!canvas) return null
 
 	// Measure content bounds on the canvas
-	const trimPaddingPx = trimPadding * scale
+	const trimPaddingPx = trimPadding * scale * (canvasWidth / width)
 	const bounds = measureContentBounds(canvas, trimPaddingPx)
 	if (!bounds) return null
 

--- a/packages/editor/src/lib/exports/getSvgJsx.test.ts
+++ b/packages/editor/src/lib/exports/getSvgJsx.test.ts
@@ -1,4 +1,13 @@
-import { Geometry2d, RecordProps, Rectangle2d, ShapeUtil, T, TLShape, createShapeId } from '../..'
+import {
+	BaseFrameLikeShapeUtil,
+	Geometry2d,
+	RecordProps,
+	Rectangle2d,
+	ShapeUtil,
+	T,
+	TLShape,
+	createShapeId,
+} from '../..'
 import { createTLStore } from '../config/createTLStore'
 import { Editor } from '../editor/Editor'
 import { Box } from '../primitives/Box'
@@ -859,5 +868,38 @@ describe('getExportDefaultBounds', () => {
 			expect(result.box?.w).toBe(100)
 			expect(result.box?.h).toBe(80)
 		})
+	})
+})
+
+// Deliberately not registered in TLGlobalShapePropsMap (test-only types leak into the api report)
+const FRAME_LIKE_TYPE = 'test-frame-like'
+
+class FrameLikeShape extends BaseFrameLikeShapeUtil<any> {
+	static override type = FRAME_LIKE_TYPE
+	static override props = { w: T.number, h: T.number }
+	getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	getIndicatorPath() {
+		return undefined
+	}
+	component() {}
+}
+
+describe('exporting a single frame-like shape', () => {
+	it('does not need the default frame shape util to be registered', async () => {
+		const editor = new Editor({
+			shapeUtils: [FrameLikeShape],
+			bindingUtils: [],
+			tools: [],
+			store: createTLStore({ shapeUtils: [FrameLikeShape], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+		const id = createShapeId('frame-like')
+		editor.createShape({ id, type: FRAME_LIKE_TYPE, x: 0, y: 0, props: { w: 100, h: 100 } } as any)
+
+		const result = await editor.getSvgElement([id], { background: true })
+		expect(result?.svg.style.backgroundColor).not.toBe('')
+		expect(result?.svg.style.backgroundColor).not.toBe('transparent')
 	})
 })

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useValue } from '@tldraw/state-react'
-import { TLFrameShape, TLShape, TLShapeId } from '@tldraw/tlschema'
+import { TLShape, TLShapeId } from '@tldraw/tlschema'
 import { TLFontFace } from '@tldraw/tlschema'
 import { hasOwnProperty, promiseWithResolve, uniqueId } from '@tldraw/utils'
 import {
@@ -117,6 +117,7 @@ export function getSvgJsx(editor: Editor, ids: TLShapeId[], opts: TLImageExportO
 			colorMode={colorMode}
 			renderingShapes={renderingShapes}
 			onMount={initialEffectPromise.resolve}
+			onError={exportDelay.fail}
 			waitUntil={exportDelay.waitUntil}
 		>
 			{}
@@ -208,6 +209,7 @@ function SvgExport({
 	colorMode,
 	renderingShapes,
 	onMount,
+	onError,
 	waitUntil,
 }: {
 	editor: Editor
@@ -221,6 +223,7 @@ function SvgExport({
 	colorMode: 'light' | 'dark'
 	renderingShapes: TLRenderingShape[]
 	onMount(): void
+	onError(error: unknown): void
 	waitUntil(promise: Promise<void>): void
 }) {
 	const masksId = useUniqueSafeId()
@@ -283,6 +286,8 @@ function SvgExport({
 			throw new Error('SvgExport should only render once - do not use with react strict mode')
 		}
 		didRenderRef.current = true
+		// the promise is caught at the end: a throwing `toSvg` would otherwise leave `onMount`
+		// pending forever, so the export would wait out its max delay and snapshot an empty svg
 		;(async () => {
 			const shapeDefs: Record<string, { pending: false; element: ReactElement }> = {}
 
@@ -418,8 +423,17 @@ function SvgExport({
 					defsById: { ...state.defsById, ...shapeDefs },
 				}))
 			})
-		})()
-	}, [bbox, editor, exportContext, masksId, renderingShapes, singleFrameShapeId, stateAtom])
+		})().catch(onError)
+	}, [
+		bbox,
+		editor,
+		exportContext,
+		masksId,
+		onError,
+		renderingShapes,
+		singleFrameShapeId,
+		stateAtom,
+	])
 
 	useEffect(() => {
 		const fontsInUse = new Set<TLFontFace>()
@@ -449,19 +463,12 @@ function SvgExport({
 	let backgroundColor = background ? colors.background : 'transparent'
 
 	if (singleFrameShapeId && background) {
-		const frameShapeUtil = editor.getShapeUtil('frame') as any as
-			| undefined
-			| {
-					options: {
-						showColors: boolean
-					}
-			  }
-		if (frameShapeUtil?.options.showColors) {
-			const shape = editor.getShape(singleFrameShapeId)! as TLFrameShape
-			backgroundColor = getColorValue(colors, shape.props.color, 'frameFill')
-		} else {
-			backgroundColor = colors.solid
-		}
+		// the frame-like shape's own util decides this - it may not be the default 'frame' util
+		const shape = editor.getShape(singleFrameShapeId)!
+		const { showColors } = editor.getShapeUtil(shape).options as { showColors?: boolean }
+		const color = showColors && 'color' in shape.props ? shape.props.color : null
+		backgroundColor =
+			typeof color === 'string' ? getColorValue(colors, color, 'frameFill') : colors.solid
 	}
 
 	return (

--- a/packages/editor/src/lib/exports/getSvgJsx.tsx
+++ b/packages/editor/src/lib/exports/getSvgJsx.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useValue } from '@tldraw/state-react'
-import { TLShape, TLShapeId } from '@tldraw/tlschema'
+import { DefaultColorStyle, TLShape, TLShapeId } from '@tldraw/tlschema'
 import { TLFontFace } from '@tldraw/tlschema'
 import { hasOwnProperty, promiseWithResolve, uniqueId } from '@tldraw/utils'
 import {
@@ -466,7 +466,12 @@ function SvgExport({
 		// the frame-like shape's own util decides this - it may not be the default 'frame' util
 		const shape = editor.getShape(singleFrameShapeId)!
 		const { showColors } = editor.getShapeUtil(shape).options as { showColors?: boolean }
-		const color = showColors && 'color' in shape.props ? shape.props.color : null
+		// the color style may live under any prop key, so look it up through the style map and
+		// fall back to a literal `color` prop for frame-like shapes that don't use the style
+		const color = showColors
+			? (editor.getShapeStyleIfExists(shape, DefaultColorStyle) ??
+				('color' in shape.props ? shape.props.color : null))
+			: null
 		backgroundColor =
 			typeof color === 'string' ? getColorValue(colors, color, 'frameFill') : colors.solid
 	}

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -1,5 +1,16 @@
-import { DefaultDashStyle, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	BaseBoxShapeUtil,
+	BaseFrameLikeShapeUtil,
+	DefaultDashStyle,
+	RecordProps,
+	T,
+	TLBaseShape,
+	createShapeId,
+	getColorValue,
+	toRichText,
+} from '@tldraw/editor'
 import { vi } from 'vitest'
+import { FrameShapeUtil } from '../../lib/shapes/frame/FrameShapeUtil'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -165,4 +176,89 @@ it('waits for required fonts to load before measuring the export', async () => {
 	const svg = await exportPromise
 	expect(resolved).toBe(true)
 	expect(svg!.svg).toMatch(/^<svg/)
+})
+
+// Not registered in TLGlobalShapePropsMap: the tldraw test project already sits at TypeScript's
+// discriminated-union limit for TLShapePartial, so one more augmentation breaks typecheck.
+const BROKEN_EXPORT_TYPE = 'my-broken-export-shape'
+const FRAME_LIKE_TYPE = 'my-frame-like-shape'
+
+type MyBrokenExportShape = TLBaseShape<typeof BROKEN_EXPORT_TYPE, { w: number; h: number }>
+type MyFrameLikeShape = TLBaseShape<typeof FRAME_LIKE_TYPE, { w: number; h: number }>
+
+class BrokenExportShapeUtil extends BaseBoxShapeUtil<any> {
+	static override type = BROKEN_EXPORT_TYPE
+	static override props: RecordProps<MyBrokenExportShape> = { w: T.number, h: T.number }
+	override getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	override component() {
+		return null as any
+	}
+	override getIndicatorPath() {
+		return undefined
+	}
+	override toSvg(): never {
+		throw new Error('toSvg failed')
+	}
+}
+
+class FrameLikeShapeUtil extends BaseFrameLikeShapeUtil<any> {
+	static override type = FRAME_LIKE_TYPE
+	static override props: RecordProps<MyFrameLikeShape> = { w: T.number, h: T.number }
+	override getDefaultProps() {
+		return { w: 100, h: 100 }
+	}
+	override component() {
+		return null as any
+	}
+	override getIndicatorPath() {
+		return undefined
+	}
+}
+
+// jsdom serializes colors as rgb(), so compare against the same normalization
+function toCssColor(color: string) {
+	const el = document.createElement('div')
+	el.style.backgroundColor = color
+	return el.style.backgroundColor
+}
+
+it('rejects when a shape throws from toSvg instead of timing out with an empty export', async () => {
+	const editor = new TestEditor({ shapeUtils: [BrokenExportShapeUtil] })
+	const id = createShapeId('broken')
+	editor.createShape({ id, type: BROKEN_EXPORT_TYPE, x: 0, y: 0, props: { w: 100, h: 100 } } as any)
+
+	await expect(editor.getSvgString([id])).rejects.toThrow('toSvg failed')
+})
+
+it('takes a single frame-like export background from the shape util of that shape', async () => {
+	const editor = new TestEditor({
+		shapeUtils: [FrameShapeUtil.configure({ showColors: true }), FrameLikeShapeUtil],
+	})
+	const frameId = createShapeId('frame')
+	const frameLikeId = createShapeId('frame-like')
+	editor.createShape({
+		id: frameId,
+		type: 'frame',
+		x: 0,
+		y: 0,
+		props: { w: 100, h: 100, color: 'red' },
+	})
+	editor.createShape({
+		id: frameLikeId,
+		type: FRAME_LIKE_TYPE,
+		x: 200,
+		y: 0,
+		props: { w: 100, h: 100 },
+	} as any)
+	const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
+
+	const frameSvg = parseSvg(await editor.getSvgString([frameId], { background: true }))
+	expect(frameSvg.style.backgroundColor).toBe(toCssColor(getColorValue(colors, 'red', 'frameFill')))
+
+	// the custom frame-like shape has no color prop, so it gets the plain solid background
+	// rather than a transparent one from reading the default frame util's options
+	const frameLikeSvg = parseSvg(await editor.getSvgString([frameLikeId], { background: true }))
+	expect(frameLikeSvg.style.backgroundColor).toBe(toCssColor(colors.solid))
 })

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -1,10 +1,12 @@
 import {
 	BaseBoxShapeUtil,
 	BaseFrameLikeShapeUtil,
+	DefaultColorStyle,
 	DefaultDashStyle,
 	RecordProps,
 	T,
 	TLBaseShape,
+	TLDefaultColorStyle,
 	createShapeId,
 	getColorValue,
 	toRichText,
@@ -182,9 +184,14 @@ it('waits for required fonts to load before measuring the export', async () => {
 // discriminated-union limit for TLShapePartial, so one more augmentation breaks typecheck.
 const BROKEN_EXPORT_TYPE = 'my-broken-export-shape'
 const FRAME_LIKE_TYPE = 'my-frame-like-shape'
+const COLORED_FRAME_LIKE_TYPE = 'my-colored-frame-like-shape'
 
 type MyBrokenExportShape = TLBaseShape<typeof BROKEN_EXPORT_TYPE, { w: number; h: number }>
 type MyFrameLikeShape = TLBaseShape<typeof FRAME_LIKE_TYPE, { w: number; h: number }>
+type MyColoredFrameLikeShape = TLBaseShape<
+	typeof COLORED_FRAME_LIKE_TYPE,
+	{ w: number; h: number; frameColor: TLDefaultColorStyle }
+>
 
 class BrokenExportShapeUtil extends BaseBoxShapeUtil<any> {
 	static override type = BROKEN_EXPORT_TYPE
@@ -208,6 +215,27 @@ class FrameLikeShapeUtil extends BaseFrameLikeShapeUtil<any> {
 	static override props: RecordProps<MyFrameLikeShape> = { w: T.number, h: T.number }
 	override getDefaultProps() {
 		return { w: 100, h: 100 }
+	}
+	override component() {
+		return null as any
+	}
+	override getIndicatorPath() {
+		return undefined
+	}
+}
+
+// The color style lives under `frameColor`, not `color`, so the export has to go through the
+// editor's style map to find it
+class ColoredFrameLikeShapeUtil extends BaseFrameLikeShapeUtil<any> {
+	static override type = COLORED_FRAME_LIKE_TYPE
+	static override props: RecordProps<MyColoredFrameLikeShape> = {
+		w: T.number,
+		h: T.number,
+		frameColor: DefaultColorStyle,
+	}
+	override options = { showColors: true }
+	override getDefaultProps() {
+		return { w: 100, h: 100, frameColor: 'black' as const }
 	}
 	override component() {
 		return null as any
@@ -261,4 +289,20 @@ it('takes a single frame-like export background from the shape util of that shap
 	// rather than a transparent one from reading the default frame util's options
 	const frameLikeSvg = parseSvg(await editor.getSvgString([frameLikeId], { background: true }))
 	expect(frameLikeSvg.style.backgroundColor).toBe(toCssColor(colors.solid))
+})
+
+it('reads a single frame-like export background from the color style under any prop key', async () => {
+	const editor = new TestEditor({ shapeUtils: [ColoredFrameLikeShapeUtil] })
+	const id = createShapeId('colored-frame-like')
+	editor.createShape({
+		id,
+		type: COLORED_FRAME_LIKE_TYPE,
+		x: 0,
+		y: 0,
+		props: { w: 100, h: 100, frameColor: 'red' },
+	} as any)
+	const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
+
+	const svg = parseSvg(await editor.getSvgString([id], { background: true }))
+	expect(svg.style.backgroundColor).toBe(toCssColor(getColorValue(colors, 'red', 'frameFill')))
 })


### PR DESCRIPTION
This PR fixes a bug where an export timed out and produced an empty SVG when a shape's `toSvg` threw, instead of failing promptly with the error. It also fixes a single-frame export asserting in bare editors that have a custom frame-like shape but no default frame util, and `trimSvgToContent` throwing on very large exports.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The async render in `SvgExport` had no error path: a throwing `toSvg` left `onMount` pending forever, so `ExportDelay.resolve` waited out its max delay and `getSvgString`/`toImage` returned a snapshot of an empty SVG. The timeout warning also printed a literal `${this.maxDelayTimeMs}` because it used a plain string.

The single-frame background reached for `editor.getShapeUtil('frame')` and cast the exported shape to `TLFrameShape`, so an editor with a custom frame-like shape and no `frame` util asserted, and a frame-like shape without a `color` prop was read as the default frame's options.

`trimSvgToContent` allocated its measurement canvas at the full export size, so a large export could exceed the browser's canvas limits, and a failing `getImageData` (tainted or unallocatable canvas) threw out of the export.

### After

`ExportDelay` has an internal `fail(error)`; the render's promise chain is caught and routed to it, so `resolve` rejects with the original error and `getSvgString`/`toImage` reject promptly. The warning is now a template literal.

The single-frame background reads `showColors` from the exported shape's own util and uses its `color` prop when present, falling back to the solid colour otherwise.

`trimSvgToContent` clamps its measurement canvas to the browser maximum (scaling the trim padding to match) and returns untrimmed when `getImageData` fails.

### Change type

- [x] `bugfix`

### Test plan

**Export hangs and produces an empty image when `toSvg` throws**

1. Run `yarn dev` and open http://localhost:5420/develop and draw a rectangle.
2. In the console, run `editor.getShapeUtil('geo').toSvg = () => { throw new Error('boom') }`.
3. Run `await editor.toImage([...editor.getCurrentPageShapeIds()], { format: 'png' })` (or use the menu: Edit > Export as > PNG).
4. On `main` the call hangs for about 5 seconds, logs the literal warning `[tldraw] Export delay timed out after ${this.maxDelayTimeMs}ms`, and resolves with a blank image. With this PR it rejects right away with `Error: boom`.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Make exports fail fast when a shape's toSvg throws, export custom frame-like shapes without the default frame util, and avoid oversized measurement canvases when trimming SVG exports.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +52 / -25  |
| Tests     | +140 / -2  |

