### PR TITLE
fix(select): stop Space+arrow and Alt+arrow from nudging the selection

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -589,7 +589,7 @@ export class Idle extends StateNode {
 					}
 					return
 				}
-				this.nudgeSelectedShapes(false)
+				this.nudgeSelectedShapes(info, false)
 				return
 			}
 		}
@@ -635,7 +635,7 @@ export class Idle extends StateNode {
 					)
 					return
 				}
-				this.nudgeSelectedShapes(true)
+				this.nudgeSelectedShapes(info, true)
 				break
 			}
 			case 'Tab': {
@@ -754,12 +754,17 @@ export class Idle extends StateNode {
 		startEditingShapeWithRichText(this.editor, id, { info })
 	}
 
-	private nudgeSelectedShapes(ephemeral = false) {
+	private nudgeSelectedShapes(info: TLKeyboardEventInfo, ephemeral = false) {
 		const {
 			editor: {
 				inputs: { keys },
 			},
 		} = this
+
+		// Space+arrow pages the camera and Alt+arrow is the change-page shortcut; both
+		// events still reach this state, so without this guard the selection also
+		// moves one unit (#10397)
+		if (info.altKey || this.editor.inputs.getIsSpacebarPanning()) return
 
 		// We want to use the "actual" shift key state,
 		// not the one that's in the editor.inputs.shiftKey,

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -56,6 +56,29 @@ describe('TLSelectTool.Idle', () => {
 		expect(nudgedShape).toBeDefined()
 		expect(nudgedShape?.x).toBe(101)
 	})
+
+	it('Does not nudge selected shapes on arrow key down while spacebar panning', () => {
+		const shape = editor.getShape(ids.box1)!
+		editor.select(shape.id)
+		editor.keyDown(' ')
+		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
+		editor.keyDown('ArrowRight')
+		editor.keyRepeat('ArrowRight')
+		editor.keyUp('ArrowRight')
+		editor.keyUp(' ')
+		expect(editor.getShape(shape.id)).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('Does not nudge selected shapes on arrow key down while alt is held', () => {
+		const shape = editor.getShape(ids.box1)!
+		editor.select(shape.id)
+		editor.keyDown('Alt')
+		editor.keyDown('ArrowRight')
+		editor.keyRepeat('ArrowRight')
+		editor.keyUp('ArrowRight')
+		editor.keyUp('Alt')
+		expect(editor.getShape(shape.id)).toMatchObject({ x: 100, y: 100 })
+	})
 })
 
 // todo: turn on feature flag for these tests or remove them


### PR DESCRIPTION
This PR fixes a bug where holding Space and tapping an arrow key (to page the camera), or pressing Alt+arrow (to change page), also nudged the selected shapes one unit. Closes #10397.

### Before

`Editor.dispatch` handles Space+arrow by animating the camera one viewport, then passes the same `key_down` on to the state chart. The Alt+arrow page shortcuts in `useKeyboardShortcuts` likewise run without stopping the event from reaching the editor. The select tool's `Idle.onKeyDown` / `onKeyRepeat` only checked for the accel key before calling `nudgeSelectedShapes`, so either navigation key also moved the selection.

### After

`nudgeSelectedShapes` returns early when `info.altKey` is set or `editor.inputs.getIsSpacebarPanning()` is true, so Space+arrow only pans and Alt+arrow only changes page. Accel+arrow adjacent-shape selection and plain/Shift arrow nudging are unchanged.

### Implementation notes

The guard uses `getIsSpacebarPanning()` rather than checking whether the Space key is down, so that when `spacebarPanning` is disabled in editor options there is no camera action to conflict with and Space+arrow keeps nudging as before.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle and select it.
2. Hold Space and press the right arrow once, then release Space: the camera pans, the rectangle stays at its position.
3. With two pages, select a shape and press Alt+right, then come back: the shape has not moved.

- [x] Unit tests — the two new tests in `SelectTool.test.ts` fail on `main` (shape ends at `x: 102`) and pass with this change

### Release notes

- Fix Space+arrow and Alt+arrow also nudging the selected shapes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -3    |
| Tests     | +23 / -0   |
