### PR TITLE
fix(editor): revoke local asset object URLs and key the cache by asset id

### DIFF
--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -1,5 +1,5 @@
-import { TLAsset, TLAssetStore, TLStoreSnapshot } from '@tldraw/tlschema'
-import { WeakCache } from '@tldraw/utils'
+import { TLAssetId, TLAssetStore, TLStoreSnapshot } from '@tldraw/tlschema'
+import { noop } from '@tldraw/utils'
 import { useEffect } from 'react'
 import { TLStoreOptions, createTLStore } from '../config/createTLStore'
 import { TLEditorSnapshot } from '../config/TLEditorSnapshot'
@@ -33,7 +33,9 @@ export function useLocalStore(
 
 		setState({ status: 'loading' })
 
-		const objectURLCache = new WeakCache<TLAsset, Promise<string | null>>()
+		// Keyed by asset id rather than record identity so that a record update doesn't mint
+		// another object url for the same blob; every url minted here is revoked on cleanup.
+		const objectURLCache = new Map<TLAssetId, Promise<string | null>>()
 		const assets: TLAssetStore = {
 			upload: async (asset, file) => {
 				await client.db.storeAsset(asset.id, file)
@@ -43,11 +45,14 @@ export function useLocalStore(
 				if (!asset.props.src) return null
 
 				if (asset.props.src.startsWith('asset:')) {
-					return await objectURLCache.get(asset, async () => {
-						const blob = await client.db.getAsset(asset.id)
-						if (!blob) return null
-						return URL.createObjectURL(blob)
-					})
+					let objectURL = objectURLCache.get(asset.id)
+					if (!objectURL) {
+						objectURL = client.db
+							.getAsset(asset.id)
+							.then((blob) => (blob ? URL.createObjectURL(blob) : null))
+						objectURLCache.set(asset.id, objectURL)
+					}
+					return await objectURL
 				}
 
 				return asset.props.src
@@ -78,6 +83,9 @@ export function useLocalStore(
 		return () => {
 			isClosed = true
 			client.close()
+			for (const objectURL of objectURLCache.values()) {
+				objectURL.then((url) => url && URL.revokeObjectURL(url), noop)
+			}
 		}
 	}, [options, setState])
 


### PR DESCRIPTION
This PR fixes a bug where locally persisted assets leaked memory: every remount or asset-record update created another blob URL that was never revoked.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The asset resolver in `useLocalStore` minted a `URL.createObjectURL` per asset record in a per-effect `WeakCache` keyed by record identity and never revoked the URLs. A record update produced a new record and therefore a new URL for the same blob, and each URL pinned the bytes behind it for the lifetime of the page.

### After

The cache is a `Map` keyed by asset id, so a record update reuses the existing URL, and every URL minted by the effect is revoked in the effect's cleanup.

### Change type

- [x] `bugfix`

### Test plan

1. In a page that mounts the editor with a `persistenceKey` and can unmount and remount it without a full reload (toggle the component in a small React app), drop an image onto the canvas.
2. Note the image's `blob:` URL in the DOM, then unmount and remount the editor several times.
3. On `main`, every remount mints a new object URL for the same asset and never revokes any of them, pinning the image bytes for the lifetime of the page. With this change, unmount revokes the URLs it minted, and an asset record update reuses the URL keyed by asset id instead of minting another.

- [x] Covered by existing tests (cleanup-only change)

### Release notes

- Stop leaking object URLs for locally persisted assets across remounts.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -8   |

