### PR TITLE
fix(editor): record onEditEnd changes in history when leaving an editing shape

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2791,57 +2791,38 @@ export class Editor extends EventEmitter<TLEventMap> {
 	setEditingShape(shape: TLShapeId | TLShape | null): this {
 		const id = typeof shape === 'string' ? shape : (shape?.id ?? null)
 
-		if (!id) {
-			// setting the editing shape to null
+		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
+		if (id && !this.canEditShape(id)) return this
+
+		this.run(() => {
+			// Clean up the previous editing shape. This runs outside the history-ignored batch below,
+			// otherwise document changes made by onEditEnd (e.g. deleting an empty text shape) are
+			// never recorded and leave a phantom undo entry whose redo resurrects the shape.
+			const prevEditingShapeId = this.getEditingShapeId()
+			if (prevEditingShapeId) {
+				const prevEditingShape = this.getShape(prevEditingShapeId)
+				if (prevEditingShape) {
+					this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
+				}
+			}
+
 			this.run(
 				() => {
-					// Clean up the previous editing shape
-					const prevEditingShapeId = this.getEditingShapeId()
-					if (prevEditingShapeId) {
-						const prevEditingShape = this.getShape(prevEditingShapeId)
-						if (prevEditingShape) {
-							this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-						}
-					}
-
 					// Clean up the editing shape state and rich text editor
 					this._updateCurrentPageState({ editingShapeId: null })
 					this._currentRichTextEditor.set(null)
+
+					if (!id) return
+
+					this.select(id)
+					this._updateCurrentPageState({ editingShapeId: id })
+
+					const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
+					this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
 				},
 				{ history: 'ignore' }
 			)
-
-			return this
-		}
-
-		// id was provided but the next editing shape was not editable or didn't exist, so do nothing
-		if (!this.canEditShape(id)) return this
-
-		// id was provided and the next editing shape is editable, so set the rich text editor to null
-		this.run(
-			() => {
-				// Clean up the previous editing shape
-				const prevEditingShapeId = this.getEditingShapeId()
-				if (prevEditingShapeId) {
-					const prevEditingShape = this.getShape(prevEditingShapeId)
-					if (prevEditingShape) {
-						this.getShapeUtil(prevEditingShape).onEditEnd?.(prevEditingShape)
-					}
-				}
-
-				// Clean up the editing shape state and rich text editor
-				this._updateCurrentPageState({ editingShapeId: null })
-				this._currentRichTextEditor.set(null)
-
-				// Set the new editing shape
-				this.select(id)
-				this._updateCurrentPageState({ editingShapeId: id })
-
-				const nextEditingShape = this.getShape(id)! // shape should be there because canEditShape checked it. Possible small chance that onEditEnd deleted it?
-				this.getShapeUtil(nextEditingShape).onEditStart?.(nextEditingShape)
-			},
-			{ history: 'ignore' }
-		)
+		})
 
 		return this
 	}

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -55,6 +55,24 @@ describe(TextShapeTool, () => {
 			props: { richText: toRichText('Hello') },
 		})
 	})
+
+	it('Records the deletion of an empty text shape so redo cannot resurrect it', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown(0, 0)
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+
+		// Exiting without typing deletes the empty shape (TextShapeUtil.onEditEnd)
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+
+		// The creation and the deletion squash to nothing, so neither undo nor redo brings it back
+		editor.undo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		editor.redo()
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
 })
 
 describe('When selecting the tool', () => {


### PR DESCRIPTION
Exiting an empty text shape left a phantom undo entry whose redo resurrected the deleted shape.

Split out of #10335 (itself split out of #10282); tracked in #10363.

### Before

- `setEditingShape` called the previous editing shape's `onEditEnd` inside a `history: 'ignore'` batch, so the deletion `TextShapeUtil.onEditEnd` performs on an empty shape was never recorded; the creation stayed in history on its own.

### After

- `setEditingShape` runs `onEditEnd` in an outer `run` before the history-ignored batch, so the deletion is recorded and squashes with the creation; neither undo nor redo brings the shape back.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420.
2. Press `T` for the text tool and click once on the canvas, then press Escape without typing anything. The empty text shape is deleted.
3. Press Cmd+Z, then Cmd+Shift+Z (redo).
4. On `main` redo resurrects the empty text shape: `editor.getCurrentPageShapes().length` in the devtools console is `1` and Cmd+A shows a selection box around an invisible shape. With this PR the page stays empty after both undo and redo.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Record document changes made by onEditEnd in history so exiting an empty text shape no longer leaves a phantom undo entry.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +24 / -43 |
| Tests     | +18 / -0 |

