### PR TITLE
fix(embed): only make the editing embed interactive

### DIFF
--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -14,7 +14,6 @@ import {
 	useColorMode,
 	useIsEditing,
 	useSvgExportContext,
-	useValue,
 } from '@tldraw/editor'
 import {
 	DEFAULT_EMBED_DEFINITIONS,
@@ -258,23 +257,6 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 		const embedInfo = this.getEmbedDefinition(url)
 
-		const isHoveringWhileEditingSameShape = useValue(
-			'is hovering',
-			() => {
-				const { editingShapeId, hoveredShapeId } = this.editor.getCurrentPageState()
-
-				if (editingShapeId && hoveredShapeId !== editingShapeId) {
-					const editingShape = this.editor.getShape(editingShapeId)
-					if (editingShape && this.editor.isShapeOfType(editingShape, 'embed')) {
-						return true
-					}
-				}
-
-				return false
-			},
-			[]
-		)
-
 		const pageRotation = this.editor.getShapePageTransform(shape)!.rotation()
 
 		if (svgExport) {
@@ -296,7 +278,9 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 			)
 		}
 
-		const isInteractive = isEditing || isHoveringWhileEditingSameShape
+		// Only the embed being edited may take the pointer. Making sibling embeds
+		// interactive steals presses meant to select them (#10408).
+		const isInteractive = isEditing
 
 		// Prevent nested embedding of tldraw
 		const isIframe =

--- a/packages/tldraw/src/test/EmbedShapeUtil.test.tsx
+++ b/packages/tldraw/src/test/EmbedShapeUtil.test.tsx
@@ -1,0 +1,81 @@
+import { act } from '@testing-library/react'
+import { Editor, TLShapeId, createShapeId } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+let editor: Editor
+let embedA: TLShapeId
+let embedB: TLShapeId
+
+function getIframe(id: TLShapeId) {
+	const container = document.getElementById(id)
+	expect(container).toBeTruthy()
+	const iframe = container!.querySelector('iframe')
+	expect(iframe).toBeTruthy()
+	return iframe!
+}
+
+beforeEach(async () => {
+	embedA = createShapeId('embedA')
+	embedB = createShapeId('embedB')
+
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+
+	await act(async () => {
+		editor.createShapes([
+			{
+				id: embedA,
+				type: 'embed',
+				x: 0,
+				y: 0,
+				props: { w: 200, h: 200, url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+			},
+			{
+				id: embedB,
+				type: 'embed',
+				x: 300,
+				y: 0,
+				props: { w: 200, h: 200, url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+			},
+		])
+	})
+})
+
+describe('EmbedShapeUtil interactivity', () => {
+	it('keeps iframes non-interactive when nothing is being edited', () => {
+		expect(getIframe(embedA).style.pointerEvents).toBe('none')
+		expect(getIframe(embedB).style.pointerEvents).toBe('none')
+	})
+
+	it('only makes the editing embed interactive', async () => {
+		await act(async () => {
+			editor.setEditingShape(embedA)
+		})
+
+		expect(getIframe(embedA).style.pointerEvents).toBe('auto')
+		expect(getIframe(embedB).style.pointerEvents).toBe('none')
+	})
+
+	it('keeps other embeds non-interactive while the pointer is over them', async () => {
+		await act(async () => {
+			editor.setEditingShape(embedA)
+			editor.setHoveredShape(embedB)
+		})
+
+		expect(getIframe(embedA).style.pointerEvents).toBe('auto')
+		expect(getIframe(embedB).style.pointerEvents).toBe('none')
+	})
+
+	it('keeps the editing embed interactive when the hovered shape goes stale', async () => {
+		await act(async () => {
+			editor.setEditingShape(embedA)
+			editor.setHoveredShape(null)
+		})
+
+		expect(getIframe(embedA).style.pointerEvents).toBe('auto')
+		expect(getIframe(embedB).style.pointerEvents).toBe('none')
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where editing one embed made every other embed on the page interactive, so pressing on a second embed scrolled or played it instead of selecting it. Closes #10408.

### Before

`EmbedShapeUtil.component` computed `isHoveringWhileEditingSameShape` as "some embed is being edited and the hovered shape is not that embed", without ever comparing the editing shape to the shape being rendered. Every embed on the page got `pointerEvents: auto` as soon as the pointer left the editing embed, and the iframes swallowed presses meant for the canvas.

### After

Only the embed whose id matches `editingShapeId` is interactive. Sibling embeds keep `pointer-events: none` regardless of what is hovered, so a press on them selects the shape as usual.

### Implementation notes

The issue suggests comparing `editingShapeId` with `shape.id` inside the hover check. Doing that makes the check strictly imply `isEditing` (which is already `getEditingShapeId() === shape.id`), so the hook became dead logic and is removed rather than rewritten; `isInteractive` is now just `isEditing`. The editing embed stays interactive when the hover state goes stale (for example when the iframe captures the pointer), which the new test covers.

### Change type

- [x] `bugfix`

### Test plan

1. Insert two YouTube embeds (main menu, Insert embed).
2. Double-click one to edit it.
3. Press on the other: it is selected instead of playing or scrolling.

- [x] Unit tests — two of the new tests in `packages/tldraw/src/test/EmbedShapeUtil.test.tsx` fail on `main` and pass with this change

### Release notes

- Fix embeds other than the one being edited capturing pointer events.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -19   |
| Tests     | +81 / -0   |
