### PR TITLE
fix(tldraw): bind frame selection to ctrl+alt+g on Windows and Linux

### DIFF
--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -587,7 +587,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			{
 				id: 'frame-selection',
 				label: 'action.frame-selection',
-				kbd: 'cmd+alt+g',
+				kbd: 'cmd+alt+g,ctrl+alt+g',
 				onSelect(source) {
 					if (!canApplySelectionAction()) return
 					if (mustGoBackToSelectToolFirst()) return

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -314,3 +314,30 @@ describe('shifted number-row shortcuts across keyboard layouts', () => {
 		expect(zoomOut).toHaveBeenCalledTimes(1)
 	})
 })
+
+// Regression test for #10422: frame-selection was the only cmd shortcut without a ctrl twin,
+// so Ctrl+Alt+G did nothing on Windows and Linux even though the shortcuts dialog listed it.
+describe('frame selection shortcut', () => {
+	it.each([
+		['cmd+alt+g (macOS)', { metaKey: true }],
+		['ctrl+alt+g (Windows / Linux)', { ctrlKey: true }],
+	])('wraps the selection in a frame on %s', async (_label, modifier) => {
+		const { editor } = await setupFocusedEditor()
+		const a = createShapeId()
+		const b = createShapeId()
+		act(() => {
+			editor.createShapes([
+				{ id: a, type: 'geo', x: 0, y: 0 },
+				{ id: b, type: 'geo', x: 200, y: 200 },
+			])
+			editor.select(a, b)
+		})
+
+		keydown(editor, { key: 'g', code: 'KeyG', altKey: true, ...modifier })
+
+		const frame = editor.getCurrentPageShapes().find((s) => editor.isShapeOfType(s, 'frame'))
+		expect(frame).toBeDefined()
+		expect(editor.getShape(a)?.parentId).toBe(frame!.id)
+		expect(editor.getShape(b)?.parentId).toBe(frame!.id)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where the "Frame selection" shortcut did nothing on Windows and Linux, even though the keyboard shortcuts dialog listed it. Closes #10422.

### Before

The `frame-selection` action in `actions.tsx` was registered as `kbd: 'cmd+alt+g'`, the only cmd shortcut in the default actions without a `ctrl+` twin. `useKeyboardShortcuts` maps `cmd` to `metaKey` only, so on non-Mac platforms Ctrl+Alt+G never matched a registration.

### After

The action is registered as `kbd: 'cmd+alt+g,ctrl+alt+g'`, matching the pattern every other cmd shortcut uses, so Ctrl+Alt+G wraps the selection in a frame on Windows and Linux.

### Change type

- [x] `bugfix`

### Test plan

1. On Windows or Linux, select two shapes and press Ctrl+Alt+G.
2. The shapes are wrapped in a new frame.

- [x] Unit tests — the new `ctrl+alt+g` test fails on `main` and passes with this change

### Release notes

- Fix the "Frame selection" shortcut (Ctrl+Alt+G) not working on Windows and Linux

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1    |
| Tests     | +27 / -0   |
