### PR TITLE
fix(editor): packShapes packs shapes of different heights into a single column

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7725,10 +7725,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		const maxWidth = commonBounds.width
 
-		// sort the shape clusters by width and then height, descending
+		// sort the shape clusters by width and then height, descending: potpack fills each row's
+		// right-hand space with the shapes that follow, so they must be no taller than the row
 		shapeClustersToPack
-			.sort((a, b) => a.pageBounds.width - b.pageBounds.width)
-			.sort((a, b) => a.pageBounds.height - b.pageBounds.height)
+			.sort((a, b) => b.pageBounds.width - a.pageBounds.width)
+			.sort((a, b) => b.pageBounds.height - a.pageBounds.height)
 
 		// Start with is (sort of) the square of the area
 		const startWidth = Math.max(Math.ceil(Math.sqrt(area / 0.95)), maxWidth)

--- a/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
+++ b/packages/tldraw/src/test/commands/__snapshots__/packShapes.test.ts.snap
@@ -38,8 +38,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 3.141592653589793,
     "type": "geo",
     "typeName": "shape",
-    "x": 192,
-    "y": 308,
+    "x": 134,
+    "y": 250,
   },
   {
     "id": "shape:boxB",
@@ -77,8 +77,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 92,
-    "y": 92,
+    "x": 150,
+    "y": 150,
   },
   {
     "id": "shape:boxC",
@@ -116,8 +116,8 @@ exports[`editor.packShapes > packs rotated shapes > packed shapes 1`] = `
     "rotation": 0,
     "type": "geo",
     "typeName": "shape",
-    "x": 208,
-    "y": 92,
+    "x": 266,
+    "y": 150,
   },
 ]
 `;

--- a/packages/tldraw/src/test/commands/packShapes.test.ts
+++ b/packages/tldraw/src/test/commands/packShapes.test.ts
@@ -74,4 +74,24 @@ describe('editor.packShapes', () => {
 			editor.getCurrentPageShapes().map((s) => ({ ...s, parentId: 'wahtever' }))
 		).toMatchSnapshot('packed shapes')
 	})
+
+	it('packs shapes of different heights into rows, tallest first', () => {
+		// With the clusters sorted ascending by height, every shape after the first was too tall
+		// for the row's remaining space and fell into a single left-hand column.
+		editor.selectAll()
+		editor.deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{ id: ids.boxA, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.boxB, type: 'geo', x: 200, y: 0, props: { w: 100, h: 60 } },
+			{ id: ids.boxC, type: 'geo', x: 400, y: 0, props: { w: 120, h: 80 } },
+			{ id: ids.boxD, type: 'geo', x: 600, y: 0, props: { w: 100, h: 120 } },
+		])
+		editor.packShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD], 20)
+		editor.expectShapeToMatch(
+			{ id: ids.boxD, x: 110, y: 0 },
+			{ id: ids.boxA, x: 230, y: 0 },
+			{ id: ids.boxC, x: 350, y: 0 },
+			{ id: ids.boxB, x: 490, y: 0 }
+		)
+	})
 })


### PR DESCRIPTION
`packShapes` packed shapes of distinct heights into a single column.

Split out of #10345 (itself split out of #10282); tracked in #10363.

### Before

- `packShapes` sorted clusters by width then height ascending, but potpack fills each row's right-hand space with the shapes that follow, so they must be no taller than the row; ascending order made every shape start a new row.

### After

- `packShapes` sorts by width then height descending (the existing "packs rotated shapes" snapshot changes accordingly).

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Draw four rectangles of clearly different heights in a row (for example short, tall, medium, taller).
3. Select all of them and choose Arrange > Pack from the context menu (or the actions menu).
4. On `main` the rectangles end up in a single vertical column. With this PR they are packed into rows, tallest first.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix packShapes packing shapes of different heights into a single column.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -3    |
| Tests     | +26 / -6    |

