### PR TITLE
fix(editor): stop recreating the editor when TldrawEditor re-renders with inline nested options

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -314,8 +314,11 @@ export const TldrawEditor = memo(function TldrawEditor({
 	// Merge deprecated props with options (options win). Nested option objects are
 	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
 	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
+	// `text` needs the deep comparison as well: `<Tldraw>` builds a fresh `tipTapConfig` inside
+	// it whenever its own `options.text` is a new identity.
 	const camera = useDeepObjectIdentity(_options?.camera)
-	const text = useShallowObjectIdentity(_options?.text ?? _textOptions)
+	const gridSteps = useDeepObjectIdentity(_options?.gridSteps)
+	const text = useDeepObjectIdentity(_options?.text ?? _textOptions)
 	const mergedDeepLinks = _options?.deepLinks ?? _deepLinks
 	const deepLinkOptions = useDeepObjectIdentity(
 		mergedDeepLinks === true ? undefined : mergedDeepLinks
@@ -324,10 +327,11 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const mergedOptions = useMemo(() => {
 		let result = _options
 		if (camera !== undefined) result = { ...result, camera }
+		if (gridSteps !== undefined) result = { ...result, gridSteps }
 		if (text !== undefined) result = { ...result, text }
 		if (deepLinks !== undefined) result = { ...result, deepLinks }
 		return result
-	}, [_options, camera, text, deepLinks])
+	}, [_options, camera, gridSteps, text, deepLinks])
 
 	// apply defaults. if you're using the bare @tldraw/editor package, we
 	// default these to the "tldraw zero" configuration. We have different

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -46,7 +46,7 @@ import { EditorProvider, useEditor } from './hooks/useEditor'
 import { EditorComponentsProvider } from './hooks/useEditorComponents'
 import { useEvent } from './hooks/useEvent'
 import { useForceUpdate } from './hooks/useForceUpdate'
-import { useShallowObjectIdentity } from './hooks/useIdentity'
+import { useDeepObjectIdentity, useShallowObjectIdentity } from './hooks/useIdentity'
 import { useLocalStore } from './hooks/useLocalStore'
 import { useRefState } from './hooks/useRefState'
 import { useStateAttribute } from './hooks/useStateAttribute'
@@ -311,18 +311,23 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const ErrorFallback =
 		components?.ErrorFallback === undefined ? DefaultErrorFallback : components?.ErrorFallback
 
-	// Merge deprecated props with options
-	// options values take precedence over the deprecated props
+	// Merge deprecated props with options (options win). Nested option objects are
+	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
+	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
+	const camera = useDeepObjectIdentity(_options?.camera)
+	const text = useShallowObjectIdentity(_options?.text ?? _textOptions)
+	const mergedDeepLinks = _options?.deepLinks ?? _deepLinks
+	const deepLinkOptions = useDeepObjectIdentity(
+		mergedDeepLinks === true ? undefined : mergedDeepLinks
+	)
+	const deepLinks = mergedDeepLinks === true ? true : deepLinkOptions
 	const mergedOptions = useMemo(() => {
 		let result = _options
-		if (_textOptions) {
-			result = { ...result, text: result?.text ?? _textOptions }
-		}
-		if (_deepLinks !== undefined) {
-			result = { ...result, deepLinks: result?.deepLinks ?? _deepLinks }
-		}
+		if (camera !== undefined) result = { ...result, camera }
+		if (text !== undefined) result = { ...result, text }
+		if (deepLinks !== undefined) result = { ...result, deepLinks }
 		return result
-	}, [_options, _textOptions, _deepLinks])
+	}, [_options, camera, text, deepLinks])
 
 	// apply defaults. if you're using the bare @tldraw/editor package, we
 	// default these to the "tldraw zero" configuration. We have different

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -311,11 +311,11 @@ export const TldrawEditor = memo(function TldrawEditor({
 	const ErrorFallback =
 		components?.ErrorFallback === undefined ? DefaultErrorFallback : components?.ErrorFallback
 
-	// Merge deprecated props with options (options win). Nested option objects are
-	// identity-stabilised too: `options` is a dependency of the editor-creating effect, so an
-	// inline `options={{ camera: { ... } }}` would otherwise recreate the editor on every render.
-	// `text` needs the deep comparison as well: `<Tldraw>` builds a fresh `tipTapConfig` inside
-	// it whenever its own `options.text` is a new identity.
+	// Merge deprecated props with options (options win). `options` is a dependency of the
+	// editor-creating effect, so it's shallow-stabilised below; the nested objects are
+	// deep-stabilised here first, or an inline `options={{ camera: { ... } }}` would still
+	// recreate the editor on every render. `text` needs the deep comparison as well: `<Tldraw>`
+	// builds a fresh `tipTapConfig` inside it whenever its own `options.text` is a new identity.
 	const camera = useDeepObjectIdentity(_options?.camera)
 	const gridSteps = useDeepObjectIdentity(_options?.gridSteps)
 	const text = useDeepObjectIdentity(_options?.text ?? _textOptions)
@@ -324,14 +324,11 @@ export const TldrawEditor = memo(function TldrawEditor({
 		mergedDeepLinks === true ? undefined : mergedDeepLinks
 	)
 	const deepLinks = mergedDeepLinks === true ? true : deepLinkOptions
-	const mergedOptions = useMemo(() => {
-		let result = _options
-		if (camera !== undefined) result = { ...result, camera }
-		if (gridSteps !== undefined) result = { ...result, gridSteps }
-		if (text !== undefined) result = { ...result, text }
-		if (deepLinks !== undefined) result = { ...result, deepLinks }
-		return result
-	}, [_options, camera, gridSteps, text, deepLinks])
+	let mergedOptions = _options
+	if (camera !== undefined) mergedOptions = { ...mergedOptions, camera }
+	if (gridSteps !== undefined) mergedOptions = { ...mergedOptions, gridSteps }
+	if (text !== undefined) mergedOptions = { ...mergedOptions, text }
+	if (deepLinks !== undefined) mergedOptions = { ...mergedOptions, deepLinks }
 
 	// apply defaults. if you're using the bare @tldraw/editor package, we
 	// default these to the "tldraw zero" configuration. We have different

--- a/packages/editor/src/lib/hooks/useIdentity.tsx
+++ b/packages/editor/src/lib/hooks/useIdentity.tsx
@@ -1,4 +1,4 @@
-import { areArraysShallowEqual, areObjectsShallowEqual } from '@tldraw/utils'
+import { areArraysShallowEqual, areObjectsShallowEqual, isEqual } from '@tldraw/utils'
 import { useRef } from 'react'
 
 function useIdentity<T>(value: T, isEqual: (a: T, b: T) => boolean): T {
@@ -48,4 +48,14 @@ const areNullableObjectsShallowEqual = (
 /** @internal */
 export function useShallowObjectIdentity<T extends object | null | undefined>(obj: T): T {
 	return useIdentity(obj, areNullableObjectsShallowEqual)
+}
+
+/**
+ * For small plain-data option objects that may nest (e.g. camera constraints), where a
+ * shallow comparison would still see a fresh identity on every render.
+ *
+ * @internal
+ */
+export function useDeepObjectIdentity<T extends object | null | undefined>(obj: T): T {
+	return useIdentity(obj, isEqual)
 }

--- a/packages/editor/src/lib/hooks/useIdentity.tsx
+++ b/packages/editor/src/lib/hooks/useIdentity.tsx
@@ -51,8 +51,9 @@ export function useShallowObjectIdentity<T extends object | null | undefined>(ob
 }
 
 /**
- * For small plain-data option objects that may nest (e.g. camera constraints), where a
- * shallow comparison would still see a fresh identity on every render.
+ * For small option objects that may nest (e.g. camera constraints), where a shallow comparison
+ * would still see a fresh identity on every render. Functions and class instances inside still
+ * compare by reference, so an inline callback or a fresh `Extension.configure()` counts as a change.
  *
  * @internal
  */

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -172,6 +172,83 @@ describe('<TldrawEditor />', () => {
 		expect(onMount.mock.lastCall![0].store).toBe(newStore)
 	})
 
+	it('keeps the editor when re-rendered with equal inline nested options', async () => {
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>,
+			{ waitForPatterns: false }
+		)
+		const initialEditor = onMount.mock.lastCall![0]
+		vi.spyOn(initialEditor, 'dispose')
+		// a fresh options object with fresh (but equal) nested objects, as an inline literal gives:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: true }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		expect(initialEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(1)
+		// deeper nesting (camera constraints, zoomSteps) is compared by value too:
+		const withConstraints = () => ({
+			camera: {
+				isLocked: true,
+				zoomSteps: [0.5, 1, 2],
+				constraints: {
+					bounds: { x: 0, y: 0, w: 100, h: 100 },
+					padding: { x: 0, y: 0 },
+					origin: { x: 0.5, y: 0.5 },
+					initialZoom: 'default' as const,
+					baseZoom: 'default' as const,
+					behavior: 'contain' as const,
+				},
+			},
+			deepLinks: { param: 'd' },
+		})
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(onMount).toHaveBeenCalledTimes(2)
+		const secondEditor = onMount.mock.lastCall![0]
+		vi.spyOn(secondEditor, 'dispose')
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={withConstraints()}
+			/>
+		)
+		expect(secondEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(2)
+		// a real change still recreates the editor:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ camera: { isLocked: false }, deepLinks: { param: 'd' } }}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(secondEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(3)
+		expect(onMount.mock.lastCall![0].getCameraOptions().isLocked).toBe(false)
+	})
+
 	it('reflects mount state via getIsMounted and the mount/unmount events', async () => {
 		const onUnmount = vi.fn()
 		const { editor, rendered } = await renderTldrawComponentWithEditor(

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -20,6 +20,7 @@ import { StrictMode } from 'react'
 import { vi } from 'vitest'
 import { defaultShapeUtils } from '../lib/defaultShapeUtils'
 import { defaultTools } from '../lib/defaultTools'
+import { Tldraw } from '../lib/Tldraw'
 import { createDrawSegments } from '../lib/utils/test-helpers'
 import { defaultAddFontsFromNode, tipTapDefaultExtensions } from '../lib/utils/text/richText'
 import {
@@ -247,6 +248,67 @@ describe('<TldrawEditor />', () => {
 		expect(secondEditor.dispose).toHaveBeenCalledTimes(1)
 		expect(onMount).toHaveBeenCalledTimes(3)
 		expect(onMount.mock.lastCall![0].getCameraOptions().isLocked).toBe(false)
+	})
+
+	it('keeps the editor when re-rendered with equal inline gridSteps', async () => {
+		const onMount = vi.fn()
+		const gridSteps = () => [{ min: -1, mid: 0.15, step: 64 }]
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ gridSteps: gridSteps() }}
+			/>,
+			{ waitForPatterns: false }
+		)
+		const initialEditor = onMount.mock.lastCall![0]
+		vi.spyOn(initialEditor, 'dispose')
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ gridSteps: gridSteps() }}
+			/>
+		)
+		expect(initialEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(1)
+		// a real change still recreates the editor:
+		rendered.rerender(
+			<TldrawEditor
+				tools={defaultTools}
+				initialState="select"
+				onMount={onMount}
+				options={{ gridSteps: [{ min: -1, mid: 0.15, step: 32 }] }}
+			/>
+		)
+		await rendered.findAllByTestId('canvas')
+		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(2)
+		expect(onMount.mock.lastCall![0].options.gridSteps).toEqual([{ min: -1, mid: 0.15, step: 32 }])
+	})
+
+	it('keeps the editor when <Tldraw /> is re-rendered with equal inline text options', async () => {
+		// <Tldraw> builds a fresh `tipTapConfig` from `options.text` each time that object changes
+		// identity, so a shallow comparison of `text` is not enough here.
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(
+			<Tldraw onMount={onMount} options={{ text: {} }} />,
+			{ waitForPatterns: true }
+		)
+		const initialEditor = onMount.mock.lastCall![0]
+		vi.spyOn(initialEditor, 'dispose')
+		rendered.rerender(<Tldraw onMount={onMount} options={{ text: {} }} />)
+		expect(initialEditor.dispose).not.toHaveBeenCalled()
+		expect(onMount).toHaveBeenCalledTimes(1)
+		// a real change still recreates the editor:
+		const addFontsFromNode = vi.fn(defaultAddFontsFromNode)
+		rendered.rerender(<Tldraw onMount={onMount} options={{ text: { addFontsFromNode } }} />)
+		await rendered.findAllByTestId('canvas')
+		expect(initialEditor.dispose).toHaveBeenCalledTimes(1)
+		expect(onMount).toHaveBeenCalledTimes(2)
+		expect(onMount.mock.lastCall![0].getTextOptions().addFontsFromNode).toBe(addFontsFromNode)
 	})
 
 	it('reflects mount state via getIsMounted and the mount/unmount events', async () => {

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -196,7 +196,6 @@ describe('<TldrawEditor />', () => {
 			/>
 		)
 		expect(initialEditor.dispose).not.toHaveBeenCalled()
-		expect(onMount).toHaveBeenCalledTimes(1)
 		// deeper nesting (camera constraints, zoomSteps) is compared by value too:
 		const withConstraints = () => ({
 			camera: {
@@ -234,7 +233,6 @@ describe('<TldrawEditor />', () => {
 			/>
 		)
 		expect(secondEditor.dispose).not.toHaveBeenCalled()
-		expect(onMount).toHaveBeenCalledTimes(2)
 		// a real change still recreates the editor:
 		rendered.rerender(
 			<TldrawEditor
@@ -273,7 +271,6 @@ describe('<TldrawEditor />', () => {
 			/>
 		)
 		expect(initialEditor.dispose).not.toHaveBeenCalled()
-		expect(onMount).toHaveBeenCalledTimes(1)
 		// a real change still recreates the editor:
 		rendered.rerender(
 			<TldrawEditor
@@ -301,7 +298,6 @@ describe('<TldrawEditor />', () => {
 		vi.spyOn(initialEditor, 'dispose')
 		rendered.rerender(<Tldraw onMount={onMount} options={{ text: {} }} />)
 		expect(initialEditor.dispose).not.toHaveBeenCalled()
-		expect(onMount).toHaveBeenCalledTimes(1)
 		// a real change still recreates the editor:
 		const addFontsFromNode = vi.fn(defaultAddFontsFromNode)
 		rendered.rerender(<Tldraw onMount={onMount} options={{ text: { addFontsFromNode } }} />)
@@ -524,22 +520,65 @@ describe('<TldrawEditor />', () => {
 		expect(onMount).toHaveBeenCalled()
 	})
 
-	it('allows updating camera options without re-creating the editor', async () => {
-		const editors: Editor[] = []
-		const onMount = vi.fn((editor: Editor) => {
-			if (!editors.includes(editor)) editors.push(editor)
-		})
-
+	it('allows updating the deprecated cameraOptions prop without re-creating the editor', async () => {
+		// `options.camera` is part of `options`, so changing it recreates the editor; only the
+		// deprecated prop is applied in place.
+		const onMount = vi.fn()
 		const renderer = await renderTldrawComponent(<TldrawEditor onMount={onMount} />, {
 			waitForPatterns: false,
 		})
+		const editor: Editor = onMount.mock.lastCall![0]
+		vi.spyOn(editor, 'dispose')
+		expect(editor.getCameraOptions().isLocked).toBe(false)
 
-		expect(editors.length).toBe(1)
-		expect(editors[0].getCameraOptions().isLocked).toBe(false)
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		renderer.rerender(<TldrawEditor onMount={onMount} cameraOptions={{ isLocked: true }} />)
+		expect(editor.dispose).not.toHaveBeenCalled()
+		expect(editor.getCameraOptions().isLocked).toBe(true)
+	})
 
-		renderer.rerender(<TldrawEditor onMount={onMount} options={{ camera: { isLocked: true } }} />)
-		expect(editors.length).toBe(1)
-		expect(editors[0].getCameraOptions().isLocked).toBe(true)
+	it('keeps the editor when re-rendered with equal deprecated textOptions and deepLinks props', async () => {
+		const registerDeepLinkListener = vi.spyOn(Editor.prototype, 'registerDeepLinkListener')
+		const addFontsFromNode = vi.fn(defaultAddFontsFromNode)
+		const render = () => (
+			<TldrawEditor
+				onMount={onMount}
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				textOptions={{ addFontsFromNode, tipTapConfig: { extensions: tipTapDefaultExtensions } }}
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				deepLinks={{ param: 'd' }}
+			/>
+		)
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(render(), { waitForPatterns: false })
+		const editor: Editor = onMount.mock.lastCall![0]
+		vi.spyOn(editor, 'dispose')
+		expect(editor.getTextOptions().addFontsFromNode).toBe(addFontsFromNode)
+		expect(registerDeepLinkListener).toHaveBeenLastCalledWith({ param: 'd' })
+
+		rendered.rerender(render())
+		expect(editor.dispose).not.toHaveBeenCalled()
+		registerDeepLinkListener.mockRestore()
+	})
+
+	it.each([
+		['options.deepLinks', { options: { deepLinks: true as const } }],
+		['the deprecated deepLinks prop', { deepLinks: true as const }],
+	])('keeps deep links enabled and the editor when re-rendered with %s: true', async (_, props) => {
+		const registerDeepLinkListener = vi.spyOn(Editor.prototype, 'registerDeepLinkListener')
+		const onMount = vi.fn()
+		const rendered = await renderTldrawComponent(<TldrawEditor onMount={onMount} {...props} />, {
+			waitForPatterns: false,
+		})
+		const editor: Editor = onMount.mock.lastCall![0]
+		vi.spyOn(editor, 'dispose')
+		expect(registerDeepLinkListener).toHaveBeenCalledTimes(1)
+		expect(registerDeepLinkListener).toHaveBeenLastCalledWith({})
+
+		rendered.rerender(<TldrawEditor onMount={onMount} {...props} />)
+		expect(editor.dispose).not.toHaveBeenCalled()
+		expect(registerDeepLinkListener).toHaveBeenCalledTimes(1)
+		registerDeepLinkListener.mockRestore()
 	})
 
 	it('will populate the store from the snapshot prop', async () => {
@@ -685,9 +724,11 @@ describe('<TldrawEditor />', () => {
 		)
 
 		expect(onMount).toHaveBeenCalledTimes(1)
+		const editor: Editor = onMount.mock.lastCall![0]
+		vi.spyOn(editor, 'dispose')
 
 		renderer.rerender(<TldrawEditor onMount={onMount} options={{ maxPages: 1 }} />)
-		expect(onMount).toHaveBeenCalledTimes(1)
+		expect(editor.dispose).not.toHaveBeenCalled()
 	})
 })
 


### PR DESCRIPTION
`TldrawEditor` disposed and recreated the `Editor` on every parent render when given inline nested options such as `options={{ camera: { ... } }}`, `deepLinks`, `text` or `gridSteps`.

Split out of #10356 (itself split out of #10282); tracked in #10363.

### Before

Only the top-level `options` object was shallow-stabilised. `options` is a dependency of the editor-creating effect, so an inline literal with a fresh nested `camera`, `deepLinks` or `text` object gave a new identity on every render and rebuilt the editor each time. `<Tldraw>` made this worse for `text`: it builds a fresh `tipTapConfig` whenever `options.text` changes identity, so even `<Tldraw options={{ text: {} }} />` recreated the editor on every parent render.

### After

`TldrawEditor` stabilises `camera`, `deepLinks`, `text` and `gridSteps` with a new internal `useDeepObjectIdentity` hook (deep `isEqual`, for small plain-data option objects that nest, like camera constraints or a `tipTapConfig` built from the same inputs), and merges those into `mergedOptions`, so equal-by-value inline options keep the same editor while a real change still recreates it.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and add a small example (or edit `apps/examples/src/misc/develop.tsx`) whose component holds a `useState` counter, renders a button that increments it, and renders `<Tldraw options={{ camera: { isLocked: true } }} onMount={() => console.log('mounted')} />` (an inline literal with a nested object).
2. Open the example and the browser console; note one `mounted` log.
3. Click the button a few times to re-render the parent.
4. On `main`, every click logs `mounted` again and the canvas flashes as the editor is disposed and recreated. With this PR, the editor stays mounted and nothing is logged.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Stop recreating the editor when `TldrawEditor` is re-rendered with inline nested `camera`, `deepLinks`, `text` or `gridSteps` options.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +32 / -11  |
| Tests     | +139 / -0  |


