### PR TITLE
fix(editor): treat a pen as a fine pointer instead of a coarse one

### DIFF
--- a/apps/docs/content/sdk-features/environment.mdx
+++ b/apps/docs/content/sdk-features/environment.mdx
@@ -100,7 +100,7 @@ function TouchFriendlyButton() {
 
 ### Coarse pointer detection
 
-The `isCoarsePointer` value tracks whether the user is currently using touch input. We detect this two ways: by listening to the `(any-pointer: coarse)` media query, and by checking `pointerType` on each pointer down event. Any pointer that isn't a mouse counts as coarse, so pen input switches to coarse mode too. Laptops with touchscreens can switch input methods mid-session; the pointer down check catches that.
+The `isCoarsePointer` value tracks whether the user is currently using touch input. We detect this two ways: by listening to the `(any-pointer: coarse)` media query, and by checking `pointerType` on each pointer down event. Only touch input counts as coarse: a mouse or a pen (such as an Apple Pencil) switches back to fine mode, since a pen is at least as precise as a mouse. Laptops with touchscreens can switch input methods mid-session; the pointer down check catches that.
 
 ```typescript
 import { tlenvReactive, react } from 'tldraw'

--- a/apps/docs/content/sdk-features/highlighting.mdx
+++ b/apps/docs/content/sdk-features/highlighting.mdx
@@ -79,7 +79,7 @@ The select tool updates hover state as the pointer moves (throttled to 32ms, and
 
 - The select tool is in `idle` or `editing_shape`
 - The pointer is over the canvas (not UI elements)
-- The pointer is not coarse (touch, and pen on some devices)
+- The pointer is not coarse (touch)
 - The editor is not changing styles
 - The shape is not already selected
 

--- a/packages/editor/src/lib/globals/environment.test.ts
+++ b/packages/editor/src/lib/globals/environment.test.ts
@@ -1,0 +1,33 @@
+import { tlenvReactive } from './environment'
+
+function pressPointer(pointerType: string) {
+	window.dispatchEvent(new PointerEvent('pointerdown', { pointerType, bubbles: true }))
+}
+
+describe('tlenvReactive.isCoarsePointer', () => {
+	afterEach(() => {
+		tlenvReactive.update((prev) => ({ ...prev, isCoarsePointer: false }))
+	})
+
+	it('flips to coarse on a touch pointerdown', () => {
+		pressPointer('touch')
+		expect(tlenvReactive.get().isCoarsePointer).toBe(true)
+	})
+
+	it('flips back to fine on a mouse pointerdown', () => {
+		pressPointer('touch')
+		pressPointer('mouse')
+		expect(tlenvReactive.get().isCoarsePointer).toBe(false)
+	})
+
+	it('treats a pen as a fine pointer', () => {
+		pressPointer('pen')
+		expect(tlenvReactive.get().isCoarsePointer).toBe(false)
+	})
+
+	it('flips back to fine when a pen follows a touch', () => {
+		pressPointer('touch')
+		pressPointer('pen')
+		expect(tlenvReactive.get().isCoarsePointer).toBe(false)
+	})
+})

--- a/packages/editor/src/lib/globals/environment.ts
+++ b/packages/editor/src/lib/globals/environment.ts
@@ -95,9 +95,9 @@ if (typeof window !== 'undefined' && !isForcedFinePointer) {
 	getGlobalWindow().addEventListener(
 		'pointerdown',
 		(e: PointerEvent) => {
-			// when the user interacts with a mouse, we assume they have a fine pointer.
-			// otherwise, we assume they have a coarse pointer.
-			const isCoarseEvent = e.pointerType !== 'mouse'
+			// Only a finger is coarse. A pen is at least as precise as a mouse, so treating it as
+			// coarse would give stylus users the touch hit margins, drag threshold, and handles.
+			const isCoarseEvent = e.pointerType === 'touch'
 			if (isCoarseEvent !== isCurrentCoarsePointer()) {
 				tlenvReactive.update((prev) => ({ ...prev, isCoarsePointer: isCoarseEvent }))
 			}

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -14,8 +14,8 @@ import { tlenv } from '../globals/environment'
  * direct-display pen.
  *
  * Note this uses {@link tlenv.isTouchDevice} — the device's fixed touch capability — not the
- * editor's dynamic `isCoarsePointer` state, which a pen `pointerdown` flips to coarse regardless
- * of device.
+ * editor's dynamic `isCoarsePointer` state, which a pen `pointerdown` leaves fine regardless of
+ * device.
  *
  * @internal
  */


### PR DESCRIPTION
This PR fixes a bug where the first press of a pen (Apple Pencil, Surface Pen, etc.) switched the editor into coarse-pointer mode: the 6px drag threshold, the 4px hit margin, the round touch rotate handle, no edge resize handles, and no formatting toolbar while editing text. Closes #10398.

### Before

The capturing window `pointerdown` listener in `packages/editor/src/lib/globals/environment.ts` set `isCoarsePointer = e.pointerType !== 'mouse'`, so `'pen'` was lumped in with `'touch'`. Every pen user got the touch-tuned thresholds and handles even though a pen is at least as precise as a mouse.

### After

Only `pointerType === 'touch'` flips `isCoarsePointer` to `true`; a pen or mouse press flips it back to `false`. The `(any-pointer: coarse)` media query path is unchanged, so a touch-screen device still starts coarse until the first pen or mouse press. The `sdk-features/environment` and `sdk-features/highlighting` docs, and the `isDirectDisplayPen` doc comment that described the old behaviour, are updated to match.

### Implementation notes

The issue left this as a product call between "pens are fine" and "revise the docs to say pens are coarse". I took the first option since it's what the issue title, the expected-behaviour line, and the input-model docs all describe. The change is the narrowest one that achieves it: `pointerType` values other than `'mouse'`, `'pen'`, and `'touch'` (the empty string for unknown devices) now count as fine rather than coarse.

### Change type

- [x] `bugfix`

### Test plan

1. On an iPad with an Apple Pencil (or a Windows tablet with a stylus), tap the canvas with the pen and select a rectangle.
2. The selection should show the square rotate handle and edge resize handles, not the round touch rotate handle.
3. Tap with a finger: the touch handles should appear. Tap again with the pen: the fine handles should come back.

- [x] Unit tests — the new `environment.test.ts` cases for pen input fail on `main` and pass with this change

### Release notes

- Fix pen and stylus input switching the editor into coarse-pointer mode; pens now keep the same hit margins, drag threshold, and handles as a mouse

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +5 / -5    |
| Tests         | +33 / -0   |
| Documentation | +2 / -2    |
