### PR TITLE
fix(tldraw): make switching pages its own undo step

### DIFF
--- a/packages/commenting/src/canvas/cluster-model.test.ts
+++ b/packages/commenting/src/canvas/cluster-model.test.ts
@@ -1,8 +1,21 @@
+import {
+	commentSchemaRecords,
+	createCommentThread,
+	createShapeId,
+	createTLSchema,
+	createTLStore,
+	defaultBindingUtils,
+	defaultShapeUtils,
+	defaultTools,
+	Editor,
+	PageRecordType,
+} from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import { createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, LeafInput } from '../clustering/types'
 import type { ClusterInput } from './cluster-input'
-import { anyFoldedLeafMoved, type ClusterModel } from './cluster-model'
+import { anyFoldedLeafMoved, revealThreadPin, type ClusterModel } from './cluster-model'
+import { defaultCommentingOptions } from './options'
 
 function node(ids: string[], x = 0, y = 0): ClusterNode {
 	const members = ids.slice().sort()
@@ -84,5 +97,55 @@ describe('anyFoldedLeafMoved', () => {
 	it('holds the freeze on mismatched inputs rather than reading past the end', () => {
 		const next = input([leaf('t1', 40, 0), leaf('t2', 10, 0)])
 		expect(anyFoldedLeafMoved(input(AT_REST), next, rendered(0.5))).toBe(false)
+	})
+})
+
+describe('revealThreadPin', () => {
+	it('records a cross-page jump as its own undo step', () => {
+		const editor = new Editor({
+			store: createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+			shapeUtils: defaultShapeUtils,
+			bindingUtils: defaultBindingUtils,
+			tools: defaultTools,
+			getContainer: () => document.body,
+		})
+		try {
+			const page1Id = editor.getCurrentPageId()
+			const page2Id = PageRecordType.createId()
+			const boxId = createShapeId()
+
+			// Set up the second page outside of history so the only undoable steps are the ones
+			// the test creates: one edit on page 1, then the jump to the pin on page 2.
+			editor.run(() => editor.createPage({ id: page2Id, name: 'Page 2' }), { history: 'ignore' })
+			editor.clearHistory()
+
+			editor.markHistoryStoppingPoint('create box')
+			editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+			const thread = createCommentThread({
+				pageId: page2Id,
+				anchor: { type: 'point', x: 50, y: 50 },
+				createdBy: 'me',
+			})
+			revealThreadPin(
+				editor,
+				thread,
+				{ leaves: [], events: [] },
+				{ minZoom: 0.1, maxZoom: 8 },
+				{ ...defaultCommentingOptions, enableClustering: false },
+				0
+			)
+			expect(editor.getCurrentPageId()).toBe(page2Id)
+
+			// The first undo only takes us back to page 1; the edit made there is still intact.
+			editor.undo()
+			expect(editor.getCurrentPageId()).toBe(page1Id)
+			expect(editor.getShape(boxId)).toBeDefined()
+
+			editor.undo()
+			expect(editor.getShape(boxId)).toBeUndefined()
+		} finally {
+			editor.dispose()
+		}
 	})
 })

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -342,6 +342,7 @@ export function revealThreadPin(
 	duration = 200
 ) {
 	if (thread.pageId !== editor.getCurrentPageId()) {
+		editor.markHistoryStoppingPoint('change-page')
 		editor.setCurrentPage(thread.pageId as any)
 	}
 

--- a/packages/commenting/src/canvas/thread-state.test.ts
+++ b/packages/commenting/src/canvas/thread-state.test.ts
@@ -1,6 +1,7 @@
 import {
 	Box,
 	commentSchemaRecords,
+	createCommentThread,
 	createShapeId,
 	createTLSchema,
 	createTLStore,
@@ -8,6 +9,7 @@ import {
 	defaultShapeUtils,
 	defaultTools,
 	Editor,
+	PageRecordType,
 	TLShapeId,
 } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -16,6 +18,7 @@ import {
 	anchorPagePoint,
 	commentCenterScreenOffset,
 	commentTargetShapeAt,
+	focusThread,
 	impreciseShapePinInset,
 	IMPRECISE_PIN_INSET_PX,
 	isBoxInInflatedViewport,
@@ -256,5 +259,37 @@ describe('isBoxInInflatedViewport', () => {
 		expect(isBoxInInflatedViewport(editor, box)).toBe(false)
 		editor.setCamera({ x: -2000, y: 0, z: 1 })
 		expect(isBoxInInflatedViewport(editor, box)).toBe(true)
+	})
+})
+
+describe('focusThread', () => {
+	it('records a cross-page jump as its own undo step', () => {
+		const page1Id = editor.getCurrentPageId()
+		const page2Id = PageRecordType.createId()
+		const boxId = createShapeId()
+
+		// Set up the second page outside of history so the only undoable steps are the ones the
+		// test creates: one edit on page 1, then the jump to the thread on page 2.
+		editor.run(() => editor.createPage({ id: page2Id, name: 'Page 2' }), { history: 'ignore' })
+		editor.clearHistory()
+
+		editor.markHistoryStoppingPoint('create box')
+		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+		const thread = createCommentThread({
+			pageId: page2Id,
+			anchor: { type: 'point', x: 50, y: 50 },
+			createdBy: 'me',
+		})
+		focusThread(editor, thread)
+		expect(editor.getCurrentPageId()).toBe(page2Id)
+
+		// The first undo only takes us back to page 1; the edit made there is still intact.
+		editor.undo()
+		expect(editor.getCurrentPageId()).toBe(page1Id)
+		expect(editor.getShape(boxId)).toBeDefined()
+
+		editor.undo()
+		expect(editor.getShape(boxId)).toBeUndefined()
 	})
 })

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -184,6 +184,7 @@ export function shapeAnchorAt(
 /** Open a thread and bring it into view — switch to its page if needed, then center its pin. @public */
 export function focusThread(editor: Editor, thread: TLCommentThread): void {
 	if (thread.pageId !== editor.getCurrentPageId()) {
+		editor.markHistoryStoppingPoint('change-page')
 		editor.setCurrentPage(thread.pageId as any)
 	}
 	openThreadId.set(editor, thread.id)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4129,6 +4129,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// If we're not on the same page, move to the page they're on
 			const isOnSamePage = presence.currentPageId === this.getCurrentPageId()
 			if (!isOnSamePage) {
+				this.markHistoryStoppingPoint('change-page')
 				this.setCurrentPage(presence.currentPageId)
 			}
 

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -507,6 +507,7 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 
 	const changePage = useCallback(
 		(id: TLPageId) => {
+			editor.markHistoryStoppingPoint('change-page')
 			editor.setCurrentPage(id)
 			trackEvent('change-page', { source: 'page-menu' })
 		},

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1700,6 +1700,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const currentPageIndex = pages.findIndex((page) => page.id === editor.getCurrentPageId())
 					if (currentPageIndex < 1) return
 					trackEvent('change-page', { source, direction: 'prev' })
+					editor.markHistoryStoppingPoint('change-page')
 					editor.setCurrentPage(pages[currentPageIndex - 1].id)
 				},
 			},
@@ -1732,6 +1733,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						return
 					}
 
+					editor.markHistoryStoppingPoint('change-page')
 					editor.setCurrentPage(pages[currentPageIndex + 1].id)
 					trackEvent('change-page', { source, direction: 'next' })
 				},

--- a/packages/tldraw/src/test/ui/changePage.test.tsx
+++ b/packages/tldraw/src/test/ui/changePage.test.tsx
@@ -1,0 +1,131 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+import { Editor, PageRecordType, TLPageId, createShapeId } from '@tldraw/editor'
+import { useEffect } from 'react'
+import { Tldraw } from '../../lib/Tldraw'
+import { TLUiActionsContextType, useActions } from '../../lib/ui/context/actions'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+function ActionCapturer({ onCapture }: { onCapture(actions: TLUiActionsContextType): void }) {
+	const actions = useActions()
+	useEffect(() => {
+		onCapture(actions)
+	}, [actions, onCapture])
+	return null
+}
+
+let editor: Editor
+let actions: TLUiActionsContextType
+let page1Id: TLPageId
+let page2Id: TLPageId
+let boxId: ReturnType<typeof createShapeId>
+
+beforeEach(async () => {
+	// jsdom has no Element.scrollTo, which the page menu calls to reveal the current page.
+	Element.prototype.scrollTo = vi.fn()
+
+	const result = await renderTldrawComponentWithEditor(
+		(onMount) => (
+			<Tldraw onMount={onMount}>
+				<ActionCapturer onCapture={(a) => (actions = a)} />
+			</Tldraw>
+		),
+		{ waitForPatterns: false }
+	)
+	editor = result.editor
+
+	page1Id = editor.getCurrentPageId()
+	page2Id = PageRecordType.createId()
+	boxId = createShapeId()
+
+	// Set up a second page outside of history so the only undoable steps are the ones the
+	// test creates: one edit on page 1, then a page switch.
+	editor.run(
+		() => {
+			editor.createPage({ id: page2Id, name: 'Page 2' })
+		},
+		{ history: 'ignore' }
+	)
+	editor.clearHistory()
+
+	act(() => {
+		editor.markHistoryStoppingPoint('create box')
+		editor.createShapes([{ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+	})
+	expect(editor.getShape(boxId)).toBeDefined()
+	expect(editor.getCurrentPageId()).toBe(page1Id)
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+function expectUndoToOnlyRevertThePageSwitch() {
+	expect(editor.getCurrentPageId()).toBe(page2Id)
+
+	act(() => {
+		editor.undo()
+	})
+
+	// The first undo only takes us back to page 1; the edit made there is still intact.
+	expect(editor.getCurrentPageId()).toBe(page1Id)
+	expect(editor.getShape(boxId)).toBeDefined()
+
+	act(() => {
+		editor.undo()
+	})
+	expect(editor.getShape(boxId)).toBeUndefined()
+}
+
+describe('undo after switching pages', () => {
+	it('change-page-next action is its own undo step', async () => {
+		await act(async () => {
+			await actions['change-page-next'].onSelect('kbd')
+		})
+		expectUndoToOnlyRevertThePageSwitch()
+	})
+
+	it('change-page-prev action is its own undo step', async () => {
+		// Start on page 2 (outside of history) so prev lands on page 1, and put the edit there.
+		editor.run(
+			() => {
+				editor.setCurrentPage(page2Id)
+			},
+			{ history: 'ignore' }
+		)
+		editor.clearHistory()
+		const page2BoxId = createShapeId()
+		act(() => {
+			editor.markHistoryStoppingPoint('create box')
+			editor.createShapes([{ id: page2BoxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+		})
+
+		await act(async () => {
+			await actions['change-page-prev'].onSelect('kbd')
+		})
+
+		expect(editor.getCurrentPageId()).toBe(page1Id)
+		act(() => {
+			editor.undo()
+		})
+		expect(editor.getCurrentPageId()).toBe(page2Id)
+		expect(editor.getShape(page2BoxId)).toBeDefined()
+		act(() => {
+			editor.undo()
+		})
+		expect(editor.getShape(page2BoxId)).toBeUndefined()
+	})
+
+	it('switching pages from the page menu is its own undo step', async () => {
+		await act(async () => {
+			fireEvent.click(screen.getByTestId('page-menu.button'))
+		})
+		const item = (await screen.findAllByTestId('page-menu.item')).find(
+			(el) => el.getAttribute('data-pageid') === page2Id
+		)!
+		expect(item).toBeDefined()
+		await act(async () => {
+			fireEvent.click(item.querySelector('.tlui-page-menu__item__button')!)
+		})
+		expectUndoToOnlyRevertThePageSwitch()
+	})
+})

--- a/packages/tldraw/src/test/zoomToUser.test.ts
+++ b/packages/tldraw/src/test/zoomToUser.test.ts
@@ -1,0 +1,63 @@
+import {
+	InstancePresenceRecordType,
+	PageRecordType,
+	TLPageId,
+	createShapeId,
+	createUserId,
+} from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor.dispose()
+})
+
+describe('zoomToUser', () => {
+	it('records a cross-page jump as its own undo step', () => {
+		const page1Id = editor.getCurrentPageId()
+		const page2Id: TLPageId = PageRecordType.createId()
+		const boxId = createShapeId()
+		const userId = createUserId('other')
+
+		// Set up the second page and the collaborator outside of history so the only undoable
+		// steps are the ones the test creates: one edit on page 1, then the jump to page 2.
+		editor.run(
+			() => {
+				editor.createPage({ id: page2Id, name: 'Page 2' })
+				editor.store.put([
+					InstancePresenceRecordType.create({
+						id: InstancePresenceRecordType.createId(userId),
+						userId,
+						userName: 'other',
+						currentPageId: page2Id,
+						cursor: { x: 100, y: 100, type: 'default', rotation: 0 },
+						camera: { x: 0, y: 0, z: 1 },
+						screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
+						lastActivityTimestamp: Date.now(),
+					}),
+				])
+			},
+			{ history: 'ignore' }
+		)
+		editor.clearHistory()
+
+		editor.markHistoryStoppingPoint('create box')
+		editor.createShapes([{ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+
+		editor.zoomToUser(userId)
+		expect(editor.getCurrentPageId()).toBe(page2Id)
+
+		// The first undo only takes us back to page 1; the edit made there is still intact.
+		editor.undo()
+		expect(editor.getCurrentPageId()).toBe(page1Id)
+		expect(editor.getShape(boxId)).toBeDefined()
+
+		editor.undo()
+		expect(editor.getShape(boxId)).toBeUndefined()
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where pressing undo after switching pages from the page menu or with Alt+arrow also reverted the edit made before the switch. Closes #10413.

### Before

The page menu's `changePage` callback and the `change-page-prev` / `change-page-next` actions called `editor.setCurrentPage` directly. `setCurrentPage` records the change with `record-preserveRedoStack` but does not mark a stopping point, so the switch merged into whatever undo step was open. Drawing a rectangle, switching pages, and pressing Ctrl/Cmd+Z removed the rectangle and changed the page in a single step. The "Go back" button on the move-to-page toast, by contrast, already called `markHistoryStoppingPoint('change-page')` first, so that path behaved differently.

### After

The page menu and both keyboard actions mark a `change-page` stopping point before calling `setCurrentPage`, matching the toast's "Go back" button. Undo after a page switch now returns to the previous page and leaves the prior edit intact; a second undo reverts the edit.

### Implementation notes

The issue flags this as a product call between "own step", "merge", or "not recorded". This PR picks "own step" since that is what the existing "Go back" toast action already does, so the fix is the most conservative one that makes every UI entry point consistent. `Editor.setCurrentPage` itself is left unchanged: the new-page flows wrap `createPage` + `setCurrentPage` in one marked batch and rely on the switch merging into that step.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle.
2. Add a page, then return with Alt+left (or pick the first page from the page menu).
3. Press Ctrl/Cmd+Z: you should land back on the second page with the rectangle still present on the first. A second undo removes the rectangle.

- [x] Unit tests — the three new tests in `packages/tldraw/src/test/ui/changePage.test.tsx` fail on `main` and pass with this change

### Release notes

- Fix undo after switching pages from the page menu or Alt+arrow so it no longer also reverts the previous edit.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -0    |
| Tests     | +131 / -0  |
