### PR TITLE
fix(editor): make the right Shift key give the large nudge step

### DIFF
--- a/packages/driver/src/lib/Driver.ts
+++ b/packages/driver/src/lib/Driver.ts
@@ -284,7 +284,7 @@ export class Driver {
 			...flags,
 			accelKey: flags.accelKey ?? isAccelKey(flags),
 			name,
-			code: KEY_CODES[key] ?? 'Key' + key[0].toUpperCase() + key.slice(1),
+			code: options.code ?? KEY_CODES[key] ?? 'Key' + key[0].toUpperCase() + key.slice(1),
 			type: 'keyboard',
 			key,
 		}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11489,9 +11489,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'keyboard': {
-				// please, please
-				if (info.key === 'ShiftRight') info.key = 'ShiftLeft'
-				if (info.key === 'AltRight') info.key = 'AltLeft'
+				// Left and right modifier keys are the same key to us. `inputs.keys` stores
+				// `code`, so normalize that: a `ShiftRight` left as-is would never match the
+				// `ShiftLeft` that nudging checks or that `_releaseShiftKey` clears.
+				if (info.code === 'ShiftRight') info.code = 'ShiftLeft'
+				if (info.code === 'AltRight') info.code = 'AltLeft'
 				if (info.code === 'ControlRight') info.code = 'ControlLeft'
 				if (info.code === 'MetaRight') info.code = 'MetaLeft'
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -105,6 +105,23 @@ describe('TLSelectTool.Idle', () => {
 		expect(editor.getShape<TLGeoShape>(ids.box1)!.props.geo).toBe('rectangle')
 		expect(editor.getOnlySelectedShapeId()).toBe(ids.box1)
 	})
+
+	it('Nudges by the large step with either Shift key held', () => {
+		const shape = editor.getShape(ids.box1)!
+		editor.select(shape.id)
+
+		editor.keyDown('Shift', { code: 'ShiftLeft' })
+		editor.keyDown('ArrowRight')
+		editor.keyUp('ArrowRight')
+		editor.keyUp('Shift', { code: 'ShiftLeft' })
+		expect(editor.getShape(shape.id)?.x).toBe(110)
+
+		editor.keyDown('Shift', { code: 'ShiftRight' })
+		editor.keyDown('ArrowRight')
+		editor.keyUp('ArrowRight')
+		editor.keyUp('Shift', { code: 'ShiftRight' })
+		expect(editor.getShape(shape.id)?.x).toBe(120)
+	})
 })
 
 // todo: turn on feature flag for these tests or remove them


### PR DESCRIPTION
This PR fixes a bug where holding the right Shift key while pressing an arrow key nudged the selection by one unit instead of ten. Closes #10417.

### Before

`Editor.dispatch` normalizes left/right modifier keys before recording them, but for Shift and Alt it rewrote `info.key` (`'ShiftRight'` → `'ShiftLeft'`) while `inputs.keys` stores `info.code`. A real `KeyboardEvent` reports `key: 'Shift'` for both keys, so that rewrite never matched anything, and a right Shift press landed in `inputs.keys` as `'ShiftRight'`. `nudgeSelectedShapes` in the select tool's `Idle` state (and the crop tool's `Idle`) checks `keys.has('ShiftLeft')` to pick the large step, so only the left key worked. The synthetic `key_up` in `_releaseShiftKey` also only clears `'ShiftLeft'`, so a stale `'ShiftRight'` could linger in the set.

### After

The normalization rewrites `info.code` for Shift and Alt, matching what it already did for Control and Meta. Either Shift key now gives the large nudge step in both the select and crop tools, and the debounced release clears the right key too.

### Implementation notes

`Driver.keyDown`/`keyUp` accept a `code` override in their options type but then unconditionally overwrote it from the key lookup table, so a test could not send `'ShiftRight'` through the normal helpers. The override now wins when given; the default is unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape.
2. Hold the right Shift key and press an arrow key. The shape moves by 10 units (or by `gridSize * 5` in grid mode), the same as with the left Shift key.

- [x] Unit tests — the new test fails on `main` (right Shift nudged by 1) and passes with this change

### Release notes

- Fix the right Shift key not giving the large nudge step when moving shapes with the arrow keys

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -4    |
| Tests     | +17 / -0   |
