### PR TITLE
fix(editor): nested 270° shapes dropped from axis-aligned clustering

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -129,7 +129,13 @@ import { Geometry2d } from '../primitives/geometry/Geometry2d'
 import { Group2d } from '../primitives/geometry/Group2d'
 import { intersectPolygonPolygon } from '../primitives/intersect'
 import { Mat, MatLike } from '../primitives/Mat'
-import { PI, approximately, areAnglesCompatible, clamp, pointInPolygon } from '../primitives/utils'
+import {
+	HALF_PI,
+	approximately,
+	areAnglesCompatible,
+	clamp,
+	pointInPolygon,
+} from '../primitives/utils'
 import { Vec, VecLike } from '../primitives/Vec'
 import { areShapesContentEqual } from '../utils/areShapesContentEqual'
 import { dataUrlToFile } from '../utils/assets'
@@ -7393,9 +7399,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		// optionally filter to axis-aligned shapes (rotation is a multiple of 90 degrees)
 		if (opts?.filterAxisAligned) {
-			freshShapes = freshShapes.filter(
-				(s) => this.getShapePageTransform(s)?.rotation() % (PI / 2) === 0
-			)
+			freshShapes = freshShapes.filter((s) => {
+				// Page rotations come back through atan2 on a composed matrix, so a 270° shape can land
+				// a hair either side of the multiple; an exact === 0 check drops it
+				const remainder = Math.abs(this.getShapePageTransform(s).rotation() % HALF_PI)
+				return Math.min(remainder, HALF_PI - remainder) < 1e-9
+			})
 		}
 
 		const clusters: { shapes: TLShape[]; pageBounds: Box }[] = []


### PR DESCRIPTION
Deeply nested 270° shapes were dropped from axis-aligned shape clustering.

Split out of #10345 (itself split out of #10282); tracked in #10363.

### Before

- The `filterAxisAligned` check in `getShapeClusters` used `rotation() % (PI / 2) === 0`; page rotations come back through `atan2` on a composed matrix, so a nested 270° shape landing a hair off the multiple was dropped.

### After

- The axis-aligned filter tolerates rounding error (`< 1e-9`) either side of a multiple of 90°.

### Change type

- [x] `bugfix`

### Test plan

1. Draw two rectangles side by side and rotate one of them 180° (`editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI)` in the console gives an exact angle).
2. Select both, group them, and rotate the group 90° — the rotated child's page rotation is now 270°, composed through the group's matrix, and lands a hair off the exact multiple.
3. Double-click into the group, select both children, and stretch them horizontally (`editor.stretchShapes(editor.getSelectedShapeIds(), 'horizontal')`).
4. On `main`, the 270° child fails the exact `% (PI / 2) === 0` check and is dropped from the operation — it stays put while its sibling stretches. With this change, it participates.

- [ ] Unit tests

### Release notes

- Fix nested 270° shapes being dropped from axis-aligned shape clustering.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -4    |


