### PR TITLE
fix(editor): arrow clusters depend on selection order

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7421,8 +7421,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shapesMovingTogether = [shape]
 			const boundsOfShapesMovingTogether: Box[] = [shapePageBounds]
 
+			// Seed with bindings in both directions, otherwise an arrow visited before the shapes it
+			// binds ends up in a cluster of its own and the result depends on input order
 			this.collectShapesViaArrowBindings({
-				bindings: this.getBindingsToShape(shape.id, 'arrow'),
+				bindings: this.getBindingsInvolvingShape(shape.id, 'arrow'),
 				initialShapes: freshShapes,
 				resultShapes: shapesMovingTogether,
 				resultBounds: boundsOfShapesMovingTogether,

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -143,6 +143,48 @@ describe('distributeShapes command', () => {
 			})
 		})
 
+		it('keeps an arrow and its bound shapes together regardless of input order', () => {
+			const arrowId = createShapeId('arrow')
+			editor.updateShapes([
+				{ id: ids.boxB, type: 'geo', x: 300, y: 0 },
+				{ id: ids.boxC, type: 'geo', x: 600, y: 0 },
+			])
+			editor.createShape({ id: arrowId, type: 'arrow', x: 50, y: 50 })
+			editor.createBindings([
+				{
+					fromId: arrowId,
+					toId: ids.boxA,
+					type: 'arrow',
+					props: {
+						terminal: 'start',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+				{
+					fromId: arrowId,
+					toId: ids.boxB,
+					type: 'arrow',
+					props: {
+						terminal: 'end',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+			])
+			// the arrow comes first: seeding its cluster from bindings *to* it alone would leave
+			// it (and then A and B) in clusters of their own and pull B up against A
+			editor.stackShapes([arrowId, ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxB, x: 300 },
+				{ id: ids.boxC, x: 410 }
+			)
+		})
+
 		it('stacks the shapes based on the most common gap', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 0)


### PR DESCRIPTION
Arrow clusters used by the stack, pack and distribute commands depended on selection order.

Split out of #10345 (itself split out of #10282); tracked in #10363.

### Before

- `getShapeClusters` seeded each cluster with `getBindingsToShape`, so an arrow visited before the shapes it binds ended up in a cluster of its own and the result depended on input order.

### After

- `getShapeClusters` seeds with `getBindingsInvolvingShape`.

### Change type

- [x] `bugfix`

### Test plan

1. Draw three rectangles in a horizontal row with space between them: A, B, C.
2. Draw an arrow from A to B so both ends bind.
3. Click the arrow first, then shift-click A, B, and C, so the arrow is first in the selection order.
4. Run stack horizontally from the actions menu (or `editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 10)` in the console).
5. On `main`, the arrow seeds a cluster of its own, so A, B, and the arrow are stacked as separate items and B is pulled up against A, compressing the arrow. With this change, A, the arrow, and B move as one cluster and keep their relative positions, with C stacked after B — the same result as selecting the boxes first.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix arrow clusters in stack, pack and distribute depending on selection order.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |
| Tests     | +42 / -0    |


