### PR TITLE
fix(editor): keep shape positions and source camera when duplicating a page

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5096,7 +5096,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const freshPage = this.getPage(id) // get the most recent version of the page anyway
 		if (!freshPage) return this
 
-		const prevCamera = { ...this.getCamera() }
+		// Read the source page's own camera rather than getCamera(), which is the
+		// current page's and is wrong when duplicating a page that isn't being viewed
+		const prevCamera = {
+			...(this.store.get(CameraRecordType.createId(freshPage.id)) ?? this.getCamera()),
+		}
 		const content = this.getContentFromCurrentPage(this.getSortedChildIdsForParent(freshPage.id))
 
 		this.run(() => {
@@ -5111,8 +5115,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this.setCamera(prevCamera)
 
 			if (content) {
-				// If we had content on the previous page, put it on the new page
-				return this.putContentOntoCurrentPage(content)
+				// Without preservePosition the paste rule recenters off-screen content
+				// in the viewport, so the copy's layout would not match the original
+				return this.putContentOntoCurrentPage(content, { preservePosition: true })
 			}
 		})
 

--- a/packages/tldraw/src/test/commands/duplicatePage.test.ts
+++ b/packages/tldraw/src/test/commands/duplicatePage.test.ts
@@ -1,4 +1,4 @@
-import { createShapeId } from '@tldraw/editor'
+import { PageRecordType, createShapeId } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -52,4 +52,44 @@ it("Doesn't duplicate the page if max pages is reached", () => {
 		editor.duplicatePage(editor.getCurrentPageId())
 	}
 	expect(editor.getPages().length).toBe(editor.options.maxPages)
+})
+
+it('Keeps shapes at their original coordinates when they are off screen', () => {
+	const id = createShapeId()
+	editor.createShapes([{ id, type: 'geo', x: 1000, y: 1000, props: { w: 100, h: 100 } }])
+	// Pan so the shape is nowhere near the viewport
+	editor.setCamera({ x: -10000, y: -10000, z: 1 })
+	expect(editor.getViewportPageBounds().collides(editor.getShapePageBounds(id)!)).toBe(false)
+
+	const existingIds = new Set(editor.getPages().map((s) => s.id))
+	editor.duplicatePage(editor.getCurrentPageId())
+
+	const newPageId = editor.getPages().find((p) => !existingIds.has(p.id))!.id
+	expect(editor.getCurrentPageId()).toBe(newPageId)
+
+	const copies = editor.getCurrentPageShapes().filter((s) => s.type === 'geo' && s.x === 1000)
+	expect(copies).toHaveLength(1)
+	expect(copies[0]).toMatchObject({ x: 1000, y: 1000 })
+})
+
+it('Uses the duplicated page camera when duplicating a page other than the current one', () => {
+	const sourcePageId = editor.getCurrentPageId()
+	const id = createShapeId()
+	editor.createShapes([{ id, type: 'geo', x: 1000, y: 1000, props: { w: 100, h: 100 } }])
+	editor.setCamera({ x: 200, y: 300, z: 2 })
+
+	const otherPageId = PageRecordType.createId()
+	editor.createPage({ id: otherPageId, name: 'Other' })
+	editor.setCurrentPage(otherPageId)
+	editor.setCamera({ x: -10000, y: -10000, z: 0.5 })
+
+	const existingIds = new Set(editor.getPages().map((s) => s.id))
+	editor.duplicatePage(sourcePageId)
+
+	const newPageId = editor.getPages().find((p) => !existingIds.has(p.id))!.id
+	expect(editor.getCurrentPageId()).toBe(newPageId)
+	expect(editor.getCamera()).toMatchObject({ x: 200, y: 300, z: 2 })
+	const copies = editor.getCurrentPageShapes().filter((s) => s.type === 'geo' && s.x === 1000)
+	expect(copies).toHaveLength(1)
+	expect(copies[0]).toMatchObject({ x: 1000, y: 1000 })
 })


### PR DESCRIPTION
This PR fixes a bug where duplicating a page moved the copied shapes when none of them were in view, so the duplicate's layout no longer matched the original. Closes #10407.

### Before

`Editor.duplicatePage` called `putContentOntoCurrentPage(content)` with no options, so positioning fell through to the standard paste rule: shapes kept their coordinates only if one of them overlapped the viewport, otherwise the whole set was recentered on `viewportPageBounds.center`. It also seeded the new page's camera from `getCamera()`, which is the camera of the page currently being viewed, not the page being duplicated.

### After

`duplicatePage` passes `preservePosition: true`, so every shape on the copy lands at the same page coordinates as on the source page regardless of where the user has panned. The new page's camera is read from the source page's own camera record (falling back to the current camera if none exists), so duplicating a page other than the current one no longer inherits the wrong camera.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle, pan until it is off screen, and duplicate the page from the page menu.
2. The copy's rectangle is at the same position as the original instead of being centered in the viewport.

- [x] Unit tests — the two new tests in `duplicatePage.test.ts` fail on `main` and pass with this change

### Release notes

- Fix duplicated pages repositioning their shapes when the content was off screen, and use the duplicated page's own camera rather than the current page's.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -3    |
| Tests     | +41 / -1   |
