### PR TITLE
fix(editor): stop Delete and other shortcuts acting on children of locked frames

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9128,7 +9128,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/** @internal */
 	private _getUnlockedShapeIds(ids: TLShapeId[]): TLShapeId[] {
-		return ids.filter((id) => !this.getShape(id)?.isLocked)
+		// A child of a locked frame or group has `isLocked: false` but must be treated as
+		// locked, otherwise it could be deleted or duplicated while the UI shows it as locked
+		return ids.filter((id) => !this.isShapeOrAncestorLocked(id))
 	}
 
 	/**

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -361,3 +361,60 @@ describe('When the selectLockedShapes option is enabled', () => {
 		expect(lockEditor.getShape(ids.lockedShapeA)).not.toBeUndefined()
 	})
 })
+
+describe('Children of locked shapes', () => {
+	const framedBox = createShapeId('framedBox')
+
+	beforeEach(() => {
+		editor.createShape({
+			id: framedBox,
+			type: 'geo',
+			x: 10,
+			y: 10,
+			parentId: ids.lockedFrame,
+			isLocked: false,
+		})
+	})
+
+	it('Cannot be deleted', () => {
+		editor.deleteShapes([framedBox, ids.groupedBoxA])
+		expect(editor.getShape(framedBox)).toBeDefined()
+		expect(editor.getShape(ids.groupedBoxA)).toBeDefined()
+	})
+
+	it('Cannot be deleted when selected via the context menu path', () => {
+		// Right-clicking a child of a locked frame selects it so the context menu can show it
+		editor.setSelectedShapes([framedBox])
+		editor.deleteShapes(editor.getSelectedShapeIds())
+		expect(editor.getShape(framedBox)).toBeDefined()
+	})
+
+	it('Cannot be duplicated', () => {
+		const shapeCount = editor.getCurrentPageShapes().length
+		editor.duplicateShapes([framedBox, ids.groupedBoxA])
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
+	})
+
+	it('Cannot be grouped', () => {
+		const shapeCount = editor.getCurrentPageShapes().length
+		editor.groupShapes([framedBox, ids.unlockedShapeA, ids.unlockedShapeB])
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount + 1)
+		expect(editor.getShape(framedBox)!.parentId).toBe(ids.lockedFrame)
+	})
+
+	it('Cannot be selected with select all', () => {
+		editor.setSelectedShapes([framedBox])
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
+	it('Can be deleted when forced', () => {
+		editor.run(
+			() => {
+				editor.deleteShapes([framedBox])
+				expect(editor.getShape(framedBox)).toBeUndefined()
+			},
+			{ ignoreShapeLock: true }
+		)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where pressing Delete removed a child of a locked frame even though the context menu's Delete item for that same selection was disabled. Closes #10419.

### Before

Right-clicking a shape inside a locked frame selects it (so the menu can offer unlock), and the menu gates Delete, Duplicate, Group, etc. with `useUnlockedSelectedShapesCount`, which uses `editor.isShapeOrAncestorLocked`. The editor commands behind those menu items (`deleteShapes`, `duplicateShapes`, `groupShapes`, `ungroupShapes`, `selectAll`) filtered their input through `Editor._getUnlockedShapeIds`, which only checked the shape's own `isLocked` flag. A child of a locked frame or group has `isLocked: false`, so the keyboard shortcut went through while the menu item was greyed out. `updateShapes` already treated children of locked ancestors as locked, so the editor was inconsistent with itself as well as with the UI.

### After

`_getUnlockedShapeIds` filters with `isShapeOrAncestorLocked`, so children of locked frames and groups are skipped by `deleteShapes`, `duplicateShapes`, `groupShapes`, `ungroupShapes`, and `selectAll`, matching the UI gating and `updateShapes`. `editor.run(fn, { ignoreShapeLock: true })` still bypasses the check as before.

### Implementation notes

The issue left open whether to relax the UI or tighten the editor. Tightening the editor is the conservative choice: it matches the existing `updateShapes` behavior and the lock semantics the select tool, eraser, and overlays already use, rather than making locked frames' children deletable from the menu.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame with a rectangle inside it and lock the frame.
2. Right-click the rectangle to select it, close the menu, press Delete. The rectangle stays.
3. Unlock the frame and repeat; the rectangle is deleted.

- [x] Unit tests — the new tests in `lockShapes.test.ts` fail on `main` and pass with this change

### Release notes

- Fix the Delete, Duplicate, and Group shortcuts acting on children of locked frames and groups, which the menu already treated as locked

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -1    |
| Tests     | +57 / -0   |
