### PR TITLE
fix(editor): setCamera zoom handling, forced animations, zoom momentum, following chains and selection screen bounds

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2654,9 +2654,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	@computed getSelectionRotatedScreenBounds(): Box | undefined {
 		const bounds = this.getSelectionRotatedPageBounds()
 		if (!bounds) return undefined
-		const { x, y } = this.pageToScreen(bounds.point)
-		const zoom = this.getZoomLevel()
-		return new Box(x, y, bounds.width * zoom, bounds.height * zoom)
+		// Don't use pageToScreen here: it reads the screen bounds without capturing them, so this
+		// computed would never invalidate when the container moves
+		const screenBounds = this.getViewportScreenBounds()
+		const { x: cx, y: cy, z: zoom } = this.getCamera()
+		return new Box(
+			(bounds.x + cx) * zoom + screenBounds.x,
+			(bounds.y + cy) * zoom + screenBounds.y,
+			bounds.width * zoom,
+			bounds.height * zoom
+		)
 	}
 
 	// Focus Group
@@ -3146,11 +3153,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const collaborators = this.getCollaborators()
 		let leaderPresence = null as null | TLInstancePresence
 		while (targetUserId && !visited.includes(targetUserId)) {
-			leaderPresence = collaborators.find((c) => c.userId === targetUserId) ?? null
-			targetUserId = leaderPresence?.followingUserId ?? null
-			if (leaderPresence) {
-				visited.push(leaderPresence.userId)
-			}
+			const nextPresence = collaborators.find((c) => c.userId === targetUserId)
+			// Stop at the last resolvable presence, otherwise a leader whose own leader has left
+			// (or whose presence hasn't arrived yet) can't be followed at all
+			if (!nextPresence) break
+			leaderPresence = nextPresence
+			targetUserId = nextPresence.followingUserId ?? null
+			visited.push(nextPresence.userId)
 		}
 		return leaderPresence
 	}
@@ -3390,7 +3399,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			...this._cameraOptions.__unsafe__getWithoutCapture(),
 			...opts,
 		})
-		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
+		// `undefined < 1` is false, so an explicit `zoomSteps: undefined` would otherwise get through
+		// and make every later camera move throw
+		if (!next.zoomSteps || next.zoomSteps.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
 		this.setCamera(this.getCamera())
 		return this
@@ -3638,11 +3649,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.stopFollowingUser()
 		}
 
-		const _point = Vec.Cast(point)
-
-		if (!Number.isFinite(_point.x)) _point.x = 0
-		if (!Number.isFinite(_point.y)) _point.y = 0
-		if (_point.z === undefined || !Number.isFinite(_point.z)) point.z = this.getZoomLevel()
+		// Resolve the zoom before building the Vec: Vec.Cast would default a missing z to 1,
+		// and a missing or non-finite z should keep the current zoom level instead
+		const _point = new Vec(
+			Number.isFinite(point.x) ? point.x : 0,
+			Number.isFinite(point.y) ? point.y : 0,
+			Number.isFinite(point.z) ? point.z! : this.getZoomLevel()
+		)
 
 		const camera = this.getConstrainedCamera(_point, opts)
 
@@ -3978,6 +3991,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		easing(t: number): number
 		start: Box
 		end: Box
+		opts: TLCameraMoveOptions
 	}
 
 	/** @internal */
@@ -3986,12 +4000,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this._viewportAnimation.elapsed += ms
 
-		const { elapsed, easing, duration, start, end } = this._viewportAnimation
+		const { elapsed, easing, duration, start, end, opts } = this._viewportAnimation
 
 		if (elapsed > duration) {
 			this.off('tick', this._animateViewport)
 			this._viewportAnimation = null
-			this._setCamera(new Vec(-end.x, -end.y, this.getViewportScreenBounds().width / end.width))
+			// Forward the caller's options, otherwise a forced move to a position outside the
+			// constraints animates there and then snaps back on this last frame
+			this._setCamera(
+				new Vec(-end.x, -end.y, this.getViewportScreenBounds().width / end.width),
+				opts
+			)
 			return
 		}
 
@@ -4045,6 +4064,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			easing,
 			start: viewportPageBounds.clone(),
 			end: targetViewportPage.clone(),
+			opts: rest,
 		}
 
 		// If we ever get a "stop-camera-animation" event, we stop
@@ -4115,9 +4135,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			let newCy = cy + dy
 			let newCz = cz
 
-			// animate zoom if z direction is passed in
+			// animate zoom if z direction is passed in. Use an exponential factor so that a single
+			// long frame can't drive the zoom to zero or negative (which would give NaN coordinates)
 			if (dirZ !== 0) {
-				newCz = cz * (1 + dirZ * currentSpeed * elapsed)
+				newCz = cz * Math.exp(dirZ * currentSpeed * elapsed)
 				// Adjust x/y to keep the viewport center fixed while zooming
 				const center = this.getViewportScreenCenter()
 				newCx += center.x / newCz - center.x / cz

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -1256,3 +1256,36 @@ test('calling setCameraOptions will apply the new constraints', () => {
 		}
 	`)
 })
+
+test('a forced animated camera move ends at the forced position', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+	editor.setCameraOptions({
+		...DEFAULT_CAMERA_OPTIONS,
+		constraints: { ...DEFAULT_CONSTRAINTS, behavior: 'contain' },
+	})
+	editor.setCamera({ x: -5000, y: -5000, z: 1 }, { force: true, animation: { duration: 100 } })
+	editor.emit('tick', 50)
+	editor.emit('tick', 100)
+	// the final frame must not re-apply the constraints that `force` bypassed
+	expect(editor.getCamera()).toMatchObject({ x: -5000, y: -5000, z: 1 })
+})
+
+test('keeps the current zoom when setCamera is called without a finite zoom', () => {
+	editor.setCamera({ x: 0, y: 0, z: 0.5 })
+	editor.setCamera({ x: 100, y: 100 })
+	expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 0.5 })
+	editor.setCamera({ x: 0, y: 0, z: NaN })
+	expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 0.5 })
+})
+
+test('slideCamera zoom momentum survives a long frame', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+	editor.setCamera({ x: 0, y: 0, z: 1 })
+	editor.slideCamera({ speed: 1, direction: { x: 0, y: 0, z: -0.01 } })
+	// a 100ms frame would have driven a linear zoom factor to zero (and the camera to NaN)
+	editor.emit('tick', 100)
+	const { x, y, z } = editor.getCamera()
+	expect(z).toBeGreaterThan(0)
+	expect(z).toBeLessThan(1)
+	expect(Number.isFinite(x) && Number.isFinite(y)).toBe(true)
+})

--- a/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
+++ b/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
@@ -47,6 +47,14 @@ describe('When resizing', () => {
 			h: 1,
 		})
 	})
+
+	it('updates the selection screen bounds when the container moves', () => {
+		editor.createShape({ type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } })
+		editor.selectAll()
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 100, y: 100 })
+		editor.setScreenBounds({ x: 300, y: 200, w: 1080, h: 720 })
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 400, y: 300 })
+	})
 })
 
 describe('When center is false', () => {

--- a/packages/tldraw/src/test/viewport-following.test.ts
+++ b/packages/tldraw/src/test/viewport-following.test.ts
@@ -1,6 +1,6 @@
+import { InstancePresenceRecordType, TLUserId, createUserId } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let editor: TestEditor
 
 beforeEach(() => {
@@ -8,6 +8,34 @@ beforeEach(() => {
 })
 
 describe('When following a user', () => {
+	it('keeps following a leader whose own leader is missing', () => {
+		const pageId = editor.getCurrentPageId()
+		const leaderId = createUserId('leader')
+		const leadersLeaderId = createUserId('leaders-leader')
+		const presence = (userId: TLUserId, followingUserId: TLUserId | null) =>
+			InstancePresenceRecordType.create({
+				id: InstancePresenceRecordType.createId(userId),
+				userId,
+				userName: userId,
+				currentPageId: pageId,
+				followingUserId,
+				camera: { x: 0, y: 0, z: 1 },
+				screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
+				lastActivityTimestamp: Date.now(),
+			})
+
+		// the leader follows someone whose presence we don't have
+		editor.store.put([presence(leaderId, leadersLeaderId)])
+		editor.startFollowingUser(leaderId)
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+
+		// the leader's leader shows up, then leaves again
+		editor.store.put([presence(leadersLeaderId, null)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+		editor.store.remove([InstancePresenceRecordType.createId(leadersLeaderId)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+	})
+
 	it.todo('starts following a user')
 	it.todo('stops following a user')
 	it.todo('stops following a user when the camera changes due to user action')


### PR DESCRIPTION
This PR fixes a bug where `setCamera({ x, y })` reset the zoom to 100% and a `NaN` zoom crashed the editor. It also fixes forced animated camera moves snapping back on their last frame, `setCameraOptions({ zoomSteps: undefined })` making every later camera move throw, a long frame driving `slideCamera`'s zoom to zero, following a user whose own leader has left, and `getSelectionRotatedScreenBounds` going stale when the container moves.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `_setCamera` built the point with `Vec.Cast`, which defaults a missing `z` to 1, and then wrote the sanitised zoom onto the caller's object rather than the `Vec` it used, so a plain `{ x, y }` zoomed to 100% and a non-finite `z` got through.
- `_animateViewport` called `_setCamera` on the final frame without the caller's options, so a `force` move to a position outside the constraints animated there and then snapped back.
- `setCameraOptions` checked `next.zoomSteps?.length < 1`, which is false for `undefined`, so an explicit `zoomSteps: undefined` was stored and every later camera move threw.
- `slideCamera` scaled the zoom linearly by `1 + dirZ * speed * elapsed`, so a single long frame could make it zero or negative and produce `NaN` coordinates.
- `_getFollowingPresence` walked the following chain and returned `null` as soon as any link was missing, so a leader whose own leader had left (or whose presence had not arrived yet) could not be followed at all.
- `getSelectionRotatedScreenBounds` used `pageToScreen`, which reads the screen bounds without capturing them, so the computed never invalidated when the container moved.

### After

- `_setCamera` resolves `x`, `y` and `z` (falling back to the current zoom) before building the `Vec`.
- `_animateViewport` keeps the caller's options and forwards them to the final `_setCamera`.
- `setCameraOptions` treats a missing or empty `zoomSteps` as `[1]`.
- `slideCamera` uses an exponential zoom factor, `Math.exp(dirZ * speed * elapsed)`.
- `_getFollowingPresence` stops at the last resolvable presence in the chain.
- `getSelectionRotatedScreenBounds` reads `getViewportScreenBounds()` and the camera directly so it tracks container moves.

### Change type

- [x] `bugfix`

### Test plan

**`setCamera({ x, y })` resets the zoom**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Zoom to 200% (`Cmd/Ctrl +` a few times, or `editor.zoomIn()` in the console).
3. In the console, run `editor.setCamera({ x: 0, y: 0 })`.
4. On `main` the zoom snaps back to 100%. With this PR the camera pans and the zoom stays at 200%.

**Forced animated camera moves snap back**

1. On http://localhost:5420/develop, in the console, run `editor.setCameraOptions({ constraints: { bounds: { x: 0, y: 0, w: 1200, h: 800 }, behavior: 'contain', padding: { x: 0, y: 0 }, origin: { x: 0.5, y: 0.5 }, initialZoom: 'fit-x', baseZoom: 'fit-x' } })`.
2. Run `editor.setCamera({ x: -5000, y: -5000, z: 1 }, { force: true, animation: { duration: 500 } })`.
3. On `main` the camera animates out to the forced position and then jumps back inside the constraint bounds on the last frame. With this PR it stays at the forced position.

**`zoomSteps: undefined` breaks every later camera move**

1. On http://localhost:5420/develop, in the console, run `editor.setCameraOptions({ zoomSteps: undefined })`.
2. Scroll or pinch to zoom, or pan the canvas.
3. On `main` the `setCameraOptions` call and every later camera move throw `Cannot read properties of undefined (reading '0')` and the canvas stops moving. With this PR the zoom steps fall back to `[1]` and panning and zooming keep working.

**Stale `getSelectionRotatedScreenBounds` when the container moves**

1. Run `yarn dev` and open http://localhost:5420/selection-ui.
2. Draw a rectangle and select it so the four duplicate buttons appear around it.
3. In the console, run `document.querySelector('.tldraw__editor').style.marginLeft = '200px'` and wait about a second for the editor to pick up the new container bounds.
4. On `main` the duplicate buttons are drawn 200px to the left of the (now shifted) rectangle. With this PR they stay attached to the rectangle.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix setCamera resetting zoom for plain {x, y} points, forced animated camera moves snapping back, zoom momentum on long frames, following a user whose own leader left, and stale selection screen bounds.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +39 / -18  |
| Tests     | +70 / -1   |

