### PR TITLE
fix(editor): stable nested options, preserve-focus blur and store onMount teardown in TldrawEditor

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -46,7 +46,7 @@ import { EditorProvider, useEditor } from './hooks/useEditor'
 import { EditorComponentsProvider } from './hooks/useEditorComponents'
 import { useEvent } from './hooks/useEvent'
 import { useForceUpdate } from './hooks/useForceUpdate'
-import { useShallowObjectIdentity } from './hooks/useIdentity'
+import { useDeepObjectIdentity, useShallowObjectIdentity } from './hooks/useIdentity'
 import { useLocalStore } from './hooks/useLocalStore'
 import { useRefState } from './hooks/useRefState'
 import { useStateAttribute } from './hooks/useStateAttribute'
@@ -311,18 +311,23 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const ErrorFallback =
 		components?.ErrorFallback === undefined ? DefaultErrorFallback : components?.ErrorFallback
 
-	// Merge deprecated props with options
-	// options values take precedence over the deprecated props
+	// Merge deprecated props with options (options win). Nested option objects are
+	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
+	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
+	const camera = useDeepObjectIdentity(_options?.camera)
+	const text = useShallowObjectIdentity(_options?.text ?? _textOptions)
+	const mergedDeepLinks = _options?.deepLinks ?? _deepLinks
+	const deepLinkOptions = useDeepObjectIdentity(
+		mergedDeepLinks === true ? undefined : mergedDeepLinks
+	)
+	const deepLinks = mergedDeepLinks === true ? true : deepLinkOptions
 	const mergedOptions = useMemo(() => {
 		let result = _options
-		if (_textOptions) {
-			result = { ...result, text: result?.text ?? _textOptions }
-		}
-		if (_deepLinks !== undefined) {
-			result = { ...result, deepLinks: result?.deepLinks ?? _deepLinks }
-		}
+		if (camera !== undefined) result = { ...result, camera }
+		if (text !== undefined) result = { ...result, text }
+		if (deepLinks !== undefined) result = { ...result, deepLinks }
 		return result
-	}, [_options, _textOptions, _deepLinks])
+	}, [_options, camera, text, deepLinks])
 
 	// apply defaults. if you're using the bare @tldraw/editor package, we
 	// default these to the "tldraw zero" configuration. We have different
@@ -660,19 +665,22 @@ function TldrawEditorWithReadyStore({
 	useEffect(
 		function handleFocusOnPointerDownForPreserveFocusMode() {
 			if (!editor) return
+			const container = editor.getContainer()
 
 			function handleFocusOnPointerDown() {
 				if (!editor) return
 				editor.focus()
 			}
 
-			function handleBlurOnPointerDown() {
+			function handleBlurOnPointerDown(e: PointerEvent) {
 				if (!editor) return
+				// The same pointerdown bubbles from the container to the body; blurring here would
+				// cancel the interaction the container listener just focused for.
+				if (container.contains(e.target as Node | null)) return
 				editor.blur()
 			}
 
 			if (autoFocus && noAutoFocus()) {
-				const container = editor.getContainer()
 				container.addEventListener('pointerdown', handleFocusOnPointerDown)
 				container.ownerDocument.body.addEventListener('pointerdown', handleBlurOnPointerDown)
 

--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -181,7 +181,7 @@ export function createTLStore({
 			},
 			onMount: (editor) => {
 				assert(editor instanceof Editor)
-				onMount?.(editor)
+				return onMount?.(editor)
 			},
 			collaboration,
 		},

--- a/packages/editor/src/lib/hooks/useIdentity.tsx
+++ b/packages/editor/src/lib/hooks/useIdentity.tsx
@@ -1,4 +1,4 @@
-import { areArraysShallowEqual, areObjectsShallowEqual } from '@tldraw/utils'
+import { areArraysShallowEqual, areObjectsShallowEqual, isEqual } from '@tldraw/utils'
 import { useRef } from 'react'
 
 function useIdentity<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
@@ -48,4 +48,14 @@ const areNullableObjectsShallowEqual = (
 /** @internal */
 export function useShallowObjectIdentity<T extends object | null | undefined>(obj: T): T {
 	return useIdentity(obj, areNullableObjectsShallowEqual)
+}
+
+/**
+ * For small plain-data option objects that may nest (e.g. camera constraints), where a
+ * shallow comparison would still see a fresh identity on every render.
+ *
+ * @internal
+ */
+export function useDeepObjectIdentity<T extends object | null | undefined>(obj: T): T {
+	return useIdentity(obj, isEqual)
 }

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -96,6 +96,21 @@ describe('<TldrawEditor />', () => {
 		)
 	})
 
+	it('runs the teardown returned by the store onMount option when unmounted', async () => {
+		const teardown = vi.fn()
+		const storeOnMount = vi.fn(() => teardown)
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [], onMount: storeOnMount })
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor store={store} tools={defaultTools} initialState="select" />,
+			{ waitForPatterns: false }
+		)
+		expect(storeOnMount).toHaveBeenCalledTimes(1)
+		expect(teardown).not.toHaveBeenCalled()
+
+		act(() => rendered.unmount())
+		expect(teardown).toHaveBeenCalledTimes(1)
+	})
+
 	it('throws if the store has different shapes to the ones passed in', async () => {
 		const spy = vi.spyOn(console, 'error').mockImplementation(noop)
 		// expect(() =>
@@ -170,6 +185,83 @@ describe('<TldrawEditor />', () => {
 		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
 		expect(onMount).toHaveBeenCalledTimes(2)
 		expect(onMount.mock.lastCall![0].store).toBe(newStore)
+	})
+
+	it('keeps the editor when re-rendered with equal inline nested options', async () => {
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>,
+			{ waitForPatterns: false }
+		)
+		const initialEditor = onMount.mock.lastCall![0]
+		vi.spyOn(initialEditor, 'dispose')
+		// a fresh options object with fresh (but equal) nested objects, as an inline literal gives:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		expect(initialEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(1)
+		// deeper nesting (camera constraints, zoomSteps) is compared by value too:
+		const withConstraints = () => ({
+			camera: {
+				isLocked: true,
+				zoomSteps: [0.5, 1, 2],
+				constraints: {
+					bounds: { x: 0, y: 0, w: 100, h: 100 },
+					padding: { x: 0, y: 0 },
+					origin: { x: 0.5, y: 0.5 },
+					initialZoom: 'default' as const,
+					baseZoom: 'default' as const,
+					behavior: 'contain' as const,
+				},
+			},
+			deepLinks: { param: 'd' },
+		})
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(onMount).toHaveBeenCalledTimes(2)
+		const secondEditor = onMount.mock.lastCall![0]
+		vi.spyOn(secondEditor, 'dispose')
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		expect(secondEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(2)
+		// a real change still recreates the editor:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: false }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(secondEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(3)
+		expect(onMount.mock.lastCall![0].getCameraOptions().isLocked).toBe(false)
 	})
 
 	it('reflects mount state via getIsMounted and the mount/unmount events', async () => {


### PR DESCRIPTION
This PR fixes a bug where `TldrawEditor` disposed and recreated the `Editor` on every parent render when given inline nested options such as `options={{ camera: { ... } }}`, `deepLinks` or `text`. It also fixes preserve-focus mode, where clicking on the canvas focused and then immediately blurred the editor, cancelling the interaction, and fixes the teardown function returned from `createTLStore`'s `onMount` option never running.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

Only the top-level `options` object was shallow-stabilised. `options` is a dependency of the editor-creating effect, so an inline literal with a fresh nested `camera`, `deepLinks` or `text` object gave a new identity on every render and rebuilt the editor each time.

In preserve-focus mode (`autoFocus` with `noAutoFocus()`), the container's pointerdown listener called `editor.focus()` and then the same event bubbled to the body listener, which called `editor.blur()`.

`createTLStore` wrapped the user's `onMount` in its own callback but did not return its result, so the teardown the user returned was discarded.

### After

`TldrawEditor` stabilises `camera` and `deepLinks` with a new internal `useDeepObjectIdentity` hook (deep `isEqual`, for small plain-data option objects that nest, like camera constraints) and `text` with `useShallowObjectIdentity`, and merges those into `mergedOptions`, so equal-by-value inline options keep the same editor while a real change still recreates it. The body pointerdown handler returns early when the event target is inside the container. `createTLStore` returns the user's `onMount` result so the teardown runs on unmount.

### Change type

- [x] `bugfix`

### Test plan

**Editor recreated on re-render with inline nested options**

1. Run `yarn dev` and add a small example (or edit `apps/examples/src/misc/develop.tsx`) whose component holds a `useState` counter, renders a button that increments it, and renders `<Tldraw options={{ camera: { isLocked: true } }} onMount={() => console.log('mounted')} />` (an inline literal with a nested object).
2. Open the example and the browser console; note one `mounted` log.
3. Click the button a few times to re-render the parent.
4. On `main`, every click logs `mounted` again and the canvas flashes as the editor is disposed and recreated. With this PR, the editor stays mounted and nothing is logged.

**Preserve-focus mode blurs on canvas click**

1. Run `yarn dev` and open http://localhost:5420/develop?tldraw_preserve_focus.
2. Click once on an empty part of the canvas, then press `r` (rectangle tool shortcut).
3. On `main`, the shortcut does nothing and `editor.getIsFocused()` in the console returns `false`: the click focused the editor and the same pointerdown immediately blurred it. With this PR, the editor stays focused and `r` selects the rectangle tool.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Stop recreating the editor when TldrawEditor is re-rendered with inline nested options, fix preserve-focus mode blurring on canvas clicks, and run the teardown returned by the store onMount option.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +32 / -14  |
| Tests     | +92 / -0   |

