### PR TITLE
fix(editor): sentence-case the error fallback refresh button

### DIFF
--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -220,7 +220,7 @@ My browser: ${navigator.userAgent}`
 									Reset data
 								</button>
 								<button className="tlui-button tl-error-boundary__refresh" onClick={refresh}>
-									Refresh Page
+									Refresh page
 								</button>
 							</div>
 						</div>


### PR DESCRIPTION
This PR sentence-cases the "Refresh page" button in the default error fallback, per the sentence-case rule in AGENTS.md. Nothing else changes.

Split out of #10282 (umbrella review of `packages/editor`); tracked in #10363.

### Before

The error fallback button read "Refresh Page".

### After

The button reads "Refresh page".

### Change type

- [x] `improvement`

### Test plan

- [x] No tests (copy only)

### Release notes

- Sentence-case the "Refresh page" button in the default error fallback.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1    |