### PR TITLE
fix(tldraw): mark a history stopping point for keyboard changes to sliders

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.test.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TldrawUiSlider } from './TldrawUiSlider'
+
+function renderSlider() {
+	const calls: string[] = []
+	const onValueChange = vi.fn((value: number) => {
+		calls.push(`change:${value}`)
+	})
+	const onHistoryMark = vi.fn((id: string) => {
+		calls.push(`mark:${id}`)
+	})
+	const result = render(
+		<TldrawUiSlider
+			data-testid="slider"
+			value={2}
+			steps={4}
+			label="style-panel.opacity"
+			title="Opacity"
+			onValueChange={onValueChange}
+			onHistoryMark={onHistoryMark}
+		/>
+	)
+	const thumb = result.getByRole('slider')
+	return { ...result, thumb, calls, onValueChange, onHistoryMark }
+}
+
+describe('TldrawUiSlider', () => {
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('marks a history stopping point before a keyboard change', () => {
+		const { thumb, calls } = renderSlider()
+
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+
+		expect(calls).toEqual(['mark:keyboard slider', 'change:1'])
+	})
+
+	it.each(['ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])(
+		'marks a history stopping point for %s',
+		(key) => {
+			const { thumb, onHistoryMark, onValueChange } = renderSlider()
+
+			fireEvent.keyDown(thumb, { key })
+
+			expect(onHistoryMark).toHaveBeenCalledTimes(1)
+			expect(onValueChange).toHaveBeenCalledTimes(1)
+		}
+	)
+
+	it('marks once for a held key so the repeat run is a single undo step', () => {
+		const { thumb, onHistoryMark, onValueChange } = renderSlider()
+
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft', repeat: true })
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft', repeat: true })
+
+		expect(onHistoryMark).toHaveBeenCalledTimes(1)
+		expect(onValueChange).toHaveBeenCalledTimes(3)
+	})
+
+	it('marks each separate key press', () => {
+		const { thumb, onHistoryMark } = renderSlider()
+
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
+
+		expect(onHistoryMark).toHaveBeenCalledTimes(3)
+	})
+
+	it('does not mark for keys that do not change the value', () => {
+		const { thumb, onHistoryMark, onValueChange } = renderSlider()
+
+		fireEvent.keyDown(thumb, { key: 'Tab' })
+		fireEvent.keyDown(thumb, { key: 'a' })
+		fireEvent.keyDown(thumb, { key: 'Enter' })
+
+		expect(onHistoryMark).not.toHaveBeenCalled()
+		expect(onValueChange).not.toHaveBeenCalled()
+	})
+
+	it('still marks a history stopping point on pointer down', () => {
+		const { getByTestId, onHistoryMark } = renderSlider()
+
+		fireEvent.pointerDown(getByTestId('slider'))
+
+		expect(onHistoryMark).toHaveBeenCalledWith('click slider')
+	})
+})

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -5,6 +5,17 @@ import { TLUiTranslationKey } from '../../hooks/useTranslation/TLUiTranslationKe
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { hideAllTooltips, TldrawUiTooltip } from './TldrawUiTooltip'
 
+const SLIDER_VALUE_KEYS = new Set([
+	'ArrowUp',
+	'ArrowDown',
+	'ArrowLeft',
+	'ArrowRight',
+	'PageUp',
+	'PageDown',
+	'Home',
+	'End',
+])
+
 /** @public */
 export interface TLUiSliderProps {
 	min?: number
@@ -82,6 +93,19 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 		}
 	}, [])
 
+	// Capture phase so the mark lands before Radix's bubble-phase onKeyDown changes the value;
+	// otherwise keyboard changes squash into the preceding history entry and undo skips past them.
+	// Repeats from a held key are skipped so the run is one undo step, like a pointer drag.
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent) => {
+			handleKeyEvent(event)
+			if (SLIDER_VALUE_KEYS.has(event.key) && !event.repeat) {
+				onHistoryMark?.('keyboard slider')
+			}
+		},
+		[handleKeyEvent, onHistoryMark]
+	)
+
 	return (
 		<div className="tlui-slider__container">
 			<TldrawUiTooltip content={titleAndLabel}>
@@ -95,7 +119,7 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 					value={value !== null ? [value] : undefined}
 					onPointerDown={handlePointerDown}
 					onValueChange={handleValueChange}
-					onKeyDownCapture={handleKeyEvent}
+					onKeyDownCapture={handleKeyDown}
 					onKeyUpCapture={handleKeyEvent}
 				>
 					<_Slider.Track className="tlui-slider__track" dir={dir}>


### PR DESCRIPTION
This PR fixes a bug where changing a slider with the keyboard (arrow keys, Page Up/Down, Home, End) did not mark an undo stopping point, so undo stepped past the slider change and reverted whatever came before it. Closes #10411.

### Before

`TldrawUiSlider` called `onHistoryMark` only from `handlePointerDown`. Keyboard changes went straight through Radix's `onKeyDown` to `onValueChange` without a mark, so they squashed into the preceding history entry. Selecting a shape, tabbing to the opacity slider, pressing left arrow, then Cmd+Z undid the opacity change and the selection together. The same applied to the image toolbar zoom slider, which shares the primitive.

### After

The slider's capture-phase keydown handler marks a history stopping point (`'keyboard slider'`) for the value-changing keys before Radix applies the change, so each key press is its own undo step like a pointer click. Key repeats from a held key do not add extra marks, so holding an arrow key produces one undo step, the same as a pointer drag.

### Implementation notes

The mark is made on keydown rather than in `onValueChange` because the slider cannot tell a keyboard change from a pointer change there, and the mark must precede the change. Pressing a value key at the slider's bound (left arrow at minimum) still marks but changes nothing; consecutive marks with no changes between them are already skipped by `HistoryManager.undo`, matching what a click on the slider at its current value already does.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape.
2. Tab to the opacity slider and press the left arrow.
3. Press Cmd/Ctrl+Z: only the opacity change is undone; the shape stays selected.

- [x] Unit tests — the new `TldrawUiSlider.test.tsx` fails on `main` and passes with this change

### Release notes

- Fix keyboard changes to the opacity and image zoom sliders not creating their own undo step

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -1   |
| Tests     | +92 / -0   |
