### PR TITLE
fix(editor): keep duplicated pages' shapes at their original coordinates

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5150,8 +5150,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.setCamera(prevCamera)
 
 			if (content) {
-				// If we had content on the previous page, put it on the new page
-				return this.putContentOntoCurrentPage(content)
+				// If we had content on the previous page, put it on the new page at the same coordinates
+				// (otherwise offscreen content gets re-centred on the viewport)
+				return this.putContentOntoCurrentPage(content, { preservePosition: true })
 			}
 		})
 

--- a/packages/tldraw/src/test/commands/duplicatePage.test.ts
+++ b/packages/tldraw/src/test/commands/duplicatePage.test.ts
@@ -53,3 +53,22 @@ it("Doesn't duplicate the page if max pages is reached", () => {
 	}
 	expect(editor.getPages().length).toBe(editor.options.maxPages)
 })
+
+it('Keeps the duplicated shapes at their original coordinates, even when offscreen', () => {
+	editor.createShapes([{ id: createShapeId('offscreen'), type: 'geo', x: 5000, y: 5000 }])
+	// look at an empty part of the page so that no shape overlaps the viewport
+	editor.setCamera({ x: -20000, y: -20000, z: 1 })
+	const positions = editor
+		.getCurrentPageShapes()
+		.map((s) => ({ x: s.x, y: s.y }))
+		.sort((a, b) => a.x - b.x)
+
+	editor.duplicatePage(editor.getCurrentPageId())
+
+	expect(
+		editor
+			.getCurrentPageShapes()
+			.map((s) => ({ x: s.x, y: s.y }))
+			.sort((a, b) => a.x - b.x)
+	).toEqual(positions)
+})


### PR DESCRIPTION
Duplicating a page moved any offscreen shapes onto the viewport instead of keeping their coordinates.

Split out of #10353 (itself split out of #10282); tracked in #10363.

### Before

`duplicatePage` called `putContentOntoCurrentPage(content)` with no options, so the pasted shapes went through the default re-centring on the viewport; shapes that weren't on screen ended up somewhere else on the new page.

### After

`duplicatePage` passes `{ preservePosition: true }`, so shapes keep their coordinates on the new page.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420/develop and draw a rectangle.
2. Pan the canvas until the rectangle is fully out of view.
3. Open the page menu in the top-left, open the current page's `...` menu and choose `Duplicate`.
4. On `main`, the new page shows the rectangle centred in the viewport. With this PR, the new page looks empty like the original did; press `Shift+1` on both pages to see the rectangle at the same position.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Keep duplicated pages' shapes at their original coordinates.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -2    |
| Tests     | +19 / -0   |