### PR TITLE
fix(select): end translate, resize, rotate, and brush gestures when a pinch starts

### DIFF
--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -288,14 +288,15 @@ describe('When resizing', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 	})
 
-	it('does not bails on interrupt while resizing', () => {
+	it('bails on interrupt while resizing and returns to text.idle', () => {
 		editor.setCurrentTool('text')
 		editor.pointerDown(0, 0)
 		vi.advanceTimersByTime(200)
 		editor.pointerMove(100, 100)
 		editor.expectToBeIn('select.resizing')
 		editor.interrupt()
-		expect(editor.getCurrentPageShapes().length).toBe(1)
+		editor.expectToBeIn('text.idle')
+		expect(editor.getCurrentPageShapes().length).toBe(0)
 	})
 
 	it('removes the pending text shape when another tool is selected mid-drag', () => {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -2,7 +2,6 @@ import {
 	Box,
 	Mat,
 	StateNode,
-	TLCancelEventInfo,
 	TLKeyboardEventInfo,
 	TLPageId,
 	TLPointerEventInfo,
@@ -99,9 +98,12 @@ export class Brushing extends StateNode {
 		this.complete()
 	}
 
-	override onCancel(info: TLCancelEventInfo) {
-		this.editor.setSelectedShapes(this.initialSelectedShapeIds)
-		this.parent.transition('idle', info)
+	override onCancel() {
+		this.cancel()
+	}
+
+	override onInterrupt() {
+		this.cancel()
 	}
 
 	override onKeyDown(info: TLKeyboardEventInfo) {
@@ -118,6 +120,11 @@ export class Brushing extends StateNode {
 
 	private complete() {
 		this.hitTestShapes()
+		this.parent.transition('idle')
+	}
+
+	private cancel() {
+		this.editor.setSelectedShapes(this.initialSelectedShapeIds)
 		this.parent.transition('idle')
 	}
 
@@ -236,10 +243,6 @@ export class Brushing extends StateNode {
 		if (current.length !== results.size || current.some((id) => !results.has(id))) {
 			editor.setSelectedShapes(Array.from(results))
 		}
-	}
-
-	override onInterrupt() {
-		this.editor.updateInstanceState({ brush: null })
 	}
 
 	private handleHit(

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -69,6 +69,10 @@ export class Cropping extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	override onExit() {
 		this.parent.setCurrentToolIdMask(undefined)
 		this.editor.snaps.clearIndicators()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/PointingCrop.ts
@@ -4,7 +4,11 @@ export class PointingCrop extends StateNode {
 	static override id = 'pointing_crop'
 
 	override onCancel() {
-		this.editor.setCurrentTool('select.crop.idle', {})
+		this.cancel()
+	}
+
+	override onInterrupt() {
+		this.cancel()
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
@@ -32,6 +36,10 @@ export class PointingCrop extends StateNode {
 
 		this.parent.transition('idle')
 		this.parent.getCurrent()?.handleEvent(info)
+	}
+
+	private cancel() {
+		this.editor.setCurrentTool('select.crop.idle', {})
 	}
 
 	startDragging(info: TLPointerEventInfo) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/TranslatingCrop.ts
@@ -51,6 +51,10 @@ export class TranslatingCrop extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	override onKeyDown(info: TLKeyboardEventInfo) {
 		switch (info.key) {
 			case 'Alt':

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -205,6 +205,10 @@ export class DraggingHandle extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	override onExit() {
 		this.parent.setCurrentToolIdMask(undefined)
 		clearArrowTargetState(this.editor)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -129,6 +129,10 @@ export class Resizing extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	private cancel() {
 		this.didFinish = true
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Rotating.ts
@@ -97,6 +97,10 @@ export class Rotating extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	// ---
 
 	private update() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -71,6 +71,10 @@ export class ScribbleBrushing extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	override onComplete() {
 		this.complete()
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -156,6 +156,10 @@ export class Translating extends StateNode {
 		this.cancel()
 	}
 
+	override onInterrupt() {
+		this.cancel()
+	}
+
 	protected startCloning() {
 		if (this.isCreating) return
 		const shapeIds = Array.from(this.editor.getSelectedShapeIds())

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1402,3 +1402,88 @@ describe('Leaving crop mode by switching tools', () => {
 		expect(editor.getCroppingShapeId()).toBe(null)
 	})
 })
+
+describe('Pinch ends an in-progress crop gesture', () => {
+	// Drive a touch pinch that begins while a one-finger drag is still down: the
+	// second finger's pointer_down arrives first, then the pinch gesture.
+	function pinchDuringDrag() {
+		editor.pointerDown(50, 50)
+		editor.pinchStart(200, 200, editor.getZoomLevel(), 0, 0, 0)
+		editor.pinchTo(200, 200, 2, 0, 0, 0)
+		editor.pinchEnd(200, 200, 2, 0, 0, 0)
+	}
+
+	it('cancels a crop resize and restores the original crop', () => {
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.expectToBeIn('select.idle')
+			.select(ids.imageB)
+			.pointerDown(500, 600, {
+				target: 'selection',
+				handle: 'bottom_left',
+				ctrlKey: true,
+				accelKey: true,
+			})
+			.expectToBeIn('select.crop.pointing_crop_handle')
+			.pointerMove(510, 590)
+			.expectToBeIn('select.crop.cropping')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).not.toMatchObject(before)
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+
+		// Lifting the remaining finger does not commit the stale crop.
+		editor.pointerMove(520, 580)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+
+	it('cancels a crop translate and restores the original crop', () => {
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.expectToBeIn('select.crop.pointing_crop')
+			.pointerMove(250, 250)
+			.expectToBeIn('select.crop.translating_crop')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).not.toMatchObject(before)
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.crop.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+
+		editor.pointerMove(200, 200)
+		editor.pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+
+	it('returns to crop idle from pointing_crop so the next drag does not translate the crop', () => {
+		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.expectToBeIn('select.crop.pointing_crop')
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.crop.idle')
+
+		editor.pointerMove(250, 250)
+		editor.expectToBeIn('select.crop.idle')
+		editor.pointerUp()
+		editor.expectToBeIn('select.crop.idle')
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+})

--- a/packages/tldraw/src/test/pinch.test.ts
+++ b/packages/tldraw/src/test/pinch.test.ts
@@ -137,3 +137,106 @@ describe('Pinch preserves the pre-gesture selection', () => {
 		expect(editor.getEditingShapeId()).toBe(ids.box1)
 	})
 })
+
+describe('Pinch ends an in-progress select tool gesture', () => {
+	// Drive a touch pinch that begins while a one-finger drag is still down: the
+	// second finger's pointer_down arrives first, then the pinch gesture.
+	function pinchDuringDrag() {
+		editor.pointerDown(300, 300)
+		editor.pinchStart(200, 200, editor.getZoomLevel(), 0, 0, 0)
+		editor.pinchTo(200, 200, 2, 0, 0, 0)
+		editor.pinchEnd(200, 200, 2, 0, 0, 0)
+	}
+
+	it('cancels a translate and leaves the shape where it started', () => {
+		editor.select(ids.box1)
+		editor.pointerMove(50, 50)
+		editor.pointerDown()
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('select.translating')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 50, y: 50 })
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0 })
+
+		// Lifting the remaining finger and moving again does not resume the drag.
+		editor.pointerMove(150, 150)
+		editor.pointerUp()
+		editor.pointerMove(200, 200)
+		editor.forceTick()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0 })
+	})
+
+	it('cancels a resize and restores the original size', () => {
+		editor.select(ids.box1)
+		editor.pointerDown(100, 100, { target: 'selection', handle: 'bottom_right' })
+		editor.pointerMove(150, 150)
+		editor.expectToBeIn('select.resizing')
+		expect(editor.getShape(ids.box1)).toMatchObject({ props: { w: 150, h: 150 } })
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0, props: { w: 100, h: 100 } })
+
+		editor.pointerMove(200, 200)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0, props: { w: 100, h: 100 } })
+	})
+
+	it('cancels a rotate and restores the original rotation', () => {
+		editor.select(ids.box1)
+		editor.pointerDown(100, 100, { target: 'selection', handle: 'bottom_right_rotate' })
+		editor.pointerMove(100, 0)
+		editor.expectToBeIn('select.rotating')
+		expect(editor.getShape(ids.box1)!.rotation).not.toBe(0)
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0, rotation: 0 })
+
+		editor.pointerMove(0, 0)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.box1)).toMatchObject({ x: 0, y: 0, rotation: 0 })
+	})
+
+	it('cancels a brush selection', () => {
+		editor.pointerDown(-50, -50)
+		editor.pointerMove(150, 150)
+		editor.expectToBeIn('select.brushing')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(editor.getInstanceState().brush).toBeNull()
+
+		// The remaining finger no longer brushes.
+		editor.pointerMove(350, 150)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(editor.getInstanceState().brush).toBeNull()
+	})
+
+	it('cancels a scribble selection', () => {
+		editor.keyDown('Alt')
+		editor.pointerDown(-50, -50)
+		editor.pointerMove(150, 150)
+		editor.expectToBeIn('select.scribble_brushing')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+
+		editor.pointerMove(250, 50)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.keyUp('Alt')
+	})
+})

--- a/packages/tldraw/src/test/pinch.test.ts
+++ b/packages/tldraw/src/test/pinch.test.ts
@@ -239,4 +239,31 @@ describe('Pinch ends an in-progress select tool gesture', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([])
 		editor.keyUp('Alt')
 	})
+
+	it('cancels a handle drag and restores the original handle position', () => {
+		const lineId = createShapeId('line1')
+		editor.createShapes([{ id: lineId, type: 'line', x: 0, y: 300 }])
+		const before = editor.getShape(lineId)!
+		editor.select(lineId)
+
+		const startHandle = editor.getShapeHandles(before)!.find((h) => h.id === 'a1')!
+		editor.pointerDown(before.x + startHandle.x, before.y + startHandle.y, {
+			target: 'handle',
+			shape: before,
+			handle: startHandle,
+		})
+		editor.pointerMove(50, 350)
+		editor.expectToBeIn('select.dragging_handle')
+		expect(editor.getShape(lineId)).not.toEqual(before)
+
+		pinchDuringDrag()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(lineId)).toEqual(before)
+
+		// Lifting the remaining finger does not commit the stale handle position.
+		editor.pointerMove(80, 380)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(lineId)).toEqual(before)
+	})
 })


### PR DESCRIPTION
This PR fixes a bug where pinching with a second finger during a select tool drag (translate, resize, rotate, or brush select) on a touch device kept the gesture alive, so lifting the fingers and moving again carried on moving or resizing shapes that were no longer selected. Closes #10395.

### Before

`pinch_start` in `Editor` dispatches `interrupt` and rolls the selection back to what it was before the first finger went down. The pointing states, hand tool, and crop handle state end their gesture on `onInterrupt`, but `Translating`, `Resizing`, `Rotating`, and `ScribbleBrushing` defined no `onInterrupt` at all, and `Brushing`'s only cleared the brush rectangle. Those states stayed current through the pinch, and the next `pointer_move`/`pointer_up` replayed their pre-pinch snapshot: a translate committed the move with nothing selected, a resize or rotate applied from the stale handle position, and the brush kept selecting.

### After

Each of those five states cancels on `onInterrupt`, the same way it does on `onCancel`: translate, resize, and rotate bail to their history mark (running the `onTranslateCancel` / `onResizeCancel` / `onRotateCancel` shape util hooks) and hand off to `onInteractionEnd` when they were entered from a creation tool, and brush and scribble restore the initial selection. All return to `select.idle`, so the remaining finger starts a fresh interaction rather than resuming the old one.

### Implementation notes

- The issue left "cancels (or completes)" open. Cancelling is the conservative reading and matches the pointing states, the hand tool, and `pinch_start` itself, which already rolls the selection back on the assumption that the first finger's work was incidental to the pinch.
- `TextShapeTool.test.ts` had an old test asserting that interrupt during a drag-to-create resize *keeps* the half-created text shape. That contradicts the issue's expected behaviour, so it now asserts the same outcome as the existing escape test (back to `text.idle`, no shape). This is the same outcome `geo.pointing` and the other `BaseBoxShapeTool` pointing states already produce on interrupt.

### Change type

- [x] `bugfix`

### Test plan

1. On a touch device, drag a shape with one finger.
2. Pinch with a second finger, then lift both.
3. Move one finger on the canvas: the shape stays where the pinch left it and is not moved or committed. Repeat with a resize handle, a rotate handle, a rectangle brush select, and an alt+drag scribble select.

- [x] Unit tests — the five new tests in `pinch.test.ts` fail on `main` and pass with this change

### Release notes

- Fix shapes continuing to move, resize, or rotate after a pinch interrupts a select tool drag on touch devices

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +27 / -8   |
| Tests     | +106 / -2  |
