### PR TITLE
fix(editor): rotateSelectionHandle for negative rotations

### DIFF
--- a/packages/editor/src/lib/primitives/Box.test.ts
+++ b/packages/editor/src/lib/primitives/Box.test.ts
@@ -1,4 +1,4 @@
-import { Box } from './Box'
+import { Box, rotateSelectionHandle } from './Box'
 import { Vec } from './Vec'
 
 describe('Box', () => {
@@ -757,5 +757,13 @@ describe('Box', () => {
 		it('returns true for zero-sized box', () => {
 			expect(new Box(0, 0, 0, 0).isValid()).toBe(true)
 		})
+	})
+})
+
+describe('rotateSelectionHandle', () => {
+	it('wraps around for negative rotations', () => {
+		expect(rotateSelectionHandle('top', Math.PI / 2)).toBe('right')
+		expect(rotateSelectionHandle('top', -Math.PI / 2)).toBe('left')
+		expect(rotateSelectionHandle('top_left', -Math.PI)).toBe('bottom_right')
 	})
 })

--- a/packages/editor/src/lib/primitives/Box.ts
+++ b/packages/editor/src/lib/primitives/Box.ts
@@ -678,7 +678,9 @@ export function rotateSelectionHandle(handle: SelectionHandle, rotation: number)
 	const numSteps = Math.round(rotation / (PI / 4))
 
 	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
+	// numSteps is negative for negative rotations, so wrap the index into range
+	const n = ORDERED_SELECTION_HANDLES.length
+	return ORDERED_SELECTION_HANDLES[(((currentIndex + numSteps) % n) + n) % n]
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -2,8 +2,6 @@ import {
 	Box,
 	HALF_PI,
 	Mat,
-	PI,
-	PI2,
 	SelectionCorner,
 	SelectionEdge,
 	StateNode,
@@ -19,6 +17,7 @@ import {
 	isAccelKey,
 	isShapeId,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -670,23 +669,3 @@ export class Resizing extends StateNode {
 }
 
 type Snapshot = ReturnType<Resizing['_createSnapshot']>
-
-const ORDERED_SELECTION_HANDLES: (SelectionEdge | SelectionCorner)[] = [
-	'top',
-	'top_right',
-	'right',
-	'bottom_right',
-	'bottom',
-	'bottom_left',
-	'left',
-	'top_left',
-]
-
-export function rotateSelectionHandle(handle: SelectionEdge | SelectionCorner, rotation: number) {
-	// first find out how many tau we need to rotate by
-	rotation = rotation % PI2
-	const numSteps = Math.round(rotation / (PI / 4))
-
-	const currentIndex = ORDERED_SELECTION_HANDLES.indexOf(handle)
-	return ORDERED_SELECTION_HANDLES[(currentIndex + numSteps) % ORDERED_SELECTION_HANDLES.length]
-}


### PR DESCRIPTION
Dragging a resize handle on a shape with a negative rotation could pick an `undefined` handle, because `rotateSelectionHandle` indexed the handle list with a negative index.

Split out of #10352 (itself split out of #10282); tracked in #10363.

### Before

- `rotateSelectionHandle` indexed `ORDERED_SELECTION_HANDLES` with `(currentIndex + numSteps) % length`; for negative rotations the index is negative and the lookup returned `undefined`. `Resizing.ts` carried its own private copy of this function with the same bug.

### After

- `rotateSelectionHandle` wraps the index into range (`((i % n) + n) % n`). `Resizing.ts` imports it from `@tldraw/editor` instead of keeping its private copy.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix rotateSelectionHandle returning undefined for negative rotations.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -23 |
| Tests     | +9 / -1 |

