### PR TITLE
fix(editor): leave crop mode when the cropping shape is deleted

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -546,6 +546,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 				nextPageState.editingShapeId = null
 			}
 
+			if (
+				prevPageState.croppingShapeId &&
+				shapesNoLongerInPage.has(prevPageState.croppingShapeId)
+			) {
+				if (!nextPageState) nextPageState = { ...prevPageState }
+				nextPageState.croppingShapeId = null
+			}
+
 			const hintingShapeIds = prevPageState.hintingShapeIds.filter(
 				(id) => !shapesNoLongerInPage.has(id)
 			)

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -286,6 +286,17 @@ describe('When in the crop.idle state', () => {
 			.expectToBeIn('select.idle')
 	})
 
+	it('deleting the cropping shape clears the cropping shape id and leaves crop mode', () => {
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.deleteShapes([ids.imageB])
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('pointing the canvas should point canvas', () => {
 		editor
 			.expectToBeIn('select.idle')


### PR DESCRIPTION
Deleting the shape being cropped left the editor in crop mode pointing at a shape that no longer existed.

Split out of #10335 (itself split out of #10282); tracked in #10363.

### Before

- `cleanupInstancePageState` cleared `editingShapeId`, hinting and erasing ids for deleted shapes but not `croppingShapeId`, so deleting the cropping shape left the editor in crop mode with a missing shape.

### After

- `cleanupInstancePageState` also clears `croppingShapeId` when the cropping shape leaves the page, so the editor returns to `select.idle`.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420, drop or paste an image onto the canvas and double-click it to enter crop mode.
2. Press Delete to delete the image while cropping.
3. On `main` `editor.getPath()` in the devtools console still reports `select.crop.idle` and `editor.getCroppingShapeId()` returns the deleted id, so clicking another image drops straight into crop mode on it. With this PR the editor returns to `select.idle` and the cropping id is cleared.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Leave crop mode and clear the cropping shape id when the cropping shape is deleted.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -0 |
| Tests     | +11 / -0 |

