### PR TITLE
fix(tldraw): make escape mid-crop-drag revert only that drag

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/Crop.ts
@@ -28,6 +28,10 @@ export class Crop extends StateNode {
 		}
 	}
 	override onCancel() {
+		// Parents handle events before children, so a cancel during a child's drag would unwind
+		// the whole session here before the child bails to its own mark. Only idle's escape ends
+		// the session; mid-drag children revert just their own change and return to idle.
+		if (this.getCurrent()?.id !== 'idle') return
 		if (!this.didExit) {
 			this.didExit = true
 			this.editor.bailToMark(this.markId)

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -595,6 +595,74 @@ describe('When in the select.crop.translating_crop state', () => {
 		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
 	})
 
+	it('pressing escape mid-drag reverts only that drag, not earlier crops in the session', () => {
+		const original = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(500, 600, { target: 'selection', handle: 'bottom', ctrlKey: false })
+			.pointerMove(510, 590)
+			.expectToBeIn('select.crop.cropping')
+			.pointerUp()
+			.expectToBeIn('select.crop.idle')
+
+		const afterFirstCrop = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(afterFirstCrop).not.toMatchObject(original)
+
+		editor
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.pointerMove(250, 250)
+			.expectToBeIn('select.crop.translating_crop')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).not.toMatchObject(afterFirstCrop)
+
+		editor.cancel().expectToBeIn('select.crop.idle')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(afterFirstCrop)
+
+		// The session is still open: escaping from idle reverts everything since crop mode began
+		editor.cancel().expectToBeIn('select.idle')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(original)
+	})
+
+	it('pressing escape mid-drag keeps the session squashing into one undo step on exit', () => {
+		const original = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(500, 600, { target: 'selection', handle: 'bottom', ctrlKey: false })
+			.pointerMove(510, 590)
+			.pointerUp()
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.pointerMove(250, 250)
+			.expectToBeIn('select.crop.translating_crop')
+			.cancel()
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.pointerMove(300, 300)
+			.pointerUp()
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(550, 550, { target: 'shape', shape: editor.getShape(ids.imageB) })
+			.pointerMove(500, 500)
+			.pointerUp()
+			.expectToBeIn('select.crop.idle')
+
+		const afterSession = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(afterSession).not.toMatchObject(original)
+
+		editor.keyDown('Enter').keyUp('Enter').expectToBeIn('select.idle')
+
+		editor.undo()
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(original)
+		editor.redo()
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(afterSession)
+	})
+
 	it('pressing enter / pointer up / complete should transition to select.crop.idle', () => {
 		const before = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
 
@@ -726,6 +794,35 @@ describe('When in the select.crop.cropping state', () => {
 			.expectToBeIn('select.crop.idle')
 
 		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(before)
+	})
+
+	it('escape / cancel mid-drag reverts only that drag, not earlier crops in the session', () => {
+		const original = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+
+		editor
+			.cancel()
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(500, 600, { target: 'selection', handle: 'bottom', ctrlKey: false })
+			.pointerMove(510, 590)
+			.expectToBeIn('select.crop.cropping')
+			.pointerUp()
+			.expectToBeIn('select.crop.idle')
+
+		const afterFirstCrop = editor.getShape<TLImageShape>(ids.imageB)!.props.crop!
+		expect(afterFirstCrop).not.toMatchObject(original)
+
+		editor
+			.pointerDown(700, 550, { target: 'selection', handle: 'right', ctrlKey: false })
+			.pointerMove(650, 550)
+			.expectToBeIn('select.crop.cropping')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).not.toMatchObject(afterFirstCrop)
+
+		editor.cancel().expectToBeIn('select.crop.idle')
+
+		expect(editor.getShape<TLImageShape>(ids.imageB)!.props.crop!).toMatchObject(afterFirstCrop)
 	})
 
 	it('pointer up / complete should commit the change and transition to crop.idle when that is the history state', () => {


### PR DESCRIPTION
This PR fixes a bug where pressing Escape during a crop handle drag or picture drag reverted every change made since crop mode began, instead of only the drag in progress. Closes #10404.

### Before

`Crop.onCancel` bailed to the session-level history mark and set `didExit` on any cancel event. Because `StateNode.handleEvent` runs the parent's handler before the child's, a cancel while in `select.crop.cropping` or `select.crop.translating_crop` unwound the whole session before the child bailed to its own (now meaningless) mark. After a picture drag the user stayed in crop mode with the session's stopping point already consumed, so a later Escape from idle no longer reverted anything and the session was no longer squashed into a single undo step on exit.

### After

`Crop.onCancel` only bails to the session mark when the current child is `idle`. Mid-drag cancels are left to `Cropping` and `TranslatingCrop`, which revert just their own change and return to `select.crop.idle`. The session stays open afterwards: Escape from idle still reverts everything since crop mode began, and Enter or clicking away still squashes the session into one undo step.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the three new tests in `cropping.test.ts` fail on `main` and pass with this change

1. Add an image and double-click it to enter crop mode.
2. Drag a corner handle in and release.
3. Start dragging the picture and press Escape mid-drag: only the picture drag is reverted, and the first crop is kept.
4. Press Escape again from idle: the whole session is reverted.

### Release notes

- Fix Escape during a crop drag reverting the whole crop session instead of only the drag in progress.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -0    |
| Tests     | +97 / -0   |
