### PR TITLE
fix(editor): duplicatePage positions, copied asset resolution, content input mutation and asset removal errors

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5150,8 +5150,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.setCamera(prevCamera)
 
 			if (content) {
-				// If we had content on the previous page, put it on the new page
-				return this.putContentOntoCurrentPage(content)
+				// If we had content on the previous page, put it on the new page at the same coordinates
+				// (otherwise offscreen content gets re-centred on the viewport)
+				return this.putContentOntoCurrentPage(content, { preservePosition: true })
 			}
 		})
 
@@ -5265,7 +5266,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.run(
 			() => {
-				this.store.props.assets.remove?.(ids)
+				// the asset store's remove is async; surface failures instead of leaving an unhandled rejection
+				Promise.resolve(this.store.props.assets.remove?.(ids)).catch((err) =>
+					console.error('Error while removing assets from the asset store:', err)
+				)
 				this.store.remove(ids)
 			},
 			{ history: 'ignore' }
@@ -9857,21 +9861,30 @@ export class Editor extends EventEmitter<TLEventMap> {
 					!asset.props.src?.startsWith('data:video') &&
 					!asset.props.src?.startsWith('http')
 				) {
-					const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
-					const objectUrl = await this.store.props.assets.resolve(asset, {
-						screenScale: 1,
-						steppedScreenScale: 1,
-						dpr: 1,
-						networkEffectiveType: null,
-						shouldResolveToOriginal: true,
-					})
-					assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
-						await fetch(objectUrl!).then((r) => r.blob())
-					)
-					assets.push(assetWithDataUrl)
-				} else {
-					assets.push(asset)
+					// If the asset can't be inlined (unresolvable src, fetch failure), fall through and
+					// keep the original record; dropping it leaves the pasted shapes pointing at an
+					// asset that doesn't exist
+					try {
+						const objectUrl = await this.store.props.assets.resolve(asset, {
+							screenScale: 1,
+							steppedScreenScale: 1,
+							dpr: 1,
+							networkEffectiveType: null,
+							shouldResolveToOriginal: true,
+						})
+						if (objectUrl) {
+							const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
+							assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
+								await fetch(objectUrl).then((r) => r.blob())
+							)
+							assets.push(assetWithDataUrl)
+							return
+						}
+					} catch {
+						// keep the original asset
+					}
 				}
+				assets.push(asset)
 			})
 		)
 		content.assets = assets
@@ -10092,7 +10105,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (shapeIdMap.has(newShape.parentId)) {
 				newShape.parentId = shapeIdMap.get(oldShape.parentId)!
 			} else {
-				rootShapeIds.push(newShape.id)
 				// newShape.parentId = pasteParentId
 				newShape.index = index
 				index = getIndexAbove(index)
@@ -10135,10 +10147,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				(asset.type === 'video' && asset.props.src?.startsWith('data:video'))
 			) {
 				// it's src is a base64 image or video; we need to create a new asset without the src,
-				// then create a new asset from the original src. So we save a copy of the original asset,
-				// then delete the src from the original asset.
-				assetsToUpdate.push(structuredClone(asset as TLImageAsset | TLVideoAsset))
-				asset.props.src = null
+				// then create a new asset from the original src. So we keep the original asset for the
+				// upload and create a copy with its src removed. Copy rather than mutate: when no
+				// migration applies, migrateStoreSnapshot hands back the caller's own record objects.
+				assetsToUpdate.push(asset as TLImageAsset | TLVideoAsset)
+				const assetWithoutSrc = structuredClone(asset as TLImageAsset | TLVideoAsset)
+				assetWithoutSrc.props.src = null
+				assetsToCreate.push(assetWithoutSrc)
+				continue
 			}
 
 			// Add the asset to the list of assets to create

--- a/packages/tldraw/src/test/commands/duplicatePage.test.ts
+++ b/packages/tldraw/src/test/commands/duplicatePage.test.ts
@@ -53,3 +53,22 @@ it("Doesn't duplicate the page if max pages is reached", () => {
 	}
 	expect(editor.getPages().length).toBe(editor.options.maxPages)
 })
+
+it('Keeps the duplicated shapes at their original coordinates, even when offscreen', () => {
+	editor.createShapes([{ id: createShapeId('offscreen'), type: 'geo', x: 5000, y: 5000 }])
+	// look at an empty part of the page so that no shape overlaps the viewport
+	editor.setCamera({ x: -20000, y: -20000, z: 1 })
+	const positions = editor
+		.getCurrentPageShapes()
+		.map((s) => ({ x: s.x, y: s.y }))
+		.sort((a, b) => a.x - b.x)
+
+	editor.duplicatePage(editor.getCurrentPageId())
+
+	expect(
+		editor
+			.getCurrentPageShapes()
+			.map((s) => ({ x: s.x, y: s.y }))
+			.sort((a, b) => a.x - b.x)
+	).toEqual(positions)
+})

--- a/packages/tldraw/src/test/commands/putContent.test.ts
+++ b/packages/tldraw/src/test/commands/putContent.test.ts
@@ -1,4 +1,4 @@
-import { TLContent, createShapeId, structuredClone } from '@tldraw/editor'
+import { AssetRecordType, TLContent, createShapeId, structuredClone } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -36,6 +36,40 @@ describe('Migrations', () => {
 		// @ts-expect-error
 		withInvalidShapeModel.shapes[0].x = 'invalid'
 		expect(() => editor.putContentOntoCurrentPage(withInvalidShapeModel)).toThrow()
+	})
+})
+
+describe('Input content', () => {
+	it('is not mutated when it carries data url assets', () => {
+		const assetId = AssetRecordType.createId('imageAsset')
+		const imageId = createShapeId('image')
+		const src = 'data:image/png;base64,AAAA'
+		editor.createAssets([
+			{
+				type: 'image',
+				id: assetId,
+				typeName: 'asset',
+				props: { w: 100, h: 100, name: '', isAnimated: false, mimeType: 'image/png', src },
+				meta: {},
+			},
+		])
+		editor.createShape({
+			id: imageId,
+			type: 'image',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100, assetId },
+		})
+		// the content holds the live records when no migration applies, so putting it into another
+		// editor must not write through to this editor's asset
+		const content = editor.getContentFromCurrentPage([imageId])!
+		const other = new TestEditor()
+		other.putContentOntoCurrentPage(content)
+
+		expect(content.assets[0].props.src).toBe(src)
+		expect(content.rootShapeIds).toEqual([imageId])
+		expect(editor.getAsset(assetId)!.props.src).toBe(src)
+		other.dispose()
 	})
 })
 


### PR DESCRIPTION
This PR fixes a bug where duplicating a page moved any offscreen shapes onto the viewport instead of keeping their coordinates. It also fixes copied content silently losing assets whose source could not be resolved or fetched, `putContentOntoCurrentPage` mutating the `TLContent` object the caller passed in (including the source editor's live asset record), and asset-store removal failures surfacing as unhandled promise rejections.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`duplicatePage` called `putContentOntoCurrentPage(content)` with no options, so the pasted shapes went through the default re-centring on the viewport; shapes that weren't on screen ended up somewhere else on the new page.

`resolveAssetsInContent` awaited `assets.resolve` and then `fetch`ed the result without a guard: an empty or unresolvable src or a failed fetch threw inside the `Promise.all`, and the asset never made it into `content.assets`, leaving the pasted shapes pointing at a missing asset.

`putContentOntoCurrentPage` set `asset.props.src = null` on data-url assets and pushed onto `rootShapeIds` directly. When no migration applies, `migrateStoreSnapshot` hands back the caller's own record objects, so these writes went through to the caller's `TLContent` — and, for content from `getContentFromCurrentPage`, to the source editor's asset.

`deleteAssets` called the asset store's async `remove()` without handling the returned promise, so a rejection was unhandled.

### After

`duplicatePage` passes `{ preservePosition: true }`, so shapes keep their coordinates on the new page.

`resolveAssetsInContent` wraps the resolve/fetch in a `try`, skips the fetch when the resolved url is empty, and on any failure keeps the original asset record in `content.assets`.

`putContentOntoCurrentPage` keeps the original asset for the upload and creates a `structuredClone` with `src` nulled for the store, and no longer pushes onto the content's `rootShapeIds` (the local `rootShapes` list already covers what that push was for).

`deleteAssets` wraps `remove()` in `Promise.resolve(...).catch(...)` and logs the error.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420/develop and draw a rectangle.
2. Pan the canvas (hold space and drag, or scroll) until the rectangle is fully out of view.
3. Open the page menu in the top-left, open the current page's `...` menu and choose `Duplicate`.
4. On `main`, the new page shows the rectangle centred in the viewport: its coordinates changed. With this PR, the new page looks empty like the original did; press `Shift+1` (zoom to fit) on both pages to see the rectangle at the same position.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Keep duplicated pages' shapes in place, stop dropping unresolved assets from copied content, don't mutate content passed to putContentOntoCurrentPage, and surface asset removal errors.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +38 / -22  |
| Tests     | +54 / -1   |

