### PR TITLE
fix(editor): tlmenus context ids and corrupt user-preference storage

### DIFF
--- a/packages/editor/src/lib/config/TLUserPreferences.test.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { deleteFromLocalStorage, setInLocalStorage } from '@tldraw/utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defaultUserPreferences, userTypeValidator } from './TLUserPreferences'
 
 describe('TLUserPreferences consistency', () => {
@@ -37,5 +38,21 @@ describe('TLUserPreferences consistency', () => {
 		const expected = ['id', ...interfaceKeys].sort()
 
 		expect(validatorKeys).toEqual(expected)
+	})
+})
+
+describe('loading stored preferences', () => {
+	afterEach(() => {
+		deleteFromLocalStorage('TLDRAW_USER_DATA_v3')
+		vi.resetModules()
+	})
+
+	it.each([
+		['corrupt json', '{not json'],
+		['a snapshot whose user is not an object', JSON.stringify({ version: 1, user: null })],
+	])('falls back to fresh preferences for %s', async (_label, stored) => {
+		setInLocalStorage('TLDRAW_USER_DATA_v3', stored)
+		const { getUserPreferences } = await import('./TLUserPreferences')
+		expect(getUserPreferences().id).toEqual(expect.any(String))
 	})
 })

--- a/packages/editor/src/lib/config/TLUserPreferences.ts
+++ b/packages/editor/src/lib/config/TLUserPreferences.ts
@@ -201,9 +201,9 @@ function migrateUserPreferences(userData: unknown): TLUserPreferences {
 
 	const snapshot = structuredClone(userData) as any
 
-	migrateSnapshot(snapshot)
-
 	try {
+		// migration dereferences `user`, which malformed stored data may not have as an object
+		migrateSnapshot(snapshot)
 		return userTypeValidator.validate(snapshot.user)
 	} catch {
 		return getFreshUserPreferences()
@@ -211,8 +211,12 @@ function migrateUserPreferences(userData: unknown): TLUserPreferences {
 }
 
 function loadUserPreferences(): TLUserPreferences {
-	const userData = (JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null') ??
-		null) as null | UserDataSnapshot
+	let userData: unknown = null
+	try {
+		userData = JSON.parse(getFromLocalStorage(USER_DATA_KEY) || 'null')
+	} catch {
+		// corrupt stored data is treated as absent rather than blocking the editor from mounting
+	}
 
 	return migrateUserPreferences(userData)
 }

--- a/packages/editor/src/lib/globals/menus.test.ts
+++ b/packages/editor/src/lib/globals/menus.test.ts
@@ -1,0 +1,33 @@
+import { tlmenus } from './menus'
+
+describe('tlmenus', () => {
+	afterEach(() => {
+		tlmenus.clearOpenMenus()
+		tlmenus._hiddenMenus = []
+	})
+
+	it('reports whether a menu is open with and without a context', () => {
+		tlmenus.addOpenMenu('main')
+		tlmenus.addOpenMenu('main', 'editor-1')
+
+		expect(tlmenus.isMenuOpen('main')).toBe(true)
+		expect(tlmenus.isMenuOpen('main', 'editor-1')).toBe(true)
+		expect(tlmenus.isMenuOpen('main', 'editor-2')).toBe(false)
+		expect(tlmenus.isMenuOpen('other')).toBe(false)
+	})
+
+	it('hides and restores the open menus of a context', () => {
+		tlmenus.addOpenMenu('main', 'editor-1')
+		tlmenus.addOpenMenu('main', 'editor-2')
+
+		tlmenus.hideOpenMenus('editor-1')
+		expect(tlmenus.getOpenMenus()).toEqual(['main-editor-2'])
+
+		tlmenus.showOpenMenus('editor-1')
+		expect(tlmenus.getOpenMenus().sort()).toEqual(['main-editor-1', 'main-editor-2'])
+
+		// closing the real menu afterwards leaves nothing behind
+		tlmenus.deleteOpenMenu('main', 'editor-1')
+		expect(tlmenus.hasOpenMenus('editor-1')).toBe(false)
+	})
+})

--- a/packages/editor/src/lib/globals/menus.ts
+++ b/packages/editor/src/lib/globals/menus.ts
@@ -106,10 +106,12 @@ export const tlmenus = {
 	 * @public
 	 */
 	hideOpenMenus(contextId?: string) {
+		// ids read back from the store already carry their context suffix, so they are deleted
+		// (and later re-added) as-is rather than suffixed again
 		this._hiddenMenus = [...this.getOpenMenus(contextId)]
 		if (this._hiddenMenus.length === 0) return
 		for (const menu of this._hiddenMenus) {
-			this.deleteOpenMenu(menu, contextId)
+			this.deleteOpenMenu(menu)
 		}
 	},
 
@@ -128,10 +130,15 @@ export const tlmenus = {
 	 */
 	showOpenMenus(contextId?: string) {
 		if (this._hiddenMenus.length === 0) return
+		const stillHidden: string[] = []
 		for (const menu of this._hiddenMenus) {
-			this.addOpenMenu(menu, contextId)
+			if (!contextId || menu.endsWith('-' + contextId)) {
+				this.addOpenMenu(menu)
+			} else {
+				stillHidden.push(menu)
+			}
 		}
-		this._hiddenMenus = []
+		this._hiddenMenus = stillHidden
 	},
 
 	/**
@@ -148,7 +155,7 @@ export const tlmenus = {
 	 * @public
 	 */
 	isMenuOpen(id: string, contextId?: string): boolean {
-		return this.getOpenMenus(contextId).includes(`${id}-${contextId}`)
+		return this.getOpenMenus(contextId).includes(contextId ? `${id}-${contextId}` : id)
 	},
 
 	/**


### PR DESCRIPTION
This PR fixes a bug where `tlmenus.hideOpenMenus(contextId)` did nothing and `showOpenMenus(contextId)` left phantom entries that kept `hasOpenMenus()` true. It also fixes the editor failing to mount when the user preferences stored in localStorage are corrupt.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`hideOpenMenus`/`showOpenMenus` passed ids read back from the store, which already carry their `-${contextId}` suffix, through `deleteOpenMenu`/`addOpenMenu` with the context id again, so the suffix was doubled: hiding with a context was a no-op and showing added phantom `id-ctx-ctx` entries. `isMenuOpen(id)` without a context looked up `${id}-undefined`.

`loadUserPreferences` parsed localStorage with a bare `JSON.parse`, and `migrateUserPreferences` ran `migrateSnapshot` (which dereferences `snapshot.user`) outside its validation `try/catch`, so malformed stored data threw during editor construction.

### After

`hideOpenMenus`/`showOpenMenus` handle the stored ids as-is; `showOpenMenus(contextId)` restores only that context's menus and keeps the rest hidden; `isMenuOpen(id)` looks up the bare id when no context is given.

`loadUserPreferences` catches a failing `JSON.parse` and `migrateUserPreferences` runs the migration inside its `try/catch`, so corrupt data falls back to fresh preferences.

### Change type

- [x] `bugfix`

### Test plan

**Corrupt user preferences in localStorage**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. In the devtools console, run `localStorage.setItem('TLDRAW_USER_DATA_v3', '{not json')`.
3. Reload the page.
4. On `main` the editor fails to mount (blank page, `SyntaxError` from `JSON.parse` in the console). With this PR the editor mounts with fresh default preferences.
5. Repeat with `localStorage.setItem('TLDRAW_USER_DATA_v3', JSON.stringify({ version: 1, user: null }))` and reload: on `main` the migration throws during mount; with this PR the editor mounts.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix hiding/showing menus by context id and tolerate corrupt user-preference data in localStorage.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +19 / -8   |
| Tests     | +51 / -1   |

