### PR TITLE
fix(tldraw): return to idle when an arrow label press ends on a deleted arrow

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -134,7 +134,13 @@ export class PointingArrowLabel extends StateNode {
 
 	override onPointerUp() {
 		const shape = this.editor.getShape<TLArrowShape>(this.shapeId)
-		if (!shape) return
+		if (!shape) {
+			// The arrow was deleted mid-press (collaborator, Delete key). Returning
+			// without transitioning leaves the tool stuck in this state, which has
+			// no pointer down handler.
+			this.complete()
+			return
+		}
 
 		if (this.didDrag || !this.wasAlreadySelected) {
 			this.complete()

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -501,6 +501,43 @@ describe('PointingLabel', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('returns to idle on pointer up when the arrow is deleted mid-press', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape(ids.arrow1)!
+		editor.select(shape.id)
+
+		editor.pointerDown(150, 100, {
+			target: 'shape',
+			shape,
+		})
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+
+		editor.deleteShapes([ids.arrow1])
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape(ids.arrow1)).toBeUndefined()
+
+		// The next press must reach the canvas again
+		editor.pointerDown(300, 300)
+		editor.expectToBeIn('select.pointing_canvas')
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('Doesnt go into pointing_arrow_label mode if not selecting the arrow shape', () => {
 		editor.createShapes([
 			{


### PR DESCRIPTION
This PR fixes a bug where releasing a press on an arrow label after the arrow was deleted (by a collaborator, or by pressing Delete while holding) left the select tool stuck in `select.pointing_arrow_label`, so the next click on the canvas did nothing until Escape or a tool switch. Closes #10406.

### Before

`PointingArrowLabel.onPointerUp` looked up the arrow by id and returned early when it was gone (`if (!shape) return`). No transition happened, so the select tool stayed in `pointing_arrow_label`, which has no pointer down handler.

### After

When the arrow no longer exists on pointer up, the state completes the interaction the same way a finished drag does: it hands off to `onInteractionEnd` if one was provided, otherwise transitions to `select.idle`. The deletion is not undone (`cancel()` would bail to the mark set on pointer down and bring the arrow back), which matches the issue's "transition to idle when the shape is gone".

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test in `SelectTool.test.ts` fails on `main` (`expected 'select.pointing_arrow_label' to be 'select.idle'`) and passes with this change

### Release notes

- Fix the select tool getting stuck after an arrow label press ends on an arrow that was deleted mid-interaction

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -1    |
| Tests     | +37 / -0   |
