### PR TITLE
fix(editor): fall back to default zoom steps when setCameraOptions gets zoomSteps undefined

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3348,7 +3348,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			...this._cameraOptions.__unsafe__getWithoutCapture(),
 			...opts,
 		})
-		if (next.zoomSteps?.length < 1) next.zoomSteps = [1]
+		// `undefined < 1` is false, so an explicit `zoomSteps: undefined` would otherwise get through
+		// and make every later camera move throw
+		if (!next.zoomSteps || next.zoomSteps.length < 1) next.zoomSteps = [1]
 		this._cameraOptions.set(next)
 		this.setCamera(this.getCamera())
 		return this


### PR DESCRIPTION
This PR fixes `setCameraOptions({ zoomSteps: undefined })` making every later camera move throw.

Split out of #10343 (itself split out of #10282); tracked in #10363.

### Before

- `setCameraOptions` checked `next.zoomSteps?.length < 1`, which is false for `undefined`, so an explicit `zoomSteps: undefined` was stored and every later camera move threw.

### After

- `setCameraOptions` treats a missing or empty `zoomSteps` as `[1]`.

### Change type

- [x] `bugfix`

### Test plan

1. On http://localhost:5420/develop, in the console, run `editor.setCameraOptions({ zoomSteps: undefined })`.
2. Scroll or pinch to zoom, or pan the canvas.
3. On `main` the `setCameraOptions` call and every later camera move throw `Cannot read properties of undefined (reading '0')` and the canvas stops moving. With this PR the zoom steps fall back to `[1]` and panning and zooming keep working.

- [ ] Unit tests

### Release notes

- Fix `setCameraOptions({ zoomSteps: undefined })` breaking every later camera move.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1 |

