### PR TITLE
fix(tldraw): keep image selected when Escape leaves crop mode

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -189,15 +189,20 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
-			if (isManipulating) {
-				if (e.key === 'Escape') {
-					editor.cancel()
-					onManipulatingEnd()
-				} else if (e.key === 'Enter') {
-					editor.complete()
-					onManipulatingEnd()
-				}
+			if (!isManipulating) return
+			if (e.key === 'Escape') {
+				editor.cancel()
+			} else if (e.key === 'Enter') {
+				editor.complete()
+			} else {
+				return
 			}
+			onManipulatingEnd()
+			// Otherwise the keydown bubbles to the container's handler, which cancels again
+			// against select.idle and clears the selection (#10405). Leaving crop mode also
+			// unmounts the slider, so refocus the container to keep shortcuts working.
+			e.stopPropagation()
+			editor.getContainer().focus()
 		}
 		const elm = sliderRef.current
 		if (elm) {

--- a/packages/tldraw/src/test/ui/ImageToolbar.test.tsx
+++ b/packages/tldraw/src/test/ui/ImageToolbar.test.tsx
@@ -1,0 +1,58 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+import { createShapeId, Editor, TLImageShape } from '@tldraw/editor'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+let editor: Editor
+const imageId = createShapeId('image') as TLImageShape['id']
+
+beforeEach(async () => {
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+
+	act(() => {
+		editor.createShapes([{ id: imageId, type: 'image', x: 0, y: 0, props: { w: 100, h: 100 } }])
+		editor.select(imageId)
+	})
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+async function enterCropMode() {
+	act(() => {
+		editor.setCroppingShape(imageId)
+		editor.setCurrentTool('select.crop.idle')
+	})
+	const slider = await screen.findByTestId('tool.image-zoom')
+	return slider.querySelector('.tlui-slider__thumb') as HTMLElement
+}
+
+describe('Image toolbar in crop mode', () => {
+	it('keeps the image selected when Escape is pressed on the zoom slider', async () => {
+		const thumb = await enterCropMode()
+
+		act(() => {
+			fireEvent.keyDown(thumb, { key: 'Escape' })
+		})
+
+		expect(editor.getCroppingShapeId()).toBe(null)
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.getSelectedShapeIds()).toEqual([imageId])
+	})
+
+	it('keeps the image selected when Enter is pressed on the zoom slider', async () => {
+		const thumb = await enterCropMode()
+
+		act(() => {
+			fireEvent.keyDown(thumb, { key: 'Enter' })
+		})
+
+		expect(editor.getCroppingShapeId()).toBe(null)
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.getSelectedShapeIds()).toEqual([imageId])
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where pressing Escape to leave image crop mode also deselected the image. Closes #10405.

### Before

Entering crop mode focuses the image toolbar's zoom slider. The slider's own `keydown` listener in `DefaultImageToolbarContent` handled Escape with `editor.cancel()` (crop idle → `select.idle`), but let the event keep bubbling. The container's keydown handler in `useDocumentEvents` then ran `editor.cancel()` a second time, now against `select.idle`, whose `onCancel` calls `selectNone()`. The `inputs.keys.has('Escape')` guard didn't help because the slider handler never touched `inputs.keys`. Enter had the same double-handling: the bubbled key_down reached `select.idle` after the slider had already completed the crop.

### After

The slider handler stops propagation once it has consumed Escape or Enter, so the container handler never sees the keypress. Escape now leaves crop mode and keeps the image selected, matching a click outside the crop. Because leaving crop mode unmounts the focused slider, the handler also refocuses the editor container, which is what the container's Escape handler used to do before the event was swallowed.

### Change type

- [x] `bugfix`

### Test plan

1. Add an image, double-click it to enter crop mode.
2. Press Escape. The image should leave crop mode and remain selected.
3. Re-enter crop mode and press Enter. Same result.

- [x] Unit tests — the new Escape test fails on `main` and passes with this change

### Release notes

- Fix Escape in image crop mode clearing the selection.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -8   |
| Tests     | +58 / -0   |
