### PR TITLE
fix(tldraw): mark a history stopping point when saving alt text

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
@@ -33,6 +33,7 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 		trackEvent('set-alt-text', { source })
 		const shape = editor.getShape<ExtractShapeByProps<{ altText: string }>>(shapeId)
 		if (!shape) return
+		editor.markHistoryStoppingPoint('set alt text')
 		editor.updateShapes([
 			{
 				id: shape.id,

--- a/packages/tldraw/src/test/ui/AltTextEditor.test.tsx
+++ b/packages/tldraw/src/test/ui/AltTextEditor.test.tsx
@@ -1,0 +1,51 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+import { createShapeId, Editor, TLImageShape } from '@tldraw/editor'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+let editor: Editor
+const imageId = createShapeId('image')
+
+beforeEach(async () => {
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+
+	act(() => {
+		editor.createShape<TLImageShape>({
+			id: imageId,
+			type: 'image',
+			x: 100,
+			y: 100,
+			props: { w: 200, h: 200 },
+		})
+		editor.markHistoryStoppingPoint('move image')
+		editor.updateShape({ id: imageId, type: 'image', x: 300 })
+		editor.select(imageId)
+	})
+})
+
+describe('AltTextEditor', () => {
+	it('undoes only the alt text change, not the action before it', async () => {
+		fireEvent.click(await screen.findByTestId('tool.image-alt-text'))
+
+		const input = (await screen.findByTestId('media-toolbar.alt-text-input')) as HTMLInputElement
+		fireEvent.change(input, { target: { value: 'A picture' } })
+		fireEvent.keyDown(input, { key: 'Enter' })
+
+		expect(editor.getShape<TLImageShape>(imageId)).toMatchObject({
+			x: 300,
+			props: { altText: 'A picture' },
+		})
+
+		act(() => {
+			editor.undo()
+		})
+
+		expect(editor.getShape<TLImageShape>(imageId)).toMatchObject({
+			x: 300,
+			props: { altText: '' },
+		})
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where pressing Ctrl/Cmd+Z after saving alt text in the image or video toolbar also undid the action that came before it. Closes #10415.

### Before

`handleComplete` in `AltTextEditor` called `editor.updateShapes` without first marking a history stopping point, so the alt text change was folded into whatever undo entry was already open (for example a move or resize of the same image). All three save paths go through `handleComplete` (Enter in the input, the confirm button, and pointing down outside the toolbar), so all three were affected. Sibling controls in the same toolbar, like the aspect ratio change in `DefaultImageToolbarContent`, already mark a stopping point.

### After

`handleComplete` calls `editor.markHistoryStoppingPoint('set alt text')` before `updateShapes`, so undo reverts only the alt text edit and leaves the previous action in place.

### Change type

- [x] `bugfix`

### Test plan

1. Add an image, select it, and move it.
2. Click the alt text button, type some text, and press Enter.
3. Press Ctrl/Cmd+Z: the alt text should clear but the image should stay where it was moved.

- [x] Unit tests — the new test in `packages/tldraw/src/test/ui/AltTextEditor.test.tsx` fails on `main` and passes with this change

### Release notes

- Fix undo after saving alt text also undoing the previous action

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -0    |
| Tests     | +51 / -0   |
