### PR TITLE
fix(editor): stop preserve-focus mode blurring the editor on canvas clicks

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -670,8 +670,10 @@ function TldrawEditorWithReadyStore({
 			function handleBlurOnPointerDown(e: PointerEvent) {
 				if (!editor) return
 				// The same pointerdown bubbles from the container to the body; blurring here would
-				// cancel the interaction the container listener just focused for.
-				if (container.contains(e.target as Node | null)) return
+				// cancel the interaction the container listener just focused for. Check the composed
+				// path rather than `e.target`: when the editor lives in a shadow DOM the target is
+				// retargeted to the shadow host by the time the event reaches the body.
+				if (e.composedPath().includes(container)) return
 				editor.blur()
 			}
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -660,19 +660,22 @@ function TldrawEditorWithReadyStore({
 	useEffect(
 		function handleFocusOnPointerDownForPreserveFocusMode() {
 			if (!editor) return
+			const container = editor.getContainer()
 
 			function handleFocusOnPointerDown() {
 				if (!editor) return
 				editor.focus()
 			}
 
-			function handleBlurOnPointerDown() {
+			function handleBlurOnPointerDown(e: PointerEvent) {
 				if (!editor) return
+				// The same pointerdown bubbles from the container to the body; blurring here would
+				// cancel the interaction the container listener just focused for.
+				if (container.contains(e.target as Node | null)) return
 				editor.blur()
 			}
 
 			if (autoFocus && noAutoFocus()) {
-				const container = editor.getContainer()
 				container.addEventListener('pointerdown', handleFocusOnPointerDown)
 				container.ownerDocument.body.addEventListener('pointerdown', handleBlurOnPointerDown)
 

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -671,8 +671,9 @@ function TldrawEditorWithReadyStore({
 				if (!editor) return
 				// The same pointerdown bubbles from the container to the body; blurring here would
 				// cancel the interaction the container listener just focused for. Check the composed
-				// path rather than `e.target`: when the editor lives in a shadow DOM the target is
-				// retargeted to the shadow host by the time the event reaches the body.
+				// path rather than `e.target`: when the editor lives in an open shadow root the target
+				// is retargeted to the shadow host by the time the event reaches the body. (A closed
+				// shadow root truncates the path at the host, so those still blur.)
 				if (e.composedPath().includes(container)) return
 				editor.blur()
 			}

--- a/packages/editor/src/lib/test/preserveFocus.test.tsx
+++ b/packages/editor/src/lib/test/preserveFocus.test.tsx
@@ -1,0 +1,66 @@
+import { act, render } from '@testing-library/react'
+import { createTLStore } from '../config/createTLStore'
+import { Editor } from '../editor/Editor'
+import { TldrawEditor } from '../TldrawEditor'
+
+// The `tldraw_preserve_focus` search param switches the editor into preserve-focus mode, where
+// a pointerdown inside the container focuses the editor and a pointerdown elsewhere blurs it.
+describe('preserve-focus mode', () => {
+	beforeEach(() => {
+		window.history.replaceState(null, '', '?tldraw_preserve_focus')
+	})
+
+	afterEach(() => {
+		window.history.replaceState(null, '', '/')
+	})
+
+	function pointerDown(target: EventTarget) {
+		act(() => {
+			target.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }))
+		})
+	}
+
+	async function mount(root: Element | ShadowRoot) {
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		const container = document.createElement('div')
+		root.appendChild(container)
+		let editor: Editor | undefined
+		await act(async () => {
+			render(
+				<TldrawEditor
+					store={store}
+					onMount={(e) => {
+						editor = e
+					}}
+				/>,
+				{ container }
+			)
+		})
+		return editor!
+	}
+
+	it('focuses on a canvas pointerdown and blurs on a pointerdown outside', async () => {
+		const editor = await mount(document.body)
+		expect(editor.getIsFocused()).toBe(false)
+
+		pointerDown(editor.getContainer().querySelector('.tl-canvas')!)
+		expect(editor.getIsFocused()).toBe(true)
+
+		pointerDown(document.body)
+		expect(editor.getIsFocused()).toBe(false)
+	})
+
+	it('keeps focus when the editor is inside a shadow root', async () => {
+		// The body listener sees the event retargeted to the shadow host, so a check on
+		// `e.target` alone would blur the editor right after the container focused it.
+		const host = document.createElement('div')
+		document.body.appendChild(host)
+		const editor = await mount(host.attachShadow({ mode: 'open' }))
+
+		pointerDown(editor.getContainer().querySelector('.tl-canvas')!)
+		expect(editor.getIsFocused()).toBe(true)
+
+		pointerDown(document.body)
+		expect(editor.getIsFocused()).toBe(false)
+	})
+})

--- a/packages/editor/src/lib/test/preserveFocus.test.tsx
+++ b/packages/editor/src/lib/test/preserveFocus.test.tsx
@@ -6,12 +6,15 @@ import { TldrawEditor } from '../TldrawEditor'
 // The `tldraw_preserve_focus` search param switches the editor into preserve-focus mode, where
 // a pointerdown inside the container focuses the editor and a pointerdown elsewhere blurs it.
 describe('preserve-focus mode', () => {
+	const mounted: Element[] = []
+
 	beforeEach(() => {
 		window.history.replaceState(null, '', '?tldraw_preserve_focus')
 	})
 
 	afterEach(() => {
 		window.history.replaceState(null, '', '/')
+		for (const el of mounted.splice(0)) el.remove()
 	})
 
 	function pointerDown(target: EventTarget) {
@@ -24,9 +27,11 @@ describe('preserve-focus mode', () => {
 		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
 		const container = document.createElement('div')
 		root.appendChild(container)
+		mounted.push(container)
 		let editor: Editor | undefined
+		let unmount = () => {}
 		await act(async () => {
-			render(
+			unmount = render(
 				<TldrawEditor
 					store={store}
 					onMount={(e) => {
@@ -34,13 +39,13 @@ describe('preserve-focus mode', () => {
 					}}
 				/>,
 				{ container }
-			)
+			).unmount
 		})
-		return editor!
+		return { editor: editor!, unmount }
 	}
 
 	it('focuses on a canvas pointerdown and blurs on a pointerdown outside', async () => {
-		const editor = await mount(document.body)
+		const { editor } = await mount(document.body)
 		expect(editor.getIsFocused()).toBe(false)
 
 		pointerDown(editor.getContainer().querySelector('.tl-canvas')!)
@@ -50,17 +55,27 @@ describe('preserve-focus mode', () => {
 		expect(editor.getIsFocused()).toBe(false)
 	})
 
-	it('keeps focus when the editor is inside a shadow root', async () => {
+	it('keeps focus when the editor is inside an open shadow root', async () => {
 		// The body listener sees the event retargeted to the shadow host, so a check on
 		// `e.target` alone would blur the editor right after the container focused it.
 		const host = document.createElement('div')
 		document.body.appendChild(host)
-		const editor = await mount(host.attachShadow({ mode: 'open' }))
+		mounted.push(host)
+		const { editor } = await mount(host.attachShadow({ mode: 'open' }))
 
 		pointerDown(editor.getContainer().querySelector('.tl-canvas')!)
 		expect(editor.getIsFocused()).toBe(true)
 
 		pointerDown(document.body)
 		expect(editor.getIsFocused()).toBe(false)
+	})
+
+	it('removes the body listener on unmount', async () => {
+		const { editor, unmount } = await mount(document.body)
+		const blur = vi.spyOn(editor, 'blur')
+
+		act(() => unmount())
+		pointerDown(document.body)
+		expect(blur).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
In preserve-focus mode, clicking on the canvas focused and then immediately blurred the editor, cancelling the interaction.

Split out of #10356 (itself split out of #10282); tracked in #10363.

### Before

In preserve-focus mode (`autoFocus` with `noAutoFocus()`), the container's pointerdown listener called `editor.focus()` and then the same event bubbled to the body listener, which called `editor.blur()`.

### After

The body pointerdown handler returns early when the container is in the event's composed path. Checking `composedPath()` rather than `e.target` also covers editors hosted inside a shadow DOM, where the body listener sees the event retargeted to the shadow host.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/develop?tldraw_preserve_focus.
2. Click once on an empty part of the canvas, then press `r` (rectangle tool shortcut).
3. On `main`, the shortcut does nothing and `editor.getIsFocused()` in the console returns `false`: the click focused the editor and the same pointerdown immediately blurred it. With this PR, the editor stays focused and `r` selects the rectangle tool.

- [x] Unit tests: `packages/editor/src/lib/test/preserveFocus.test.tsx` covers the plain and shadow-root cases.

### Release notes

- Fix preserve-focus mode blurring the editor on canvas clicks.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -2    |


