### PR TITLE
fix(editor): keep unresolvable assets in copied content

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9872,12 +9872,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 							shouldResolveToOriginal: true,
 						})
 						if (objectUrl) {
-							const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
-							assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
-								await fetch(objectUrl).then((r) => r.blob())
-							)
-							assets.push(assetWithDataUrl)
-							return
+							// fetch resolves on 4xx/5xx, so without this check a 404 error page would be
+							// inlined as a data:text/html src
+							const response = await fetch(objectUrl)
+							if (response.ok) {
+								const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
+								assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(await response.blob())
+								assets.push(assetWithDataUrl)
+								return
+							}
 						}
 					} catch {
 						// keep the original asset

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9860,21 +9860,30 @@ export class Editor extends EventEmitter<TLEventMap> {
 					!asset.props.src?.startsWith('data:video') &&
 					!asset.props.src?.startsWith('http')
 				) {
-					const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
-					const objectUrl = await this.store.props.assets.resolve(asset, {
-						screenScale: 1,
-						steppedScreenScale: 1,
-						dpr: 1,
-						networkEffectiveType: null,
-						shouldResolveToOriginal: true,
-					})
-					assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
-						await fetch(objectUrl!).then((r) => r.blob())
-					)
-					assets.push(assetWithDataUrl)
-				} else {
-					assets.push(asset)
+					// If the asset can't be inlined (unresolvable src, fetch failure), fall through and
+					// keep the original record; dropping it leaves the pasted shapes pointing at an
+					// asset that doesn't exist
+					try {
+						const objectUrl = await this.store.props.assets.resolve(asset, {
+							screenScale: 1,
+							steppedScreenScale: 1,
+							dpr: 1,
+							networkEffectiveType: null,
+							shouldResolveToOriginal: true,
+						})
+						if (objectUrl) {
+							const assetWithDataUrl = structuredClone(asset as TLImageAsset | TLVideoAsset)
+							assetWithDataUrl.props.src = await FileHelpers.blobToDataUrl(
+								await fetch(objectUrl).then((r) => r.blob())
+							)
+							assets.push(assetWithDataUrl)
+							return
+						}
+					} catch {
+						// keep the original asset
+					}
 				}
+				assets.push(asset)
 			})
 		)
 		content.assets = assets

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9881,9 +9881,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 								assets.push(assetWithDataUrl)
 								return
 							}
+							console.warn(`Could not inline asset ${asset.id}: fetch returned ${response.status}`)
 						}
-					} catch {
-						// keep the original asset
+					} catch (err) {
+						console.warn(`Could not inline asset ${asset.id}`, err)
 					}
 				}
 				assets.push(asset)

--- a/packages/tldraw/src/test/resolveAssetsInContent.test.ts
+++ b/packages/tldraw/src/test/resolveAssetsInContent.test.ts
@@ -1,0 +1,96 @@
+import {
+	AssetRecordType,
+	TLAssetStore,
+	TLContent,
+	TLImageAsset,
+	createShapeId,
+} from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+const assetId = AssetRecordType.createId('a')
+const shapeId = createShapeId('image')
+
+function createContent(assets: Partial<TLAssetStore>) {
+	const editor = new TestEditor({}, { assets: { upload: async () => ({ src: '' }), ...assets } })
+	editor.createAssets([
+		{
+			id: assetId,
+			typeName: 'asset',
+			type: 'image',
+			meta: {},
+			props: {
+				w: 100,
+				h: 100,
+				name: 'a.png',
+				isAnimated: false,
+				mimeType: 'image/png',
+				src: 'asset:a',
+			},
+		},
+	])
+	editor.createShape({ id: shapeId, type: 'image', x: 0, y: 0, props: { assetId, w: 100, h: 100 } })
+	return { editor, content: editor.getContentFromCurrentPage([shapeId])! }
+}
+
+// jsdom's Blob and Node's Response disagree, so a real Response stringifies the blob
+function mockResponse(ok: boolean, body: string, type: string) {
+	return { ok, status: ok ? 200 : 404, blob: async () => new Blob([body], { type }) }
+}
+
+function originalAsset(content: TLContent) {
+	return structuredClone(content.assets.find((a) => a.id === assetId) as TLImageAsset)
+}
+
+describe('Editor.resolveAssetsInContent', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('inlines a fetched asset as a data url', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => mockResponse(true, 'png-bytes', 'image/png'))
+		)
+		const { editor, content } = createContent({ resolve: async () => 'https://example.com/a.png' })
+
+		const result = await editor.resolveAssetsInContent(content)
+
+		const asset = result!.assets[0] as TLImageAsset
+		expect(asset.props.src).toMatch(/^data:image\/png;base64,/)
+		expect(vi.mocked(fetch).mock.calls[0][0]).toBe('https://example.com/a.png')
+	})
+
+	it('keeps the original asset when resolve returns null', async () => {
+		vi.stubGlobal('fetch', vi.fn())
+		const { editor, content } = createContent({ resolve: async () => null })
+		const expected = originalAsset(content)
+
+		const result = await editor.resolveAssetsInContent(content)
+
+		expect(result!.assets).toEqual([expected])
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('keeps the original asset when the fetch rejects', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+		const { editor, content } = createContent({ resolve: async () => 'https://example.com/a.png' })
+		const expected = originalAsset(content)
+
+		const result = await editor.resolveAssetsInContent(content)
+
+		expect(result!.assets).toEqual([expected])
+	})
+
+	it('keeps the original asset when the fetch responds with a non-OK status', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => mockResponse(false, '<html>not found</html>', 'text/html'))
+		)
+		const { editor, content } = createContent({ resolve: async () => 'https://example.com/a.png' })
+		const expected = originalAsset(content)
+
+		const result = await editor.resolveAssetsInContent(content)
+
+		expect(result!.assets).toEqual([expected])
+	})
+})


### PR DESCRIPTION
Copied content silently lost assets whose source could not be resolved or fetched, leaving the pasted shapes pointing at a missing asset.

Split out of #10353 (itself split out of #10282); tracked in #10363.

### Before

`resolveAssetsInContent` awaited `assets.resolve` and then `fetch`ed the result without a guard: an empty or unresolvable src or a failed fetch threw inside the `Promise.all`, and the asset never made it into `content.assets`.

### After

`resolveAssetsInContent` wraps the resolve/fetch in a `try`, skips the fetch when the resolved url is empty, and on any failure keeps the original asset record in `content.assets`.

### Change type

- [x] `bugfix`

### Test plan

1. Use an asset store whose `resolve` returns `null` or whose url fails to fetch for an image asset.
2. Copy the image shape and paste it. On `main` the paste has no asset record for the shape; with this PR the original asset record is kept.

- [ ] Unit tests

### Release notes

- Stop dropping unresolvable assets from copied content.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +23 / -14  |