### PR TITLE
fix(editor): support the rotate/resize cursor types and encode the cursor colour

### DIFF
--- a/apps/docs/content/sdk-features/cursors.mdx
+++ b/apps/docs/content/sdk-features/cursors.mdx
@@ -30,31 +30,34 @@ The `type` determines the visual appearance—like `'default'`, `'grab'`, or `'n
 
 tldraw supports these cursor types:
 
-| Type          | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `default`     | Standard pointer arrow                         |
-| `pointer`     | Hand indicating clickable element              |
-| `cross`       | Crosshair for precise positioning              |
-| `comment`     | Speech bubble for placing comments             |
-| `grab`        | Open hand for draggable content                |
-| `grabbing`    | Closed hand while dragging                     |
-| `text`        | I-beam for text editing                        |
-| `move`        | Four-way arrow for moving elements             |
-| `zoom-in`     | Magnifying glass with plus                     |
-| `zoom-out`    | Magnifying glass with minus                    |
-| `ew-resize`   | Horizontal resize (east-west)                  |
-| `ns-resize`   | Vertical resize (north-south)                  |
-| `nesw-resize` | Diagonal resize (northeast-southwest)          |
-| `nwse-resize` | Diagonal resize (northwest-southeast)          |
-| `nesw-rotate` | Rotation handle (northeast-southwest position) |
-| `nwse-rotate` | Rotation handle (northwest-southeast position) |
-| `senw-rotate` | Rotation handle (southeast-northwest position) |
-| `swne-rotate` | Rotation handle (southwest-northeast position) |
-| `none`        | Hidden cursor                                  |
+| Type            | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `default`       | Standard pointer arrow                                    |
+| `pointer`       | Hand indicating clickable element                         |
+| `cross`         | Crosshair for precise positioning                         |
+| `comment`       | Speech bubble for placing comments                        |
+| `grab`          | Open hand for draggable content                           |
+| `grabbing`      | Closed hand while dragging                                |
+| `text`          | I-beam for text editing                                   |
+| `move`          | Four-way arrow for moving elements                        |
+| `zoom-in`       | Magnifying glass with plus                                |
+| `zoom-out`      | Magnifying glass with minus                               |
+| `ew-resize`     | Horizontal resize (east-west)                             |
+| `ns-resize`     | Vertical resize (north-south)                             |
+| `nesw-resize`   | Diagonal resize (northeast-southwest)                     |
+| `nwse-resize`   | Diagonal resize (northwest-southeast)                     |
+| `nesw-rotate`   | Rotation handle (northeast-southwest position)            |
+| `nwse-rotate`   | Rotation handle (northwest-southeast position)            |
+| `senw-rotate`   | Rotation handle (southeast-northwest position)            |
+| `swne-rotate`   | Rotation handle (southwest-northeast position)            |
+| `none`          | Hidden cursor                                             |
+| `rotate`        | Static rotation cursor (falls back to `pointer`)          |
+| `resize-edge`   | Static edge resize cursor (falls back to `ew-resize`)     |
+| `resize-corner` | Static corner resize cursor (falls back to `nesw-resize`) |
 
 Static cursors like `default`, `pointer`, and `grab` are prerendered SVG cursors defined as CSS custom properties in tldraw's stylesheet (`--tl-cursor-default`, `--tl-cursor-grab`, and so on). Dynamic cursors like the resize and rotate types are generated at runtime as SVGs with the current rotation applied. The canvas reads the result from the `--tl-cursor` variable.
 
-> `TLCursorType` also includes `resize-edge`, `resize-corner`, and `rotate` for schema compatibility. The default cursor rendering doesn't support them, so don't pass them to `setCursor`.
+The `rotate`, `resize-edge`, and `resize-corner` types are static too: they map to `--tl-cursor-rotate`, `--tl-cursor-resize-edge`, and `--tl-cursor-resize-corner`, which default to the browser's `pointer`, `ew-resize`, and `nesw-resize` cursors and ignore the cursor rotation. Use the direction-specific `*-resize` and `*-rotate` types when you want the rotated SVG cursors.
 
 ## Setting the cursor
 

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -33,7 +33,8 @@ function getCursorCss(
 	)
 }
 
-const STATIC_CURSORS = [
+// Cursors that map straight to a prerendered `--tl-cursor-*` css variable rather than a runtime svg.
+const STATIC_CURSORS = new Set<TLCursorType>([
 	'default',
 	'pointer',
 	'cross',
@@ -47,11 +48,11 @@ const STATIC_CURSORS = [
 	'rotate',
 	'resize-edge',
 	'resize-corner',
-]
+])
 
 type CursorFunction = (rotation: number, flip: boolean, color: string) => string
 
-const CURSORS: Record<TLCursorType, CursorFunction> = {
+const DYNAMIC_CURSORS: Record<TLCursorType, CursorFunction> = {
 	none: () => 'none',
 	'ew-resize': (r, f, c) => getCursorCss(EDGE_SVG, r, 0, f, c),
 	'ns-resize': (r, f, c) => getCursorCss(EDGE_SVG, r, 90, f, c),
@@ -65,7 +66,8 @@ const CURSORS: Record<TLCursorType, CursorFunction> = {
 
 /** @public */
 export function getCursor(cursor: TLCursorType, rotation = 0, color = 'black') {
-	return CURSORS[cursor](radiansToDegrees(rotation), false, color)
+	if (STATIC_CURSORS.has(cursor)) return `var(--tl-cursor-${cursor})`
+	return DYNAMIC_CURSORS[cursor](radiansToDegrees(rotation), false, color)
 }
 
 export function useCursor() {
@@ -77,8 +79,9 @@ export function useCursor() {
 		() => {
 			const { type, rotation } = editor.getInstanceState().cursor
 
-			if (STATIC_CURSORS.includes(type)) {
-				container.style.setProperty('--tl-cursor', `var(--tl-cursor-${type})`)
+			// Static cursors don't need the theme colour, so skip reading it to avoid depending on it.
+			if (STATIC_CURSORS.has(type)) {
+				container.style.setProperty('--tl-cursor', getCursor(type))
 				return
 			}
 

--- a/packages/editor/src/lib/hooks/useCursor.ts
+++ b/packages/editor/src/lib/hooks/useCursor.ts
@@ -23,8 +23,9 @@ function getCursorCss(
 	const dx = 1 * c - 1 * s
 	const dy = 1 * s + 1 * c
 
+	// A raw '#' in the colour (hex) would end the unencoded data url as a fragment.
 	return (
-		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${color};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
+		`url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' style='color: ${encodeURIComponent(color)};'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='${dx}' dy='${dy}' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g fill='none' transform='rotate(${
 			r + tr
 		} 16 16)${f ? ` scale(-1,-1) translate(0, -32)` : ''}' filter='url(%23shadow)'>` +
 		svg.replaceAll(`"`, `'`) +
@@ -43,6 +44,9 @@ const STATIC_CURSORS = [
 	'text',
 	'zoom-in',
 	'zoom-out',
+	'rotate',
+	'resize-edge',
+	'resize-corner',
 ]
 
 type CursorFunction = (rotation: number, flip: boolean, color: string) => string

--- a/packages/editor/src/lib/test/useCursor.test.tsx
+++ b/packages/editor/src/lib/test/useCursor.test.tsx
@@ -1,0 +1,29 @@
+import { act, render } from '@testing-library/react'
+import { createTLStore } from '../config/createTLStore'
+import { Editor } from '../editor/Editor'
+import { getCursor } from '../hooks/useCursor'
+import { TL_CONTAINER_CLASS, TldrawEditor } from '../TldrawEditor'
+
+describe('useCursor', () => {
+	it('maps the static schema cursor types to their css variables', async () => {
+		let editor: Editor
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} onMount={(e) => void (editor = e)} />)
+		})
+		const container = document.querySelector(`.${TL_CONTAINER_CLASS}`) as HTMLElement
+
+		for (const type of ['rotate', 'resize-edge', 'resize-corner', 'default'] as const) {
+			act(() => editor.setCursor({ type, rotation: 0 }))
+			expect(container.style.getPropertyValue('--tl-cursor')).toBe(`var(--tl-cursor-${type})`)
+		}
+	})
+})
+
+describe('getCursor', () => {
+	it('encodes the colour so a hex value does not end the data url as a fragment', () => {
+		const css = getCursor('ew-resize', 0, '#000000')
+		expect(css).toContain("style='color: %23000000;'")
+		expect(css).not.toContain('#')
+	})
+})

--- a/packages/editor/src/lib/test/useCursor.test.tsx
+++ b/packages/editor/src/lib/test/useCursor.test.tsx
@@ -21,6 +21,13 @@ describe('useCursor', () => {
 })
 
 describe('getCursor', () => {
+	it('returns the css variable for the static cursor types', () => {
+		for (const type of ['rotate', 'resize-edge', 'resize-corner', 'default'] as const) {
+			expect(getCursor(type)).toBe(`var(--tl-cursor-${type})`)
+			expect(getCursor(type, Math.PI / 2, '#000000')).toBe(`var(--tl-cursor-${type})`)
+		}
+	})
+
 	it('encodes the colour so a hex value does not end the data url as a fragment', () => {
 		const css = getCursor('ew-resize', 0, '#000000')
 		expect(css).toContain("style='color: %23000000;'")


### PR DESCRIPTION
This PR fixes a bug where `editor.setCursor({ type: 'resize-corner' })` (and the other schema-valid `rotate` and `resize-edge` cursor types) threw instead of showing a cursor. It also fixes every SVG cursor disappearing when the theme's cursor colour is a hex value.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`useCursor` had no entries for `rotate`, `resize-edge` or `resize-corner`, so those types fell through to the `CURSORS` lookup and threw. The theme cursor colour was interpolated raw into the `data:image/svg+xml` URL, so a hex colour's `#` terminated the URL as a fragment and the SVG never rendered.

### After

`rotate`, `resize-edge` and `resize-corner` are listed as static cursors and map to the existing `--tl-cursor-*` CSS variables. The colour is percent-encoded before interpolation.

### Change type

- [x] `bugfix`

### Test plan

**`setCursor` with the rotate/resize cursor types**

1. Run `yarn dev` and open http://localhost:5420/develop with the devtools console open.
2. In the console run `editor.setCursor({ type: 'resize-corner', rotation: 0 })` and move the pointer over the canvas.
3. On `main` an error is thrown (`CURSORS[cursor] is not a function`) and the cursor does not change. With this PR the cursor becomes the resize-corner cursor; `rotate` and `resize-edge` work the same way.

**Hex cursor colour in a theme**

1. On http://localhost:5420/develop, in the console run `const t = structuredClone(editor.getTheme('default')); t.colors.light.cursor = '#000000'; editor.updateTheme(t)` (use `colors.dark` if the editor is in dark mode).
2. Draw a rectangle, select it and hover a corner or edge resize handle.
3. On `main` the SVG resize cursor does not render and the browser falls back to the hand pointer. With this PR the resize arrow cursor shows as usual.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix setCursor throwing for rotate/resize cursor types and hex cursor colours breaking SVG cursors.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -1    |
| Tests     | +29 / -0   |

