### PR TITLE
fix(editor): duplicateShapes tolerates missing ids and offsets descendants once

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6645,7 +6645,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getShapeAndDescendantIds(ids: TLShapeId[]): Set<TLShapeId> {
 		const shapeIds = new Set<TLShapeId>()
-		for (const shape of ids.map((id) => this.getShape(id)!).sort(sortByIndex)) {
+		for (const shape of compact(ids.map((id) => this.getShape(id))).sort(sortByIndex)) {
 			shapeIds.add(shape.id)
 			this.visitDescendants(shape, (descendantId) => {
 				shapeIds.add(descendantId)
@@ -7123,7 +7123,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 						let ox = 0
 						let oy = 0
 
-						if (offset && initialIds.has(originalId)) {
+						// Only offset the roots of the duplicated tree: a descendant that was also passed in
+						// follows its duplicated parent, so offsetting it too would move it twice
+						if (
+							offset &&
+							initialIds.has(originalId) &&
+							!shapeIdSet.has(originalShape.parentId as TLShapeId)
+						) {
 							const parentTransform = this.getShapeParentTransform(originalShape)
 							const vec = new Vec(offset.x, offset.y).rot(-parentTransform!.rotation())
 							ox = vec.x

--- a/packages/tldraw/src/test/duplicate.test.ts
+++ b/packages/tldraw/src/test/duplicate.test.ts
@@ -41,6 +41,28 @@ it('duplicates a shape with an offset', () => {
 	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
 })
 
+it('ignores ids of shapes that do not exist', () => {
+	editor.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	editor.duplicateShapes([ids.box1, createShapeId('nope')], { x: 10, y: 10 })
+	expect(editor.getCurrentPageShapes().length).toBe(2)
+	expect(editor.getLastCreatedShape()).toMatchObject({ x: 10, y: 10 })
+})
+
+it('offsets a duplicated descendant only once when its ancestor is also duplicated', () => {
+	editor.createShapes([
+		{ id: ids.box1, type: 'frame', x: 0, y: 0, props: { w: 500, h: 500 } },
+		{ id: ids.box2, type: 'geo', parentId: ids.box1, x: 50, y: 50, props: { w: 100, h: 100 } },
+	])
+	editor.duplicateShapes([ids.box1, ids.box2], { x: 1000, y: 0 })
+	const frameCopy = editor
+		.getCurrentPageShapes()
+		.find((s) => s.type === 'frame' && s.id !== ids.box1)!
+	const childCopy = editor.getSortedChildIdsForParent(frameCopy.id)
+	expect(childCopy).toHaveLength(1)
+	// the child follows its duplicated parent; it should not be offset a second time
+	expect(editor.getShapePageBounds(childCopy[0])).toMatchObject({ x: 1050, y: 50 })
+})
+
 it("doesn't duplicate locked shapes", () => {
 	editor
 		.createShape({ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })


### PR DESCRIPTION
This PR fixes a bug where `duplicateShapes` (and `getContentFromCurrentPage` and `toImage`) threw when given an id that no longer exists. It also fixes duplicating a shape together with one of its descendants placing the duplicated descendant outside its duplicated parent.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`getShapeAndDescendantIds` mapped ids through `getShape(id)!` and then sorted by index, so a stale id produced an `undefined` entry and a throw in everything built on it. In `duplicateShapes`, the offset was applied to every shape whose id was in the input set, so a descendant passed alongside its ancestor was offset once by following its duplicated parent and again on its own.

### After

`getShapeAndDescendantIds` drops unknown ids with `compact`. `duplicateShapes` only offsets shapes whose parent is not itself in the duplicated set, so nested duplicates move exactly once with their parent.

### Change type

- [x] `bugfix`

### Test plan

**Unknown id throws**

1. Run `yarn dev`, open http://localhost:5420/develop and draw a rectangle.
2. In the browser console run `editor.duplicateShapes([editor.getCurrentPageShapes()[0].id, 'shape:nope'], { x: 20, y: 20 })`.
3. On `main`, this throws (`Cannot read properties of undefined (reading 'index')`) and nothing is duplicated. With this PR, the rectangle is duplicated 20px down-right and the unknown id is ignored.

**Descendant offset twice**

1. On the same page, draw a frame (`f`) and draw a rectangle inside it.
2. In the console run `const f = editor.getCurrentPageShapes().find(s => s.type === 'frame'); editor.duplicateShapes([f.id, editor.getSortedChildIdsForParent(f.id)[0]], { x: 1000, y: 0 })`.
3. On `main`, the duplicated frame is empty: its rectangle was offset a second time and landed outside the frame's clip (page x ≈ 2050 instead of 1050). With this PR, the rectangle sits inside the duplicated frame at the same relative position as the original.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Make duplicateShapes ignore unknown ids and offset nested duplicates only once.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -2    |
| Tests     | +22 / -0   |

