### PR TITLE
fix(editor): run the teardown returned by the createTLStore onMount option

### DIFF
--- a/packages/editor/src/lib/config/createTLStore.ts
+++ b/packages/editor/src/lib/config/createTLStore.ts
@@ -181,7 +181,7 @@ export function createTLStore({
 			},
 			onMount: (editor) => {
 				assert(editor instanceof Editor)
-				onMount?.(editor)
+				return onMount?.(editor)
 			},
 			collaboration,
 		},

--- a/packages/tldraw/src/test/TldrawEditor.test.tsx
+++ b/packages/tldraw/src/test/TldrawEditor.test.tsx
@@ -96,6 +96,21 @@ describe('<TldrawEditor />', () => {
 		)
 	})
 
+	it('runs the teardown returned by the store onMount option when unmounted', async () => {
+		const teardown = vi.fn()
+		const storeOnMount = vi.fn(() => teardown)
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [], onMount: storeOnMount })
+		const rendered = await renderTldrawComponent(
+			<TldrawEditor store={store} tools={defaultTools} initialState="select" />,
+			{ waitForPatterns: false }
+		)
+		expect(storeOnMount).toHaveBeenCalledTimes(1)
+		expect(teardown).not.toHaveBeenCalled()
+
+		act(() => rendered.unmount())
+		expect(teardown).toHaveBeenCalledTimes(1)
+	})
+
 	it('throws if the store has different shapes to the ones passed in', async () => {
 		const spy = vi.spyOn(console, 'error').mockImplementation(noop)
 		// expect(() =>


### PR DESCRIPTION
The teardown function returned from `createTLStore`'s `onMount` option never ran.

Split out of #10356 (itself split out of #10282); tracked in #10363.

### Before

`createTLStore` wrapped the user's `onMount` in its own callback but did not return its result, so the teardown the user returned was discarded.

### After

`createTLStore` returns the user's `onMount` result so the teardown runs on unmount.

### Change type

- [x] `bugfix`

### Test plan

1. Create a store whose `onMount` returns a teardown, mount it, then unmount the editor:
   ```tsx
   const store = createTLStore({ onMount: () => () => console.log('teardown') })
   // render <Tldraw store={store} />, then unmount it
   ```
2. On `main`, `teardown` never logs because `createTLStore` discarded the returned function. With this change, it logs on unmount.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Run the teardown returned by the `createTLStore` `onMount` option when the editor unmounts.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1    |
| Tests     | +15 / -0   |


