### PR TITLE
fix(editor): keep collaboration-mode readonly syncs out of undo history

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -940,7 +940,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const mode = this.store.props.collaboration.mode
 			this.disposables.add(
 				react('update collaboration mode', () => {
-					this.store.put([{ ...this.getInstanceState(), isReadonly: mode.get() === 'readonly' }])
+					const isReadonly = mode.get() === 'readonly'
+					// only track `mode`, and keep the sync out of the user's undo history
+					unsafe__withoutCapture(() =>
+						this._updateInstanceState({ isReadonly }, { history: 'ignore' })
+					)
 				})
 			)
 		}

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -913,6 +913,9 @@ describe('instance.isReadonly', () => {
 		expect(editor.getIsReadonly()).toBe(false)
 		mode.set('readonly')
 		expect(editor.getIsReadonly()).toBe(true)
+
+		// syncing the mode is not a user edit, so it must not show up in the undo history
+		expect(editor.getCanUndo()).toBe(false)
 	})
 })
 


### PR DESCRIPTION
Syncing the collaboration mode into `isReadonly` wrote the whole instance state and polluted the user's undo history.

Split out of #10335 (itself split out of #10282); tracked in #10363.

### Before

- The `update collaboration mode` reaction did `store.put` on the whole instance state, tracking every instance-state field and recording the write in history.

### After

- The reaction calls `_updateInstanceState({ isReadonly }, { history: 'ignore' })` inside `unsafe__withoutCapture`, so it tracks only `mode` and leaves undo history untouched.

### Change type

- [x] `bugfix`

### Test plan

1. Mount an editor whose store has a collaboration mode signal, e.g. `createTLStore({ collaboration: { mode: atom('mode', 'readwrite') } })` — a `useSync` store in a shared room does this.
2. Draw a shape, then flip the mode to `'readonly'` and back to `'readwrite'`.
3. Press Cmd+Z. On `main`, each mode flip recorded an instance-state write in history, so the first undos change nothing on the canvas. With this change, the first undo removes the shape.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Keep collaboration-mode readonly syncs out of the user's undo history.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -1 |
| Tests     | +3 / -0 |


