### PR TITLE
fix(select): remove pending shape when a creating resize is exited mid-drag

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeTool.test.ts
@@ -229,6 +229,17 @@ describe('When in the resizing state while creating a geo shape', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('Removes the pending geo shape when another tool is selected mid-drag', () => {
+		editor.setCurrentTool('geo')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('select.resizing')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		editor.setCurrentTool('draw')
+		editor.expectToBeIn('draw.idle')
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
+
 	it('Returns to geo.idle on complete if tool lock is enabled', () => {
 		editor.updateInstanceState({ isToolLocked: true })
 		editor.setCurrentTool('geo')

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -298,6 +298,21 @@ describe('When resizing', () => {
 		expect(editor.getCurrentPageShapes().length).toBe(1)
 	})
 
+	it('removes the pending text shape when another tool is selected mid-drag', () => {
+		editor.setCurrentTool('text')
+		editor.pointerDown(0, 0)
+		vi.advanceTimersByTime(200)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('select.resizing')
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		editor.setCurrentTool('geo')
+		editor.expectToBeIn('geo.idle')
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.pointerUp(100, 100)
+		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
+
 	it('preserves the top left when the text has a fixed width', () => {
 		editor.setCurrentTool('text')
 		const x = 0

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -43,6 +43,10 @@ export class Resizing extends StateNode {
 	// A switch to detect when the user is holding ctrl
 	private didHoldCommand = false
 
+	// Set once complete() or cancel() has run, so onExit can tell an orderly finish apart from
+	// being exited from outside (e.g. a tool shortcut pressed mid-drag)
+	private didFinish = false
+
 	// we transition into the resizing state from the geo pointing state, which starts with a shape of size w: 1, h: 1,
 	// so if the user drags x: +50, y: +50 after mouseDown, the shape will be w: 51, h: 51, which is too many pixels, alas
 	// so we allow passing a further offset into this state to negate such issues
@@ -55,6 +59,7 @@ export class Resizing extends StateNode {
 
 		this.info = info
 		this.didHoldCommand = false
+		this.didFinish = false
 
 		if (typeof info.onInteractionEnd === 'string') {
 			this.parent.setCurrentToolIdMask(info.onInteractionEnd)
@@ -126,6 +131,8 @@ export class Resizing extends StateNode {
 	}
 
 	private cancel() {
+		this.didFinish = true
+
 		// Call onResizeCancel callback before resetting
 		const { shapeSnapshots } = this.snapshot
 
@@ -152,6 +159,8 @@ export class Resizing extends StateNode {
 	}
 
 	private complete() {
+		this.didFinish = true
+
 		kickoutOccludedShapes(this.editor, this.snapshot.selectedShapeIds)
 
 		this.handleResizeEnd()
@@ -543,6 +552,12 @@ export class Resizing extends StateNode {
 		setBatchLabelSizeCache(this.editor, null)
 		if (this.info.isCreating && this.editor.getHintingShapeIds().length > 0) {
 			this.editor.setHintingShapes([])
+		}
+		// Exited mid-creation without complete() or cancel(), e.g. a tool shortcut pressed while
+		// dragging out a text box: the shape created at the drag threshold was never committed and
+		// would otherwise be left behind, empty and invisible (#10401)
+		if (this.info.isCreating && !this.didFinish) {
+			this.editor.bailToMark(this.markId)
 		}
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -43,8 +43,7 @@ export class Resizing extends StateNode {
 	// A switch to detect when the user is holding ctrl
 	private didHoldCommand = false
 
-	// Set once complete() or cancel() has run, so onExit can tell an orderly finish apart from
-	// being exited from outside (e.g. a tool shortcut pressed mid-drag)
+	// Set by complete() and cancel(); see onExit for what happens when neither ran
 	private didFinish = false
 
 	// we transition into the resizing state from the geo pointing state, which starts with a shape of size w: 1, h: 1,


### PR DESCRIPTION
This PR fixes a bug where pressing a tool shortcut (R, D, etc.) while dragging out a fixed-width text box left an empty, invisible text shape on the canvas. Closes #10401.

### Before

The text tool's `Pointing` state creates the text shape as soon as the drag passes the fixed-width threshold and hands off to `select.resizing` with `isCreating: true`. `Resizing` only bailed to its creation mark in `cancel()` (Escape), so when the state was exited from outside by a tool switch, neither `complete()` nor `cancel()` ran and the shape stayed behind. It was never edited, so the empty-text cleanup that runs when editing ends never removed it; it was invisible but brushable and counted toward the shape limit.

### After

`Resizing` tracks whether `complete()` or `cancel()` ran. When a creating resize is exited without either, `onExit` bails to the creation mark, so the pending shape is removed the same way Escape removes it. Normal completion (pointer up) and Escape are unchanged.

### Implementation notes

The fix is in `Resizing` rather than the text tool, as the issue's decision suggests, so it applies to every creating resize. A shape being drag-created with the geo or frame tool is now also removed when a tool shortcut is pressed mid-drag, instead of leaving a partially sized shape behind. A test covers the geo case alongside the text one.

### Change type

- [x] `bugfix`

### Test plan

1. Pick the text tool, drag a wide box, and press R while still dragging.
2. Release, pick the select tool, and brush across the area. On `main` an empty selection box appears; with this PR nothing is selected.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix an invisible empty text shape being left behind when switching tools while dragging out a text box.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +14 / -0   |
| Tests     | +26 / -0   |
