### PR TITLE
fix(tldraw): mark a history stopping point in unlock all

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1480,6 +1480,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						}
 					}
 					if (updates.length > 0) {
+						editor.markHistoryStoppingPoint('unlock all')
 						editor.updateShapes(updates)
 					}
 				},

--- a/packages/tldraw/src/test/ui/unlockAll.test.tsx
+++ b/packages/tldraw/src/test/ui/unlockAll.test.tsx
@@ -1,0 +1,55 @@
+import { act } from '@testing-library/react'
+import { createShapeId } from '@tldraw/editor'
+import { useEffect } from 'react'
+import { Tldraw } from '../../lib/Tldraw'
+import { TLUiActionsContextType, useActions } from '../../lib/ui/context/actions'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+function ActionCapturer({ onCapture }: { onCapture(actions: TLUiActionsContextType): void }) {
+	const actions = useActions()
+	useEffect(() => {
+		onCapture(actions)
+	}, [actions, onCapture])
+	return null
+}
+
+async function setup() {
+	let actions: TLUiActionsContextType | null = null
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => (
+			<Tldraw onMount={onMount}>
+				<ActionCapturer onCapture={(a) => (actions = a)} />
+			</Tldraw>
+		),
+		{ waitForPatterns: false }
+	)
+	return { editor, unlockAll: actions!['unlock-all'] }
+}
+
+describe('unlock-all action', () => {
+	it('marks a history stopping point so undo does not roll back earlier changes', async () => {
+		const { editor, unlockAll } = await setup()
+
+		const lockedId = createShapeId()
+		const laterId = createShapeId()
+		act(() => {
+			editor.markHistoryStoppingPoint('create locked')
+			editor.createShape({ id: lockedId, type: 'geo', x: 0, y: 0, isLocked: true })
+			editor.markHistoryStoppingPoint('create later')
+			editor.createShape({ id: laterId, type: 'geo', x: 200, y: 0 })
+		})
+
+		act(() => {
+			unlockAll.onSelect('context-menu')
+		})
+		expect(editor.getShape(lockedId)!.isLocked).toBe(false)
+
+		act(() => {
+			editor.undo()
+		})
+
+		// the unlock is undone, but the shape created before it survives
+		expect(editor.getShape(lockedId)!.isLocked).toBe(true)
+		expect(editor.getShape(laterId)).toBeDefined()
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where one undo after "Unlock all" also reverts whatever change came before it. Closes #10409.

### Before

The `unlock-all` action in `actions.tsx` called `editor.updateShapes` without marking a history stopping point, so the unlock landed in the same undo entry as the previous operation. Lock a shape, draw a second shape, run "Unlock all", press Ctrl/Cmd+Z: the second shape disappears along with the unlock.

### After

`unlock-all` calls `editor.markHistoryStoppingPoint('unlock all')` before `updateShapes`, matching the neighbouring `toggle-lock` action. Undo now reverts only the unlock.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle and lock it (Shift+L).
2. Draw a second rectangle.
3. Right-click the canvas and choose "Unlock all".
4. Press Ctrl/Cmd+Z: the first rectangle is locked again and the second rectangle is still there.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix undo after "Unlock all" also reverting the change made before it.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -0    |
| Tests     | +55 / -0   |
