### PR TITLE
fix(editor): end the active interaction when the browser cancels a pointer

### DIFF
--- a/apps/examples/e2e/tests/test-pointer-cancel.spec.ts
+++ b/apps/examples/e2e/tests/test-pointer-cancel.spec.ts
@@ -1,0 +1,147 @@
+import { CDPSession, expect, Page } from '@playwright/test'
+import { Editor } from 'tldraw'
+import test from '../fixtures/fixtures'
+import { setupOrReset } from '../shared-e2e'
+
+declare const editor: Editor
+
+/*
+ * Playwright's input APIs can't produce a `pointercancel`, so these tests drive
+ * Chrome directly: a `touchCancel` through CDP makes the browser generate the
+ * pointercancel itself, which is the path a system-interrupted touch takes (an
+ * edge swipe, an incoming call). Checked against iPadOS Safari, which emits
+ * `pointercancel` with `pointerType: 'touch'` and `button: -1` for those
+ * gestures, and none at all for a rejected palm.
+ */
+
+type TouchEventType = 'touchStart' | 'touchEnd' | 'touchMove' | 'touchCancel'
+type MouseEventType = 'mousePressed' | 'mouseReleased' | 'mouseMoved'
+
+async function startTouchSession(page: Page): Promise<CDPSession> {
+	const cdp = await page.context().newCDPSession(page)
+	// The desktop project has no touch points of its own.
+	await cdp.send('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 5 })
+	return cdp
+}
+
+function touch(cdp: CDPSession, type: TouchEventType, points: [number, number][] = []) {
+	return cdp.send('Input.dispatchTouchEvent', {
+		type,
+		touchPoints: points.map(([x, y], i) => ({ x, y, id: i })),
+	})
+}
+
+function pen(cdp: CDPSession, type: MouseEventType, x: number, y: number) {
+	return cdp.send('Input.dispatchMouseEvent', {
+		type,
+		x,
+		y,
+		button: 'left',
+		buttons: type === 'mouseReleased' ? 0 : 1,
+		clickCount: 1,
+		pointerType: 'pen',
+		force: 0.5,
+	})
+}
+
+const getState = (page: Page) =>
+	page.evaluate(() => ({
+		path: editor.getPath(),
+		isPointing: editor.inputs.getIsPointing(),
+		buttons: [...editor.inputs.buttons],
+	}))
+
+test.describe('Cancelled pointers', () => {
+	test.beforeEach(setupOrReset)
+
+	test('ends a select drag', async ({ page }) => {
+		const cdp = await startTouchSession(page)
+		await page.evaluate(() => editor.setCurrentTool('select'))
+
+		await touch(cdp, 'touchStart', [[200, 300]])
+		await touch(cdp, 'touchMove', [[340, 420]])
+		expect(await getState(page)).toMatchObject({ path: 'select.brushing', isPointing: true })
+
+		await touch(cdp, 'touchCancel')
+
+		// The button comes from the pointerdown: pointercancel reports -1, which would
+		// otherwise stay stuck in inputs.buttons.
+		expect(await getState(page)).toEqual({
+			path: 'select.idle',
+			isPointing: false,
+			buttons: [],
+		})
+	})
+
+	test('ends a draw stroke', async ({ page }) => {
+		const cdp = await startTouchSession(page)
+		await page.evaluate(() => editor.setCurrentTool('draw'))
+
+		await touch(cdp, 'touchStart', [[300, 300]])
+		await touch(cdp, 'touchMove', [[380, 400]])
+		expect(await getState(page)).toMatchObject({ path: 'draw.drawing', isPointing: true })
+
+		await touch(cdp, 'touchCancel')
+
+		expect(await getState(page)).toMatchObject({ path: 'draw.idle', isPointing: false })
+	})
+
+	test('lets the next touch start a fresh stroke rather than continuing the old one', async ({
+		page,
+	}) => {
+		const cdp = await startTouchSession(page)
+		await page.evaluate(() => editor.setCurrentTool('draw'))
+
+		await touch(cdp, 'touchStart', [[200, 300]])
+		await touch(cdp, 'touchMove', [[260, 360]])
+		await touch(cdp, 'touchCancel')
+
+		await touch(cdp, 'touchStart', [[600, 500]])
+		await touch(cdp, 'touchMove', [[660, 560]])
+		await touch(cdp, 'touchEnd')
+
+		// A draw tool left in its drawing state extends the cancelled shape instead of
+		// starting a new one, so the two gestures come back as a single stroke.
+		expect(await page.evaluate(() => editor.getCurrentPageShapes().length)).toBe(2)
+	})
+
+	/**
+	 * iPadOS rejects a resting palm before it reaches the page, so these two never
+	 * fire in practice on a real device. They pin the guards that keep a cancelled
+	 * touch from ending the pen's own interaction if one ever does arrive.
+	 */
+	test.describe('in pen mode', () => {
+		test('a cancelled palm landing after the pen leaves the stroke alone', async ({ page }) => {
+			const cdp = await startTouchSession(page)
+			await page.evaluate(() => {
+				editor.updateInstanceState({ isPenMode: true })
+				editor.setCurrentTool('draw')
+			})
+
+			await pen(cdp, 'mousePressed', 300, 300)
+			await pen(cdp, 'mouseMoved', 380, 400)
+
+			await touch(cdp, 'touchStart', [[700, 800]])
+			await touch(cdp, 'touchCancel')
+
+			expect(await getState(page)).toMatchObject({ path: 'draw.drawing', isPointing: true })
+		})
+
+		test('a cancelled palm landing before the pen leaves the stroke alone', async ({ page }) => {
+			const cdp = await startTouchSession(page)
+			await page.evaluate(() => {
+				editor.updateInstanceState({ isPenMode: false })
+				editor.setCurrentTool('draw')
+			})
+
+			// The palm is accepted while pen mode is still off, so its button is recorded;
+			// the pen then turns pen mode on before the palm is cancelled.
+			await touch(cdp, 'touchStart', [[700, 800]])
+			await pen(cdp, 'mousePressed', 300, 300)
+			await pen(cdp, 'mouseMoved', 380, 400)
+			await touch(cdp, 'touchCancel')
+
+			expect(await getState(page)).toMatchObject({ path: 'draw.drawing', isPointing: true })
+		})
+	})
+})

--- a/apps/examples/e2e/tests/test-pointer-cancel.spec.ts
+++ b/apps/examples/e2e/tests/test-pointer-cancel.spec.ts
@@ -96,8 +96,8 @@ test.describe('Cancelled pointers', () => {
 		await touch(cdp, 'touchMove', [[260, 360]])
 		await touch(cdp, 'touchCancel')
 
-		await touch(cdp, 'touchStart', [[600, 500]])
-		await touch(cdp, 'touchMove', [[660, 560]])
+		await touch(cdp, 'touchStart', [[160, 480]])
+		await touch(cdp, 'touchMove', [[220, 540]])
 		await touch(cdp, 'touchEnd')
 
 		// A draw tool left in its drawing state extends the cancelled shape instead of
@@ -121,7 +121,7 @@ test.describe('Cancelled pointers', () => {
 			await pen(cdp, 'mousePressed', 300, 300)
 			await pen(cdp, 'mouseMoved', 380, 400)
 
-			await touch(cdp, 'touchStart', [[700, 800]])
+			await touch(cdp, 'touchStart', [[160, 500]])
 			await touch(cdp, 'touchCancel')
 
 			expect(await getState(page)).toMatchObject({ path: 'draw.drawing', isPointing: true })
@@ -135,10 +135,14 @@ test.describe('Cancelled pointers', () => {
 			})
 
 			// The palm is accepted while pen mode is still off, so its button is recorded;
-			// the pen then turns pen mode on before the palm is cancelled.
-			await touch(cdp, 'touchStart', [[700, 800]])
+			// the pen then turns pen mode on before the palm is cancelled. The pen press
+			// only auto-enables pen mode on a touch device (isDirectDisplayPen reads
+			// tlenv.isTouchDevice, fixed at load), and the desktop project enables touch
+			// through CDP after the page has loaded, so set it here instead.
+			await touch(cdp, 'touchStart', [[160, 500]])
 			await pen(cdp, 'mousePressed', 300, 300)
 			await pen(cdp, 'mouseMoved', 380, 400)
+			await page.evaluate(() => editor.updateInstanceState({ isPenMode: true }))
 			await touch(cdp, 'touchCancel')
 
 			expect(await getState(page)).toMatchObject({ path: 'draw.drawing', isPointing: true })

--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -189,6 +189,45 @@ export function MenuClickCapture() {
 		[editor]
 	)
 
+	const handlePointerCancel = useCallback(
+		(e: PointerEvent) => {
+			const state = rPointerState.current
+			if (!state.isDown) {
+				// A right-click press was forwarded to the canvas, so let the canvas
+				// handler end it.
+				canvasEvents.onPointerCancel?.(e)
+				return
+			}
+
+			// The canvas's own cancel handler doesn't know about this element's pointer
+			// state, so without this the overlay stays mounted over the canvas and
+			// swallows the next interaction after the browser cancels a press.
+			if (editor.inputs.getIsPointing()) {
+				editor.interrupt()
+				editor.dispatch({
+					type: 'pointer',
+					target: 'canvas',
+					name: 'pointer_up',
+					...getPointerInfo(editor, e),
+					// pointercancel reports button -1
+					button: state.button,
+				})
+			} else {
+				editor.markEventAsHandled(e)
+			}
+
+			releasePointerCapture(e.currentTarget, e)
+			setIsPointing(false)
+			rPointerState.current = {
+				isDown: false,
+				isDragging: false,
+				button: 0,
+				start: new Vec(e.clientX, e.clientY),
+			}
+		},
+		[canvasEvents, editor]
+	)
+
 	return (
 		showElement && (
 			<div
@@ -198,6 +237,7 @@ export function MenuClickCapture() {
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}
+				onPointerCancel={handlePointerCancel}
 				onContextMenu={(e) => {
 					e.preventDefault()
 					e.stopPropagation()

--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -29,6 +29,7 @@ export function MenuClickCapture() {
 		isDown: false,
 		isDragging: false,
 		button: 0,
+		pointerId: -1,
 		start: new Vec(),
 	})
 
@@ -69,6 +70,11 @@ export function MenuClickCapture() {
 
 	const handlePointerDown = useCallback(
 		(e: PointerEvent) => {
+			// This overlay tracks a single press. A second pointer landing while one is active —
+			// a palm resting on the glass beside a pen — must not take over the gesture, or its
+			// own cancel would end the press it stole.
+			if (rPointerState.current.isDown) return
+
 			const button = getPointerEventButton(e)
 			if (button !== 0 && button !== 2) return
 
@@ -94,6 +100,7 @@ export function MenuClickCapture() {
 				isDown: true,
 				isDragging: false,
 				button,
+				pointerId: e.pointerId,
 				start: new Vec(e.clientX, e.clientY),
 			}
 
@@ -111,7 +118,7 @@ export function MenuClickCapture() {
 	const handlePointerMove = useCallback(
 		(e: PointerEvent) => {
 			const state = rPointerState.current
-			if (!state.isDown) return
+			if (!state.isDown || state.pointerId !== e.pointerId) return
 
 			// Left-click: wait for the drag threshold before forwarding anything, then
 			// replay pointerdown at the original start so the editor records the
@@ -144,15 +151,17 @@ export function MenuClickCapture() {
 
 	const handlePointerUp = useCallback(
 		(e: PointerEvent) => {
-			const isStaticRightClick =
-				rPointerState.current.button === 2 && !rPointerState.current.isDragging
+			const state = rPointerState.current
+			if (!state.isDown || state.pointerId !== e.pointerId) return
+
+			const isStaticRightClick = state.button === 2 && !state.isDragging
 
 			editor.dispatch({
 				type: 'pointer',
 				target: 'canvas',
 				name: 'pointer_up',
 				...getPointerInfo(editor, e),
-				button: rPointerState.current.button === 2 ? 2 : getPointerEventButton(e),
+				button: state.button === 2 ? 2 : getPointerEventButton(e),
 			})
 
 			if (isStaticRightClick && editor.options.rightClickPanning) {
@@ -183,6 +192,7 @@ export function MenuClickCapture() {
 				isDown: false,
 				isDragging: false,
 				button: 0,
+				pointerId: -1,
 				start: new Vec(e.clientX, e.clientY),
 			}
 		},
@@ -192,9 +202,9 @@ export function MenuClickCapture() {
 	const handlePointerCancel = useCallback(
 		(e: PointerEvent) => {
 			const state = rPointerState.current
-			if (!state.isDown) {
-				// A right-click press was forwarded to the canvas, so let the canvas
-				// handler end it.
+			if (!state.isDown || state.pointerId !== e.pointerId) {
+				// Either a right-click press that was forwarded to the canvas, or a pointer this
+				// overlay never tracked. Neither is ours to end, so let the canvas handler decide.
 				canvasEvents.onPointerCancel?.(e)
 				return
 			}
@@ -222,6 +232,7 @@ export function MenuClickCapture() {
 				isDown: false,
 				isDragging: false,
 				button: 0,
+				pointerId: -1,
 				start: new Vec(e.clientX, e.clientY),
 			}
 		},

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -19,13 +19,14 @@ export function useCanvasEvents() {
 	const events = useMemo(
 		function canvasEvents() {
 			let isSecondaryClickPointerDown = false
-			let pointerDownButton = 0
+			// The button each accepted press started with, by pointer id. pointercancel
+			// reports button -1, so the synthetic pointer_up needs the original.
+			const pointerDownButtons = new Map<number, number>()
 
 			function onPointerDown(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				const button = getPointerEventButton(e)
 				isSecondaryClickPointerDown = button === 2
-				pointerDownButton = button
 
 				// With right-click panning disabled, fire right_click on press and let the
 				// native contextmenu through so the menu opens at the pointer-down location.
@@ -47,6 +48,15 @@ export function useCanvasEvents() {
 
 				setPointerCapture(e.currentTarget, e)
 
+				// Only remember presses the editor will act on. A rejected palm in pen mode
+				// must not overwrite the button of the pen press it lands on top of, or the
+				// pen's pointercancel would release the wrong button and skip the
+				// stylus-eraser tool restore.
+				const isPenMode = editor.getInstanceState().isPenMode
+				if (!editor.inputs.getIsPinching() && !(isPenMode && e.pointerType !== 'pen')) {
+					pointerDownButtons.set(e.pointerId, button)
+				}
+
 				editor.dispatch({
 					type: 'pointer',
 					target: 'canvas',
@@ -58,6 +68,7 @@ export function useCanvasEvents() {
 
 			function onPointerUp(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
+				pointerDownButtons.delete(e.pointerId)
 				const button = isSecondaryClickPointerDown ? 2 : getPointerEventButton(e)
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
@@ -95,14 +106,17 @@ export function useCanvasEvents() {
 
 			function onPointerCancel(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
+				const pointerDownButton = pointerDownButtons.get(e.pointerId)
+				pointerDownButtons.delete(e.pointerId)
 				// In pen mode a cancelled touch is usually a rejected palm, and the pen's own
 				// interaction must survive it.
 				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
 
 				releasePointerCapture(e.currentTarget, e)
 
-				// Nothing to end if the press itself was filtered out (pen mode, unsupported button).
-				if (!editor.inputs.getIsPointing()) return
+				// Nothing to end if the press itself was filtered out (pen mode, unsupported
+				// button), or if this pointer never started an accepted press.
+				if (!editor.inputs.getIsPointing() || pointerDownButton === undefined) return
 
 				// The browser has taken the pointer (edge swipe, incoming call) and will never send
 				// pointerup, so end the gesture here or the tool stays stuck in its pointing or
@@ -113,8 +127,6 @@ export function useCanvasEvents() {
 					target: 'canvas',
 					name: 'pointer_up',
 					...getPointerInfo(editor, e),
-					// pointercancel reports button -1, which would leave the pressed button
-					// stuck in inputs.buttons
 					button: pointerDownButton,
 				})
 				isSecondaryClickPointerDown = false

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -19,11 +19,13 @@ export function useCanvasEvents() {
 	const events = useMemo(
 		function canvasEvents() {
 			let isSecondaryClickPointerDown = false
+			let pointerDownButton = 0
 
 			function onPointerDown(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				const button = getPointerEventButton(e)
 				isSecondaryClickPointerDown = button === 2
+				pointerDownButton = button
 
 				// With right-click panning disabled, fire right_click on press and let the
 				// native contextmenu through so the menu opens at the pointer-down location.
@@ -88,6 +90,33 @@ export function useCanvasEvents() {
 					})
 					e.currentTarget.dispatchEvent(contextMenuEvent)
 				}
+				isSecondaryClickPointerDown = false
+			}
+
+			function onPointerCancel(e: React.PointerEvent) {
+				if (editor.wasEventAlreadyHandled(e)) return
+				// In pen mode a cancelled touch is usually a rejected palm, and the pen's own
+				// interaction must survive it.
+				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
+
+				releasePointerCapture(e.currentTarget, e)
+
+				// Nothing to end if the press itself was filtered out (pen mode, unsupported button).
+				if (!editor.inputs.getIsPointing()) return
+
+				// The browser has taken the pointer (edge swipe, incoming call) and will never send
+				// pointerup, so end the gesture here or the tool stays stuck in its pointing or
+				// dragging state and the next touch continues it.
+				editor.interrupt()
+				editor.dispatch({
+					type: 'pointer',
+					target: 'canvas',
+					name: 'pointer_up',
+					...getPointerInfo(editor, e),
+					// pointercancel reports button -1, which would leave the pressed button
+					// stuck in inputs.buttons
+					button: pointerDownButton,
+				})
 				isSecondaryClickPointerDown = false
 			}
 
@@ -201,6 +230,7 @@ export function useCanvasEvents() {
 			return {
 				onPointerDown,
 				onPointerUp,
+				onPointerCancel,
 				onPointerEnter,
 				onPointerLeave,
 				onDragOver,

--- a/packages/tldraw/src/test/pointercancel-dom.test.tsx
+++ b/packages/tldraw/src/test/pointercancel-dom.test.tsx
@@ -33,11 +33,17 @@ const ids = {
 	a: createShapeId('a'),
 }
 
+interface PointerOpts {
+	pointerId?: number
+	pointerType?: string
+	button?: number
+}
+
 function pointerEvent(
 	type: 'pointerdown' | 'pointermove' | 'pointercancel',
 	clientX: number,
 	clientY: number,
-	{ pointerId = 1, pointerType = 'touch' } = {}
+	{ pointerId = 1, pointerType = 'touch', button = 0 }: PointerOpts = {}
 ) {
 	const e = new (globalThis as any).PointerEvent(type, {
 		bubbles: true,
@@ -45,7 +51,7 @@ function pointerEvent(
 		clientX,
 		clientY,
 		// pointercancel never reports a pressed button
-		button: type === 'pointercancel' ? -1 : 0,
+		button: type === 'pointercancel' ? -1 : button,
 		pointerId,
 		pointerType,
 		isPrimary: pointerId === 1,
@@ -69,32 +75,20 @@ async function setupScene() {
 		])
 	})
 
-	async function pointerDown(
-		x: number,
-		y: number,
-		opts?: { pointerId?: number; pointerType?: string }
-	) {
+	async function pointerDown(x: number, y: number, opts?: PointerOpts) {
 		await act(async () => {
 			canvas.dispatchEvent(pointerEvent('pointerdown', x, y, opts))
 			editor.emit('tick', 16)
 		})
 	}
 	// pointermove is listened for on the document body, not the canvas
-	async function pointerMove(
-		x: number,
-		y: number,
-		opts?: { pointerId?: number; pointerType?: string }
-	) {
+	async function pointerMove(x: number, y: number, opts?: PointerOpts) {
 		await act(async () => {
 			document.body.dispatchEvent(pointerEvent('pointermove', x, y, opts))
 			editor.emit('tick', 16)
 		})
 	}
-	async function pointerCancel(
-		x: number,
-		y: number,
-		opts?: { pointerId?: number; pointerType?: string }
-	) {
+	async function pointerCancel(x: number, y: number, opts?: PointerOpts) {
 		await act(async () => {
 			canvas.dispatchEvent(pointerEvent('pointercancel', x, y, opts))
 			editor.emit('tick', 16)
@@ -170,6 +164,27 @@ describe('pointercancel via real DOM events', () => {
 		expect(editor.inputs.getIsPointing()).toBe(true)
 	})
 
+	it('restores the tool after a stylus-eraser press even if a rejected palm landed in between', async () => {
+		const { editor, pointerDown, pointerCancel } = await setupScene()
+
+		await act(async () => {
+			editor.updateInstanceState({ isPenMode: true })
+		})
+		// The eraser button switches to the eraser tool until the pen lifts
+		await pointerDown(500, 500, { pointerId: 1, pointerType: 'pen', button: 5 })
+		expect(editor.getCurrentToolId()).toBe('eraser')
+
+		// A palm lands; pen mode ignores it, so it must not replace the pen's button
+		await pointerDown(700, 700, { pointerId: 2, pointerType: 'touch' })
+		expect(editor.getCurrentToolId()).toBe('eraser')
+
+		await pointerCancel(500, 500, { pointerId: 1, pointerType: 'pen' })
+
+		expect(editor.getCurrentToolId()).toBe('select')
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.inputs.buttons.size).toBe(0)
+	})
+
 	it('does nothing when no press was registered', async () => {
 		const { editor, pointerCancel } = await setupScene()
 
@@ -181,5 +196,66 @@ describe('pointercancel via real DOM events', () => {
 
 		expect(editor.isIn('select.idle')).toBe(true)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.a])
+	})
+})
+
+describe('pointercancel on the menu click capture overlay', () => {
+	it('unmounts the overlay and ends the editor interaction', async () => {
+		const { editor, pointerMove } = await setupScene()
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+		expect(overlay()).not.toBeNull()
+
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50))
+		})
+		// The press closed the menu, but the overlay stays while the pointer is down
+		expect(editor.menus.hasAnyOpenMenus()).toBe(false)
+		expect(overlay()).not.toBeNull()
+
+		// Dragging past the threshold replays pointerdown into the editor
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointermove', 300, 100))
+		})
+		await pointerMove(320, 120)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+		expect(editor.isIn('select.translating')).toBe(true)
+
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointercancel', 320, 120))
+			editor.emit('tick', 16)
+		})
+
+		expect(overlay()).toBeNull()
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.inputs.buttons.size).toBe(0)
+	})
+
+	it('unmounts the overlay when a press is cancelled before it starts dragging', async () => {
+		const { editor } = await setupScene()
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50))
+		})
+		expect(overlay()).not.toBeNull()
+
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointercancel', 250, 50))
+		})
+
+		expect(overlay()).toBeNull()
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(false)
 	})
 })

--- a/packages/tldraw/src/test/pointercancel-dom.test.tsx
+++ b/packages/tldraw/src/test/pointercancel-dom.test.tsx
@@ -1,0 +1,185 @@
+import { act } from '@testing-library/react'
+import { Box, createShapeId } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+// These tests drive the real DOM handlers in useCanvasEvents rather than
+// dispatching synthetic editor events, because pointercancel is only ever
+// observed at the DOM layer. jsdom is missing a few browser APIs those handlers
+// rely on, so we polyfill them here.
+
+if (typeof (globalThis as any).PointerEvent === 'undefined') {
+	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
+		pointerId: number
+		pointerType: string
+		pressure: number
+		isPrimary: boolean
+		constructor(type: string, params: any = {}) {
+			super(type, params)
+			this.pointerId = params.pointerId ?? 0
+			this.pointerType = params.pointerType ?? ''
+			this.pressure = params.pressure ?? 0
+			this.isPrimary = params.isPrimary ?? false
+		}
+	}
+}
+if (!Element.prototype.setPointerCapture) {
+	Element.prototype.setPointerCapture = () => {}
+	Element.prototype.releasePointerCapture = () => {}
+	Element.prototype.hasPointerCapture = () => false
+}
+
+const ids = {
+	a: createShapeId('a'),
+}
+
+function pointerEvent(
+	type: 'pointerdown' | 'pointermove' | 'pointercancel',
+	clientX: number,
+	clientY: number,
+	{ pointerId = 1, pointerType = 'touch' } = {}
+) {
+	const e = new (globalThis as any).PointerEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		clientX,
+		clientY,
+		// pointercancel never reports a pressed button
+		button: type === 'pointercancel' ? -1 : 0,
+		pointerId,
+		pointerType,
+		isPrimary: pointerId === 1,
+	})
+	// jsdom's getCoalescedEvents returns an empty list, which makes tools that
+	// opt into coalesced events (draw) drop every pointermove
+	e.getCoalescedEvents = () => [e]
+	return e
+}
+
+async function setupScene() {
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+	const canvas = document.querySelector('[data-testid="canvas"]') as HTMLElement
+	await act(async () => {
+		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+		editor.createShapes([
+			{ id: ids.a, type: 'geo', x: 200, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+		])
+	})
+
+	async function pointerDown(
+		x: number,
+		y: number,
+		opts?: { pointerId?: number; pointerType?: string }
+	) {
+		await act(async () => {
+			canvas.dispatchEvent(pointerEvent('pointerdown', x, y, opts))
+			editor.emit('tick', 16)
+		})
+	}
+	// pointermove is listened for on the document body, not the canvas
+	async function pointerMove(
+		x: number,
+		y: number,
+		opts?: { pointerId?: number; pointerType?: string }
+	) {
+		await act(async () => {
+			document.body.dispatchEvent(pointerEvent('pointermove', x, y, opts))
+			editor.emit('tick', 16)
+		})
+	}
+	async function pointerCancel(
+		x: number,
+		y: number,
+		opts?: { pointerId?: number; pointerType?: string }
+	) {
+		await act(async () => {
+			canvas.dispatchEvent(pointerEvent('pointercancel', x, y, opts))
+			editor.emit('tick', 16)
+		})
+	}
+
+	return { editor, canvas, pointerDown, pointerMove, pointerCancel }
+}
+
+describe('pointercancel via real DOM events', () => {
+	it('ends a select-tool drag and clears the pressed state', async () => {
+		const { editor, pointerDown, pointerMove, pointerCancel } = await setupScene()
+
+		await pointerDown(250, 50)
+		await pointerMove(300, 100)
+		expect(editor.isIn('select.translating')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+
+		await pointerCancel(300, 100)
+
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+		expect(editor.inputs.buttons.size).toBe(0)
+	})
+
+	it('lets the next touch start a fresh interaction', async () => {
+		const { editor, pointerDown, pointerMove, pointerCancel } = await setupScene()
+
+		await pointerDown(250, 50)
+		await pointerMove(300, 100)
+		await pointerCancel(300, 100)
+
+		await pointerDown(600, 600)
+		expect(editor.isIn('select.pointing_canvas')).toBe(true)
+	})
+
+	it('closes an in-progress draw stroke', async () => {
+		const { editor, pointerDown, pointerMove, pointerCancel } = await setupScene()
+
+		await act(async () => {
+			editor.setCurrentTool('draw')
+		})
+		await pointerDown(500, 500)
+		await pointerMove(550, 550)
+		expect(editor.isIn('draw.drawing')).toBe(true)
+		const stroke = editor.getCurrentPageShapes().find((s) => s.type === 'draw')!
+		expect(stroke).toMatchObject({ props: { isComplete: false } })
+
+		await pointerCancel(550, 550)
+
+		expect(editor.isIn('draw.idle')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.getShape(stroke.id)).toMatchObject({ props: { isComplete: true } })
+	})
+
+	it('ignores a cancelled touch while a pen is drawing in pen mode', async () => {
+		const { editor, pointerDown, pointerMove, pointerCancel } = await setupScene()
+
+		await act(async () => {
+			editor.setCurrentTool('draw')
+			editor.updateInstanceState({ isPenMode: true })
+		})
+		await pointerDown(500, 500, { pointerId: 1, pointerType: 'pen' })
+		await pointerMove(550, 550, { pointerId: 1, pointerType: 'pen' })
+		expect(editor.isIn('draw.drawing')).toBe(true)
+
+		// A palm lands and is rejected by the system
+		await pointerCancel(700, 700, { pointerId: 2, pointerType: 'touch' })
+
+		expect(editor.isIn('draw.drawing')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+	})
+
+	it('does nothing when no press was registered', async () => {
+		const { editor, pointerCancel } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a)
+		})
+
+		await pointerCancel(500, 500)
+
+		expect(editor.isIn('select.idle')).toBe(true)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.a])
+	})
+})

--- a/packages/tldraw/src/test/pointercancel-dom.test.tsx
+++ b/packages/tldraw/src/test/pointercancel-dom.test.tsx
@@ -236,6 +236,71 @@ describe('pointercancel on the menu click capture overlay', () => {
 		expect(editor.inputs.buttons.size).toBe(0)
 	})
 
+	it('ignores a cancel from a pointer it never tracked', async () => {
+		// A palm resting on the overlay beside a drawing pen: the overlay is full screen for
+		// the whole press, so the palm lands on it, and its cancel must not end the pen's stroke.
+		const { editor, pointerMove } = await setupScene()
+		editor.setCurrentTool('draw')
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+
+		// The pen presses the overlay to dismiss the menu, then drags into a stroke.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50, { pointerType: 'pen' }))
+		})
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointermove', 300, 100, { pointerType: 'pen' }))
+		})
+		await pointerMove(320, 120, { pointerType: 'pen' })
+		expect(editor.isIn('draw.drawing')).toBe(true)
+
+		// The palm lands on the overlay and the OS rejects it.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+			overlay()!.dispatchEvent(pointerEvent('pointercancel', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+		})
+
+		expect(editor.isIn('draw.drawing')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+	})
+
+	it('does not let another pointer drag the tracked press past the threshold', async () => {
+		// The overlay defers the editor pointer_down until the press crosses the drag
+		// threshold, measured from the tracked press's start. A palm landing and sliding
+		// must not be what crosses it, or it replays a pointer_down the user never made.
+		const { editor } = await setupScene()
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+
+		// The pen presses to dismiss the menu but stays put, well inside the threshold.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50, { pointerType: 'pen' }))
+		})
+		expect(editor.inputs.getIsPointing()).toBe(false)
+
+		// The palm lands far away and slides.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+			overlay()!.dispatchEvent(pointerEvent('pointermove', 900, 900, { pointerId: 2 }))
+			editor.emit('tick', 16)
+		})
+
+		// No pointer_down was replayed, so the editor never started an interaction.
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.isIn('select.idle')).toBe(true)
+	})
+
 	it('unmounts the overlay when a press is cancelled before it starts dragging', async () => {
 		const { editor } = await setupScene()
 


### PR DESCRIPTION
This PR fixes a bug where a touch gesture that the system interrupts (an edge swipe, an incoming call, palm rejection) left the canvas stuck mid-interaction: a drag kept going from its old origin, a stroke stayed open, a laser trail never faded, and the next touch was swallowed or continued the old gesture. Closes #10394.

### Before

`useCanvasEvents` returned handlers for `pointerdown`, `pointerup`, `pointerenter` and `pointerleave`, but nothing for `pointercancel`. When the browser cancels a pointer it never sends `pointerup`, so `inputs.isPointing` stayed `true`, `inputs.buttons` kept the pressed button, the long-press timer kept running, and the active tool stayed in whatever pointing or dragging state it was in until an unrelated `pointerup` happened to arrive. The `touchcancel` listener in `useGestureEvents` only tears down pinch state, not the pointer state machine.

### After

The canvas handles `pointercancel`. If the editor is tracking a press, it calls `editor.interrupt()` and then dispatches a `pointer_up` at the cancel position with the button recorded at `pointerdown`. The interrupt lets states that treat an interruption as a discard (pointing states, a draw dot, hand dragging) bail out, and the `pointer_up` ends everything else and runs the existing pressed-state cleanup (`isPointing`, `isDragging`, `buttons`, long-press timer, stylus-eraser tool restore). The next touch starts a fresh interaction.

### Implementation notes

- `interrupt` rather than `cancel`: `cancel` is what Escape dispatches, and in idle states it has side effects (select tool clears the selection, draw/hand/eraser switch back to select, editing exits). A cancelled touch can land while a tool is idle or editing, so `cancel` was too broad. `interrupt` is already the signal used for pinch start and pen-mode switchover and is a no-op in those states.
- In pen mode, `pointercancel` from a non-pen pointer is ignored, mirroring `onPointerEnter`/`onPointerLeave`. A rejected palm must not end the pencil's stroke.
- The handler returns early when `inputs.isPointing` is false, so a cancel for a press the editor filtered out (pen mode, unsupported button) does nothing.
- The synthetic `pointer_up` uses the button from `pointerdown` because `pointercancel` reports `button: -1`, which would leave the real button stuck in `inputs.buttons`.
- The `pointerdown` button is tracked per pointer id and only for presses the editor accepts, so a rejected palm in pen mode cannot overwrite the button of the pen press it lands on top of (which would skip the stylus-eraser tool restore).
- `MenuClickCapture` gets its own `pointercancel` handler: it ends the editor interaction the same way and resets the overlay's own pointer state so it unmounts instead of staying over the canvas.

### Change type

- [x] `bugfix`

### Test plan

Needs a touch device: start a drag with the select tool, swipe in from the screen edge so the OS cancels the touch, then touch the canvas again. The drag should have ended and the new touch should start a fresh interaction.

- [x] Unit tests — the behaviour tests in `pointercancel-dom.test.tsx` (select drag, draw stroke, next touch, stylus-eraser restore after a rejected palm, menu click capture overlay) fail on `main` and pass with this change; the two guard tests (pen mode, no registered press) pass on both.

### Release notes

- Fix touch gestures staying stuck when the browser cancels the pointer (edge swipe, incoming call, palm rejection).

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +75 / -3   |
| Tests     | +270 / -0  |

