### PR TITLE
fix(tldraw): remove the new note and stay in select when cancelling a clone handle drag

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -230,6 +230,34 @@ it('Creates an adjacent note when dragging the clone handle', () => {
 	editor.expectToBeIn('select.editing_shape')
 })
 
+it('Removes the new note and stays in the select tool when cancelling a clone handle drag', () => {
+	editor.createShape({ type: 'note', x: 1000, y: 1000 })
+	const shape = editor.getLastCreatedShape()!
+	const handle = editor.getShapeHandles(shape.id)![1]
+
+	editor
+		.select(shape.id)
+		.pointerDown(handle.x, handle.y, {
+			target: 'handle',
+			shape,
+			handle,
+		})
+		.expectToBeIn('select.pointing_handle')
+		.pointerMove(handle.x + 30, handle.y + 30)
+		.forceTick()
+		.expectToBeIn('select.translating')
+
+	const newShape = editor.getLastCreatedShape()
+	expect(newShape.id).not.toBe(shape.id)
+
+	editor.cancel()
+
+	expect(editor.getShape(newShape.id)).toBeUndefined()
+	expect(editor.getCurrentPageShapeIds()).toEqual(new Set([shape.id]))
+	expect(editor.getCurrentToolId()).toBe('select')
+	editor.expectToBeIn('select.idle')
+})
+
 describe('Clone handles and attribution', () => {
 	function createNoteWithAttribution() {
 		editor.createShape({ type: 'note', x: 1000, y: 1000 })

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -121,6 +121,8 @@ export class PointingHandle extends StateNode {
 			const noteUtil = editor.getShapeUtil(shape) as NoteShapeUtil
 			const dv = getDisplayValues(noteUtil, shape)
 
+			// Translating bails to this mark on cancel; without it, Escape mid-drag leaves the new note behind
+			const markId = editor.markHistoryStoppingPoint('creating note from clone handle')
 			const nextNote = getNoteForAdjacentPosition(editor, shape, handle, true)
 			if (nextNote) {
 				// Center the shape on the current pointer
@@ -142,8 +144,8 @@ export class PointingHandle extends StateNode {
 						...this.info,
 						target: 'shape',
 						shape: editor.getShape(nextNote),
-						onInteractionEnd: 'note',
 						isCreating: true,
+						creatingMarkId: markId,
 						onCreate: () => {
 							// When we're done, start editing it
 							startEditingShapeWithRichText(editor, nextNote, { selectAll: true })


### PR DESCRIPTION
This PR fixes a bug where pressing Escape while dragging a new note out of a selected note's clone handle left the new note on the canvas and switched the current tool to the note tool. Closes #10403.

### Before

`PointingHandle.startDraggingHandle` entered `select.translating` with `isCreating: true` and `onInteractionEnd: 'note'` but no `creatingMarkId`. `Translating.onEnter` then fell back to looking for a legacy `creating:<shapeId>` mark, which the note helper never creates (it marks `'creating note shape'`), so `markId` stayed empty, `cancel()` bailed to nothing, and `onInteractionEnd` sent the user to the note tool.

### After

`PointingHandle` places a history mark before creating the adjacent note and passes it as `creatingMarkId`, so Escape bails to that mark and removes the new note. The `onInteractionEnd: 'note'` is dropped for the clone handle path, so both cancel and complete stay in the select tool, which is where the drag started.

### Change type

- [x] `bugfix`

### Test plan

1. Create a note, switch to the select tool and select it.
2. Drag one of its clone handles, then press Escape mid-drag.
3. The new note disappears and the select tool is still current.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix Escape during a note clone handle drag leaving the new note behind and switching to the note tool.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |
| Tests     | +28 / -0   |
