### PR TITLE
fix(editor): don't leave the menu click-capture overlay stuck after a right-click pan

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -72,6 +72,22 @@ export function MenuClickCapture() {
 			const button = getPointerEventButton(e)
 			if (button !== 0 && button !== 2) return
 
+			if (button === 2 && editor.options.rightClickPanning) {
+				// Forward right-click pointerdown through the canvas's own handler so
+				// pointer capture is set on the canvas (load-bearing: without this
+				// the context menu briefly flashes closed during consecutive right-clicks).
+				// The canvas owns the rest of the gesture, so don't capture or mark
+				// pointing here: this element's pointerup would never fire, leaving it
+				// mounted over the canvas after the menu closes.
+				// We don't clearOpenMenus() — Radix's DismissableLayer closes the menu
+				// via outside-click detection, keeping its internal state in sync.
+				const canvas =
+					editor.getContainer().querySelector<HTMLDivElement>('.tl-canvas') ?? e.currentTarget
+				canvasEvents.onPointerDown?.({ ...e, currentTarget: canvas })
+				swallowNextNativeContextMenu()
+				return
+			}
+
 			flushSync(() => setIsPointing(true))
 			setPointerCapture(e.currentTarget, e)
 			rPointerState.current = {
@@ -82,23 +98,9 @@ export function MenuClickCapture() {
 			}
 
 			if (button === 2) {
-				if (!editor.options.rightClickPanning) {
-					// Right-click panning off: close the open menu and swallow the native
-					// contextmenu that would otherwise briefly open a new one (causing a flash).
-					swallowNextNativeContextMenu()
-					editor.menus.clearOpenMenus()
-					return
-				}
-				// Forward right-click pointerdown through the canvas's own handler so
-				// pointer capture is also set on the canvas (load-bearing: without this
-				// the context menu briefly flashes closed during consecutive right-clicks).
-				// We don't clearOpenMenus() — Radix's DismissableLayer closes the menu
-				// via outside-click detection, keeping its internal state in sync.
-				const canvas =
-					editor.getContainer().querySelector<HTMLDivElement>('.tl-canvas') ?? e.currentTarget
-				canvasEvents.onPointerDown?.({ ...e, currentTarget: canvas })
+				// Right-click panning off: swallow the native contextmenu that would otherwise
+				// briefly open a new menu (causing a flash) once the open one closes below.
 				swallowNextNativeContextMenu()
-				return
 			}
 
 			editor.menus.clearOpenMenus()
@@ -113,8 +115,7 @@ export function MenuClickCapture() {
 
 			// Left-click: wait for the drag threshold before forwarding anything, then
 			// replay pointerdown at the original start so the editor records the
-			// correct drag origin. Right-click forwards moves immediately (pointerdown
-			// was already dispatched in handlePointerDown).
+			// correct drag origin. Right-click forwards moves immediately.
 			if (state.button !== 2 && !state.isDragging) {
 				if (
 					Vec.Dist2(state.start, new Vec(e.clientX, e.clientY)) <=


### PR DESCRIPTION
This PR fixes a bug where, with `rightClickPanning` enabled, right-click panning while a menu was open left the click-capture overlay over the canvas, so the next click was swallowed.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

`MenuClickCapture.handlePointerDown` captured the pointer on the overlay and marked it as pointing, then forwarded the right-click pointerdown to the canvas, which captured the pointer again. The pointerup therefore landed on the canvas, the overlay's `handlePointerUp` never ran, `isPointing` stayed true and the overlay kept covering the canvas after the menu closed.

### After

The right-click + panning branch forwards the pointerdown through the canvas handler without capturing the pointer or marking the overlay as pointing, so the canvas owns the rest of the gesture and the overlay unmounts with the menu as before. The left-click and right-click-without-panning paths are unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/develop (right-click panning is on by default).
2. Draw a rectangle with the Rectangle tool, then right-click on empty canvas to open the context menu.
3. With the menu open, press and hold the right mouse button on the canvas, drag to pan, and release.
4. Left-click the rectangle.
5. On `main`, the click is swallowed by the click-capture overlay still sitting over the canvas and the rectangle is not selected (hover and selection only work again after another click). With this PR, the rectangle is selected on the first click.

- [x] Covered by existing tests (`rightClickPanning.test.ts`, `right-click-context-menu.test.ts`) and the right-click e2e suite

### Release notes

- Fix the click-capture overlay staying over the canvas after right-click panning with a menu open.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +19 / -18  |

