### PR TITLE
fix(editor): stackShapes reorders shapes when a gap is given

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7616,12 +7616,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let shapeGap: number = 0
 
+		// Stack in spatial order rather than input (z) order, otherwise shapes swap places
+		shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
+
 		if (_gap === 0) {
 			// note: this is not used in the current tldraw.com; there we use a specified stack
 
 			const gaps: Record<number, number> = {}
-
-			shapeClustersToStack.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])
 
 			// Collect all of the gaps between shapes. We want to find
 			// patterns (equal gaps between shapes) and use the most common

--- a/packages/tldraw/src/test/commands/stackShapes.test.ts
+++ b/packages/tldraw/src/test/commands/stackShapes.test.ts
@@ -143,6 +143,18 @@ describe('distributeShapes command', () => {
 			})
 		})
 
+		it('stacks in spatial order, not selection order, when a gap is given', () => {
+			// boxC sits between boxA and boxB on the page but comes after both in the input
+			editor.updateShapes([{ id: ids.boxC, type: 'geo', x: 50, y: 0 }])
+			editor.stackShapes([ids.boxA, ids.boxB, ids.boxC], 'horizontal', 10)
+			vi.advanceTimersByTime(1000)
+			editor.expectShapeToMatch(
+				{ id: ids.boxA, x: 0 },
+				{ id: ids.boxC, x: 110 },
+				{ id: ids.boxB, x: 220 }
+			)
+		})
+
 		it('stacks the shapes based on the most common gap', () => {
 			editor.setSelectedShapes([ids.boxA, ids.boxB, ids.boxC, ids.boxD])
 			editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 0)


### PR DESCRIPTION
`stackShapes` swapped shapes around when an explicit gap was given.

Split out of #10345 (itself split out of #10282); tracked in #10363.

### Before

- `stackShapes` only sorted clusters spatially in the auto-gap (`gap === 0`) branch, so an explicit gap stacked shapes in selection (z) order.

### After

- `stackShapes` sorts spatially before both branches.

### Change type

- [x] `bugfix`

### Test plan

1. Open http://localhost:5420/develop and draw three rectangles in this creation order: the first on the right, the second on the left, the third in the middle.
2. Select all three and choose Arrange > Stack horizontally.
3. On `main` the rectangles are rearranged into creation order (the first-drawn one becomes the leftmost). With this PR they keep their left-to-right order and only the gaps change.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix stackShapes reordering shapes when a gap is given.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -2    |
| Tests     | +12 / -0    |

