### PR TITLE
fix(editor): ClickManager compares pointer positions in client coordinates and clears its timer

### DIFF
--- a/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
+++ b/packages/editor/src/lib/editor/managers/ClickManager/ClickManager.ts
@@ -94,7 +94,7 @@ export class ClickManager {
 				switch (this._clickState) {
 					case 'pendingDouble': {
 						this._clickState = 'pendingOverflow'
-						this._clickTimeout = this._getClickTimeout(this._clickState)
+						this._getClickTimeout(this._clickState)
 						return {
 							...info,
 							type: 'click',
@@ -114,7 +114,7 @@ export class ClickManager {
 						// overflow
 					}
 				}
-				this._clickTimeout = this._getClickTimeout(this._clickState)
+				this._getClickTimeout(this._clickState)
 				return info
 			}
 			case 'pointer_up': {
@@ -141,10 +141,12 @@ export class ClickManager {
 				return info
 			}
 			case 'pointer_move': {
+				// Compare in client coordinates like _clickScreenPoint; the container-relative
+				// inputs screen point would add the container offset and cancel on any movement.
 				if (
 					this._clickState !== 'idle' &&
 					this._clickScreenPoint &&
-					Vec.Dist2(this._clickScreenPoint, this.editor.inputs.getCurrentScreenPoint()) >
+					Vec.Dist2(this._clickScreenPoint, info.point) >
 						(this.editor.getInstanceState().isCoarsePointer
 							? this.editor.options.coarseDragDistanceSquared
 							: this.editor.options.dragDistanceSquared)

--- a/packages/tldraw/src/test/ClickManager.test.ts
+++ b/packages/tldraw/src/test/ClickManager.test.ts
@@ -263,6 +263,24 @@ it('Cancels when click moves', () => {
 	expect(event.name).toBe('pointer_up')
 })
 
+it('Does not cancel a double click on a small move when the container is offset', () => {
+	// click points are client coordinates; comparing them against the container-relative
+	// screen point used to cancel on any movement at all in an offset container
+	editor.setScreenBounds({ x: 300, y: 100, w: 1080, h: 720 })
+	const events: any[] = []
+	editor.addListener('event', (info) => events.push(info))
+
+	editor.pointerDown(500, 400).pointerMove(501, 400).pointerUp(501, 400).pointerDown(501, 400)
+
+	expect(events).toMatchObject([
+		{ name: 'pointer_down' },
+		{ name: 'pointer_move' },
+		{ name: 'pointer_up' },
+		{ name: 'pointer_down' },
+		{ name: 'double_click', type: 'click', phase: 'down' },
+	])
+})
+
 it('Resets when the focus layer changes', () => {
 	const boxId = editor.testShapeID('box')
 	const otherBoxId = editor.testShapeID('otherBox')


### PR DESCRIPTION
This PR fixes a bug where a small pointer jitter cancelled a pending double click when the editor container was offset from the page origin. It also fixes the click manager's timeout never being cleared.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

In `ClickManager`, the `pointer_move` drag-cancel check compared the stored pointer-down point (client coordinates) against `inputs.getCurrentScreenPoint()` (container-relative), so the measured distance was inflated by the container offset and any movement exceeded the drag threshold. Separately, `_clickTimeout = this._getClickTimeout(...)` assigned the return value of a method that returns nothing, overwriting the stored timer id with `undefined` so `clearTimeout` never cleared anything.

### After

The drag-cancel check compares the stored point against `info.point`, which is in the same client coordinate space. `_getClickTimeout` is called for its side effect only, so the timer id it stores is kept and can be cleared.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/inset, where the editor container is inset 100 px from the page origin.
2. Double click on empty canvas while nudging the pointer by a pixel or two between the two clicks (easy on a trackpad; a double click with no movement at all is not affected).
3. On `main` the second click is treated as a plain click and no text shape is created, while the same gesture works on the full-screen http://localhost:5420/develop. With this PR the double click registers and a text editor opens, as it does in the full-screen example.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix double clicks being cancelled by small pointer movements when the editor container is offset from the page origin.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -3    |
| Tests     | +18 / -0   |

