### PR TITLE
refactor(dotcom): remove legacy user-owns-file code paths

### DIFF
--- a/apps/dotcom/client/src/pages/admin/UsersSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/UsersSection.tsx
@@ -120,6 +120,7 @@ function DeletedFilesTable({
 									{file.id}
 								</td>
 								<td>{file.owningGroupId === userId ? 'Home' : (file.workspaceName ?? '—')}</td>
+								<td>{file.workspaceRole ?? '—'}</td>
 								<td>{new Date(file.updatedAt).toLocaleString()}</td>
 								<td>
 									<AdminButton

--- a/apps/dotcom/client/src/pages/admin/UsersSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/UsersSection.tsx
@@ -120,7 +120,6 @@ function DeletedFilesTable({
 									{file.id}
 								</td>
 								<td>{file.owningGroupId === userId ? 'Home' : (file.workspaceName ?? '—')}</td>
-								<td>{file.workspaceRole ?? (file.ownerId === userId ? 'owner' : '—')}</td>
 								<td>{new Date(file.updatedAt).toLocaleString()}</td>
 								<td>
 									<AdminButton

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -908,7 +908,6 @@ export class TldrawApp {
 	canUpdateFile(fileId: string): boolean {
 		const file = this.getFile(fileId)
 		if (!file) return false
-		if (file.ownerId) return file.ownerId === this.userId
 		if (file.owningGroupId) {
 			const role = this.getWorkspaceMembership(file.owningGroupId)?.role
 			return can(role, 'accessFiles')

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -939,7 +939,8 @@ export class TldrawApp {
 	}
 
 	/**
-	 * Remove a user's file states for a file and delete the file if the user is the owner of the file.
+	 * Remove the user's file state and the workspace's link to a file, deleting the file itself only
+	 * if that workspace is the one that owns it.
 	 */
 	async deleteOrForgetFile(fileId: string, workspaceId: string = this.getHomeWorkspaceId()) {
 		// Optimistic update, remove file and file states

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -40,7 +40,7 @@ function comment(overrides: Partial<CommentNotificationInput> = {}): CommentNoti
 		createdAt: at(0),
 		body: body('hello'),
 		read: undefined,
-		file: { ownerId: THIRD },
+		file: { owningGroupId: THIRD },
 		thread: { createdBy: OTHER },
 		...overrides,
 	}
@@ -53,7 +53,7 @@ describe('categorizeCommentNotifications', () => {
 
 	it("labels another user's comment on a board I own as owned-board", () => {
 		const result = categorizeCommentNotifications(
-			[comment({ file: { ownerId: ME }, thread: { createdBy: OTHER } })],
+			[comment({ file: { owningGroupId: ME }, thread: { createdBy: OTHER } })],
 			ME
 		)
 		expect(result).toHaveLength(1)
@@ -63,7 +63,7 @@ describe('categorizeCommentNotifications', () => {
 
 	it('excludes my own comments', () => {
 		const result = categorizeCommentNotifications(
-			[comment({ authorId: ME, file: { ownerId: ME }, body: body('hi ', [ME]) })],
+			[comment({ authorId: ME, file: { owningGroupId: ME }, body: body('hi ', [ME]) })],
 			ME
 		)
 		expect(result).toEqual([])
@@ -71,7 +71,7 @@ describe('categorizeCommentNotifications', () => {
 
 	it('labels a reply in a thread I started as reply', () => {
 		const result = categorizeCommentNotifications(
-			[comment({ thread: { createdBy: ME }, file: { ownerId: THIRD } })],
+			[comment({ thread: { createdBy: ME }, file: { owningGroupId: THIRD } })],
 			ME
 		)
 		expect(result.map((n) => n.primaryReason)).toEqual(['reply'])
@@ -83,7 +83,7 @@ describe('categorizeCommentNotifications', () => {
 			authorId: OTHER,
 			createdAt: at(10),
 			thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(0) }] },
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 		})
 		const result = categorizeCommentNotifications([theirReply], ME)
 		expect(result).toHaveLength(1)
@@ -98,13 +98,13 @@ describe('categorizeCommentNotifications', () => {
 			id: 'comment:b1',
 			createdAt: at(0),
 			thread,
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 		})
 		const before2 = comment({
 			id: 'comment:b2',
 			createdAt: at(10),
 			thread,
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 		})
 		expect(categorizeCommentNotifications([before1, before2], ME)).toEqual([])
 	})
@@ -122,13 +122,13 @@ describe('categorizeCommentNotifications', () => {
 			id: 'comment:pre',
 			createdAt: at(0),
 			thread,
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 		})
 		const postJoin = comment({
 			id: 'comment:post',
 			createdAt: at(20),
 			thread,
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 		})
 		const result = categorizeCommentNotifications([preJoin, postJoin], ME)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:post'])
@@ -139,7 +139,7 @@ describe('categorizeCommentNotifications', () => {
 		// A starts a thread, B replies right away: A's opening comment is context B already saw,
 		// not a reply to B, no matter how narrowly it predates B's join.
 		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(0) + 5_000 }] }
-		const opener = comment({ createdAt: at(0), thread, file: { ownerId: THIRD } })
+		const opener = comment({ createdAt: at(0), thread, file: { owningGroupId: THIRD } })
 		expect(categorizeCommentNotifications([opener], ME)).toEqual([])
 	})
 
@@ -147,13 +147,13 @@ describe('categorizeCommentNotifications', () => {
 		// The gate is strict: same-instant means "not after me". Postgres stamps createdAt
 		// monotonically per thread (migration 046), so real replies can never tie with my join.
 		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
-		const tied = comment({ createdAt: at(10), thread, file: { ownerId: THIRD } })
+		const tied = comment({ createdAt: at(10), thread, file: { owningGroupId: THIRD } })
 		expect(categorizeCommentNotifications([tied], ME)).toEqual([])
 	})
 
 	it('keeps a reply stamped just after my join', () => {
 		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
-		const reply = comment({ createdAt: at(10) + 1, thread, file: { ownerId: THIRD } })
+		const reply = comment({ createdAt: at(10) + 1, thread, file: { owningGroupId: THIRD } })
 		const result = categorizeCommentNotifications([reply], ME)
 		expect(result.map((n) => n.primaryReason)).toEqual(['reply'])
 	})
@@ -161,7 +161,7 @@ describe('categorizeCommentNotifications', () => {
 	it("ignores others' comments in the thread relation when deriving my join time", () => {
 		// defense in depth: the query only syncs my own, but a foreign row must not count
 		const thread = { createdBy: OTHER, comments: [{ authorId: THIRD, createdAt: at(0) }] }
-		const theirs = comment({ createdAt: at(10), thread, file: { ownerId: THIRD } })
+		const theirs = comment({ createdAt: at(10), thread, file: { owningGroupId: THIRD } })
 		expect(categorizeCommentNotifications([theirs], ME)).toEqual([])
 	})
 
@@ -172,7 +172,7 @@ describe('categorizeCommentNotifications', () => {
 					createdAt: at(0),
 					body: body('hey ', [ME]),
 					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] },
-					file: { ownerId: THIRD },
+					file: { owningGroupId: THIRD },
 				}),
 			],
 			ME
@@ -185,7 +185,7 @@ describe('categorizeCommentNotifications', () => {
 
 	it('never labels reply when the thread relation is missing', () => {
 		const result = categorizeCommentNotifications(
-			[comment({ thread: null, file: { ownerId: ME } })],
+			[comment({ thread: null, file: { owningGroupId: ME } })],
 			ME
 		)
 		expect(result).toHaveLength(1)
@@ -198,7 +198,7 @@ describe('categorizeCommentNotifications', () => {
 				comment({
 					createdAt: at(0),
 					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] },
-					file: { ownerId: ME },
+					file: { owningGroupId: ME },
 				}),
 			],
 			ME
@@ -212,7 +212,7 @@ describe('categorizeCommentNotifications', () => {
 			[
 				comment({
 					body: body('hey ', [ME]),
-					file: { ownerId: THIRD },
+					file: { owningGroupId: THIRD },
 					thread: { createdBy: OTHER },
 				}),
 			],
@@ -226,7 +226,7 @@ describe('categorizeCommentNotifications', () => {
 		const result = categorizeCommentNotifications(
 			[
 				comment({
-					file: { ownerId: THIRD },
+					file: { owningGroupId: THIRD },
 					thread: { createdBy: OTHER },
 					body: body('hey ', [THIRD]),
 				}),
@@ -238,7 +238,13 @@ describe('categorizeCommentNotifications', () => {
 
 	it('tags multiple reasons with mention > reply > owned-board precedence', () => {
 		const result = categorizeCommentNotifications(
-			[comment({ file: { ownerId: ME }, thread: { createdBy: ME }, body: body('hey ', [ME]) })],
+			[
+				comment({
+					file: { owningGroupId: ME },
+					thread: { createdBy: ME },
+					body: body('hey ', [ME]),
+				}),
+			],
 			ME
 		)
 		expect(result).toHaveLength(1)
@@ -247,17 +253,17 @@ describe('categorizeCommentNotifications', () => {
 	})
 
 	it('sorts newest first', () => {
-		const older = comment({ id: 'comment:old', createdAt: at(0), file: { ownerId: ME } })
-		const newer = comment({ id: 'comment:new', createdAt: at(10), file: { ownerId: ME } })
+		const older = comment({ id: 'comment:old', createdAt: at(0), file: { owningGroupId: ME } })
+		const newer = comment({ id: 'comment:new', createdAt: at(10), file: { owningGroupId: ME } })
 		const result = categorizeCommentNotifications([older, newer], ME)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:new', 'comment:old'])
 	})
 
 	it('marks a comment notification unread until it has a read receipt', () => {
-		const unread = categorizeCommentNotifications([comment({ file: { ownerId: ME } })], ME)
+		const unread = categorizeCommentNotifications([comment({ file: { owningGroupId: ME } })], ME)
 		expect(unread[0].unread).toBe(true)
 		const read = categorizeCommentNotifications(
-			[comment({ file: { ownerId: ME }, read: { readAt: at(1) } })],
+			[comment({ file: { owningGroupId: ME }, read: { readAt: at(1) } })],
 			ME
 		)
 		expect(read[0].unread).toBe(false)
@@ -271,7 +277,7 @@ describe('buildReactionNotifications', () => {
 		return comment({
 			authorId: ME,
 			thread: { createdBy: ME },
-			file: { ownerId: THIRD },
+			file: { owningGroupId: THIRD },
 			reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }],
 			...overrides,
 		})
@@ -369,7 +375,7 @@ describe('buildReactionNotifications', () => {
 			ME
 		)
 		const replied = categorizeCommentNotifications(
-			[comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })],
+			[comment({ id: 'comment:replied', createdAt: at(10), file: { owningGroupId: ME } })],
 			ME
 		)
 		const result = mergeNotifications(replied, reacted)
@@ -381,13 +387,13 @@ describe('mergeNotifications', () => {
 	it('merges multiple feeds newest first', () => {
 		const a = categorizeCommentNotifications(
 			[
-				comment({ id: 'comment:a1', createdAt: at(0), file: { ownerId: ME } }),
-				comment({ id: 'comment:a2', createdAt: at(20), file: { ownerId: ME } }),
+				comment({ id: 'comment:a1', createdAt: at(0), file: { owningGroupId: ME } }),
+				comment({ id: 'comment:a2', createdAt: at(20), file: { owningGroupId: ME } }),
 			],
 			ME
 		)
 		const b = categorizeCommentNotifications(
-			[comment({ id: 'comment:b1', createdAt: at(10), file: { ownerId: ME } })],
+			[comment({ id: 'comment:b1', createdAt: at(10), file: { owningGroupId: ME } })],
 			ME
 		)
 		const result = mergeNotifications(a, b)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -6,7 +6,7 @@ import { extractMentionIds } from '@tldraw/dotcom-shared'
  * - `mention` — the comment `@`-mentions the user
  * - `reply` — the comment is in a thread the user is a part of (started, or has commented in),
  *   posted after they joined it
- * - `owned-board` — the comment is on a file the user owns
+ * - `owned-board` — the comment is on a board in the user's own home workspace
  * - `reaction` — the user's own comment, reacted to by someone else. The only reason about the
  *   user's own comments, so it never combines with the others
  *
@@ -37,7 +37,7 @@ export interface CommentNotificationInput {
 	/** The caller's read receipt — a related row when present, absent (falsy) when unread. Its
 	 *  `readAt` dates the receipt, which is what lets a reaction newer than it re-unread the entry. */
 	read?: { readAt?: number | null } | null
-	file?: { ownerId?: string | null; name?: string | null } | null
+	file?: { owningGroupId?: string | null; name?: string | null } | null
 	thread?: {
 		createdBy?: string | null
 		shapeId?: string | null
@@ -100,7 +100,7 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
 		if (comment.createdAt > joinedThreadAt(comment.thread, userId)) reasons.push('reply')
-		if (comment.file?.ownerId === userId) reasons.push('owned-board')
+		if (comment.file?.owningGroupId === userId) reasons.push('owned-board')
 		if (reasons.length === 0) continue
 
 		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!

--- a/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
@@ -11,7 +11,6 @@ export function useHasFileAdminRights(fileId?: string): boolean {
 			if (!fileId) return false
 			const file = app?.getFile(fileId)
 			if (!file) return false
-			if (file.ownerId) return file.ownerId === app.userId
 			if (file.owningGroupId) {
 				const role = app.getWorkspaceMembership(file.owningGroupId)?.role
 				return can(role, 'accessFiles')

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -833,9 +833,7 @@ export class TLFileDurableObject extends DurableObject {
 
 					// Check if user has owner access (directly or via group membership)
 					let hasOwnerAccess = false
-					if (file.ownerId && file.ownerId === auth?.userId) {
-						hasOwnerAccess = true
-					} else if (file.owningGroupId && auth?.userId) {
+					if (file.owningGroupId && auth?.userId) {
 						// Check the user can access the owning group's files
 						const groupCheckTimer = this.timer()
 						const role = await getRole(this.db, auth.userId, file.owningGroupId)
@@ -959,9 +957,7 @@ export class TLFileDurableObject extends DurableObject {
 		}
 
 		let hasOwnerAccess = false
-		if (file.ownerId && file.ownerId === auth?.userId) {
-			hasOwnerAccess = true
-		} else if (file.owningGroupId && auth?.userId) {
+		if (file.owningGroupId && auth?.userId) {
 			const role = await getRole(this.db, auth.userId, file.owningGroupId)
 			if (can(role, 'accessFiles')) {
 				hasOwnerAccess = true
@@ -2599,9 +2595,6 @@ export class TLFileDurableObject extends DurableObject {
 				room.closeSession(session.sessionId, TLSyncErrorCloseEventReason.NOT_FOUND)
 				continue
 			}
-			// allow the owner to stay connected
-			// Check if user owns the file directly
-			if (file.ownerId && session.meta.userId === file.ownerId) continue
 
 			const canAccessFiles = async () => {
 				const role = await getRole(this.db, session.meta.userId, file.owningGroupId)
@@ -2621,10 +2614,7 @@ export class TLFileDurableObject extends DurableObject {
 		}
 	}
 
-	async appFileRecordDidDelete({
-		id,
-		publishedSlug,
-	}: Pick<TlaFile, 'id' | 'ownerId' | 'publishedSlug'>) {
+	async appFileRecordDidDelete({ id, publishedSlug }: Pick<TlaFile, 'id' | 'publishedSlug'>) {
 		if (this._documentInfo?.deleted) return
 
 		this._fileRecordCache = null

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -169,18 +169,10 @@ export const adminRoutes = createRouter<Environment>()
 				.leftJoin('group_file', 'group_file.fileId', 'file.id')
 				.where('file.isDeleted', '=', false)
 				.where((eb) =>
-					eb.or([
-						eb('file.ownerId', '=', userRow.id),
-						eb(
-							'group_file.groupId',
-							'in',
-							memberships.length ? memberships.map((m) => m.id) : ['']
-						),
-					])
+					eb('group_file.groupId', 'in', memberships.length ? memberships.map((m) => m.id) : [''])
 				)
-				// distinctOn dedupes before the limit is applied, so a file matching both the owner
-				// clause and multiple group memberships (join fanout) still only counts once against
-				// the 500 cap.
+				// distinctOn dedupes before the limit is applied, so a file matching multiple
+				// group memberships (join fanout) still only counts once against the 500 cap.
 				.distinctOn('file.id')
 				.orderBy('file.id')
 				.selectAll('file')
@@ -545,7 +537,6 @@ export const adminRoutes = createRouter<Environment>()
 			)
 			.where((eb) =>
 				eb.or([
-					eb('file.ownerId', '=', userRow.id),
 					eb('file.owningGroupId', '=', userRow.id),
 					eb(
 						'file.owningGroupId',
@@ -651,7 +642,7 @@ export const adminRoutes = createRouter<Environment>()
 		const file = await pg
 			.selectFrom('file')
 			.where('id', '=', slug)
-			.select(['id', 'name', 'ownerId', 'owningGroupId', 'isDeleted', 'createSource'])
+			.select(['id', 'name', 'owningGroupId', 'isDeleted', 'createSource'])
 			.executeTakeFirst()
 
 		const snapshot = await getFileSnapshot(env, slug, true)
@@ -842,7 +833,6 @@ export const adminRoutes = createRouter<Environment>()
 				.selectFrom('file')
 				.where('id', '=', slug)
 				.select([
-					'ownerId',
 					'owningGroupId',
 					'createdAt',
 					'updatedAt',
@@ -922,7 +912,7 @@ export const adminRoutes = createRouter<Environment>()
 		const stats: AdminFileStatsResponseBody = {
 			file: fileRow
 				? {
-						ownerType: fileRow.ownerId ? 'user' : fileRow.owningGroupId ? 'group' : 'none',
+						ownerType: fileRow.owningGroupId ? 'group' : 'none',
 						createdAt: fileRow.createdAt,
 						updatedAt: fileRow.updatedAt,
 						isDeleted: fileRow.isDeleted,

--- a/apps/dotcom/sync-worker/src/undeleteFile.test.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.test.ts
@@ -104,30 +104,6 @@ describe('undeleteFile', () => {
 		expect(inserts).toEqual([])
 	})
 
-	it('clears the flag and restores the owner file_state', async () => {
-		const file = makeFile()
-		const { db, updates, inserts, getTransactionCount } = makeFakeDb(file)
-		expect(await undeleteFile(db, file.id)).toEqual({
-			result: 'restored',
-			file,
-		})
-		expect(getTransactionCount()).toBe(1)
-		expect(updates).toEqual([
-			{ table: 'file', values: { isDeleted: false, updatedAt: expect.any(Number) } },
-		])
-		expect(inserts).toEqual([
-			{
-				table: 'file_state',
-				values: {
-					userId: 'user-1',
-					fileId: 'file-1',
-					firstVisitAt: expect.any(Number),
-					isFileOwner: true,
-				},
-			},
-		])
-	})
-
 	it('bumps lastPublished when restoring a published file, to trigger a republish', async () => {
 		const file = makeFile({ published: true, lastPublished: 123 })
 		const { db, updates } = makeFakeDb(file)

--- a/apps/dotcom/sync-worker/src/undeleteFile.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.ts
@@ -7,10 +7,9 @@ export type UndeleteFileResult =
 	| { result: 'group_deleted'; file: TlaFile }
 	| { result: 'restored'; file: TlaFile }
 
-// Restores a soft-deleted file: clears isDeleted, re-creates the owner's file_state (if the
-// file has an ownerId) and the owning group's group_file link (if owningGroupId). The caller
-// pokes the file effect processor's outbox after a successful restore; Zero replicates the
-// row changes to clients on its own.
+// Restores a soft-deleted file: clears isDeleted and re-creates the owning group's group_file
+// link (if owningGroupId). The caller pokes the file effect processor's outbox after a
+// successful restore; Zero replicates the row changes to clients on its own.
 export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<UndeleteFileResult> {
 	return db.transaction().execute(async (tx) => {
 		const file = await tx.selectFrom('file').where('id', '=', fileId).selectAll().executeTakeFirst()
@@ -40,14 +39,6 @@ export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<Unde
 			})
 			.where('id', '=', fileId)
 			.execute()
-
-		if (file.ownerId) {
-			await tx
-				.insertInto('file_state')
-				.values({ userId: file.ownerId, fileId, firstVisitAt: now, isFileOwner: true })
-				.onConflict((oc) => oc.columns(['userId', 'fileId']).doNothing())
-				.execute()
-		}
 
 		if (file.owningGroupId) {
 			await tx

--- a/apps/dotcom/sync-worker/src/undeleteFile.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.ts
@@ -16,6 +16,8 @@ export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<Unde
 		if (!file) return { result: 'not_found' }
 		if (!file.isDeleted) return { result: 'not_deleted', file }
 
+		// owningGroupId is nullable until #10050's follow-up migration makes it NOT NULL; this
+		// guard goes with it.
 		if (file.owningGroupId) {
 			const group = await tx
 				.selectFrom('group')

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -129,11 +129,11 @@ export type SignedInAuth = ReturnType<
 > & { userId: string }
 
 /**
- * Whether a user may *view* a file: they own it, they can reach it through the group that owns it, or
- * it is shared via link — in which case `sharedLinkType` is irrelevant, since a link shared for
+ * Whether a user may *view* a file: they can reach it through the group that owns it, or it is
+ * shared via link — in which case `sharedLinkType` is irrelevant, since a link shared for
  * editing is also one that can be viewed.
  *
- * The read-side counterpart of `requireWriteAccessToFile`, which is the same three checks plus a
+ * The read-side counterpart of `requireWriteAccessToFile`, which is the same two checks plus a
  * `sharedLinkType === 'edit'` requirement. Kept as a separate function rather than a parameter on
  * that one, because the two differ in how they answer as well as what they ask: this returns a
  * boolean where that throws a `StatusError` naming the reason. A caller that must not reveal whether

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -128,60 +128,6 @@ export type SignedInAuth = ReturnType<
 	Extract<Awaited<ReturnType<ClerkClient['authenticateRequest']>>, { isSignedIn: true }>['toAuth']
 > & { userId: string }
 
-export async function requireWriteAccessToFile(
-	request: IRequest,
-	env: Environment,
-	roomId: string
-) {
-	const auth = await requireAuth(request, env)
-
-	const db = createPostgresConnectionPool(env, 'sync-worker/hasWriteAccessToFile')
-
-	try {
-		const file = await db
-			.selectFrom('file')
-			.select('ownerId')
-			.select('owningGroupId')
-			.select('shared')
-			.select('sharedLinkType')
-			.where('id', '=', roomId)
-			.executeTakeFirst()
-
-		if (!file) {
-			throw new StatusError(404, 'File not found')
-		}
-
-		// If the user is the owner of the file, they have write access
-		if (file.ownerId === auth.userId) {
-			return
-		}
-
-		// If the file is owned by a group, check the user can access its files
-		if (file.owningGroupId) {
-			const role = await getRole(db, auth.userId, file.owningGroupId)
-			if (can(role, 'accessFiles')) {
-				return
-			}
-		}
-
-		// If the file is not shared, the user does not have write access
-		if (!file.shared) {
-			throw new StatusError(403, 'File is not shared')
-		}
-
-		// If the file is shared but not for editing, deny access
-		if (file.sharedLinkType !== 'edit') {
-			throw new StatusError(403, 'File is shared but not for editing')
-		}
-
-		// file is shared and for editing, allow access
-		return
-	} finally {
-		// Ensure database connection is properly closed
-		await db.destroy()
-	}
-}
-
 /**
  * Whether a user may *view* a file: they own it, they can reach it through the group that owns it, or
  * it is shared via link — in which case `sharedLinkType` is irrelevant, since a link shared for
@@ -217,7 +163,7 @@ export async function hasReadAccessToFile(
 	try {
 		const file = await db
 			.selectFrom('file')
-			.select(['id', 'ownerId', 'owningGroupId', 'shared', 'isDeleted'])
+			.select(['id', 'owningGroupId', 'shared', 'isDeleted'])
 			.where('id', '=', fileId)
 			.executeTakeFirst()
 
@@ -226,7 +172,6 @@ export async function hasReadAccessToFile(
 			ok: true,
 			file: { id: file.id, shared: file.shared, isDeleted: false },
 		} as const
-		if (file.ownerId === userId) return granted
 		if (file.owningGroupId) {
 			const role = await getRole(db, userId, file.owningGroupId)
 			if (can(role, 'accessFiles')) return granted

--- a/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
@@ -107,10 +107,12 @@ describe('hasReadAccessToFile', () => {
 		expect(await hasReadAccessToFile(env, 'user-1', 'nope')).toEqual(DENIED)
 	})
 
-	// Checked before ownership, so a soft-deleted board stops being readable for its owner too — the
-	// board is in the trash, and a screenshot of it is not something to serve out of the MCP tools.
-	it('refuses a deleted file even for its owner', async () => {
-		mockFileRow({ ownerId: 'user-1', isDeleted: true })
+	// Checked before workspace access, so a soft-deleted board stops being readable for the members
+	// of its own workspace too — the board is in the trash, and a screenshot of it is not something
+	// to serve out of the MCP tools.
+	it('refuses a deleted file even for a workspace member', async () => {
+		mockFileRow({ owningGroupId: 'group-1', isDeleted: true })
+		vi.mocked(getRole).mockResolvedValue('member' as any)
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(DENIED)
 	})
 

--- a/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
@@ -75,12 +75,7 @@ describe('hasReadAccessToFile', () => {
 		expect(lastQuery.table).toBe('file')
 		expect(lastQuery.where).toEqual(['id', '=', 'file-1'])
 		// Every column the decision below reads, plus the id handed back to the caller.
-		expect(lastQuery.columns).toEqual(['id', 'ownerId', 'owningGroupId', 'shared', 'isDeleted'])
-	})
-
-	it('admits the owner', async () => {
-		mockFileRow({ ownerId: 'user-1' })
-		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(granted())
+		expect(lastQuery.columns).toEqual(['id', 'owningGroupId', 'shared', 'isDeleted'])
 	})
 
 	// Unlike the write check, `sharedLinkType` is irrelevant: a link shared for editing is also one

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -313,7 +313,7 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 			const file = await db
 				.selectFrom('file')
 				.where('id', '=', fileId)
-				.select(['ownerId', 'owningGroupId', 'shared', 'sharedLinkType'])
+				.select(['owningGroupId', 'shared', 'sharedLinkType'])
 				.executeTakeFirst()
 			if (!file) return { ok: false, error: 'File not found' }
 
@@ -327,9 +327,7 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 			}
 
 			const isSharedEdit = file.shared && file.sharedLinkType === 'edit'
-			if (userId && file.ownerId === userId) {
-				// owner
-			} else if (isSharedEdit) {
+			if (isSharedEdit) {
 				// shared for editing
 			} else if (userId && file.owningGroupId) {
 				const role = await getRole(db, userId, file.owningGroupId)

--- a/internal/scripts/dotcom/cleanup-test-files.ts
+++ b/internal/scripts/dotcom/cleanup-test-files.ts
@@ -29,7 +29,7 @@ async function cleanupTestFiles() {
 	await stagingClient.connect()
 
 	try {
-		const selectQuery = `SELECT id FROM file WHERE file."ownerId" = $1 AND id LIKE 'test_%'`
+		const selectQuery = `SELECT id FROM file WHERE file."owningGroupId" = $1 AND id LIKE 'test_%'`
 		const selectResult = await stagingClient.query(selectQuery, [env.STAGING_OWNER_ID])
 
 		const fileIds = selectResult.rows.map((row: any) => row.id)

--- a/internal/scripts/dotcom/copy-random-files-to-staging.ts
+++ b/internal/scripts/dotcom/copy-random-files-to-staging.ts
@@ -114,7 +114,10 @@ async function copyFilesToStaging(fileIds: string[]) {
 					isEmpty: false,
 					isDeleted: false,
 					createSource: null,
-					owningGroupId: null,
+					// the staging user's home workspace: home group id is the user's own id. Must be set —
+					// file_owner_xor_check rejects a row with neither owner, and cleanup-test-files finds
+					// these rows by owningGroupId.
+					owningGroupId: env.STAGING_OWNER_ID,
 				}
 
 				const insertQuery = `
@@ -137,6 +140,12 @@ async function copyFilesToStaging(fileIds: string[]) {
 					testFile.isDeleted,
 					testFile.owningGroupId,
 				])
+
+				await stagingClient.query(
+					`INSERT INTO group_file ("fileId", "groupId", "createdAt", "updatedAt", "index")
+					 VALUES ($1, $2, $3, $4, NULL)`,
+					[testFile.id, testFile.owningGroupId, now, now]
+				)
 
 				copiedIds.push(newId)
 			} catch (error) {

--- a/internal/scripts/dotcom/copy-random-files-to-staging.ts
+++ b/internal/scripts/dotcom/copy-random-files-to-staging.ts
@@ -100,9 +100,9 @@ async function copyFilesToStaging(fileIds: string[]) {
 				const testFile: TlaFile = {
 					id: newId,
 					name: 'Test File',
-					ownerId: env.STAGING_OWNER_ID,
+					ownerId: null,
 					ownerName: 'Test User',
-					ownerAvatar: '',
+					ownerAvatar: null,
 					thumbnail: '',
 					shared: false,
 					sharedLinkType: 'link',
@@ -118,15 +118,13 @@ async function copyFilesToStaging(fileIds: string[]) {
 				}
 
 				const insertQuery = `
-					INSERT INTO file (id, name, "ownerId", "ownerName", "ownerAvatar", thumbnail, shared, "sharedLinkType", published, "lastPublished", "publishedSlug", "createdAt", "updatedAt", "isEmpty", "isDeleted", "owningGroupId")
-					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+					INSERT INTO file (id, name, "ownerName", thumbnail, shared, "sharedLinkType", published, "lastPublished", "publishedSlug", "createdAt", "updatedAt", "isEmpty", "isDeleted", "owningGroupId")
+					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 				`
 				await stagingClient.query(insertQuery, [
 					testFile.id,
 					testFile.name,
-					testFile.ownerId,
 					testFile.ownerName,
-					testFile.ownerAvatar,
 					testFile.thumbnail,
 					testFile.shared,
 					testFile.sharedLinkType,

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -290,9 +290,7 @@ function createMockTx(
 				// Handle the specific SQL for assertNotMaxFiles
 				if (sql.includes('count(*)') && sql.includes('"file"')) {
 					const userId = params[0]
-					const count = store.file.filter(
-						(f) => !f.isDeleted && (f.ownerId === userId || f.owningGroupId === userId)
-					).length
+					const count = store.file.filter((f) => !f.isDeleted && f.owningGroupId === userId).length
 					return [{ count: String(count) }]
 				}
 				return []
@@ -442,6 +440,8 @@ describe('file mutations', () => {
 	})
 
 	it('cannot change immutable field (ownerId)', async () => {
+		// ownerId is unused by the app but still declared and still guarded, so nothing can write
+		// it while the column exists. The guard and this test both go in the column-drop PR.
 		const s = baseStore()
 		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
 		s.file.push(f)
@@ -759,7 +759,7 @@ describe('onEnterFile', () => {
 	it('mirrors a group-less (legacy) file into home so it stays findable', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: null, ownerId: userId, shared: true })],
+			file: [makeFile({ id: fileId, owningGroupId: null, shared: true })],
 			file_state: [],
 			group: [makeGroup({ id: userId })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
@@ -1406,22 +1406,6 @@ describe('immutable column bypass attempts', () => {
 	const userId = 'user_aaaa11112222bbbb'
 	const groupId = 'group_aaa11112222bbb'
 
-	it('cannot change file.ownerId to self', async () => {
-		const s = {
-			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })],
-			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
-			comment: [],
-			comment_read: [],
-		}
-		const { tx } = createMockTx(s)
-		const m = createMutators(userId)
-		await expectForbidden(() => m.file.update(tx, { id: 'file_aaaa11112222bbbb', ownerId: userId }))
-	})
-
 	it('cannot change file.owningGroupId', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
@@ -1555,13 +1539,12 @@ describe('file access control logic', () => {
 		)
 	})
 
-	it('cannot enter file with neither ownerId nor owningGroupId', async () => {
+	it('cannot enter file without owningGroupId', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
 			file: [
 				makeFile({
 					id: 'file_orphan12345678a',
-					ownerId: null,
 					owningGroupId: null,
 					shared: false,
 				}),
@@ -1680,22 +1663,6 @@ describe('createFile from source (duplicate) access control', () => {
 		await expectBadRequest(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
 	})
 
-	it('cannot duplicate an inaccessible legacy (ownerId-owned) file', async () => {
-		const s = {
-			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: sourceId, ownerId: 'user_someoneElse1234', shared: false })],
-			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
-			comment: [],
-			comment_read: [],
-		}
-		const { tx } = createMockTx(s, { location: 'server' })
-		const m = createMutators(userId)
-		await expectForbidden(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
-	})
-
 	it('does not gate non-file createSource prefixes (e.g. published)', async () => {
 		// a published-doc copy uses a different prefix and must still work even
 		// when there is no readable `file` row for the source id
@@ -1731,7 +1698,7 @@ describe('comment.markRead / comment.markUnread', () => {
 	function commentState(): TableStore {
 		return {
 			user: [makeUser({ id: 'owner1' }), makeUser({ id: 'other1' })],
-			file: [makeFile({ id: 'file1', ownerId: 'owner1' })],
+			file: [makeFile({ id: 'file1', owningGroupId: 'owner1' })],
 			file_state: [],
 			group: [],
 			group_user: [],
@@ -1819,8 +1786,8 @@ describe('comment.markManyRead', () => {
 		return {
 			user: [makeUser({ id: 'owner1' }), makeUser({ id: 'other1' })],
 			file: [
-				makeFile({ id: 'file1', ownerId: 'owner1' }),
-				makeFile({ id: 'file2', ownerId: 'owner1' }),
+				makeFile({ id: 'file1', owningGroupId: 'owner1' }),
+				makeFile({ id: 'file2', owningGroupId: 'owner1' }),
 			],
 			file_state: [],
 			group: [],

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -108,7 +108,7 @@ function assertValidId(id: string) {
  * @param tx - The transaction
  * @param userId - The user ID to check permissions for
  * @param file - The file to check permissions on
- * @param allowGuestAccess - If true, shared files are accessible even if user isn't owner/member
+ * @param allowGuestAccess - If true, shared files are accessible even if the user isn't a member
  */
 async function assertUserCanAccessFileInternal(
 	tx: Transaction<TlaSchema>,
@@ -124,9 +124,7 @@ async function assertUserCanAccessFileInternal(
 		return
 	}
 
-	if (!file.owningGroupId) {
-		assert(file.owningGroupId, ZErrorCode.bad_request)
-	}
+	assert(file.owningGroupId, ZErrorCode.bad_request)
 	const role = await getRole(tx, userId, file.owningGroupId)
 	assert(can(role, 'accessFiles'), ZErrorCode.forbidden)
 }
@@ -135,7 +133,7 @@ async function assertUserCanAccessFileInternal(
  * Check if a user can access (read) a file.
  * A user can access a file if:
  * - They are a member of the owning workspace (new model: user is in file.owningGroupId)
- * - The file is shared (regardless of ownership model)
+ * - The file is shared
  */
 async function assertUserCanAccessFile(tx: Transaction<TlaSchema>, userId: string, file: TlaFile) {
 	await assertUserCanAccessFileInternal(tx, userId, file, true)
@@ -662,7 +660,7 @@ export function createMutators(userId: string) {
 				await tx.mutate.group_file.delete({ fileId, groupId: file.owningGroupId })
 			}
 
-			// Transfer file ownership from user to group
+			// Point the file at its new workspace
 			await tx.mutate.file.update({
 				id: fileId,
 				owningGroupId: workspaceId,

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -124,23 +124,16 @@ async function assertUserCanAccessFileInternal(
 		return
 	}
 
-	if (file.ownerId) {
-		// Legacy model: user must own the file
-		assert(file.ownerId === userId, ZErrorCode.forbidden)
-	} else if (file.owningGroupId) {
-		// New model: user must be a member of the owning workspace
-		const role = await getRole(tx, userId, file.owningGroupId)
-		assert(can(role, 'accessFiles'), ZErrorCode.forbidden)
-	} else {
-		// File has neither ownerId nor owningGroupId - invalid state
-		assert(false, ZErrorCode.bad_request)
+	if (!file.owningGroupId) {
+		assert(file.owningGroupId, ZErrorCode.bad_request)
 	}
+	const role = await getRole(tx, userId, file.owningGroupId)
+	assert(can(role, 'accessFiles'), ZErrorCode.forbidden)
 }
 
 /**
  * Check if a user can access (read) a file.
  * A user can access a file if:
- * - They own it (legacy model: file.ownerId matches userId)
  * - They are a member of the owning workspace (new model: user is in file.owningGroupId)
  * - The file is shared (regardless of ownership model)
  */
@@ -151,7 +144,6 @@ async function assertUserCanAccessFile(tx: Transaction<TlaSchema>, userId: strin
 /**
  * Check if a user can update (write to) a file.
  * A user can update a file if:
- * - They own it (legacy model: file.ownerId matches userId)
  * - They are a member of the owning workspace (new model: user is in file.owningGroupId)
  * Note: Sharing only grants read access, not write access
  */
@@ -174,20 +166,6 @@ export function createMutators(userId: string) {
 			},
 		},
 		file: {
-			/** @deprecated */
-			deleteOrForget: async (tx: Tx, { id }: { id: string }) => {
-				const file = await tx.run(zql.file.where('id', '=', id).one())
-				if (!file) return
-				await tx.mutate.file_state.delete({ fileId: id, userId })
-				if (file.ownerId && file.ownerId === userId) {
-					await tx.mutate.file.update({
-						id: file.id,
-						ownerId: file.ownerId,
-						publishedSlug: file.publishedSlug,
-						isDeleted: true,
-					})
-				}
-			},
 			update: async (tx: Tx, _file: TlaFilePartial) => {
 				disallowImmutableMutations(_file, immutableColumns.file)
 				const file = await tx.run(zql.file.where('id', '=', _file.id).one())
@@ -285,32 +263,6 @@ export function createMutators(userId: string) {
 			},
 		},
 
-		/** @deprecated */
-		init: async (tx: Tx, { user, time }: { user: TlaUser; time: number }) => {
-			assert(user.id === userId, ZErrorCode.forbidden)
-			time = ensureSensibleTimestamp(time)
-			await tx.mutate.user.insert({ ...user, flags: '' })
-			await tx.mutate.group.insert({
-				id: userId,
-				name: user.name,
-				createdAt: time,
-				updatedAt: time,
-				isDeleted: false,
-				inviteSecret: null,
-				inviteLinkEnabled: true,
-			})
-			await tx.mutate.group_user.insert({
-				userId,
-				groupId: userId,
-				createdAt: time,
-				updatedAt: time,
-				role: 'owner',
-				index: 'a1' as IndexKey,
-				userColor: user.color,
-				userName: user.name,
-			})
-		},
-
 		createFile: async (
 			tx: Tx,
 			{
@@ -366,10 +318,8 @@ export function createMutators(userId: string) {
 			await tx.mutate.file.insert({
 				id: fileId,
 				name,
-				ownerId: null,
 				owningGroupId: workspaceId,
 				ownerName: '',
-				ownerAvatar: '',
 				thumbnail: '',
 				shared: true,
 				sharedLinkType: 'edit',
@@ -397,8 +347,6 @@ export function createMutators(userId: string) {
 				lastVisitAt: null,
 				firstVisitAt: null,
 				lastSessionState: null,
-				// isFileOwner is no longer used in new model.
-				isFileOwner: false,
 			})
 		},
 

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -56,13 +56,13 @@ export const queries = defineQueries({
 	 * Recent comments that concern the current user, for the app-level notifications feed. Someone
 	 * else's comment qualifies when it matches at least one of three categories:
 	 *
-	 * - it's on a file the user owns
+	 * - it's on a board in the user's own home workspace
 	 * - it's in a thread the user is a part of (started, or has commented in) and on a file they
 	 *   can still access — a reply
 	 * - it `@`-mentions the user (via the `comment_mention` rows the file's Durable Object
 	 *   extracts from the body, since mentions live inside rich-text JSON that ZQL can't reach),
 	 *   provided the user can access the file: they have a file_state for it, or it belongs to a
-	 *   workspace they're a member of. Ownership carries its own access evidence; replies and
+	 *   workspace they're a member of. A home board carries its own access evidence; replies and
 	 *   mentions need an explicit current-access gate because historical thread participation can
 	 *   outlive access to the file.
 	 *
@@ -90,8 +90,8 @@ export const queries = defineQueries({
 			.whereExists('file', (f) => f.where('isDeleted', '=', false))
 			.where(({ and, or, exists }) =>
 				or(
-					// on a board the user owns
-					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+					// on a board in the user's own home workspace (home group id === user id)
+					exists('file', (f) => f.where('owningGroupId', '=', ctx.userId)),
 					// a reply: in a thread the user started or has commented in, on a file they
 					// can still access
 					and(
@@ -191,7 +191,6 @@ export const queries = defineQueries({
 			// having authored a comment doesn't outlive access to the board it's on
 			.where(({ or, exists }) =>
 				or(
-					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
 					exists('file', (f) =>
 						f.where(({ or, exists }) =>
 							or(

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -158,7 +158,7 @@ export const queries = defineQueries({
 	/**
 	 * The caller's own comments that someone else has reacted to, for the notifications feed's
 	 * "reacted to your comment" entries. Uses the same access building blocks as {@link comments}
-	 * (owner, file state, group membership). Ordering by reaction time is client-side:
+	 * (file state, group membership). Ordering by reaction time is client-side:
 	 * `buildReactionNotifications` stamps each entry with its newest foreign reaction and
 	 * `mergeNotifications` sorts on it.
 	 *

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -85,7 +85,7 @@ export const file = table('file')
 		ownerId: string().optional(),
 		owningGroupId: string().optional(),
 		ownerName: string(),
-		ownerAvatar: string(),
+		ownerAvatar: string().optional(),
 		thumbnail: string(),
 		shared: boolean(),
 		sharedLinkType: string(),
@@ -229,12 +229,7 @@ export const comment_reaction = table('comment_reaction')
 	})
 	.primaryKey('id')
 
-const fileRelationships = relationships(file, ({ one, many }) => ({
-	owner: one({
-		sourceField: ['ownerId'],
-		destField: ['id'],
-		destSchema: user,
-	}),
+const fileRelationships = relationships(file, ({ many }) => ({
 	states: many({
 		sourceField: ['id'],
 		destField: ['fileId'],

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -339,10 +339,7 @@ export interface AdminFileAssetProblem {
 
 /** Response of the admin file-assets diagnostics endpoint. */
 export interface AdminFileAssetsResponseBody {
-	file: Pick<
-		TlaFile,
-		'id' | 'name' | 'ownerId' | 'owningGroupId' | 'isDeleted' | 'createSource'
-	> | null
+	file: Pick<TlaFile, 'id' | 'name' | 'owningGroupId' | 'isDeleted' | 'createSource'> | null
 	/** null exists = not checked (prefix needs slug translation) or the check failed */
 	source: { raw: string; exists: boolean | null } | null
 	shapes: {
@@ -379,7 +376,7 @@ export interface AdminFileAssetsResponseBody {
 export interface AdminFileStatsResponseBody {
 	/** null when no `file` row exists — legacy rooms have a snapshot but no row */
 	file: {
-		ownerType: 'user' | 'group' | 'none'
+		ownerType: 'group' | 'none'
 		createdAt: number
 		updatedAt: number
 		isDeleted: boolean


### PR DESCRIPTION
In order to drop the `file.ownerId` columns from Postgres, this PR first removes everything that reads or writes them. Every user is on the groups model — files are owned by a workspace via `owningGroupId` — so the `ownerId` branches scattered through the access checks, mutators, admin routes and client helpers are unreachable. Production confirms it: `SELECT count(*) FROM "file" WHERE "ownerId" IS NOT NULL` and `WHERE "owningGroupId" IS NULL` both return 0, as do both halves of the home-workspace check.

Zero requires column removal to go client → API → DB, which is the reverse of our deploy pipeline (`migrations → zero-cache → sync-worker → client`). So this PR is code only. The columns stay in Postgres and stay declared in `tlaSchema.ts`, along with the `immutableColumns` guard that stops a client writing them in the meantime. The migration that drops them lands separately, at least a release later, with all its DDL in one transaction — every schema change on a replicated table resets zero-cache's view-syncer pipelines and rehydrates every connected client.

One behaviour change worth reviewing on its own terms: the `owned-board` notification reason ("*X* commented on your board") keys off `file.ownerId`, so it has been silently dead for every file since groups landed. This re-keys it to the home workspace (`owningGroupId === userId`), which is what "your board" meant before. It deliberately stays quiet for shared-workspace boards, where a catch-all would notify every member about every comment; members still get `mention`, `reply` and `reaction` there. The case it restores is the one with a real gap today — a guest comments on a personal board you shared by link, and you're neither mentioned nor in the thread, so you currently hear nothing.

Also removes the deprecated `deleteOrForget` and `init` mutators. Both lost their last call site in #6905/#7058 (Oct–Nov 2025), so no live client can still call them.

Relates to #10050.

### Change type

- [x] `other`

### Test plan

1. Open a board in a shared workspace, confirm it still loads, renames, shares and deletes.
2. Open a board in your home workspace, confirm the same.
3. As a guest on a link-shared board, confirm you can view/edit per the link type and that an unshared board is refused.
4. Have someone comment on a board in your home workspace without mentioning you — confirm a "commented on your board" notification appears.
5. Admin panel: look up a user, confirm their files and workspaces list, and that file-stats reports `ownerType: group`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Restore the "commented on your board" notification, which had stopped firing for all boards.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +12 / -73  |
| Tests          | +43 / -99  |
| Apps           | +17 / -106 |
| Config/tooling | +5 / -7    |
