### PR TITLE
fix(tldraw): mark an undo step before changing an arrowhead

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -472,6 +472,7 @@ export class Idle extends StateNode {
 				const changes = util.onDoubleClickHandle?.(shape, handle)
 
 				if (changes) {
+					this.editor.markHistoryStoppingPoint('double click handle')
 					this.editor.updateShapes([changes])
 				} else {
 					// If the shape's double click handler has not created a change,

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
@@ -112,6 +112,7 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 										type="icon"
 										key={item.value}
 										onClick={() => {
+											ctx.onHistoryMark('select style dropdown item')
 											onValueChange(styleA, item.value)
 											tlmenus.deleteOpenMenu(idA, editor.contextId)
 											setIsOpenA(false)
@@ -153,6 +154,7 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 										title={`${msg(labelB)} — ${msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)}`}
 										data-testid={`style.${uiTypeB}.${item.value}`}
 										onClick={() => {
+											ctx.onHistoryMark('select style dropdown item')
 											onValueChange(styleB, item.value)
 											tlmenus.deleteOpenMenu(idB, editor.contextId)
 											setIsOpenB(false)

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -744,6 +744,31 @@ describe('When double clicking a selection handle that registers as a canvas eve
 
 		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
 	})
+
+	it('Undoes an arrowhead toggled by handle double-click without undoing the selection', () => {
+		const id = createShapeId()
+		overlayEditor
+			.createShapes([
+				{
+					id,
+					type: 'arrow',
+					x: 100,
+					y: 100,
+					props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+				},
+			])
+			.selectNone()
+		overlayEditor.markHistoryStoppingPoint('before selecting arrow')
+		overlayEditor.select(id)
+
+		overlayEditor.doubleClick(200, 200)
+		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('none')
+
+		overlayEditor.undo()
+
+		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
+		expect(overlayEditor.getSelectedShapeIds()).toEqual([id])
+	})
 })
 
 describe('When editing shapes', () => {

--- a/packages/tldraw/src/test/ui/StylePanel.test.tsx
+++ b/packages/tldraw/src/test/ui/StylePanel.test.tsx
@@ -1,5 +1,5 @@
-import { act, screen, waitFor } from '@testing-library/react'
-import { DefaultColorStyle, Editor } from '@tldraw/editor'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { createShapeId, DefaultColorStyle, Editor, TLArrowShape } from '@tldraw/editor'
 import { Tldraw } from '../../lib/Tldraw'
 import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
 
@@ -42,5 +42,36 @@ describe('StylePanel', () => {
 		await waitFor(() => {
 			expect(getBlackColorSwatch().style.color).toBe('rgb(29, 29, 29)')
 		})
+	})
+
+	it('marks an undo step when changing an arrowhead', async () => {
+		const id = createShapeId()
+		act(() => {
+			editor
+				.createShapes<TLArrowShape>([
+					{
+						id,
+						type: 'arrow',
+						x: 100,
+						y: 100,
+						props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+					},
+				])
+				.selectNone()
+			editor.markHistoryStoppingPoint('before selecting arrow')
+			editor.select(id)
+		})
+
+		fireEvent.click(await screen.findByTestId('style.arrowheadEnd'))
+		fireEvent.click(await screen.findByTestId('style.arrowheadEnd.none'))
+
+		expect(editor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('none')
+
+		act(() => {
+			editor.undo()
+		})
+
+		expect(editor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
+		expect(editor.getSelectedShapeIds()).toEqual([id])
 	})
 })


### PR DESCRIPTION
This PR fixes a bug where changing an arrowhead did not create its own undo step, so pressing undo afterwards also reverted the step before it (usually the click that selected the arrow). Closes #10410.

### Before

`StylePanelDoubleDropdownPicker` — the only picker used for arrowheads — called `onValueChange` directly from its item buttons, while `StylePanelDropdownPicker` and `StylePanelButtonPicker` call `ctx.onHistoryMark` first. Likewise, the `handle` case of `Idle.onDoubleClick` in the select tool applied the result of `onDoubleClickHandle` with `updateShapes` and no mark, so double-clicking an arrow's end handle to toggle its head folded into the previous history entry.

### After

Both item buttons in `StylePanelDoubleDropdownPicker` mark a history stopping point before calling `onValueChange`, matching the other style pickers. `Idle.onDoubleClick` marks a stopping point before applying an `onDoubleClickHandle` change. Undo now reverts just the arrowhead change and leaves the arrow selected.

### Change type

- [x] `bugfix`

### Test plan

1. Draw an arrow, then click to select it.
2. Change the End arrowhead in the style panel, or double-click the arrow's end handle.
3. Press Ctrl/Cmd+Z. The arrowhead reverts and the arrow stays selected.

- [x] Unit tests — both new tests fail on `main` and pass with this change

### Release notes

- Fix changing an arrowhead (from the style panel or by double-clicking an arrow handle) not creating its own undo step.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -0    |
| Tests     | +58 / -2   |
