### PR TITLE
fix(editor): areAnglesCompatible for angles with different signs

### DIFF
--- a/packages/editor/src/lib/primitives/utils.test.ts
+++ b/packages/editor/src/lib/primitives/utils.test.ts
@@ -1,4 +1,4 @@
-import { getPointInArcT } from './utils'
+import { areAnglesCompatible, getPointInArcT } from './utils'
 
 describe('getPointInArcT', () => {
 	it('should return 0 for the start of the arc', () => {
@@ -55,5 +55,14 @@ describe('getPointInArcT', () => {
 		const B = 2.2 // End angle
 		const P = 1.1 // Point angle, should be near the end
 		expect(getPointInArcT(mAB, A, B, P)).toBe(1)
+	})
+})
+
+describe('areAnglesCompatible', () => {
+	it('treats angles a multiple of PI/2 apart as compatible regardless of sign', () => {
+		expect(areAnglesCompatible(-Math.PI / 4, Math.PI / 4)).toBe(true)
+		expect(areAnglesCompatible(Math.PI / 2 - 1e-9, 0)).toBe(true)
+		expect(areAnglesCompatible(Math.PI, -Math.PI / 2)).toBe(true)
+		expect(areAnglesCompatible(0, Math.PI / 3)).toBe(false)
 	})
 })

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -189,7 +189,10 @@ export function snapAngle(r: number, segments: number): number {
  * @public
  */
 export function areAnglesCompatible(a: number, b: number) {
-	return a === b || approximately((a % (Math.PI / 2)) - (b % (Math.PI / 2)), 0)
+	// Reduce the difference, not each angle: a sign-preserving % on each made
+	// -PI/4 and PI/4 incompatible. A remainder just under PI/2 is a multiple too.
+	const d = Math.abs(a - b) % (Math.PI / 2)
+	return approximately(d, 0) || approximately(d, Math.PI / 2)
 }
 
 /**


### PR DESCRIPTION
Resizing a rotated shape with a negative rotation (for example after rotating anticlockwise) was forced into an aspect-locked resize because `areAnglesCompatible` treated `-π/4` and `π/4` as incompatible.

Split out of #10352 (itself split out of #10282); tracked in #10363.

### Before

- `areAnglesCompatible` applied a sign-preserving `%` to each angle separately, so angles a multiple of π/2 apart but with different signs (for example `-π/4` and `π/4`) came out incompatible, which forced aspect-locked resizes.

### After

- `areAnglesCompatible` reduces the absolute difference modulo π/2 and accepts a remainder of either ~0 or ~π/2.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix areAnglesCompatible for angles with different signs, which forced aspect-locked resizes on shapes with a negative rotation.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1 |
| Tests     | +10 / -1 |

