### PR TITLE
fix(editor): Vec.prototype.cross computed the wrong y component

### DIFF
--- a/packages/editor/src/lib/primitives/Vec.test.ts
+++ b/packages/editor/src/lib/primitives/Vec.test.ts
@@ -339,6 +339,13 @@ describe('Vec.Slope', () => {
 	})
 })
 
+describe('Vec.cross', () => {
+	it('Matches the static Vec.Cross.', () => {
+		expect(Vec.Cross(new Vec(1, 2, 3), new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
+		expect(new Vec(1, 2, 3).cross(new Vec(4, 5, 6))).toMatchObject({ x: -3, y: 6 })
+	})
+})
+
 describe('Vec.ToAngle', () => {
 	it('Gets an angle from a vector.', () => {
 		expect(Vec.ToAngle(new Vec(1, 0.5))).toEqual(0.4636476090008061)

--- a/packages/editor/src/lib/primitives/Vec.ts
+++ b/packages/editor/src/lib/primitives/Vec.ts
@@ -164,9 +164,9 @@ export class Vec {
 	}
 
 	cross(V: VecLike) {
-		this.x = this.y * V.z! - this.z * V.y
-		this.y = this.z * V.x - this.x * V.z!
-		// this.z = this.x * V.y - this.y * V.x
+		const { x, y, z } = this
+		this.x = y * V.z! - z * V.y
+		this.y = z * V.x - x * V.z!
 		return this
 	}
 


### PR DESCRIPTION
`Vec.prototype.cross` returned the wrong `y` component because it overwrote `this.x` before reading it.

Split out of #10352 (itself split out of #10282); tracked in #10363.

### Before

- `Vec.prototype.cross` overwrote `this.x` before using it to compute `this.y`.

### After

- `Vec.prototype.cross` reads `x`, `y`, `z` into locals before writing, matching the static `Vec.Cross`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix Vec.prototype.cross returning the wrong y component.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -3 |
| Tests     | +7 / -0 |

