### PR TITLE
fix(editor): update getSelectionRotatedScreenBounds when the container moves

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2649,9 +2649,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	@computed getSelectionRotatedScreenBounds(): Box | undefined {
 		const bounds = this.getSelectionRotatedPageBounds()
 		if (!bounds) return undefined
-		const { x, y } = this.pageToScreen(bounds.point)
-		const zoom = this.getZoomLevel()
-		return new Box(x, y, bounds.width * zoom, bounds.height * zoom)
+		// Don't use pageToScreen here: it reads the screen bounds without capturing them, so this
+		// computed would never invalidate when the container moves
+		const screenBounds = this.getViewportScreenBounds()
+		const { x: cx, y: cy, z: zoom } = this.getCamera()
+		return new Box(
+			(bounds.x + cx) * zoom + screenBounds.x,
+			(bounds.y + cy) * zoom + screenBounds.y,
+			bounds.width * zoom,
+			bounds.height * zoom
+		)
 	}
 
 	// Focus Group

--- a/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
+++ b/packages/tldraw/src/test/commands/updateViewportPageBounds.test.ts
@@ -47,6 +47,14 @@ describe('When resizing', () => {
 			h: 1,
 		})
 	})
+
+	it('updates the selection screen bounds when the container moves', () => {
+		editor.createShape({ type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } })
+		editor.selectAll()
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 100, y: 100 })
+		editor.setScreenBounds({ x: 300, y: 200, w: 1080, h: 720 })
+		expect(editor.getSelectionRotatedScreenBounds()).toMatchObject({ x: 400, y: 300 })
+	})
 })
 
 describe('When center is false', () => {


### PR DESCRIPTION
This PR fixes `getSelectionRotatedScreenBounds` going stale when the container moves.

Split out of #10343 (itself split out of #10282); tracked in #10363.

### Before

- `getSelectionRotatedScreenBounds` used `pageToScreen`, which reads the screen bounds without capturing them, so the computed never invalidated when the container moved.

### After

- `getSelectionRotatedScreenBounds` reads `getViewportScreenBounds()` and the camera directly so it tracks container moves.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/selection-ui.
2. Draw a rectangle and select it so the four duplicate buttons appear around it.
3. In the console, run `document.querySelector('.tldraw__editor').style.marginLeft = '200px'` and wait about a second for the editor to pick up the new container bounds.
4. On `main` the duplicate buttons are drawn 200px to the left of the (now shifted) rectangle. With this PR they stay attached to the rectangle.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix `getSelectionRotatedScreenBounds` going stale when the editor container moves.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -3 |
| Tests     | +8 / -0 |

