### PR TITLE
fix(editor): stop setErasingShapes mutating its input array

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -72,6 +72,7 @@ import {
 	Result,
 	ZERO_INDEX_KEY,
 	annotateError,
+	areArraysShallowEqual,
 	assert,
 	assertExists,
 	bind,
@@ -3006,26 +3007,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setErasingShapes(shapes: TLShapeId[] | TLShape[]): this {
+		// copy before sorting: the caller may pass a store-owned (frozen) array
 		const ids =
 			typeof shapes[0] === 'string'
-				? (shapes as TLShapeId[])
+				? (shapes as TLShapeId[]).slice()
 				: (shapes as TLShape[]).map((shape) => shape.id)
 		ids.sort() // sort the incoming ids
 		const erasingShapeIds = this.getErasingShapeIds()
 		this.run(
 			() => {
-				if (ids.length === erasingShapeIds.length) {
-					// if the new ids are the same length as the current ids, they might be the same.
-					// presuming the current ids are also sorted, check each item to see if it's the same;
-					// if we find any unequal, then we know the new ids are different.
-					for (let i = 0; i < ids.length; i++) {
-						if (ids[i] !== erasingShapeIds[i]) {
-							this._updateCurrentPageState({ erasingShapeIds: ids })
-							break
-						}
-					}
-				} else {
-					// if the ids are a different length, then we know they're different.
+				// the current ids are also sorted, so a shallow comparison tells us whether they changed
+				if (!areArraysShallowEqual(ids, erasingShapeIds)) {
 					this._updateCurrentPageState({ erasingShapeIds: ids })
 				}
 			},

--- a/packages/editor/src/lib/hooks/usePeerIds.ts
+++ b/packages/editor/src/lib/hooks/usePeerIds.ts
@@ -1,4 +1,5 @@
 import { useComputed, useValue } from '@tldraw/state-react'
+import { areArraysShallowEqual } from '@tldraw/utils'
 import { uniq } from '../utils/uniq'
 import { useEditor } from './useEditor'
 
@@ -17,7 +18,7 @@ export function usePeerIds() {
 	const $userIds = useComputed(
 		'userIds',
 		() => uniq(editor.getVisibleCollaborators().map((p) => p.userId)).sort(),
-		{ isEqual: (a, b) => a.join(',') === b.join?.(',') },
+		{ isEqual: areArraysShallowEqual },
 		[editor]
 	)
 


### PR DESCRIPTION
`setErasingShapes` sorted the caller's array in place, which throws when passed a store-owned (frozen) array such as `editor.getSelectedShapeIds()`.

Split out of #10335 (itself split out of #10282); tracked in #10363.

### Before

- `setErasingShapes` sorted its input array in place, which throws on a frozen store-owned array, and compared it to the current ids with a hand-rolled loop.

### After

- `setErasingShapes` copies the ids before sorting and compares with `areArraysShallowEqual`; `usePeerIds` uses the same helper for its `isEqual`.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, open http://localhost:5420, draw a shape and select it.
2. In the devtools console run `editor.setErasingShapes(editor.getSelectedShapeIds())` (the selected ids array is frozen in dev builds).
3. On `main` the call throws `TypeError: Cannot assign to read only property '0'` from the in-place sort. With this PR it succeeds and the shape is marked as erasing.

- [ ] Unit tests

### Release notes

- Stop setErasingShapes mutating its input array so it accepts store-owned (frozen) arrays.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -14 |

