### PR TITLE
fix(editor): packShapes, stackShapes and shape clustering ordering

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -129,7 +129,13 @@ import { Geometry2d } from '../primitives/geometry/Geometry2d'
 import { Group2d } from '../primitives/geometry/Group2d'
 import { intersectPolygonPolygon } from '../primitives/intersect'
 import { Mat, MatLike } from '../primitives/Mat'
-import { PI, approximately, areAnglesCompatible, clamp, pointInPolygon } from '../primitives/utils'
+import {
+	HALF_PI,
+	approximately,
+	areAnglesCompatible,
+	clamp,
+	pointInPolygon,
+} from '../primitives/utils'
 import { Vec, VecLike } from '../primitives/Vec'
 import { areShapesContentEqual } from '../utils/areShapesContentEqual'
 import { dataUrlToFile } from '../utils/assets'
@@ -7456,9 +7462,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// optionally filter to axis-aligned shapes (rotation is a multiple of 90 degrees)
 		if (opts?.filterAxisAligned) {
-			freshShapes = freshShapes.filter(
-				(s) => this.getShapePageTransform(s)?.rotation() % (PI / 2) === 0
-			)
+			freshShapes = freshShapes.filter((s) => {
+				// Page rotations come back through atan2 on a composed matrix, so a 270° shape can land
+				// a hair either side of the multiple; an exact === 0 check drops it
+				const remainder = Math.abs(this.getShapePageTransform(s).rotation() % HALF_PI)
+				return Math.min(remainder, HALF_PI - remainder) < 1e-9
+			})
 		}
 
 		const clusters: { shapes: TLShape[]; pageBounds: Box }[] = []
@@ -7484,8 +7493,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shapesMovingTogether = [shape]
 			const boundsOfShapesMovingTogether: Box[] = [shapePageBounds]
 
+			// Seed with bindings in both directions, otherwise an arrow visited before the shapes it
+			// binds ends up in a cluster of its own and the result depends on input order
 			this.collectShapesViaArrowBindings({
-				bindings: this.getBindingsToShape(shape.id, 'arrow'),
+				bindings: this.getBindingsInvolvingShape(shape.id, 'arrow'),
 				initialShapes: freshShapes,
 				resultShapes: shapesMovingTogether,
 				resultBounds: boundsOfShapesMovingTogether,
@@ -7679,12 +7690,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let shapeGap: number = 0
 
+		// Stack in spatial order rather than input (z) order, otherwise shapes swap places
+		shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
+
 		if (_gap === 0) {
 			// note: this is not used in the current tldraw.com; there we use a specified stack
 
 			const gaps: Record<number, number> = {}
-
-			shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
 
 			// Collect all of the gaps between shapes. We want to find
 			// patterns (equal gaps between shapes) and use the most common
@@ -7789,10 +7801,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const maxWidth = commonBounds.width
 
-		// sort the shape clusters by width and then height, descending
+		// sort the shape clusters by width and then height, descending: potpack fills each row's
+		// right-hand space with the shapes that follow, so they must be no taller than the row
 		shapeClustersToPack
-			.sort((a, b) => a.pageBounds.width - b.pageBounds.width)
-			.sort((a, b) => a.pageBounds.height - b.pageBounds.height)
+			.sort((a, b) => b.pageBounds.width - a.pageBounds.width)
+			.sort((a, b) => b.pageBounds.height - a.pageBounds.height)
 
 		// Start with is (sort of) the square of the area
 		const startWidth = Math.max(Math.ceil(Math.sqrt(area / 0.95)), maxWidth)

--- a/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
+++ b/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
@@ -38,8 +38,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 3.141592653589793,
     "type": "geo",
     "typeName": "shape",
-    "x": 192,
-    "y": 308,
+    "x": 134,
+    "y": 250,
   },
   {
     "id": "shape:boxB",
@@ -77,8 +77,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 92,
-    "y": 92,
+    "x": 150,
+    "y": 150,
   },
   {
     "id": "shape:boxC",
@@ -116,8 +116,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 208,
-    "y": 92,
+    "x": 266,
+    "y": 150,
   },
 ]
 `;

--- a/packages/tldraw/src/test/commands/packShapes.test.ts
+++ b/packages/tldraw/src/test/commands/packShapes.test.ts
@@ -74,4 +74,24 @@ describe('editor.packShapes', () => {
 			editor.getCurrentPageShapes().map((s) => ({ ...s, parentId: 'wahtever' }))
 		).toMatchSnapshot('packed shapes')
 	})
+
+	it('packs shapes of different heights into rows, tallest first', () => {
+		// With the clusters sorted ascending by height, every shape after the first was too tall
+		// for the row's remaining space and fell into a single left-hand column.
+		editor.selectAll()
+		editor.deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{ id: ids.boxA, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.boxB, type: 'geo', x: 200, y: 0, props: { w: 100, h: 60 } },
+			{ id: ids.boxC, type: 'geo', x: 400, y: 0, props: { w: 120, h: 80 } },
+			{ id: ids.boxD, type: 'geo', x: 600, y: 0, props: { w: 100, h: 120 } },
+		])
+		editor.packShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD], 20)
+		editor.expectShapeToMatch(
+			{ id: ids.boxD, x: 110, y: 0 },
+			{ id: ids.boxA, x: 230, y: 0 },
+			{ id: ids.boxC, x: 350, y: 0 },
+			{ id: ids.boxB, x: 490, y: 0 }
+		)
+	})
 })

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -143,6 +143,60 @@ describe('distributeShapes command', () => {
 			})
 		})
 
+		it('keeps an arrow and its bound shapes together regardless of input order', () => {
+			const arrowId = createShapeId('arrow')
+			editor.updateShapes([
+				{ id: ids.boxB, type: 'geo', x: 300, y: 0 },
+				{ id: ids.boxC, type: 'geo', x: 600, y: 0 },
+			])
+			editor.createShape({ id: arrowId, type: 'arrow', x: 50, y: 50 })
+			editor.createBindings([
+				{
+					fromId: arrowId,
+					toId: ids.boxA,
+					type: 'arrow',
+					props: {
+						terminal: 'start',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+				{
+					fromId: arrowId,
+					toId: ids.boxB,
+					type: 'arrow',
+					props: {
+						terminal: 'end',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+			])
+			// the arrow comes first: seeding its cluster from bindings *to* it alone would leave
+			// it (and then A and B) in clusters of their own and pull B up against A
+			editor.stackShapes([arrowId, ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxB, x: 300 },
+				{ id: ids.boxC, x: 410 }
+			)
+		})
+
+		it('stacks in spatial order, not selection order, when a gap is given', () => {
+			// boxC sits between boxA and boxB on the page but comes after both in the input
+			editor.updateShapes([{ id: ids.boxC, type: 'geo', x: 50, y: 0 }])
+			editor.stackShapes([ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxC, x: 110 },
+				{ id: ids.boxB, x: 220 }
+			)
+		})
+
 		it('stacks the shapes based on the most common gap', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 0)


### PR DESCRIPTION
This PR fixes a bug where `packShapes` packed shapes of distinct heights into a single column. It also fixes `stackShapes` swapping shapes around when an explicit gap is given, arrow clusters depending on selection order, and deeply nested 270° shapes being dropped from axis-aligned clustering.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `packShapes` sorted clusters by width then height ascending, but potpack fills each row's right-hand space with the shapes that follow, so they must be no taller than the row; ascending order made every shape start a new row.
- `stackShapes` only sorted clusters spatially in the auto-gap (`gap === 0`) branch, so an explicit gap stacked shapes in selection (z) order.
- `getShapeClusters` seeded each cluster with `getBindingsToShape`, so an arrow visited before the shapes it binds ended up in a cluster of its own and the result depended on input order.
- Its `filterAxisAligned` check used `rotation() % (PI / 2) === 0`; page rotations come back through `atan2` on a composed matrix, so a nested 270° shape landing a hair off the multiple was dropped.

### After

- `packShapes` sorts by width then height descending (the existing "packs rotated shapes" snapshot changes accordingly).
- `stackShapes` sorts spatially before both branches.
- `getShapeClusters` seeds with `getBindingsInvolvingShape`.
- The axis-aligned filter tolerates rounding error (`< 1e-9`) either side of a multiple of 90°.

### Change type

- [x] `bugfix`

### Test plan

**Pack puts shapes of different heights in a single column**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Draw four rectangles of clearly different heights in a row (for example short, tall, medium, taller).
3. Select all of them and choose Arrange > Pack from the context menu (or the actions menu).
4. On `main` the rectangles end up in a single vertical column. With this PR they are packed into rows, tallest first.

**Stack horizontally reorders shapes**

1. Open http://localhost:5420/develop and draw three rectangles in this creation order: the first on the right, the second on the left, the third in the middle.
2. Select all three and choose Arrange > Stack horizontally.
3. On `main` the rectangles are rearranged into creation order (the first-drawn one becomes the leftmost). With this PR they keep their left-to-right order and only the gaps change.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix packShapes packing into a single column, stackShapes reordering shapes when a gap is given, and arrow clusters depending on selection order.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +23 / -10  |
| Tests           | +74 / -0   |
| Automated files | +6 / -6    |

