### PR TITLE
fix(tldraw): keep the previous tool highlighted while the zoom tool is active

### DIFF
--- a/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
+++ b/packages/tldraw/src/lib/tools/ZoomTool/ZoomTool.ts
@@ -24,12 +24,12 @@ export class ZoomTool extends StateNode {
 		this.info = info
 		// onInteractionEnd is a path like 'select.idle', extract just the tool ID for the mask
 		const toolId = info.onInteractionEnd?.split('.')[0]
-		this.parent.setCurrentToolIdMask(toolId)
+		this.setCurrentToolIdMask(toolId)
 		this.updateCursor()
 	}
 
 	override onExit() {
-		this.parent.setCurrentToolIdMask(undefined)
+		this.setCurrentToolIdMask(undefined)
 		this.editor.updateInstanceState({ zoomBrush: null, cursor: { type: 'default', rotation: 0 } })
 	}
 

--- a/packages/tldraw/src/test/ZoomTool.test.ts
+++ b/packages/tldraw/src/test/ZoomTool.test.ts
@@ -200,6 +200,34 @@ describe('TLSelectTool.Zooming', () => {
 	})
 })
 
+describe('current tool id mask', () => {
+	beforeEach(() => {
+		editor = new TestEditor()
+	})
+
+	it('reports the previous tool as the current tool id while the zoom tool is active', () => {
+		editor.setCurrentTool('draw')
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'draw.idle' })
+		editor.expectToBeIn('zoom.idle')
+		expect(editor.getCurrentToolId()).toBe('draw')
+	})
+
+	it('clears the mask when returning to the previous tool', () => {
+		editor.setCurrentTool('draw')
+		editor.setCurrentTool('zoom', { onInteractionEnd: 'draw.idle' })
+		editor.keyUp('z')
+		editor.expectToBeIn('draw.idle')
+		expect(editor.getCurrentToolId()).toBe('draw')
+		editor.setCurrentTool('select')
+		expect(editor.getCurrentToolId()).toBe('select')
+	})
+
+	it('reports zoom when entered without a previous tool', () => {
+		editor.setCurrentTool('zoom')
+		expect(editor.getCurrentToolId()).toBe('zoom')
+	})
+})
+
 describe('ZoomQuick', () => {
 	beforeEach(() => {
 		editor = new TestEditor()


### PR DESCRIPTION
This PR fixes a bug where holding `Z` for the zoom tool cleared the toolbar's active tool highlight instead of keeping the previous tool's button lit. Closes #10418.

### Before

`ZoomTool.onEnter` wrote the tool id mask on `this.parent`, which is the root state node. `Editor.getCurrentToolId` reads the mask from the current tool (`this.root.getCurrent()`), so the mask on root was never consulted and the toolbar saw `'zoom'`, which has no button.

### After

`ZoomTool` sets and clears the mask on itself, matching how `EraserTool` handles its `onInteractionEnd` mask. While `Z` is held, `getCurrentToolId()` returns the previous tool's id (for example `'draw'`), so its toolbar button stays highlighted.

### Change type

- [x] `bugfix`

### Test plan

1. Select the draw tool, then hold `Z`.
2. The draw tool button stays highlighted in the toolbar while `Z` is held.
3. Release `Z`; the draw tool is still active and highlighted.

- [x] Unit tests — the new "reports the previous tool as the current tool id while the zoom tool is active" test fails on `main` (`expected 'zoom' to be 'draw'`) and passes with this change

### Release notes

- Fix the toolbar losing its active tool highlight while holding `Z` for the zoom tool

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -2    |
| Tests     | +28 / -0   |
