### PR TITLE
fix(select): mark history before brushing, right-click deselect, Enter on groups, and keyboard traversal

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2498,7 +2498,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	private _selectShapesAndZoom(ids: TLShapeId[]) {
-		this.markHistoryStoppingPoint('selecting adjacent shape')
+		// setSelectedShapes is a no-op for an unchanged selection (Tab with a single shape,
+		// Ctrl+arrow with no neighbour); marking anyway would leave an empty stopping point
+		// that makes undo available with nothing to undo
+		const selectedShapeIds = this.getSelectedShapeIds()
+		const isSelectionChanging =
+			ids.length !== selectedShapeIds.length || ids.some((id) => !selectedShapeIds.includes(id))
+		if (isSelectionChanging) {
+			this.markHistoryStoppingPoint('selecting adjacent shape')
+		}
 		this.setSelectedShapes(ids)
 		this.zoomToSelectionIfOffscreen(256, {
 			animation: {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2498,6 +2498,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	private _selectShapesAndZoom(ids: TLShapeId[]) {
+		this.markHistoryStoppingPoint('selecting adjacent shape')
 		this.setSelectedShapes(ids)
 		this.zoomToSelectionIfOffscreen(256, {
 			animation: {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -24,16 +24,18 @@ export class Brushing extends StateNode {
 	initialSelectedShapeIds: TLShapeId[] = []
 	excludedShapeIds = new Set<TLShapeId>()
 	isWrapMode = false
+	private didMarkHistory = false
 
 	viewportDidChange = false
 	cleanupViewportChangeReactor() {
 		void null
 	} // cleanup function for the viewport reactor
 
-	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
+	override onEnter(info: TLPointerEventInfo & { target: 'canvas'; didMarkHistory?: boolean }) {
 		const { editor } = this
 		const altKey = editor.inputs.getAltKey()
 
+		this.didMarkHistory = info.didMarkHistory ?? false
 		this.isWrapMode = editor.user.getIsWrapMode()
 
 		this.viewportDidChange = false
@@ -170,10 +172,7 @@ export class Brushing extends StateNode {
 				editor.updateInstanceState({ brush: { ...brush.toJson() } })
 			}
 
-			const current = editor.getSelectedShapeIds()
-			if (current.length !== results.size || current.some((id) => !results.has(id))) {
-				editor.setSelectedShapes(Array.from(results))
-			}
+			this.selectBrushedShapes(results)
 			return
 		}
 
@@ -228,10 +227,22 @@ export class Brushing extends StateNode {
 			editor.updateInstanceState({ brush: { ...brush.toJson() } })
 		}
 
+		this.selectBrushedShapes(results)
+	}
+
+	private selectBrushedShapes(results: Set<TLShapeId>) {
+		const { editor } = this
 		const current = editor.getSelectedShapeIds()
-		if (current.length !== results.size || current.some((id) => !results.has(id))) {
-			editor.setSelectedShapes(Array.from(results))
+		if (current.length === results.size && current.every((id) => results.has(id))) return
+
+		// Without a stopping point the brush selection merges into the previous history entry
+		// and undo reverts that edit too (#10412). Marking here, right before the first real
+		// selection change, keeps a brush that hits nothing out of the undo stack.
+		if (!this.didMarkHistory) {
+			editor.markHistoryStoppingPoint('brushing')
+			this.didMarkHistory = true
 		}
+		editor.setSelectedShapes(Array.from(results))
 	}
 
 	override onInterrupt() {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -529,7 +529,10 @@ export class Idle extends StateNode {
 					return
 				}
 
-				this.editor.selectNone()
+				if (selectedShapeIds.length > 0) {
+					this.editor.markHistoryStoppingPoint('selecting none')
+					this.editor.selectNone()
+				}
 				break
 			}
 			case 'shape': {
@@ -659,6 +662,7 @@ export class Idle extends StateNode {
 
 				// On enter, if every selected shape is a group, then select all of the children of the groups
 				if (selectedShapes.every((shape) => this.editor.isShapeOfType(shape, 'group'))) {
+					this.editor.markHistoryStoppingPoint('selecting group children')
 					this.editor.setSelectedShapes(
 						selectedShapes.flatMap((shape) => this.editor.getSortedChildIdsForParent(shape.id))
 					)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -4,12 +4,17 @@ import { selectOnCanvasPointerUp } from '../../selection-logic/selectOnCanvasPoi
 export class PointingCanvas extends StateNode {
 	static override id = 'pointing_canvas'
 
+	private didMark = false
+
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
 		const additiveSelectionKey = info.shiftKey || info.accelKey
+
+		this.didMark = false
 
 		if (!additiveSelectionKey) {
 			if (this.editor.getSelectedShapeIds().length > 0) {
 				this.editor.markHistoryStoppingPoint('selecting none')
+				this.didMark = true
 				this.editor.selectNone()
 			}
 		}
@@ -17,6 +22,13 @@ export class PointingCanvas extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
+			// A brush from an empty selection has no mark yet, so its selection
+			// would merge into the previous history entry and undo would revert
+			// that edit too (#10412). Marking only here keeps a plain click on
+			// empty canvas out of the undo stack.
+			if (!this.didMark) {
+				this.editor.markHistoryStoppingPoint('brushing')
+			}
 			this.parent.transition('brushing', info)
 		}
 	}

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -22,14 +22,10 @@ export class PointingCanvas extends StateNode {
 
 	override onPointerMove(info: TLPointerEventInfo) {
 		if (this.editor.inputs.getIsDragging()) {
-			// A brush from an empty selection has no mark yet, so its selection
-			// would merge into the previous history entry and undo would revert
-			// that edit too (#10412). Marking only here keeps a plain click on
-			// empty canvas out of the undo stack.
-			if (!this.didMark) {
-				this.editor.markHistoryStoppingPoint('brushing')
-			}
-			this.parent.transition('brushing', info)
+			// Brushing marks its own stopping point before its first selection change, unless the
+			// deselect above already placed one; a second mark would split a click-drag that
+			// starts from an existing selection into two undo steps
+			this.parent.transition('brushing', { ...info, didMarkHistory: this.didMark })
 		}
 	}
 

--- a/packages/tldraw/src/test/select.test.tsx
+++ b/packages/tldraw/src/test/select.test.tsx
@@ -187,3 +187,124 @@ describe('When brushing arrows', () => {
 		expect(editor.getSelectedShapeIds()).toStrictEqual([])
 	})
 })
+
+// Each of these selection changes happens while the select tool is idle with no
+// pending history mark, so without a stopping point the selection change merges
+// into the entry that created the shape and undo deletes the shape (#10412).
+describe('Selection changes while idle are their own undo step', () => {
+	const ids = {
+		box1: createShapeId('box1'),
+		box2: createShapeId('box2'),
+		group1: createShapeId('group1'),
+	}
+
+	beforeEach(() => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor.setCamera({ x: 0, y: 0, z: 1 })
+	})
+
+	function createBoxesWithNothingSelected() {
+		editor.markHistoryStoppingPoint('create boxes')
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+			{ id: ids.box2, type: 'geo', x: 400, y: 100, props: { w: 100, h: 100 } },
+		])
+		editor.selectNone()
+		editor.setCurrentTool('select')
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	}
+
+	it('brushing from an empty selection', () => {
+		createBoxesWithNothingSelected()
+
+		editor.pointerDown(50, 50).pointerMove(250, 250).pointerUp(250, 250)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(editor.getShape(ids.box1)).toBeDefined()
+		expect(editor.getShape(ids.box2)).toBeDefined()
+	})
+
+	it('brushing from an existing selection is a single undo step', () => {
+		createBoxesWithNothingSelected()
+		editor.setSelectedShapes([ids.box2])
+
+		editor.pointerDown(50, 50).pointerMove(250, 250).pointerUp(250, 250)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+	})
+
+	it('right-clicking empty canvas to clear the selection', () => {
+		createBoxesWithNothingSelected()
+		editor.setSelectedShapes([ids.box1])
+
+		editor.rightClick(700, 700)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getShape(ids.box1)).toBeDefined()
+	})
+
+	it('pressing Enter with only groups selected', () => {
+		createBoxesWithNothingSelected()
+		editor.groupShapes([ids.box1, ids.box2], { groupId: ids.group1 })
+		editor.setSelectedShapes([ids.group1])
+
+		editor.keyDown('Enter').keyUp('Enter')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
+		expect(editor.getShape(ids.group1)).toBeDefined()
+	})
+
+	it('Tab traversal', () => {
+		createBoxesWithNothingSelected()
+		editor.setSelectedShapes([ids.box1])
+
+		editor.keyDown('Tab').keyUp('Tab')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getShape(ids.box2)).toBeDefined()
+	})
+
+	it('Ctrl+arrow traversal', () => {
+		createBoxesWithNothingSelected()
+		editor.setSelectedShapes([ids.box1])
+
+		editor.keyDown('ArrowRight', { ctrlKey: true }).keyUp('ArrowRight', { ctrlKey: true })
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getShape(ids.box2)).toBeDefined()
+	})
+
+	it('Ctrl+Shift+arrow parent and child traversal', () => {
+		createBoxesWithNothingSelected()
+		editor.groupShapes([ids.box1, ids.box2], { groupId: ids.group1 })
+		editor.setSelectedShapes([ids.group1])
+
+		editor
+			.keyDown('ArrowDown', { ctrlKey: true, shiftKey: true })
+			.keyUp('ArrowDown', { ctrlKey: true, shiftKey: true })
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		editor
+			.keyDown('ArrowUp', { ctrlKey: true, shiftKey: true })
+			.keyUp('ArrowUp', { ctrlKey: true, shiftKey: true })
+		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
+
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.undo()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
+		expect(editor.getShape(ids.group1)).toBeDefined()
+	})
+})

--- a/packages/tldraw/src/test/select.test.tsx
+++ b/packages/tldraw/src/test/select.test.tsx
@@ -226,6 +226,16 @@ describe('Selection changes while idle are their own undo step', () => {
 		expect(editor.getShape(ids.box2)).toBeDefined()
 	})
 
+	it('brushing that hits nothing does not make undo available', () => {
+		createBoxesWithNothingSelected()
+		editor.clearHistory()
+		expect(editor.getCanUndo()).toBe(false)
+
+		editor.pointerDown(700, 700).pointerMove(800, 800).pointerUp(800, 800)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(editor.getCanUndo()).toBe(false)
+	})
+
 	it('brushing from an existing selection is a single undo step', () => {
 		createBoxesWithNothingSelected()
 		editor.setSelectedShapes([ids.box2])
@@ -272,6 +282,18 @@ describe('Selection changes while idle are their own undo step', () => {
 		editor.undo()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getShape(ids.box2)).toBeDefined()
+	})
+
+	it('Tab with a single shape does not make undo available', () => {
+		editor.createShapes([{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
+		editor.setSelectedShapes([ids.box1])
+		editor.setCurrentTool('select')
+		editor.clearHistory()
+		expect(editor.getCanUndo()).toBe(false)
+
+		editor.keyDown('Tab').keyUp('Tab')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getCanUndo()).toBe(false)
 	})
 
 	it('Ctrl+arrow traversal', () => {


### PR DESCRIPTION
This PR fixes a bug where undo after a brush selection, a right-click on empty canvas, Enter on a selected group, or Tab / Ctrl+arrow traversal reverted the previous edit as well, typically deleting the shape the user had just drawn. Closes #10412.

### Before

Clicking, Shift-clicking, and select-all each call `markHistoryStoppingPoint` before changing the selection, so undo rewinds only the selection change. Four idle-state selection changes did not:

- `PointingCanvas` marked only when something was already selected, and `Brushing` never marked, so a brush that started from an empty selection had no stopping point.
- `Idle.onRightClick` on the canvas called `selectNone()` without a mark.
- `Idle.onKeyUp` for Enter on groups called `setSelectedShapes` without a mark.
- `Editor.selectAdjacentShape`, `selectParentShape`, and `selectFirstChildShape` all ended in `_selectShapesAndZoom`, which did not mark.

Without a mark, the selection change folded into the pending history entry (for example the draw tool's new line), and undo reverted both at once.

### After

Each of those paths marks before changing the selection, so undo rewinds only the selection change.

### Implementation notes

- The brushing mark lives in `PointingCanvas.onPointerMove`, placed when the drag starts, rather than in `Brushing.onEnter` or unconditionally in `PointingCanvas.onEnter`. Marking unconditionally on enter would put an empty mark on the stack for a plain click on empty canvas, which flips `getCanUndo()` to true with nothing to undo (`Editor.test.tsx` guards this). Marking in `Brushing.onEnter` would split a click-drag that starts from an existing selection into two undo steps (deselect, then brush selection), because `PointingCanvas` already marks before clearing the selection. The `didMark` flag keeps that gesture a single step; a test covers it.
- The right-click path marks only when there is a selection to clear, matching `selectOnCanvasPointerUp`, so right-clicking empty canvas with nothing selected still leaves the undo stack untouched.
- The keyboard traversal mark is in the private `_selectShapesAndZoom` so all three editor traversal methods get it in one place. This means calling `editor.selectAdjacentShape()` programmatically now also records a stopping point.
- Brushing entered by Ctrl-dragging from a shape or handle (`PointingShape`, `PointingHandle`, `PointingArrowLabel`) is not covered here; the issue scopes brushing to a drag that starts on the canvas.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a line with the draw tool, switch to select, brush over it, press Ctrl/Cmd+Z. The line stays; only the selection clears.
2. Select a shape, right-click empty canvas, undo. The selection comes back.
3. Group two shapes, select the group, press Enter, undo. The group is selected again.
4. Select a shape, press Tab (or Ctrl/Cmd+Right), undo. The original shape is selected again.

- [x] Unit tests — the new tests in `packages/tldraw/src/test/select.test.tsx` fail on `main` and pass with this change

### Release notes

- Fix undo reverting the previous edit after brushing, right-clicking empty canvas, pressing Enter on a group, or keyboard traversal of the selection

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -1   |
| Tests     | +121 / -0  |
