### PR TITLE
fix(editor): Vec.Slope vertical guard compared the wrong axis

### DIFF
--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -336,6 +336,9 @@ describe('Vec.Slope', () => {
 		expect(Vec.Slope(new Vec(0, 0), new Vec(50, 100))).toEqual(2)
 		expect(Vec.Slope(new Vec(0, 0), new Vec(-50, 100))).toEqual(-2)
 		expect(Vec.Slope(new Vec(123, 456), new Vec(789, 24))).toEqual(-0.6486486486486487)
+		// A.x happened to equal B.y here, which used to trip the vertical guard
+		expect(Vec.Slope(new Vec(1, 0), new Vec(0, 1))).toEqual(-1)
+		expect(Vec.Slope(new Vec(5, 0), new Vec(5, 10))).toBeNaN()
 	})
 })
 

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -497,7 +497,7 @@ export class Vec {
 	}
 
 	static Slope(A: VecLike, B: VecLike): number {
-		if (A.x === B.y) return NaN
+		if (A.x === B.x) return NaN
 		return (A.y - B.y) / (A.x - B.x)
 	}
 


### PR DESCRIPTION
`Vec.Slope` returned `NaN` for some non-vertical slopes because its vertical-line guard compared `A.x` with `B.y`.

Split out of #10352 (itself split out of #10282); tracked in #10363.

### Before

- `Vec.Slope` checked `A.x === B.y` for the vertical case instead of `A.x === B.x`, so any pair where those happened to match returned `NaN`.

### After

- `Vec.Slope` compares `A.x` with `B.x`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix Vec.Slope returning NaN for some non-vertical slopes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1 |
| Tests     | +3 / -0 |

