### PR TITLE
fix(editor): pen-mode palm rejection, indirect-pen double clicks and the stylus eraser guard

### DIFF
--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -1101,6 +1101,27 @@ describe('dispatch event emission', () => {
 
 		expect(eventHandler).toHaveBeenCalledWith(pinchEndEvent)
 	})
+
+	it('ignores the stylus eraser button when no eraser tool is registered', () => {
+		const pointerDown = {
+			type: 'pointer' as const,
+			name: 'pointer_down' as const,
+			target: 'canvas' as const,
+			point: { x: 100, y: 100, z: 0.5 },
+			pointerId: 1,
+			button: 5,
+			isPen: true,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+		}
+
+		expect(() => testEditor.dispatch(pointerDown)).not.toThrow()
+		expect(() => testEditor.dispatch({ ...pointerDown, name: 'pointer_up' })).not.toThrow()
+		expect(testEditor.getCrashingError()).toBeNull()
+	})
 })
 
 describe('setTool', () => {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11375,15 +11375,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// Ignore pointer events while we're pinching
 				if (inputs.getIsPinching()) return
 
-				this.inputs.updateFromEvent(info)
 				const { isPen } = info
 				const { isPenMode } = instanceState
 
+				// In pen mode, reject non-pen input (a resting palm) before it touches any
+				// state: otherwise updateFromEvent moves the origin point out from under the
+				// pen's drag, and a palm pointer_up clears the pen's isPointing/isDragging.
+				if (isPenMode && !isPen) return
+
+				this.inputs.updateFromEvent(info)
+
 				switch (info.name) {
 					case 'pointer_down': {
-						// If we're in pen mode and the input is not a pen type, then stop here
-						if (isPenMode && !isPen) return
-
 						// A pointer down starts a new interaction, so flush any modifier that's
 						// still lingering in its release-debounce window: treat it as released now.
 						this._releaseDebouncedModifiers()
@@ -11435,8 +11438,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.interrupt()
 						}
 
-						// On devices with erasers (like the Surface Pen or Wacom Pen), button 5 is the eraser
-						if (info.button === STYLUS_ERASER_BUTTON) {
+						// On devices with erasers (like the Surface Pen or Wacom Pen), button 5 is the eraser.
+						// Guarded on the eraser tool existing: the bare editor can be configured without
+						// it, and an unguarded transition would throw and crash the editor.
+						if (info.button === STYLUS_ERASER_BUTTON && this.getStateDescendant('eraser')) {
 							this._restoreToolId = this.getCurrentToolId()
 							this.complete()
 							this.setCurrentTool('eraser')
@@ -11464,9 +11469,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						break
 					}
 					case 'pointer_move': {
-						// If the user is in pen mode, but the pointer is not a pen, stop here.
-						if (!isPen && isPenMode) return
-
 						const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.getCamera())
 
 						// Right-click pointing: waiting to see if this becomes a drag
@@ -11528,9 +11530,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 						clearTimeout(this._longPressTimeout)
 						// Remove the button from the buttons set
 						inputs.buttons.delete(info.button)
-
-						// If we're in pen mode and we're not using a pen, stop here
-						if (instanceState.isPenMode && !isPen) return
 
 						// Right-click pointing ended without dragging—this is a static
 						// right-click, so let it through to the state chart as right_click.
@@ -11601,7 +11600,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								})
 							}
 						} else {
-							if (info.button === STYLUS_ERASER_BUTTON) {
+							if (info.button === STYLUS_ERASER_BUTTON && this.getStateDescendant('eraser')) {
 								// If we were erasing with a stylus button, restore the tool we were using before we started erasing
 								this.complete()
 								this.setCurrentTool(this._restoreToolId)
@@ -11729,9 +11728,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				this.setCurrentTool('select')
 			}
 
-			// If a left click pointer event, send the event to the click manager.
+			// Send the event to the click manager. In pen mode only pen clicks count; otherwise
+			// every pointer does, including an indirect tablet stylus (a pen that never enables
+			// pen mode), which would otherwise never produce double-click events.
 			const { isPenMode } = this.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
-			if (info.isPen === isPenMode) {
+			if (!isPenMode || info.isPen) {
 				// The click manager may return a new event, i.e. a double click event
 				// depending on the event coming in and its own state. If the event has
 				// changed then hand both events to the statechart

--- a/packages/tldraw/src/test/ClickManager.test.ts
+++ b/packages/tldraw/src/test/ClickManager.test.ts
@@ -293,3 +293,20 @@ it('Resets when the focus layer changes', () => {
 	expect(events).toMatchObject([{ name: 'pointer_down' }])
 	expect(events).toHaveLength(1)
 })
+
+it('Emits double click events for an indirect pen outside pen mode', () => {
+	const events: any[] = []
+	editor.addListener('event', (info) => events.push(info))
+
+	// An indirect desktop tablet stylus reports as a pen but never enables pen mode, so
+	// its clicks still have to reach the click manager to produce double-click events.
+	const pen = { isPen: true, isPenDirect: false }
+	editor.pointerDown(0, 0, pen).pointerUp(0, 0, pen).pointerDown(0, 0, pen)
+	expect(editor.getInstanceState().isPenMode).toBe(false)
+	expect(events).toMatchObject([
+		{ name: 'pointer_down' },
+		{ name: 'pointer_up' },
+		{ name: 'pointer_down' },
+		{ name: 'double_click', type: 'click', phase: 'down' },
+	])
+})

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -1,4 +1,4 @@
-import { TLDrawShape, Vec } from '@tldraw/editor'
+import { TLDrawShape, Vec, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -121,5 +121,34 @@ describe('forgiving palm touches when entering pen mode', () => {
 		const bounds = editor.getShapePageBounds(shape.id)!
 		expect(bounds.minX).toBeGreaterThan(200)
 		expect(bounds.minY).toBeGreaterThan(200)
+	})
+})
+
+describe('palm touches while in pen mode', () => {
+	it('ignores a palm touch without disturbing the pen drag in progress', () => {
+		const id = createShapeId('box')
+		editor.createShapes([
+			{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+		])
+		editor.updateInstanceState({ isPenMode: true })
+
+		const pen = { target: 'canvas', isPen: true } as const
+		const palm = { target: 'canvas', isPen: false } as const
+
+		editor.pointerDown(150, 150, pen)
+		editor.pointerMove(170, 170, pen)
+		editor.expectToBeIn('select.translating')
+
+		// A palm lands and lifts while the pen is still down. It must be ignored before it
+		// can reset the drag origin or clear the pen's pointing state.
+		editor.pointerDown(600, 600, palm)
+		editor.pointerUp(600, 600, palm)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+		expect(editor.inputs.getOriginPagePoint()).toMatchObject({ x: 150, y: 150 })
+
+		editor.pointerMove(200, 200, pen)
+		editor.expectShapeToMatch({ id, x: 150, y: 150 })
+		editor.pointerUp(200, 200, pen)
+		editor.expectToBeIn('select.idle')
 	})
 })


### PR DESCRIPTION
This PR fixes a bug where a palm resting on the screen disturbed an in-progress pen-mode drag. It also fixes double and triple clicks not firing for indirect desktop tablet styluses, and a crash when the stylus eraser button is used in an editor configured without an eraser tool.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The pointer handler in `Editor.dispatch` called `inputs.updateFromEvent(info)` first and only then rejected non-pen events per case, so in pen mode a palm touch had already moved the origin point out from under the pen's drag, and a palm `pointer_up` cleared the pen's `isPointing`/`isDragging`.

The click-manager gate was `info.isPen === isPenMode`, so an indirect tablet stylus (which reports `isPen` but never enables pen mode) never reached the click manager and produced no double clicks.

The stylus eraser button called `setCurrentTool('eraser')` unconditionally, which threw when the editor had no eraser tool.

### After

Non-pen events in pen mode are rejected before `updateFromEvent` runs, so a palm touch never reaches input state. The click-manager gate is `!isPenMode || info.isPen`: in pen mode only pen clicks count, otherwise every pointer does. Both eraser-button transitions are guarded on `getStateDescendant('eraser')`.

### Change type

- [x] `bugfix`

### Test plan

**Palm touch disturbs a pen-mode drag**

1. Run `yarn dev` and open http://localhost:5420/develop on a touch device with a stylus (for example an iPad with Apple Pencil).
2. Draw a stroke with the stylus so the editor enters pen mode, then switch to the select tool and draw a rectangle with the stylus.
3. Start dragging the rectangle with the stylus and, mid-drag, rest a finger or palm on the screen, then lift it while still dragging the stylus.
4. On `main` the rectangle jumps away from the stylus or the drag ends early. With this PR the touch is ignored and the drag continues smoothly under the stylus.

**Indirect tablet stylus never double-clicks**

1. Open http://localhost:5420/develop on a desktop with an external drawing tablet (for example a Wacom tablet).
2. Draw a rectangle with the stylus using the rectangle tool, then switch to the select tool and double-tap the rectangle with the stylus.
3. On `main` nothing happens (no text editing starts). With this PR the double-tap enters text editing, the same as a double-click with the mouse.

**Stylus eraser button crashes an editor without an eraser tool**

1. Open http://localhost:5420/only-editor with a stylus that has an eraser button (for example a Surface Pen or Wacom Pen).
2. Press the eraser end (or hold the eraser button) and touch the canvas.
3. On `main` the editor crashes with an error about the missing `eraser` tool. With this PR the eraser button is ignored and the editor keeps working.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix palm touches disturbing pen-mode drags, double-click for desktop tablet styluses, and a crash when a stylus eraser is used without an eraser tool.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -15  |
| Tests     | +68 / -1   |

