### PR TITLE
fix(editor): unaligned flips, resize callbacks and resizeBox max clamp

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8392,6 +8392,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			initialShape: TLShape
 			isAspectRatioLocked: boolean
 			initialPageTransform: MatLike
+			dragHandle?: TLResizeHandle
+			mode?: TLResizeMode
+			skipStartAndEndCallbacks?: boolean
 		}
 	) {
 		const { type } = options.initialShape
@@ -8416,19 +8419,25 @@ export class Editor extends EventEmitter<TLEventMap> {
 			initialBounds: options.initialBounds,
 			isAspectRatioLocked: options.isAspectRatioLocked,
 			initialPageTransform: options.initialPageTransform,
+			dragHandle: options.dragHandle,
+			mode: options.mode,
+			// this is one frame of the same resize, not a new one, so don't fire start/end again
+			skipStartAndEndCallbacks: options.skipStartAndEndCallbacks,
 		})
 
 		// then if the shape is flipped in one axis only, we need to apply an extra rotation
 		// to make sure the shape is mirrored correctly
 		if (Math.sign(scale.x) * Math.sign(scale.y) < 0) {
-			// We need to compute the new local rotation that will result in the negated page rotation.
-			// For a shape with local rotation `localRot` and parent page rotation `parentRot`:
+			// Mirroring across an axis at angle `axisRot` maps a page rotation `pageRot` to
+			// `2 * axisRot - pageRot`. For a shape with local rotation `localRot` and parent page
+			// rotation `parentRot`:
 			// - pageRot = parentRot + localRot
-			// - newPageRot = -pageRot (we want to negate the page rotation)
+			// - newPageRot = 2 * axisRot - pageRot
 			// - newPageRot = parentRot + newLocalRot (parent hasn't changed)
-			// - Therefore: newLocalRot = -pageRot - parentRot = -(parentRot + localRot) - parentRot = -localRot - 2*parentRot
+			// - Therefore: newLocalRot = 2 * axisRot - localRot - 2 * parentRot
 			const parentRotation = this.getShapeParentTransform(id).rotation()
-			const rotation = -options.initialShape.rotation - 2 * parentRotation
+			const rotation =
+				2 * options.scaleAxisRotation - options.initialShape.rotation - 2 * parentRotation
 			this.updateShapes([{ id, type, rotation }])
 		}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -137,6 +137,7 @@ import {
 	areAnglesCompatible,
 	clamp,
 	pointInPolygon,
+	shortAngleDist,
 } from '../primitives/utils'
 import { Vec, VecLike } from '../primitives/Vec'
 import { areShapesContentEqual } from '../utils/areShapesContentEqual'
@@ -8429,15 +8430,29 @@ export class Editor extends EventEmitter<TLEventMap> {
 		// to make sure the shape is mirrored correctly
 		if (Math.sign(scale.x) * Math.sign(scale.y) < 0) {
 			// Mirroring across an axis at angle `axisRot` maps a page rotation `pageRot` to
-			// `2 * axisRot - pageRot`. For a shape with local rotation `localRot` and parent page
-			// rotation `parentRot`:
+			// `2 * axisRot - pageRot`. For a shape with local rotation `localRot` whose parent had
+			// page rotation `parentRot` when the resize began:
 			// - pageRot = parentRot + localRot
 			// - newPageRot = 2 * axisRot - pageRot
-			// - newPageRot = parentRot + newLocalRot (parent hasn't changed)
-			// - Therefore: newLocalRot = 2 * axisRot - localRot - 2 * parentRot
+			// - newPageRot = (parentRot + parentDelta) + newLocalRot
+			// - Therefore: newLocalRot = 2 * axisRot - localRot - 2 * parentRot - parentDelta
+			// `parentDelta` is how far the parent has rotated since the resize began. Nested resizes
+			// commit ancestors before descendants, so an unaligned parent may itself have been
+			// flipped by the time its child gets here; reading the parent's current rotation as if
+			// it were the initial one would then double-count that flip.
 			const parentRotation = this.getShapeParentTransform(id).rotation()
+			// take the shortest arc so the stored rotation doesn't drift by 2π when the parent
+			// hasn't moved and the initial page rotation happens to be wrapped
+			const parentDelta = shortAngleDist(
+				Mat.Cast(options.initialPageTransform).rotation() - options.initialShape.rotation,
+				parentRotation
+			)
+			const initialParentRotation = parentRotation - parentDelta
 			const rotation =
-				2 * options.scaleAxisRotation - options.initialShape.rotation - 2 * parentRotation
+				2 * options.scaleAxisRotation -
+				options.initialShape.rotation -
+				2 * initialParentRotation -
+				parentDelta
 			this.updateShapes([{ id, type, rotation }])
 		}
 

--- a/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/resizeBox.ts
@@ -1,5 +1,6 @@
 import { VecModel } from '@tldraw/tlschema'
 import { Box } from '../../../primitives/Box'
+import { clamp } from '../../../primitives/utils'
 import { Vec } from '../../../primitives/Vec'
 import { TLResizeHandle } from '../../types/selection-types'
 import type { TLBaseBoxShape } from '../BaseBoxShapeUtil'
@@ -36,29 +37,31 @@ export function resizeBox<T extends TLBaseBoxShape>(
 	const offset = new Vec(0, 0)
 
 	if (w > 0) {
-		if (w < minWidth) {
+		const clampedW = clamp(w, minWidth, maxWidth)
+		if (clampedW !== w) {
 			switch (handle) {
 				case 'top_left':
 				case 'left':
 				case 'bottom_left': {
-					offset.x = w - minWidth
+					offset.x = w - clampedW
 					break
 				}
 				case 'top':
 				case 'bottom': {
-					offset.x = (w - minWidth) / 2
+					offset.x = (w - clampedW) / 2
 					break
 				}
 				default: {
 					offset.x = 0
 				}
 			}
-			w = minWidth
+			w = clampedW
 		}
 	} else {
 		offset.x = w
 		w = -w
-		if (w < minWidth) {
+		const clampedW = clamp(w, minWidth, maxWidth)
+		if (clampedW !== w) {
 			switch (handle) {
 				case 'top_left':
 				case 'left':
@@ -67,26 +70,27 @@ export function resizeBox<T extends TLBaseBoxShape>(
 					break
 				}
 				default: {
-					offset.x = -minWidth
+					offset.x = -clampedW
 				}
 			}
 
-			w = minWidth
+			w = clampedW
 		}
 	}
 
 	if (h > 0) {
-		if (h < minHeight) {
+		const clampedH = clamp(h, minHeight, maxHeight)
+		if (clampedH !== h) {
 			switch (handle) {
 				case 'top_left':
 				case 'top':
 				case 'top_right': {
-					offset.y = h - minHeight
+					offset.y = h - clampedH
 					break
 				}
 				case 'right':
 				case 'left': {
-					offset.y = (h - minHeight) / 2
+					offset.y = (h - clampedH) / 2
 					break
 				}
 				default: {
@@ -94,12 +98,13 @@ export function resizeBox<T extends TLBaseBoxShape>(
 				}
 			}
 
-			h = minHeight
+			h = clampedH
 		}
 	} else {
 		offset.y = h
 		h = -h
-		if (h < minHeight) {
+		const clampedH = clamp(h, minHeight, maxHeight)
+		if (clampedH !== h) {
 			switch (handle) {
 				case 'top_left':
 				case 'top':
@@ -108,10 +113,10 @@ export function resizeBox<T extends TLBaseBoxShape>(
 					break
 				}
 				default: {
-					offset.y = -minHeight
+					offset.y = -clampedH
 				}
 			}
-			h = minHeight
+			h = clampedH
 		}
 	}
 
@@ -122,8 +127,8 @@ export function resizeBox<T extends TLBaseBoxShape>(
 		x,
 		y,
 		props: {
-			w: Math.min(maxWidth, w),
-			h: Math.min(maxHeight, h),
+			w,
+			h,
 		},
 	}
 }

--- a/packages/tldraw/src/test/resizeBox.test.ts
+++ b/packages/tldraw/src/test/resizeBox.test.ts
@@ -103,4 +103,29 @@ describe('Resize box', () => {
 			},
 		})
 	})
+
+	it('Keeps the opposite edges fixed when clamping to the maximum size', () => {
+		const results = resizeBox(
+			shape,
+			{
+				newPoint: { x: -100, y: -100 },
+				handle: 'top_left',
+				mode: 'resize_bounds',
+				scaleX: 2,
+				scaleY: 2,
+				initialBounds: new Box(0, 0, 100, 100),
+				initialShape: shape,
+			},
+			{ maxWidth: 150, maxHeight: 150 }
+		)
+		// The bottom right corner stays at (100, 100), so the box spans -50..100 on each axis
+		expect(results).toMatchObject({
+			x: -50,
+			y: -50,
+			props: {
+				w: 150,
+				h: 150,
+			},
+		})
+	})
 })

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3462,6 +3462,37 @@ describe('resizing a selection of mixed rotations', () => {
 		editor.pointerDownOnHandle('bottom_right').pointerMove(100, 25)
 		expect(roundedPageBounds(ids.boxA, 0.5)).toMatchObject({ x: 0, y: 0, w: 20, h: 20 })
 	})
+
+	it('mirrors an unaligned shape across the rotated selection axis when flipping', () => {
+		// C is rotated 0.3 inside a group that is then rotated by 0.5, so C's page rotation (0.8)
+		// is out of alignment with the selection axes and takes the unaligned resize path
+		const alignedId = createShapeId('aligned')
+		const unalignedId = createShapeId('unaligned')
+		editor.createShapes([
+			box(alignedId, 0, 0, 100, 50),
+			{ ...box(unalignedId, 200, 0, 100, 50), rotation: 0.3 },
+		])
+		editor.groupShapes([alignedId, unalignedId])
+		const groupId = editor.getOnlySelectedShapeId()!
+		editor.rotateShapesBy([groupId], 0.5)
+		editor.select(groupId)
+
+		const selectionBounds = editor.getSelectionRotatedPageBounds()!
+		const centerBefore = editor.getShapePageBounds(unalignedId)!.center
+		// mirror across the selection's left edge, which is where the right handle ends up
+		const expectedCenter = Vec.RotWith(centerBefore, selectionBounds.point, -0.5)
+		expectedCenter.x = selectionBounds.point.x - (expectedCenter.x - selectionBounds.point.x)
+		expectedCenter.rotWith(selectionBounds.point, 0.5)
+
+		editor.resizeSelection({ scaleX: -1 }, 'right')
+
+		// a flip across an axis at angle θ maps a page rotation r to 2θ - r; negating the rotation
+		// (as if θ were 0) leaves the shape off by 2θ
+		expect(editor.getShapePageTransform(unalignedId).rotation()).toBeCloseTo(2 * 0.5 - 0.8)
+		const centerAfter = editor.getShapePageBounds(unalignedId)!.center
+		expect(centerAfter.x).toBeCloseTo(expectedCenter.x)
+		expect(centerAfter.y).toBeCloseTo(expectedCenter.y)
+	})
 })
 
 // describe('Icons', () => {

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3493,6 +3493,46 @@ describe('resizing a selection of mixed rotations', () => {
 		expect(centerAfter.x).toBeCloseTo(expectedCenter.x)
 		expect(centerAfter.y).toBeCloseTo(expectedCenter.y)
 	})
+
+	it('mirrors an unaligned child of an unaligned group when flipping', () => {
+		// The inner group is rotated 0.2 inside an outer group that is rotated 0.5, so the inner
+		// group's page rotation (0.7) and its child's page rotation (0.3 + 0.7 = 1.0) are both out of
+		// alignment with the selection axes. The inner group is committed before its child, so the
+		// child's new rotation must be computed against the inner group's *flipped* rotation.
+		const alignedId = createShapeId('aligned')
+		const innerAlignedId = createShapeId('innerAligned')
+		const unalignedId = createShapeId('unaligned')
+		editor.createShapes([
+			box(alignedId, 0, 0, 100, 50),
+			box(innerAlignedId, 200, 100, 100, 50),
+			{ ...box(unalignedId, 200, 0, 100, 50), rotation: 0.3 },
+		])
+		editor.groupShapes([innerAlignedId, unalignedId])
+		const innerGroupId = editor.getOnlySelectedShapeId()!
+		editor.rotateShapesBy([innerGroupId], 0.2)
+		editor.groupShapes([alignedId, innerGroupId])
+		const outerGroupId = editor.getOnlySelectedShapeId()!
+		editor.rotateShapesBy([outerGroupId], 0.5)
+		editor.select(outerGroupId)
+
+		expect(editor.getShapePageTransform(innerGroupId).rotation()).toBeCloseTo(0.7)
+		expect(editor.getShapePageTransform(unalignedId).rotation()).toBeCloseTo(1.0)
+
+		const selectionBounds = editor.getSelectionRotatedPageBounds()!
+		const centerBefore = editor.getShapePageBounds(unalignedId)!.center
+		const expectedCenter = Vec.RotWith(centerBefore, selectionBounds.point, -0.5)
+		expectedCenter.x = selectionBounds.point.x - (expectedCenter.x - selectionBounds.point.x)
+		expectedCenter.rotWith(selectionBounds.point, 0.5)
+
+		editor.resizeSelection({ scaleX: -1 }, 'right')
+
+		// each shape's page rotation is mirrored across the selection axis: r -> 2 * 0.5 - r
+		expect(editor.getShapePageTransform(innerGroupId).rotation()).toBeCloseTo(2 * 0.5 - 0.7)
+		expect(editor.getShapePageTransform(unalignedId).rotation()).toBeCloseTo(2 * 0.5 - 1.0)
+		const centerAfter = editor.getShapePageBounds(unalignedId)!.center
+		expect(centerAfter.x).toBeCloseTo(expectedCenter.x)
+		expect(centerAfter.y).toBeCloseTo(expectedCenter.y)
+	})
 })
 
 // describe('Icons', () => {

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -1,4 +1,11 @@
-import { createShapeId, TLFrameShape, TLGeoShape, TLGroupShape, TLLineShape } from '@tldraw/editor'
+import {
+	createShapeId,
+	TLFrameShape,
+	TLGeoShape,
+	TLGroupShape,
+	TLLineShape,
+	Vec,
+} from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from './TestEditor'
 
@@ -243,6 +250,56 @@ describe('When interacting with a shape...', () => {
 
 		// Should have called end once now
 		expect(calls).toEqual(['start', 'change', 'change', 'end'])
+	})
+
+	it('Fires resizing events once for an unaligned shape in a rotated selection', () => {
+		const util = editor.getShapeUtil<TLGeoShape>('geo')
+
+		const calls: string[] = []
+
+		util.onResizeStart = () => {
+			calls.push('start')
+		}
+
+		util.onResize = () => {
+			calls.push('change')
+		}
+
+		util.onResizeEnd = () => {
+			calls.push('end')
+		}
+
+		// The geo shape is rotated inside a group that is then rotated, so its page rotation is out
+		// of alignment with the selection and it takes the unaligned resize path
+		const unalignedId = createShapeId('unaligned')
+		const noteId = createShapeId('note')
+		editor.createShapes([
+			{ id: unalignedId, type: 'geo', x: 500, y: 500, rotation: 0.3, props: { w: 100, h: 50 } },
+			{ id: noteId, type: 'note', x: 700, y: 500 },
+		])
+		editor.groupShapes([unalignedId, noteId])
+		const groupId = editor.getOnlySelectedShapeId()!
+		editor.rotateShapesBy([groupId], 0.5)
+		editor.select(groupId)
+
+		const handlePoint = editor.getSelectionRotatedPageBounds()!.getHandlePoint('bottom_right')
+		const start = Vec.RotWith(handlePoint, editor.getSelectionRotatedPageBounds()!.point, 0.5)
+
+		editor.pointerDown(start.x, start.y, { target: 'selection', handle: 'bottom_right' })
+		editor.expectToBeIn('select.pointing_resize_handle')
+		expect(calls).toEqual([])
+
+		editor.pointerMove(start.x - 50, start.y - 50)
+		editor.expectToBeIn('select.resizing')
+		expect(calls).toEqual(['start', 'change'])
+
+		editor.pointerMove(start.x - 60, start.y - 50)
+		editor.pointerMove(start.x - 70, start.y - 60)
+		expect(calls).toEqual(['start', 'change', 'change', 'change'])
+
+		editor.pointerUp(start.x - 70, start.y - 60)
+		editor.expectToBeIn('select.idle')
+		expect(calls).toEqual(['start', 'change', 'change', 'change', 'end'])
 	})
 
 	it('Fires resizing cancel events', () => {


### PR DESCRIPTION
This PR fixes a bug where flipping a rotated child of a rotated selection during a resize left it at the wrong rotation. It also fixes `onResizeStart` and `onResizeEnd` firing on every frame for unaligned shapes, and the fixed edge of a `resizeBox` shape sliding once it hit `maxWidth` or `maxHeight`.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`_resizeUnalignedShape` negated the page rotation when a resize flipped one axis, which is only correct when the selection's scale axis is unrotated. It also re-entered `resizeShape` without forwarding `skipStartAndEndCallbacks`, `mode` and `dragHandle`, so each frame of the same resize looked like a new one and ran the start/end callbacks again. `resizeBox` computed the offset from the min clamp only and applied `maxWidth`/`maxHeight` afterwards with `Math.min`, so the position was still based on the unclamped size and the fixed edge moved.

### After

`_resizeUnalignedShape` mirrors across the scale axis (`2 * axisRot - pageRot`) and passes `skipStartAndEndCallbacks`, `mode` and `dragHandle` through to `resizeShape`. `resizeBox` clamps to both min and max before computing the offset, so the max clamp adjusts the offset the same way the min clamp does.

### Change type

- [x] `bugfix`

### Test plan

**Flipping a rotated child of a rotated selection**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Draw two rectangles side by side and rotate the right one by about 20° with its rotate handle.
3. Select both, group them (Cmd+G), then rotate the group by about 30° with the group's rotate handle.
4. With the group still selected, drag the right edge resize handle leftward past the left edge so the group flips horizontally.
5. On `main` the pre-rotated rectangle ends up at the wrong angle (off by twice the group rotation) and is no longer a mirror image of where it started. With this PR it mirrors across the selection's axis and the group remains a mirror image of the original.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix flipped children of rotated selections getting the wrong rotation, repeated onResizeStart/End for unaligned shapes, and the fixed edge sliding when resizeBox hits maxWidth/maxHeight.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +35 / -21  |
| Tests     | +56 / -0   |

