### PR TITLE
fix(editor): don't mutate the content passed to putContentOntoCurrentPage

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10095,7 +10095,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (shapeIdMap.has(newShape.parentId)) {
 				newShape.parentId = shapeIdMap.get(oldShape.parentId)!
 			} else {
-				rootShapeIds.push(newShape.id)
 				// newShape.parentId = pasteParentId
 				newShape.index = index
 				index = getIndexAbove(index)
@@ -10138,10 +10137,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				(asset.type === 'video' && asset.props.src?.startsWith('data:video'))
 			) {
 				// it's src is a base64 image or video; we need to create a new asset without the src,
-				// then create a new asset from the original src. So we save a copy of the original asset,
-				// then delete the src from the original asset.
-				assetsToUpdate.push(structuredClone(asset as TLImageAsset | TLVideoAsset))
-				asset.props.src = null
+				// then create a new asset from the original src. So we keep the original asset for the
+				// upload and create a copy with its src removed. Copy rather than mutate: when no
+				// migration applies, migrateStoreSnapshot hands back the caller's own record objects.
+				assetsToUpdate.push(asset as TLImageAsset | TLVideoAsset)
+				const assetWithoutSrc = structuredClone(asset as TLImageAsset | TLVideoAsset)
+				assetWithoutSrc.props.src = null
+				assetsToCreate.push(assetWithoutSrc)
+				continue
 			}
 
 			// Add the asset to the list of assets to create

--- a/packages/tldraw/src/test/commands/putContent.test.ts
+++ b/packages/tldraw/src/test/commands/putContent.test.ts
@@ -1,4 +1,4 @@
-import { TLContent, createShapeId, structuredClone } from '@tldraw/editor'
+import { AssetRecordType, TLContent, createShapeId, structuredClone } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -36,6 +36,40 @@ describe('Migrations', () => {
 		// @ts-expect-error
 		withInvalidShapeModel.shapes[0].x = 'invalid'
 		expect(() => editor.putContentOntoCurrentPage(withInvalidShapeModel)).toThrow()
+	})
+})
+
+describe('Input content', () => {
+	it('is not mutated when it carries data url assets', () => {
+		const assetId = AssetRecordType.createId('imageAsset')
+		const imageId = createShapeId('image')
+		const src = 'data:image/png;base64,AAAA'
+		editor.createAssets([
+			{
+				type: 'image',
+				id: assetId,
+				typeName: 'asset',
+				props: { w: 100, h: 100, name: '', isAnimated: false, mimeType: 'image/png', src },
+				meta: {},
+			},
+		])
+		editor.createShape({
+			id: imageId,
+			type: 'image',
+			x: 0,
+			y: 0,
+			props: { w: 100, h: 100, assetId },
+		})
+		// the content holds the live records when no migration applies, so putting it into another
+		// editor must not write through to this editor's asset
+		const content = editor.getContentFromCurrentPage([imageId])!
+		const other = new TestEditor()
+		other.putContentOntoCurrentPage(content)
+
+		expect(content.assets[0].props.src).toBe(src)
+		expect(content.rootShapeIds).toEqual([imageId])
+		expect(editor.getAsset(assetId)!.props.src).toBe(src)
+		other.dispose()
 	})
 })
 


### PR DESCRIPTION
`putContentOntoCurrentPage` mutated the `TLContent` object the caller passed in, including the source editor's live asset record when the content came from `getContentFromCurrentPage`.

Split out of #10353 (itself split out of #10282); tracked in #10363.

### Before

`putContentOntoCurrentPage` set `asset.props.src = null` on data-url assets and pushed onto `rootShapeIds` directly. When no migration applies, `migrateStoreSnapshot` hands back the caller's own record objects, so these writes went through to the caller's `TLContent` — and, for content from `getContentFromCurrentPage`, to the source editor's asset.

### After

`putContentOntoCurrentPage` keeps the original asset for the upload and creates a `structuredClone` with `src` nulled for the store, and no longer pushes onto the content's `rootShapeIds` (the local `rootShapes` list already covers what that push was for).

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test fails on `main` and passes with this change

Steps to test manually:

1. Run `yarn dev` and open http://localhost:5420/develop (this page exposes `window.editor`; with no asset store configured, dropped images are stored as data urls).
2. Drag an image file onto the canvas and leave it selected.
3. In the browser console, run:

   ```js
   const content = editor.getContentFromCurrentPage(editor.getSelectedShapeIds())
   const src = content.assets[0].props.src
   const assetId = content.assets[0].id
   editor.putContentOntoCurrentPage(content, { point: { x: 600, y: 100 } })
   console.log({
   	inputSrcIntact: content.assets[0].props.src === src,
   	rootShapeIds: content.rootShapeIds.length,
   	sourceAssetIntact: editor.getAsset(assetId).props.src === src,
   })
   ```

4. On `main` this logs `inputSrcIntact: false`, `rootShapeIds: 2`, `sourceAssetIntact: false` — the put wrote through to the content object and to the source editor's live asset record. With this change all three are `true` / `1`.
5. A copy of the image should appear at the new point and the original should still render normally.

### Release notes

- Don't mutate the content passed to `putContentOntoCurrentPage`.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -5    |
| Tests     | +35 / -1   |
