### PR TITLE
fix(editor): don't enter a tool's initial child on top of one its onEnter transitioned to

### DIFF
--- a/packages/editor/src/lib/editor/tools/StateNode.test.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.test.ts
@@ -238,6 +238,70 @@ describe('StateNode.addChild', () => {
 	})
 })
 
+describe('StateNode.enter', () => {
+	let idleExits = 0
+
+	class Idle extends StateNode {
+		static override id = 'idle'
+		override onExit() {
+			idleExits++
+		}
+	}
+
+	class Pointing extends StateNode {
+		static override id = 'pointing'
+	}
+
+	class ToolWithEnterTransition extends StateNode {
+		static override id = 'enterTransition'
+		static override initial = 'idle'
+		static override children() {
+			return [Idle, Pointing]
+		}
+
+		override onEnter(info: { startPointing?: boolean }) {
+			if (info?.startPointing) this.transition('pointing', info)
+		}
+	}
+
+	class OtherTool extends StateNode {
+		static override id = 'other'
+	}
+
+	let editor: Editor
+
+	beforeEach(() => {
+		idleExits = 0
+		editor = new Editor({
+			initialState: 'other',
+			shapeUtils: [],
+			bindingUtils: [],
+			tools: [OtherTool, ToolWithEnterTransition],
+			store: createTLStore({ shapeUtils: [], bindingUtils: [] }),
+			getContainer: () => document.body,
+		})
+	})
+
+	it('enters the initial child when onEnter does not transition', () => {
+		editor.setCurrentTool('enterTransition')
+		expect(editor.root.getPath()).toBe('root.enterTransition.idle')
+		expect(editor.root.children!['enterTransition'].children!['idle'].getIsActive()).toBe(true)
+	})
+
+	it('does not enter the initial child on top of a child that onEnter transitioned to', () => {
+		editor.setCurrentTool('enterTransition', { startPointing: true })
+		const tool = editor.root.children!['enterTransition']
+		expect(editor.root.getPath()).toBe('root.enterTransition.pointing')
+		expect(tool.children!['pointing'].getIsActive()).toBe(true)
+		expect(tool.children!['idle'].getIsActive()).toBe(false)
+		// The stale (never re-entered) idle child must not get a spurious onExit
+		expect(idleExits).toBe(0)
+
+		editor.setCurrentTool('other')
+		expect(tool.children!['pointing'].getIsActive()).toBe(false)
+	})
+})
+
 describe('current tool id mask', () => {
 	// Tool mask test classes
 	class ToolA extends StateNode {

--- a/packages/editor/src/lib/editor/tools/StateNode.ts
+++ b/packages/editor/src/lib/editor/tools/StateNode.ts
@@ -152,7 +152,9 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			}
 
 			if (prevChildState?.id !== nextChildState.id) {
-				prevChildState?.exit(info, id)
+				// The previous child is inactive when transitioning from a parent's onEnter (or from a
+				// node that was already exited); exiting it again would fire a spurious onExit
+				if (prevChildState?.getIsActive()) prevChildState.exit(info, id)
 				currState._current.set(nextChildState)
 				nextChildState.enter(info, prevChildState?.id || 'initial')
 				if (!nextChildState.getIsActive()) break
@@ -188,10 +190,18 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 			this.editor.performance._notifyInteractionStart(this.id, this.getPath())
 		}
 
+		const currentBeforeEnter = this.getCurrent()
 		this._isActive.set(true)
 		this.onEnter?.(info, from)
 
-		if (this.children && this.initial && this.getIsActive()) {
+		// If onEnter already transitioned to a child, entering the initial child on top of it would
+		// leave that child active but orphaned
+		if (
+			this.children &&
+			this.initial &&
+			this.getIsActive() &&
+			this.getCurrent() === currentBeforeEnter
+		) {
 			const initial = this.children[this.initial]
 			this._current.set(initial)
 			initial.enter(info, from)


### PR DESCRIPTION
This PR fixes a bug where a tool whose `onEnter` transitions to a child state ended up with two active children: the one `onEnter` chose and the tool's initial child entered on top of it. It also fixes `transition` calling `onExit` on a child that was never entered.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`StateNode.enter` set `_isActive`, ran `onEnter`, and then unconditionally set `_current` to the initial child and entered it. If `onEnter` had already transitioned to another child, that child stayed active but orphaned (never exited) while the initial child was entered on top of it. `transition` also exited `prevChildState` whenever its id differed from the next child's, even when that previous child was not active, so a stale child received a spurious `onExit`.

### After

`StateNode.enter` records `getCurrent()` before running `onEnter` and only enters the initial child if the current child is unchanged afterwards. `transition` only exits the previous child when `getIsActive()` is true.

### Change type

- [x] `bugfix`

### Test plan

1. Register a tool whose `onEnter` transitions to a non-initial child:
   ```ts
   class A extends StateNode { static override id = 'a' }
   class B extends StateNode { static override id = 'b' }
   class MyTool extends StateNode {
   	static override id = 'mytool'
   	static override initial = 'a'
   	static override children = () => [A, B]
   	override onEnter() { this.transition('b') }
   }
   ```
2. Select it and check the path: `editor.setCurrentTool('mytool'); editor.getPath()`.
3. On `main`, the initial child is entered on top of the one `onEnter` chose: the path reports `mytool.a` while `b` stays active but orphaned, never receiving `onExit`. With this change, the path is `mytool.b` and only that child is active.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix tools whose onEnter transitions to a child state ending up with two active children.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +12 / -2   |
| Tests     | +64 / -0   |

