### PR TITLE
fix(editor): Vec.Slope, Vec.cross, areAnglesCompatible, rotateSelectionHandle and dotted dash props

### DIFF
--- a/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
+++ b/packages/editor/src/lib/editor/shapes/shared/getPerfectDashProps.ts
@@ -87,6 +87,9 @@ export function getPerfectDashProps(
 
 	dashCount = Math.floor(totalLength / dashLength / (2 * ratio))
 	dashCount -= dashCount % snap
+	// A path shorter than one dash period (or of zero length, where the count is NaN) would
+	// otherwise divide by zero below and produce an invalid dasharray; draw a single dash instead
+	if (!(dashCount >= 1)) dashCount = 1
 
 	if (dashCount < 3 && style === 'dashed') {
 		if (totalLength / strokeWidth < 4) {

--- a/packages/editor/src/lib/primitives/Box.test.ts
+++ b/packages/editor/src/lib/primitives/Box.test.ts
@@ -1,4 +1,4 @@
-import { Box } from './Box'
+import { Box, rotateSelectionHandle } from './Box'
 import { Vec } from './Vec'
 
 describe('Box', () => {
@@ -757,5 +757,13 @@ describe('Box', () => {
 		it('returns true for zero-sized box', () => {
 			expect(new Box(0, 0, 0, 0).isValid()).toBe(true)
 		})
+	})
+})
+
+describe('rotateSelectionHandle', () => {
+	it('wraps around for negative rotations', () => {
+		expect(rotateSelectionHandle('top', Math.PI / 2)).toBe('right')
+		expect(rotateSelectionHandle('top', -Math.PI / 2)).toBe('left')
+		expect(rotateSelectionHandle('top_left', -Math.PI)).toBe('bottom_right')
 	})
 })

--- a/packages/editor/src/lib/primitives/Box.ts
+++ b/packages/editor/src/lib/primitives/Box.ts
@@ -678,7 +678,9 @@ export function rotateSelectionHandle(handle: SelectionHandle, rotation: number)
 	const numSteps = Math.round(rotation / (PI / 4))
 
 	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
+	// numSteps is negative for negative rotations, so wrap the index into range
+	const n = ORDERED_SELECTION_HANDLES.length
+	return ORDERED_SELECTION_HANDLES[(((currentIndex + numSteps) % n) + n) % n]
 }
 
 /** @public */

--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -336,6 +336,16 @@ describe('Vec.Slope', () => {
 		expect(Vec.Slope(new Vec(0, 0), new Vec(50, 100))).toEqual(2)
 		expect(Vec.Slope(new Vec(0, 0), new Vec(-50, 100))).toEqual(-2)
 		expect(Vec.Slope(new Vec(123, 456), new Vec(789, 24))).toEqual(-0.6486486486486487)
+		// A.x happened to equal B.y here, which used to trip the vertical guard
+		expect(Vec.Slope(new Vec(1, 0), new Vec(0, 1))).toEqual(-1)
+		expect(Vec.Slope(new Vec(5, 0), new Vec(5, 10))).toBeNaN()
+	})
+})
+
+describe('Vec.cross', () => {
+	it('Matches the static Vec.Cross.', () => {
+		expect(Vec.Cross(new Vec(1, 2, 3), new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
+		expect(new Vec(1, 2, 3).cross(new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
 	})
 })
 

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -164,9 +164,9 @@ export class Vec {
 	}
 
 	cross(V: VecLike) {
-		this.x = this.y * V.z! - this.z * V.y
-		this.y = this.z * V.x - this.x * V.z!
-		// this.z = this.x * V.y - this.y * V.x
+		const { x, y, z } = this
+		this.x = y * V.z! - z * V.y
+		this.y = z * V.x - x * V.z!
 		return this
 	}
 
@@ -497,7 +497,7 @@ export class Vec {
 	}
 
 	static Slope(A: VecLike, B: VecLike): number {
-		if (A.x === B.y) return NaN
+		if (A.x === B.x) return NaN
 		return (A.y - B.y) / (A.x - B.x)
 	}
 

--- a/packages/editor/src/lib/primitives/utils.test.ts
+++ b/packages/editor/src/lib/primitives/utils.test.ts
@@ -1,4 +1,4 @@
-import { getPointInArcT } from './utils'
+import { areAnglesCompatible, getPointInArcT } from './utils'
 
 describe('getPointInArcT', () => {
 	it('should return 0 for the start of the arc', () => {
@@ -55,5 +55,14 @@ describe('getPointInArcT', () => {
 		const B = 2.2 // End angle
 		const P = 1.1 // Point angle, should be near the end
 		expect(getPointInArcT(mAB, A, B, P)).toBe(1)
+	})
+})
+
+describe('areAnglesCompatible', () => {
+	it('treats angles a multiple of PI/2 apart as compatible regardless of sign', () => {
+		expect(areAnglesCompatible(-Math.PI / 4, Math.PI / 4)).toBe(true)
+		expect(areAnglesCompatible(Math.PI / 2 - 1e-9, 0)).toBe(true)
+		expect(areAnglesCompatible(Math.PI, -Math.PI / 2)).toBe(true)
+		expect(areAnglesCompatible(0, Math.PI / 3)).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -189,7 +189,10 @@ export function snapAngle(r: number, segments: number): number {
  * @public
  */
 export function areAnglesCompatible(a: number, b: number) {
-	return a === b || approximately((a % (Math.PI / 2)) - (b % (Math.PI / 2)), 0)
+	// Reduce the difference, not each angle: a sign-preserving % on each made
+	// -PI/4 and PI/4 incompatible. A remainder just under PI/2 is a multiple too.
+	const d = Math.abs(a - b) % (Math.PI / 2)
+	return approximately(d, 0) || approximately(d, Math.PI / 2)
 }
 
 /**

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -2,8 +2,6 @@ import {
 	Box,
 	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,6 +17,7 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -670,23 +669,3 @@ export class Resizing extends StateNode {
 }
 
 type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
-}


### PR DESCRIPTION
This PR fixes a bug where resizing a rotated shape with a negative rotation (for example after rotating anticlockwise) was forced into an aspect-locked resize, and where dragging a resize handle on such a shape could pick an `undefined` handle. It also fixes `Vec.Slope` returning `NaN` for some non-vertical slopes, `Vec.prototype.cross` returning the wrong `y` component, and very short dotted paths rendering with an `Infinity NaN` dasharray.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

- `areAnglesCompatible` applied a sign-preserving `%` to each angle separately, so angles a multiple of π/2 apart but with different signs (for example `-π/4` and `π/4`) came out incompatible, which forced aspect-locked resizes.
- `rotateSelectionHandle` indexed `ORDERED_SELECTION_HANDLES` with `(currentIndex + numSteps) % length`; for negative rotations the index is negative and the lookup returned `undefined`. `Resizing.ts` carried its own private copy of this function with the same bug.
- `Vec.Slope` checked `A.x === B.y` for the vertical case instead of `A.x === B.x`, so any pair where those happened to match returned `NaN`.
- `Vec.prototype.cross` overwrote `this.x` before using it to compute `this.y`.
- `getPerfectDashProps` divided by `dashCount` when computing the dotted dasharray; for a path shorter than one dash period the count is zero (or `NaN` for a zero-length path), producing `Infinity NaN`.

### After

- `areAnglesCompatible` reduces the absolute difference modulo π/2 and accepts a remainder of either ~0 or ~π/2.
- `rotateSelectionHandle` wraps the index into range (`((i % n) + n) % n`). `Resizing.ts` imports it from `@tldraw/editor` instead of keeping its private copy.
- `Vec.Slope` compares `A.x` with `B.x`.
- `Vec.prototype.cross` reads `x`, `y`, `z` into locals before writing, matching the static `Vec.Cross`.
- `getPerfectDashProps` clamps `dashCount` to at least 1, so a too-short path draws a single dash.

### Change type

- [x] `bugfix`

### Test plan

**Dotted dasharray on a very short path**

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Pick the Line tool (`L`) and in the style panel set Dash to Dotted and Size to Extra large.
3. Click once on the canvas (or drag a line shorter than about 10 px) to create a tiny line, then switch back to the Select tool.
4. In devtools, inspect the line's `<path>` element inside `.tl-shape`.
5. On `main` its `stroke-dasharray` is `Infinity NaN`, which the browser ignores so the stub draws solid. With this PR the dasharray is a valid pair of numbers and the line renders as a single dot.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix Vec.Slope, Vec.cross, areAnglesCompatible for negative angles, rotateSelectionHandle for negative rotations, and dotted dash arrays for very short paths.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +15 / -28  |
| Tests     | +29 / -2   |

