### PR TITLE
fix(editor): keep following a user whose own leader is missing

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3141,11 +3141,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const collaborators = this.getCollaborators()
 		let leaderPresence = null as null | TLInstancePresence
 		while (targetUserId && !visited.includes(targetUserId)) {
-			leaderPresence = collaborators.find((c) => c.userId === targetUserId) ?? null
-			targetUserId = leaderPresence?.followingUserId ?? null
-			if (leaderPresence) {
-				visited.push(leaderPresence.userId)
-			}
+			const nextPresence = collaborators.find((c) => c.userId === targetUserId)
+			// Stop at the last resolvable presence, otherwise a leader whose own leader has left
+			// (or whose presence hasn't arrived yet) can't be followed at all
+			if (!nextPresence) break
+			leaderPresence = nextPresence
+			targetUserId = nextPresence.followingUserId ?? null
+			visited.push(nextPresence.userId)
 		}
 		return leaderPresence
 	}

--- a/packages/tldraw/src/test/viewport-following.test.ts
+++ b/packages/tldraw/src/test/viewport-following.test.ts
@@ -1,6 +1,6 @@
+import { InstancePresenceRecordType, TLUserId, createUserId } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let editor: TestEditor
 
 beforeEach(() => {
@@ -8,6 +8,34 @@ beforeEach(() => {
 })
 
 describe('When following a user', () => {
+	it('keeps following a leader whose own leader is missing', () => {
+		const pageId = editor.getCurrentPageId()
+		const leaderId = createUserId('leader')
+		const leadersLeaderId = createUserId('leaders-leader')
+		const presence = (userId: TLUserId, followingUserId: TLUserId | null) =>
+			InstancePresenceRecordType.create({
+				id: InstancePresenceRecordType.createId(userId),
+				userId,
+				userName: userId,
+				currentPageId: pageId,
+				followingUserId,
+				camera: { x: 0, y: 0, z: 1 },
+				screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
+				lastActivityTimestamp: Date.now(),
+			})
+
+		// the leader follows someone whose presence we don't have
+		editor.store.put([presence(leaderId, leadersLeaderId)])
+		editor.startFollowingUser(leaderId)
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+
+		// the leader's leader shows up, then leaves again
+		editor.store.put([presence(leadersLeaderId, null)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+		editor.store.remove([InstancePresenceRecordType.createId(leadersLeaderId)])
+		expect(editor.getInstanceState().followingUserId).toBe(leaderId)
+	})
+
 	it.todo('starts following a user')
 	it.todo('stops following a user')
 	it.todo('stops following a user when the camera changes due to user action')


### PR DESCRIPTION
This PR fixes following a user whose own leader has left (or whose presence has not arrived yet).

Split out of #10343 (itself split out of #10282); tracked in #10363.

### Before

- `_getFollowingPresence` walked the following chain and returned `null` as soon as any link was missing, so a leader whose own leader had left (or whose presence had not arrived yet) could not be followed at all.

### After

- `_getFollowingPresence` stops at the last resolvable presence in the chain.

### Change type

- [x] `bugfix`

### Test plan

1. Open a shared room with three users A, B, and C, and have B follow A (B clicks A's avatar).
2. Have A close their tab while B keeps following.
3. Have C click B's avatar to follow B.
4. On `main`, the chain walk hits A's missing presence and gives up, so C's camera never tracks B. With this change, the walk stops at the last resolvable presence and C follows B.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix following a user whose own leader has left or has no presence yet.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -5 |
| Tests     | +29 / -1 |


