### PR TITLE
fix(editor): surface asset store removal errors in deleteAssets

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5265,7 +5265,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.run(
 			() => {
-				this.store.props.assets.remove?.(ids)
+				// the asset store's remove is async; surface failures instead of leaving an unhandled rejection
+				Promise.resolve(this.store.props.assets.remove?.(ids)).catch((err) =>
+					console.error('Error while removing assets from the asset store:', err)
+				)
 				this.store.remove(ids)
 			},
 			{ history: 'ignore' }


### PR DESCRIPTION
Asset-store removal failures surfaced as unhandled promise rejections.

Split out of #10353 (itself split out of #10282); tracked in #10363.

### Before

`deleteAssets` called the asset store's async `remove()` without handling the returned promise, so a rejection was unhandled.

### After

`deleteAssets` wraps `remove()` in `Promise.resolve(...).catch(...)` and logs the error.

### Change type

- [x] `bugfix`

### Test plan

1. Use an asset store whose `remove` rejects, then delete an asset. On `main` this is an unhandled rejection; with this PR it is logged via `console.error`.

- [ ] Unit tests

### Release notes

- Log asset store removal errors instead of leaving an unhandled rejection.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |