### PR TITLE
fix(editor): keep slideCamera zoom momentum finite on long frames

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4073,9 +4073,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			let newCy = cy + dy
 			let newCz = cz
 
-			// animate zoom if z direction is passed in
+			// animate zoom if z direction is passed in. Use an exponential factor so that a single
+			// long frame can't drive the zoom to zero or negative (which would give NaN coordinates)
 			if (dirZ !== 0) {
-				newCz = cz * (1 + dirZ * currentSpeed * elapsed)
+				newCz = cz * Math.exp(dirZ * currentSpeed * elapsed)
 				// Adjust x/y to keep the viewport center fixed while zooming
 				const center = this.getViewportScreenCenter()
 				newCx += center.x / newCz - center.x / cz

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -1256,3 +1256,15 @@ test('calling setCameraOptions will apply the new constraints', () => {
 		}
 	`)
 })
+
+test('slideCamera zoom momentum survives a long frame', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+	editor.setCamera({ x: 0, y: 0, z: 1 })
+	editor.slideCamera({ speed: 1, direction: { x: 0, y: 0, z: -0.01 } })
+	// a 100ms frame would have driven a linear zoom factor to zero (and the camera to NaN)
+	editor.emit('tick', 100)
+	const { x, y, z } = editor.getCamera()
+	expect(z).toBeGreaterThan(0)
+	expect(z).toBeLessThan(1)
+	expect(Number.isFinite(x) && Number.isFinite(y)).toBe(true)
+})


### PR DESCRIPTION
This PR fixes a long frame driving `slideCamera`'s zoom to zero and producing `NaN` camera coordinates.

Split out of #10343 (itself split out of #10282); tracked in #10363.

### Before

- `slideCamera` scaled the zoom linearly by `1 + dirZ * speed * elapsed`, so a single long frame could make it zero or negative and produce `NaN` coordinates.

### After

- `slideCamera` uses an exponential zoom factor, `Math.exp(dirZ * speed * elapsed)`.

### Change type

- [x] `bugfix`

### Test plan

1. In the console, start a zoom-out slide and immediately block the main thread to force a long frame:
   ```js
   editor.slideCamera({ speed: 1, direction: { x: 0, y: 0, z: -1 }, friction: 0.01 })
   const t = performance.now()
   while (performance.now() - t < 2000) {}
   ```
2. On `main`, the long frame makes the linear factor `1 + dirZ * speed * elapsed` zero or negative, the zoom collapses, and the camera coordinates go `NaN` — the canvas goes blank. With this change, the exponential factor keeps the zoom finite and the slide continues.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix `slideCamera` zoom momentum driving the zoom to zero on a long frame.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -2 |
| Tests     | +12 / -0 |


