### PR TITLE
fix(editor): make a dropped file or url its own undo step

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -153,6 +153,7 @@ export function useCanvasEvents() {
 				if (e.dataTransfer?.files?.length) {
 					const files = Array.from(e.dataTransfer.files)
 
+					editor.markHistoryStoppingPoint('drop')
 					await editor.putExternalContent({
 						type: 'files',
 						files,
@@ -163,6 +164,7 @@ export function useCanvasEvents() {
 
 				const url = e.dataTransfer.getData('url')
 				if (url) {
+					editor.markHistoryStoppingPoint('drop')
 					await editor.putExternalContent({
 						type: 'url',
 						url,

--- a/packages/editor/src/lib/test/useCanvasEvents.test.tsx
+++ b/packages/editor/src/lib/test/useCanvasEvents.test.tsx
@@ -1,0 +1,74 @@
+import { act, render } from '@testing-library/react'
+import { Editor } from '../editor/Editor'
+import { TldrawEditor } from '../TldrawEditor'
+
+function dropEvent(dataTransfer: { files: File[]; getData(type: string): string }) {
+	const event = new Event('drop', { bubbles: true, cancelable: true })
+	Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+	return event
+}
+
+describe('useCanvasEvents drop handling', () => {
+	let editor: Editor
+	let canvas: HTMLElement
+
+	beforeEach(async () => {
+		await act(async () => {
+			render(
+				<TldrawEditor
+					shapeUtils={[]}
+					bindingUtils={[]}
+					onMount={(e) => {
+						editor = e
+					}}
+				/>
+			)
+		})
+		canvas = document.querySelector('[data-testid="canvas"]') as HTMLElement
+
+		// Stand-ins for the default handlers: any undoable change will do.
+		editor.registerExternalContentHandler('files', async () => {
+			editor.createPage({ name: 'dropped' })
+		})
+		editor.registerExternalContentHandler('url', async () => {
+			editor.createPage({ name: 'dropped' })
+		})
+
+		// An unmarked change before the drop, like a stroke the user just drew.
+		editor.createPage({ name: 'before drop' })
+	})
+
+	afterEach(() => {
+		editor?.dispose()
+	})
+
+	function pageNames() {
+		return editor.getPages().map((p) => p.name)
+	}
+
+	it('makes a dropped file its own undo step', async () => {
+		await act(async () => {
+			canvas.dispatchEvent(
+				dropEvent({ files: [new File(['x'], 'x.png', { type: 'image/png' })], getData: () => '' })
+			)
+		})
+		expect(pageNames()).toEqual(['Page 1', 'before drop', 'dropped'])
+
+		editor.undo()
+
+		expect(pageNames()).toEqual(['Page 1', 'before drop'])
+	})
+
+	it('makes a dropped url its own undo step', async () => {
+		await act(async () => {
+			canvas.dispatchEvent(
+				dropEvent({ files: [], getData: (type) => (type === 'url' ? 'https://example.com' : '') })
+			)
+		})
+		expect(pageNames()).toEqual(['Page 1', 'before drop', 'dropped'])
+
+		editor.undo()
+
+		expect(pageNames()).toEqual(['Page 1', 'before drop'])
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where undoing after dropping a file or url onto the canvas also undid the change made before the drop. Closes #10414.

### Before

`onDrop` in `useCanvasEvents` called `editor.putExternalContent` for dropped files and urls without marking a history stopping point first. The shapes the drop created merged into whatever unmarked change preceded them (for example a stroke the user had just drawn), so a single Ctrl/Cmd+Z removed both. Paste (`'paste'`) and the media picker (`'insert media'`) already mark before they put content.

### After

Both `onDrop` branches call `editor.markHistoryStoppingPoint('drop')` before `putExternalContent`, so a drop is its own undo step and undo removes only the dropped content.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a stroke.
2. Drop an image file (or a url) onto the canvas.
3. Press Ctrl/Cmd+Z — only the dropped content is removed; the stroke stays.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix undo after dropping a file or url onto the canvas also undoing the previous change

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -0    |
| Tests     | +74 / -0   |
