### PR TITLE
fix(editor): deselect shapes when toggleLock locks a mixed selection

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7229,27 +7229,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (this.getIsReadonly() || ids.length === 0) return this
 
-		let allLocked = true,
-			allUnlocked = true
+		let allLocked = true
 		const shapesToToggle: TLShape[] = []
 		for (const id of ids) {
 			const shape = this.getShape(id)
 			if (shape) {
 				shapesToToggle.push(shape)
-				if (shape.isLocked) {
-					allUnlocked = false
-				} else {
-					allLocked = false
-				}
+				if (!shape.isLocked) allLocked = false
 			}
 		}
 		this.run(() => {
-			if (allUnlocked) {
-				this.updateShapes(
-					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: true }))
-				)
-				this.setSelectedShapes([])
-			} else if (allLocked) {
+			if (allLocked) {
 				this.updateShapes(
 					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: false }))
 				)
@@ -7257,6 +7247,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				this.updateShapes(
 					shapesToToggle.map((shape) => ({ id: shape.id, type: shape.type, isLocked: true }))
 				)
+				this.setSelectedShapes([])
 			}
 		})
 

--- a/packages/tldraw/src/test/commands/lockShapes.test.ts
+++ b/packages/tldraw/src/test/commands/lockShapes.test.ts
@@ -88,6 +88,17 @@ describe('Locking', () => {
 		// Locking deselects the shape
 		expect(editor.getSelectedShapeIds()).toEqual([])
 	})
+
+	it('Locks and deselects a mixed selection of locked and unlocked shapes', () => {
+		editor.run(() => editor.setSelectedShapes([ids.lockedShapeA, ids.unlockedShapeA]), {
+			ignoreShapeLock: true,
+		})
+		editor.toggleLock(editor.getSelectedShapeIds())
+		expect(
+			[ids.lockedShapeA, ids.unlockedShapeA].map((id) => editor.getShape(id)!.isLocked)
+		).toStrictEqual([true, true])
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
 })
 
 describe('Locked shapes', () => {


### PR DESCRIPTION
This PR fixes a bug where locking a selection that mixes locked and unlocked shapes (for example, brush over a locked and an unlocked rectangle and press Shift+L) locked every shape but left them all selected, drawing a selection box around shapes that can no longer be selected. Closes #10420.

### Before

`Editor.toggleLock` had three branches: all-unlocked locked the shapes and called `setSelectedShapes([])`; all-locked unlocked them; mixed locked the shapes but never cleared the selection. So the outcome of a lock depended on whether one of the selected shapes happened to be locked already.

### After

The all-unlocked and mixed branches are merged into a single "lock" branch that updates the shapes and clears the selection, so locking always deselects regardless of the selection's starting mix. Unlocking is unchanged.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new test in `lockShapes.test.ts` fails on `main` and passes with this change

### Release notes

- Fix locking a mixed selection of locked and unlocked shapes leaving the shapes selected

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -13   |
| Tests     | +11 / -0   |
