### PR TITLE
fix(arrows): remove the pressed arrow when switching tools before dragging

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
@@ -88,6 +88,23 @@ describe('When in the pointing state', () => {
 		editor.setCurrentTool('arrow').pointerDown(0, 0).pointerMove(10, 10)
 		editor.expectToBeIn('select.dragging_handle')
 	})
+
+	it('removes the pressed arrow when switching tools before dragging', () => {
+		const shapesBefore = editor.getCurrentPageShapes().length
+		editor.setCurrentTool('arrow').pointerDown(0, 0)
+		expect(editor.getCurrentPageShapes().length).toBe(shapesBefore + 1)
+		editor.setCurrentTool('geo')
+		expect(editor.getCurrentPageShapes().length).toBe(shapesBefore)
+		editor.expectToBeIn('geo.idle')
+	})
+
+	it('removes the pressed arrow when switching to the select tool before dragging', () => {
+		const shapesBefore = editor.getCurrentPageShapes().length
+		editor.setCurrentTool('arrow').pointerDown(0, 0)
+		editor.setCurrentTool('select')
+		expect(editor.getCurrentPageShapes().length).toBe(shapesBefore)
+		editor.expectToBeIn('select.idle')
+	})
 })
 
 // This could be moved to dragging_handle

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -37,7 +37,12 @@ export class Pointing extends StateNode {
 	}
 
 	override onExit() {
-		this.shape = undefined
+		// The press already created the arrow, so leaving without a drag (pointer up, cancel, or a
+		// tool switch) would otherwise strand a zero-length stub on the canvas
+		if (this.shape) {
+			this.editor.bailToMark(this.markId)
+			this.shape = undefined
+		}
 		clearArrowTargetState(this.editor)
 		this.clearPreciseTimeout()
 	}
@@ -55,8 +60,11 @@ export class Pointing extends StateNode {
 
 			this.updateArrowShapeEndHandle()
 
+			// Hand the arrow off before exiting so onExit does not bail it away
+			const shape = this.shape
+			this.shape = undefined
 			this.editor.setCurrentTool('select.dragging_handle', {
-				shape: this.shape,
+				shape,
 				handle: { id: 'end', type: 'vertex', index: 'a3', x: 0, y: 0 },
 				isCreating: true,
 				creatingMarkId: this.markId || undefined,
@@ -87,10 +95,6 @@ export class Pointing extends StateNode {
 	}
 
 	cancel() {
-		if (this.shape) {
-			// the arrow might not have been created yet!
-			this.editor.bailToMark(this.markId)
-		}
 		this.parent.transition('idle')
 	}
 


### PR DESCRIPTION
This PR fixes a bug where pressing on empty canvas with the arrow tool and then switching tools (for example pressing `R`) before moving left a tiny stub arrow on the canvas. Closes #10402.

### Before

`arrow.pointing`'s `onEnter` creates the arrow shape immediately when there is nothing under the pointer, and relied on `cancel()` to bail to the creation mark on pointer up, cancel, complete, or interrupt. A tool switch exits the state through `onExit` without going through `cancel()`, so the mark was never bailed to and the zero-length arrow stayed on the page.

### After

`onExit` bails to the creation mark whenever the state still owns an uncommitted arrow, so every way out of `pointing` without a drag leaves nothing behind. `cancel()` now just transitions to `idle`. The one exit that should keep the arrow, the hand-off to `select.dragging_handle` on drag, clears the state's reference to the shape before switching so `onExit` does not bail it away.

### Change type

- [x] `bugfix`

### Test plan

1. Pick the arrow tool.
2. Press on empty canvas and, without moving, press `R` (or click another tool).
3. Release and zoom in at the press point: there is no stub arrow.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix a stub arrow being left on the canvas when switching tools during an arrow press.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +10 / -6   |
| Tests     | +17 / -0   |
