### PR TITLE
fix(editor): measure each text node with its own offsets in measureElementTextNodeSpans

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -307,6 +307,37 @@ describe('TextManager', () => {
 			expect(result.spans[0].text).toBe(`a${family}b`)
 		})
 
+		it('should measure each text node with its own offsets', () => {
+			const starts: [unknown, number][] = []
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn((node: unknown, offset: number) => starts.push([node, offset])),
+					setEnd: vi.fn(),
+					getClientRects: vi.fn(() => [
+						{ width: 10, height: 16, left: 0, top: 0, right: 10, bottom: 16 },
+					]),
+				}
+			})
+
+			const first = { nodeType: 3, textContent: 'ab' }
+			const second = { nodeType: 3, textContent: 'cd' }
+			const mockElementWithText = {
+				childNodes: [first, { nodeType: 1 }, second],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			textManager.measureElementTextNodeSpans(mockElementWithText as any)
+
+			// the range must be placed in the node being measured, not the first one
+			expect(starts).toEqual([
+				[first, 0],
+				[first, 1],
+				[second, 0],
+				[second, 1],
+			])
+		})
+
 		it('should handle truncation option', () => {
 			const mockTextNode = {
 				nodeType: 3, // TEXT_NODE

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -338,6 +338,49 @@ describe('TextManager', () => {
 			])
 		})
 
+		it('should stop measuring later text nodes once the first line is truncated', () => {
+			const starts: [unknown, number][] = []
+			let current: { textContent: string } | null = null
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn((node: { textContent: string }, offset: number) => {
+						current = node
+						starts.push([node, offset])
+					}),
+					setEnd: vi.fn(),
+					// the second node sits on a new line
+					getClientRects: vi.fn(() => {
+						const top = current?.textContent === 'cd' ? 16 : 0
+						return [{ width: 10, height: 16, left: 0, top, right: 10, bottom: top + 16 }]
+					}),
+				}
+			})
+
+			const first = { nodeType: 3, textContent: 'ab' }
+			const second = { nodeType: 3, textContent: 'cd' }
+			const third = { nodeType: 3, textContent: 'ef' }
+			const mockElementWithText = {
+				childNodes: [first, second, third],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			const result = textManager.measureElementTextNodeSpans(mockElementWithText as any, {
+				shouldTruncateToFirstLine: true,
+			})
+
+			expect(result).toEqual({
+				spans: [{ box: { x: 0, y: 0, w: 10, h: 16 }, text: 'ab' }],
+				didTruncate: true,
+			})
+			// the third node must never be measured
+			expect(starts).toEqual([
+				[first, 0],
+				[first, 1],
+				[second, 0],
+			])
+		})
+
 		it('should handle truncation option', () => {
 			const mockTextNode = {
 				nodeType: 3, // TEXT_NODE

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -292,10 +292,8 @@ export class TextManager extends EditorManager {
 		const offsetX = -elmBounds.left
 		const offsetY = -elmBounds.top
 
-		// we measure by creating a range that spans each character in the elements text node
+		// we measure by creating a range that spans each character in the elements text nodes
 		const range = new Range()
-		const textNode = element.childNodes[0]
-		let idx = 0
 
 		let currentSpan = null
 		let prevCharWasSpaceCharacter = null
@@ -303,12 +301,15 @@ export class TextManager extends EditorManager {
 		let prevCharLeftForRTLTest = 0
 		let didTruncate = false
 		for (const childNode of element.childNodes) {
+			if (didTruncate) break
 			if (childNode.nodeType !== Node.TEXT_NODE) continue
 
+			// offsets are per text node, or the range would index past the node's end
+			let idx = 0
 			for (const segment of iterateGraphemes(childNode.textContent ?? '')) {
 				// place the range around the grapheme we're interested in
-				range.setStart(textNode, idx)
-				range.setEnd(textNode, idx + segment.length)
+				range.setStart(childNode, idx)
+				range.setEnd(childNode, idx + segment.length)
 				// measure the range. some browsers return multiple rects for the
 				// first char in a new line - one for the line break, and one for
 				// the character itself. we're only interested in the character.


### PR DESCRIPTION
This PR fixes a bug where measuring text in an element with more than one text node threw `IndexSizeError` or measured the wrong characters.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`TextManager.measureElementTextNodeSpans` captured `element.childNodes[0]` once and kept a single running offset while iterating every child text node, so for the second and later nodes the range was still placed in the first node. Offsets past that node's end threw, and offsets within it measured the first node's characters instead.

### After

The range is placed in the text node currently being measured, with offsets restarted per node. Iteration also stops once the text has been truncated instead of continuing into later nodes.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420/develop and open the devtools console.
2. Run `const el = document.createElement('div'); el.append(document.createTextNode('ab'), document.createTextNode('cd')); document.body.append(el)`.
3. Run `editor.textMeasure.measureElementTextNodeSpans(el)`.
4. On `main`, this throws `IndexSizeError` (the range is placed in the first text node with offsets past its end). With this PR, it returns one span with text `abcd` and a width covering all four characters.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix text measurement for elements containing more than one text node.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -5    |
| Tests     | +31 / -0   |

