### PR TITLE
fix(editor): reset edge-scroll delay and ramp when the dragging state exits

### DIFF
--- a/apps/docs/content/sdk-features/edge-scrolling.mdx
+++ b/apps/docs/content/sdk-features/edge-scrolling.mdx
@@ -27,7 +27,7 @@ The built-in select tool does this in its Translating (moving shapes), Brushing 
 
 ## Tool integration
 
-To add edge scrolling to a custom tool, call `updateEdgeScrolling()` from the tick handler of the state where dragging happens, and only while the user is dragging:
+To add edge scrolling to a custom tool, call `updateEdgeScrolling()` from the tick handler of the state where dragging happens, and only while the user is dragging. Call [EdgeScrollManager#reset](?) when the state exits so a drag that ends in the edge zone doesn't leave the delay and ramp primed for the next one:
 
 ```typescript
 import { StateNode, TLTickEventInfo } from 'tldraw'
@@ -40,10 +40,14 @@ export class CustomDragState extends StateNode {
 		if (!editor.inputs.getIsDragging() || editor.inputs.getIsPanning()) return
 		editor.edgeScrollManager.updateEdgeScrolling(elapsed)
 	}
+
+	override onExit() {
+		this.editor.edgeScrollManager.reset()
+	}
 }
 ```
 
-[EdgeScrollManager#getIsEdgeScrolling](?) returns true while the pointer is inside the edge zone, including during the start delay, and false once it leaves. Use it to show an indicator in your own UI.
+[EdgeScrollManager#getIsEdgeScrolling](?) returns true while the pointer is inside the edge zone, including during the start delay, and false once it leaves or the state resets the manager. Use it to show an indicator in your own UI.
 
 ## Configuration options
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -870,6 +870,7 @@ export class EdgeScrollManager {
     editor: Editor;
     // (undocumented)
     getIsEdgeScrolling(): boolean;
+    reset(): void;
     updateEdgeScrolling(elapsed: number): void;
 }
 

--- a/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.test.ts
@@ -387,4 +387,32 @@ describe('EdgeScrollManager', () => {
 			expect(editor.setCamera).not.toHaveBeenCalled()
 		})
 	})
+
+	describe('reset', () => {
+		it('clears the scrolling flag', () => {
+			mockInputs.setCurrentScreenPoint(new Vec(5, 300))
+			edgeScrollManager.updateEdgeScrolling(16)
+			expect(edgeScrollManager.getIsEdgeScrolling()).toBe(true)
+
+			edgeScrollManager.reset()
+			expect(edgeScrollManager.getIsEdgeScrolling()).toBe(false)
+		})
+
+		it('makes the next gesture wait for the delay again when it starts in the edge zone', () => {
+			// First gesture ends inside the edge zone, past the delay
+			mockInputs.setCurrentScreenPoint(new Vec(5, 300))
+			edgeScrollManager.updateEdgeScrolling(300)
+			expect(editor.setCamera).toHaveBeenCalled()
+
+			edgeScrollManager.reset()
+			editor.setCamera.mockClear()
+
+			// Next gesture starts in the zone: still inside the delay, so no scroll yet
+			edgeScrollManager.updateEdgeScrolling(16)
+			expect(editor.setCamera).not.toHaveBeenCalled()
+
+			edgeScrollManager.updateEdgeScrolling(200)
+			expect(editor.setCamera).toHaveBeenCalled()
+		})
+	})
 })

--- a/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.ts
+++ b/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.ts
@@ -18,6 +18,19 @@ export class EdgeScrollManager {
 	}
 
 	/**
+	 * Forget the current edge-scroll delay and ramp. Call this when the state that was
+	 * calling {@link EdgeScrollManager.updateEdgeScrolling} exits; otherwise a drag that
+	 * ends inside the edge zone leaves the timer primed, and the next drag that starts
+	 * there scrolls at full speed with no delay or ease-in.
+	 *
+	 * @public
+	 */
+	reset() {
+		this._isEdgeScrolling = false
+		this._edgeScrollDuration = -1
+	}
+
+	/**
 	 * Update the camera position when the mouse is close to the edge of the screen.
 	 * Run this on every tick when in a state where edge scrolling is enabled.
 	 *

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -73,6 +73,7 @@ export class Brushing extends StateNode {
 	override onExit() {
 		this.initialSelectedShapeIds = []
 		this.editor.updateInstanceState({ brush: null })
+		this.editor.edgeScrollManager.reset()
 
 		this.cleanupViewportChangeReactor()
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -540,6 +540,7 @@ export class Resizing extends StateNode {
 		this.parent.setCurrentToolIdMask(undefined)
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 		this.editor.snaps.clearIndicators()
+		this.editor.edgeScrollManager.reset()
 		setBatchLabelSizeCache(this.editor, null)
 		if (this.info.isCreating && this.editor.getHintingShapeIds().length > 0) {
 			this.editor.setHintingShapes([])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -112,6 +112,7 @@ export class Translating extends StateNode {
 		this.editor.snaps.clearIndicators()
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 		this.dragAndDropManager.clear()
+		this.editor.edgeScrollManager.reset()
 	}
 
 	override onTick({ elapsed }: TLTickEventInfo) {

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -200,6 +200,40 @@ describe('When translating...', () => {
 	})
 })
 
+describe('When translating into the edge zone across gestures', () => {
+	beforeEach(() => {
+		editor.dispose()
+		// Default edgeScrollDelay and edgeScrollEaseDuration, unlike the suite above
+		editor = new TestEditor()
+		editor.user.updateUserPreferences({ edgeScrollSpeed: 1 })
+		editor.createShapes([box(ids.box1, 10, 10, 100, 100)])
+	})
+
+	it('waits for the delay again on a drag that starts where the previous one ended', () => {
+		// Drag into the right edge zone and hold until the camera scrolls
+		editor.pointerDown(50, 50, ids.box1).pointerMove(1078, 50)
+		editor.forceTick(20)
+		expect(editor.getCamera().x).toBeLessThan(0)
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.edgeScrollManager.getIsEdgeScrolling()).toBe(false)
+
+		const cameraAfterFirstDrag = editor.getCamera()
+
+		// Start a second drag in the edge zone: one 16ms tick is well inside the 200ms delay
+		editor.pointerDown(1078, 50, ids.box1).pointerMove(1078, 70)
+		editor.expectToBeIn('select.translating')
+		expect(editor.getCamera()).toMatchObject({
+			x: cameraAfterFirstDrag.x,
+			y: cameraAfterFirstDrag.y,
+		})
+
+		// Past the delay the camera scrolls again
+		editor.forceTick(20)
+		expect(editor.getCamera().x).toBeLessThan(cameraAfterFirstDrag.x)
+	})
+})
+
 describe('When cloning...', () => {
 	beforeEach(() => {
 		editor.createShapes([


### PR DESCRIPTION
This PR fixes a bug where a drag that starts in the edge-scroll zone scrolls the camera at full speed immediately, with no start delay or ease-in, if the previous drag ended in that zone. Closes #10399.

### Before

`EdgeScrollManager` keeps `_isEdgeScrolling` and `_edgeScrollDuration` as instance state, and only resets them when a tick sees the pointer outside the edge zone. The select tool's Translating, Resizing, and Brushing states stop ticking the manager as soon as the pointer is released, so a drag that ends inside the zone never produces that resetting tick. The accumulated duration (already past `edgeScrollDelay + edgeScrollEaseDuration`) survives into the next gesture, and its first tick in the zone moves the camera at the full eased speed.

### After

`EdgeScrollManager` has a public `reset()` that clears the flag and the accumulated duration. The Translating, Resizing, and Brushing states call it from `onExit`, so every drag starts with the same delay and ramp regardless of where the last one ended. `getIsEdgeScrolling()` also returns `false` once the drag ends rather than staying `true` until the next gesture leaves the zone.

The edge scrolling docs now tell custom tools to call `reset()` from their drag state's `onExit`.

### Implementation notes

The issue's decision was to reset the manager when the ticking state exits, so the reset is explicit at the call sites rather than inferred by the manager from pointer events. Custom tools that tick the manager need to add the `onExit` call to get the fix; the docs example covers that.

### Change type

- [x] `bugfix`

### API changes

- Added `EdgeScrollManager.reset()` to clear the edge-scroll delay and ramp when a dragging state exits

### Test plan

1. Draw a rectangle.
2. Drag it into the right edge until the camera scrolls, and release there.
3. Press on it again and drag along the edge: the camera should wait for the usual delay and ease in, instead of scrolling at once.

- [x] Unit tests — the new `translating.test.ts` case fails on `main` (camera moves on the second drag's first tick) and passes with this change

### Release notes

- Fix edge scrolling starting at full speed with no delay when a drag begins where the previous drag ended in the edge zone

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +16 / -0   |
| Tests           | +62 / -0   |
| Automated files | +1 / -0    |
| Documentation   | +6 / -2    |
