### PR TITLE
fix(tldraw): ignore selection action shortcuts while a pointer gesture is in progress

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1683,8 +1683,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.flatten-to-image',
 				kbd: 'shift+f',
 				onSelect: async (source) => {
+					if (!canApplySelectionAction()) return
 					const ids = editor.getSelectedShapeIds()
-					if (ids.length === 0) return
 
 					editor.markHistoryStoppingPoint('flattening to image')
 					trackEvent('flatten-to-image', { source })

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -136,7 +136,12 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 		}
 
 		function canApplySelectionAction() {
-			return editor.isIn('select') && editor.getSelectedShapeIds().length > 0
+			// Only the idle states count: while a pointer gesture is in progress (translating,
+			// resizing, brushing, cropping, ...) a shortcut would act on the very shapes being
+			// dragged, e.g. delete removes the shape under the pointer and lock stops it
+			// following the drag (#10396).
+			if (!editor.isIn('select.idle') && !editor.isIn('select.crop.idle')) return false
+			return editor.getSelectedShapeIds().length > 0
 		}
 
 		function scaleShapes(scaleFactor: number) {

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -435,4 +435,23 @@ describe('selection action shortcuts during a pointer gesture', () => {
 
 		flipShapes.mockRestore()
 	})
+
+	it('ignores flatten to image while translating', async () => {
+		const { editor } = await setupDraggingShape()
+		// Flatten runs asynchronously and would otherwise delete the dragged shape once its export
+		// resolves. Resolving undefined makes the real flatten a no-op while still showing whether the
+		// export pipeline was entered.
+		const getSvgString = vi.spyOn(editor, 'getSvgString').mockResolvedValue(undefined)
+
+		keydown(editor, { key: 'f', code: 'KeyF', shiftKey: true })
+		await act(async () => {})
+		expect(getSvgString).not.toHaveBeenCalled()
+
+		pointer(editor, 'pointer_up', 150, 150)
+		keydown(editor, { key: 'f', code: 'KeyF', shiftKey: true })
+		await act(async () => {})
+		expect(getSvgString).toHaveBeenCalledTimes(1)
+
+		getSvgString.mockRestore()
+	})
 })

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react'
-import { createShapeId, Editor } from '@tldraw/editor'
+import { Box, createShapeId, Editor } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { Tldraw } from '../../lib/Tldraw'
 import { DefaultKeyboardShortcutsDialogContent } from '../../lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialogContent'
@@ -339,5 +339,100 @@ describe('frame selection shortcut', () => {
 		expect(frame).toBeDefined()
 		expect(editor.getShape(a)?.parentId).toBe(frame!.id)
 		expect(editor.getShape(b)?.parentId).toBe(frame!.id)
+	})
+})
+
+function pointer(
+	editor: Editor,
+	name: 'pointer_down' | 'pointer_move' | 'pointer_up',
+	x: number,
+	y: number
+) {
+	act(() => {
+		editor.dispatch({
+			type: 'pointer',
+			target: 'canvas',
+			name,
+			point: { x, y },
+			pointerId: 1,
+			button: 0,
+			isPen: false,
+			shiftKey: false,
+			altKey: false,
+			ctrlKey: false,
+			metaKey: false,
+			accelKey: false,
+		})
+		editor.emit('tick', 16)
+	})
+}
+
+// Regression tests for #10396: selection action shortcuts (delete, lock, align, ...) used to
+// run in the middle of a pointer gesture, e.g. deleting the very shape being dragged.
+describe('selection action shortcuts during a pointer gesture', () => {
+	async function setupDraggingShape() {
+		const { editor } = await setupFocusedEditor()
+		act(() => {
+			editor.updateViewportScreenBounds(new Box(0, 0, 1000, 800))
+		})
+
+		const id = createShapeId()
+		act(() => {
+			editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+			editor.select(id)
+		})
+
+		// Press on the shape and drag it far enough to start translating.
+		pointer(editor, 'pointer_down', 50, 50)
+		pointer(editor, 'pointer_move', 150, 150)
+		expect(editor.getPath()).toBe('select.translating')
+
+		return { editor, id }
+	}
+
+	it('ignores delete while translating and applies it once the drag has ended', async () => {
+		const { editor, id } = await setupDraggingShape()
+
+		keydown(editor, { key: 'Delete', code: 'Delete' })
+		expect(editor.getShape(id)).toBeDefined()
+		expect(editor.getPath()).toBe('select.translating')
+
+		// The drag keeps following the pointer.
+		pointer(editor, 'pointer_move', 250, 250)
+		expect(editor.getShape(id)).toMatchObject({ x: 200, y: 200 })
+
+		pointer(editor, 'pointer_up', 250, 250)
+		expect(editor.getPath()).toBe('select.idle')
+
+		keydown(editor, { key: 'Delete', code: 'Delete' })
+		expect(editor.getShape(id)).toBeUndefined()
+	})
+
+	it('ignores toggle lock while translating', async () => {
+		const { editor, id } = await setupDraggingShape()
+
+		keydown(editor, { key: 'l', code: 'KeyL', shiftKey: true })
+		expect(editor.getShape(id)!.isLocked).toBe(false)
+
+		pointer(editor, 'pointer_move', 250, 250)
+		expect(editor.getShape(id)).toMatchObject({ x: 200, y: 200 })
+		pointer(editor, 'pointer_up', 250, 250)
+
+		keydown(editor, { key: 'l', code: 'KeyL', shiftKey: true })
+		expect(editor.getShape(id)!.isLocked).toBe(true)
+	})
+
+	it('ignores flip while translating so the drag does not leave a stray undo step', async () => {
+		const { editor } = await setupDraggingShape()
+		const flipShapes = vi.spyOn(editor, 'flipShapes')
+
+		keydown(editor, { key: 'h', code: 'KeyH', shiftKey: true })
+		expect(flipShapes).not.toHaveBeenCalled()
+
+		pointer(editor, 'pointer_up', 150, 150)
+		keydown(editor, { key: 'h', code: 'KeyH', shiftKey: true })
+		expect(flipShapes).toHaveBeenCalledTimes(1)
+
+		flipShapes.mockRestore()
 	})
 })


### PR DESCRIPTION
This PR fixes a bug where selection action shortcuts (Delete, Shift+L, Cmd+G, align, flip, and so on) ran in the middle of a drag, acting on the very shapes being translated, resized, rotated, brushed or cropped. Closes #10396.

### Before

Every selection action in `actions.tsx` is gated on `canApplySelectionAction()`, which only checked `editor.isIn('select')` and a non-empty selection. Any child state of the select tool passed, so pressing Delete while dragging a shape removed it from under the pointer, Shift+L locked it so the drag stopped following, and align/flip applied and were then overwritten by the next pointer move, leaving a stray undo step.

### After

`canApplySelectionAction()` only passes in `select.idle` and `select.crop.idle`. Shortcuts pressed during a pointer gesture are ignored; the same shortcut works as before once the pointer is released.

### Implementation notes

The issue offered two options: gate on the idle states, or complete the gesture first. This takes the gating option as the more conservative one, since it never mutates the drag state while the pointer is still down.

`useCanApplySelectionAction()` in `menu-hooks.ts` (used to enable/disable menu items) is left unchanged. Menus already call `editor.complete()` when they open, so they can't be open mid-gesture and their enabled state doesn't need the extra check.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle, press on it and drag without releasing.
2. Press Delete, Shift+L, Shift+H or Cmd+G mid-drag: nothing happens and the shape keeps following the pointer.
3. Release and press the shortcut again: it applies as usual.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix selection action shortcuts (delete, lock, align, flip, group, ...) firing in the middle of a drag instead of waiting for the gesture to end.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -1    |
| Tests     | +96 / -1   |
