### PR TITLE
fix(editor): let drops inside the canvas reach React and scope gesture listeners per editor

### DIFF
--- a/apps/examples/src/examples/shapes/tools/drop-zone-shape/DropZoneShapeExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/drop-zone-shape/DropZoneShapeExample.tsx
@@ -1,0 +1,29 @@
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+import { DropZoneShapeUtil } from './drop-zone-shape-util'
+import './drop-zone-shape.css'
+
+// There's a guide at the bottom of this file!
+
+// [1]
+const customShapeUtils = [DropZoneShapeUtil]
+
+export default function DropZoneShapeExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={customShapeUtils}
+				onMount={(editor) => {
+					editor.createShape({ type: 'drop-zone', x: 100, y: 100 })
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+[1]
+The shape util array is defined outside the component so it keeps the same identity across
+renders. See drop-zone-shape-util.tsx for the shape itself, which shows how to let a shape
+accept dropped files instead of the canvas.
+*/

--- a/apps/examples/src/examples/shapes/tools/drop-zone-shape/README.md
+++ b/apps/examples/src/examples/shapes/tools/drop-zone-shape/README.md
@@ -1,0 +1,14 @@
+---
+title: Shape that accepts dropped files
+component: ./DropZoneShapeExample.tsx
+priority: 3
+keywords: [drop, drag and drop, files, image, custom shape, html, ondrop, upload]
+---
+
+A custom shape with its own drop zone that shows an image dropped onto it.
+
+---
+
+Dropping a file onto the canvas normally creates an image or video shape. A shape can claim drops for itself instead: set `pointer-events: all` on its `HTMLContainer`, then handle React's `onDragOver` and `onDrop` on the element and call `stopPropagation()` so the canvas doesn't also handle the file.
+
+Try dragging an image file from your desktop onto the dashed box. The image is kept in memory only, so it's not persisted or synced; a real app would upload the file and store a URL in the shape's props. See `drop-zone-shape-util.tsx` for the shape.

--- a/apps/examples/src/examples/shapes/tools/drop-zone-shape/drop-zone-shape-util.tsx
+++ b/apps/examples/src/examples/shapes/tools/drop-zone-shape/drop-zone-shape-util.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import { BaseBoxShapeUtil, HTMLContainer, RecordProps, T, TLShape } from 'tldraw'
+
+// There's a guide at the bottom of this file!
+
+const DROP_ZONE_SHAPE_TYPE = 'drop-zone'
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[DROP_ZONE_SHAPE_TYPE]: { w: number; h: number }
+	}
+}
+
+export type IDropZoneShape = TLShape<typeof DROP_ZONE_SHAPE_TYPE>
+
+export class DropZoneShapeUtil extends BaseBoxShapeUtil<IDropZoneShape> {
+	static override type = DROP_ZONE_SHAPE_TYPE
+	static override props: RecordProps<IDropZoneShape> = {
+		w: T.number,
+		h: T.number,
+	}
+
+	getDefaultProps(): IDropZoneShape['props'] {
+		return { w: 300, h: 300 }
+	}
+
+	component(shape: IDropZoneShape) {
+		return <DropZone shape={shape} />
+	}
+
+	getIndicatorPath(shape: IDropZoneShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+function DropZone({ shape }: { shape: IDropZoneShape }) {
+	// [1]
+	const [imageUrl, setImageUrl] = useState<string | null>(null)
+	const [isDragOver, setIsDragOver] = useState(false)
+
+	useEffect(() => {
+		if (!imageUrl) return
+		return () => URL.revokeObjectURL(imageUrl)
+	}, [imageUrl])
+
+	return (
+		<HTMLContainer
+			className={`drop-zone ${isDragOver ? 'drop-zone__over' : ''}`}
+			style={{ width: shape.props.w, height: shape.props.h }}
+			// [2]
+			onDragOver={(e) => {
+				e.preventDefault()
+				e.stopPropagation()
+				setIsDragOver(true)
+			}}
+			onDragLeave={() => setIsDragOver(false)}
+			onDrop={(e) => {
+				e.preventDefault()
+				e.stopPropagation()
+				setIsDragOver(false)
+				// [3]
+				const file = Array.from(e.dataTransfer.files).find((f) => f.type.startsWith('image/'))
+				if (file) setImageUrl(URL.createObjectURL(file))
+			}}
+		>
+			{imageUrl ? <img src={imageUrl} alt="" /> : <span>Drop an image here</span>}
+		</HTMLContainer>
+	)
+}
+
+/*
+This is a custom shape, for a more in-depth look at how to create a custom shape,
+see our custom shape example.
+
+[1]
+The dropped image lives in component state only, so it isn't persisted or synced and
+disappears if the shape remounts. A real app would upload the file and store a URL in the
+shape's props instead.
+
+[2]
+The shape's container has `pointer-events: all` (see drop-zone-shape.css) so it receives
+drag events at all. The browser only fires `drop` on an element whose `dragover` called
+`preventDefault`, and `stopPropagation` keeps the canvas from also handling the file and
+creating an image shape from it.
+
+[3]
+Only the first image file is used; anything else dropped on the shape is ignored.
+*/

--- a/apps/examples/src/examples/shapes/tools/drop-zone-shape/drop-zone-shape.css
+++ b/apps/examples/src/examples/shapes/tools/drop-zone-shape/drop-zone-shape.css
@@ -1,0 +1,25 @@
+.drop-zone {
+	pointer-events: all;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	border: 2px dashed var(--tl-color-text-3);
+	border-radius: 8px;
+	background-color: var(--tl-color-background);
+	color: var(--tl-color-text-1);
+	font-family: var(--tl-font-sans);
+	font-size: 14px;
+}
+
+.drop-zone__over {
+	border-color: var(--tl-color-selected);
+	border-style: solid;
+}
+
+.drop-zone img {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	pointer-events: none;
+}

--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -29,8 +29,12 @@ export function useDocumentEvents() {
 			// re-dispatched, which would lead to an infinite loop.
 			if ((e as any).isSpecialRedispatchedEvent) return
 			preventDefault(e)
-			e.stopPropagation()
 			const cvs = container.querySelector('.tl-canvas')
+			// A drop on the canvas itself already reaches the canvas (and any shape's own React
+			// drop handlers) by bubbling; stopping it here would hide it from React, which
+			// delegates from the root above this container.
+			if (cvs?.contains(e.target as Node | null)) return
+			e.stopPropagation()
 			if (!cvs) return
 			const newEvent = new DragEvent(e.type, e)
 			;(newEvent as any).isSpecialRedispatchedEvent = true
@@ -277,10 +281,13 @@ export function useDocumentEvents() {
 
 		container.addEventListener('wheel', handleWheel, { passive: false })
 
+		// Not the shared `preventDefault` reference: the DOM dedupes identical listeners, so with two
+		// editors in one document the first cleanup would otherwise remove it for both.
+		const handleGesture = (e: Event) => preventDefault(e)
 		const ownerDoc = container.ownerDocument
-		ownerDoc.addEventListener('gesturestart', preventDefault)
-		ownerDoc.addEventListener('gesturechange', preventDefault)
-		ownerDoc.addEventListener('gestureend', preventDefault)
+		ownerDoc.addEventListener('gesturestart', handleGesture)
+		ownerDoc.addEventListener('gesturechange', handleGesture)
+		ownerDoc.addEventListener('gestureend', handleGesture)
 
 		container.addEventListener('keydown', handleKeyDown)
 		container.addEventListener('keyup', handleKeyUp)
@@ -290,9 +297,9 @@ export function useDocumentEvents() {
 
 			container.removeEventListener('wheel', handleWheel)
 
-			ownerDoc.removeEventListener('gesturestart', preventDefault)
-			ownerDoc.removeEventListener('gesturechange', preventDefault)
-			ownerDoc.removeEventListener('gestureend', preventDefault)
+			ownerDoc.removeEventListener('gesturestart', handleGesture)
+			ownerDoc.removeEventListener('gesturechange', handleGesture)
+			ownerDoc.removeEventListener('gestureend', handleGesture)
 
 			container.removeEventListener('keydown', handleKeyDown)
 			container.removeEventListener('keyup', handleKeyUp)

--- a/packages/editor/src/lib/test/useDocumentEvents.test.tsx
+++ b/packages/editor/src/lib/test/useDocumentEvents.test.tsx
@@ -1,0 +1,31 @@
+import { act, render } from '@testing-library/react'
+import { vi } from 'vitest'
+import { createTLStore } from '../config/createTLStore'
+import { TldrawEditor } from '../TldrawEditor'
+
+describe('useDocumentEvents drop handling', () => {
+	// The container's native drop listener used to stop propagation before the event reached
+	// React's root, so React onDrop handlers inside the canvas never fired.
+	it('lets a drop inside the canvas reach React drop handlers there', async () => {
+		const onDrop = vi.fn((e: React.DragEvent) => e.stopPropagation())
+		function DropTarget() {
+			return <div data-testid="drop-target" onDrop={onDrop} />
+		}
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} components={{ OnTheCanvas: DropTarget }} />)
+		})
+
+		const target = document.querySelector('[data-testid="drop-target"]')!
+		expect(target.closest('.tl-canvas')).not.toBeNull()
+		const event = new Event('drop', { bubbles: true, cancelable: true })
+		Object.defineProperty(event, 'dataTransfer', { value: { files: [], getData: () => '' } })
+		act(() => {
+			target.dispatchEvent(event)
+		})
+
+		expect(onDrop).toHaveBeenCalledTimes(1)
+		// the browser default (navigating to the dropped file) is still prevented
+		expect(event.defaultPrevented).toBe(true)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where React `onDrop`/`onDragOver` handlers rendered inside the canvas (shape components, custom UI) never received drops, because every drop was hijacked onto the canvas. It also fixes Safari gesture suppression breaking for both editors when two editors share a document and one unmounts.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The container-level native drop/dragover listener in `useDocumentEvents` called `stopPropagation` on every event before redispatching it to `.tl-canvas`. React delegates from its root above the container, so the event never reached React and in-canvas handlers did not fire.

The document `gesturestart`/`gesturechange`/`gestureend` listeners were registered with the shared `preventDefault` function reference. The DOM dedupes identical listeners, so with two editors in one document the first editor's cleanup removed the listener for both.

### After

Events whose target is inside `.tl-canvas` only `preventDefault` and keep bubbling, so React handlers there fire and the browser default is still suppressed; the redispatch path is kept for targets outside the canvas.

Each effect registers its own `handleGesture` closure, so one editor's cleanup only removes its own listeners.

This PR also adds a `drop-zone-shape` example (shapes/tools) — a custom shape whose `HTMLContainer` handles `onDragOver`/`onDrop` to show a dropped image — which demonstrates the fixed behaviour and serves as a manual test.

### Change type

- [x] `bugfix`

### Test plan

**Drops inside the canvas**

1. Run `yarn dev` and open a small custom example that renders `<Tldraw components={{ OnTheCanvas }} />`, where `OnTheCanvas` returns a `<div>` with `style={{ pointerEvents: 'all', width: 200, height: 200, background: 'pink' }}`, `onDragOver={(e) => e.preventDefault()}` and `onDrop={(e) => { e.stopPropagation(); console.log('dropped') }}`.
2. Open the devtools console.
3. Drag an image file from your desktop and drop it onto the pink box.
4. On `main`, nothing is logged and the canvas creates an image shape instead. With this PR, `dropped` is logged, no image shape is created, and the browser still does not navigate to the file.

**Safari gesture suppression with two editors**

1. In Safari, run `yarn dev` and open a small custom example that renders two `<Tldraw />` components side by side, with a button that unmounts the second one.
2. Click the button to unmount the second editor.
3. Pinch on the trackpad over the remaining editor.
4. On `main`, the whole page zooms (Safari's default pinch behaviour is no longer prevented). With this PR, the page does not zoom and the editor handles the pinch.

- [x] Unit tests — the new test fails on `main` and passes with this change
- [x] Manual: open the new `drop-zone-shape` example and drag an image file onto the shape. On `main` the shape never receives it and the canvas creates an image shape instead; with this change the image appears inside the shape and no extra shape is created. Dropping elsewhere on the canvas still creates an image shape.

### Release notes

- Let React drop handlers inside the canvas receive drop events and keep Safari gesture suppression working with multiple editors on a page.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +14 / -7   |
| Tests     | +31 / -0   |
| Examples  | +158 / -0  |


