### PR TITLE
fix(editor): skip locked shapes in Tab and arrow-key traversal

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2287,12 +2287,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 			firstParentId &&
 			selectedShapeIds.every((shapeId) => this.getShape(shapeId)?.parentId === firstParentId) &&
 			!isPageId(firstParentId)
-		const filteredShapes = isSelectedWithinContainer
-			? this.getCurrentPageShapes().filter((shape) => shape.parentId === firstParentId)
-			: this.getCurrentPageShapes().filter((shape) => isPageId(shape.parentId))
-		const readingOrderShapes = isSelectedWithinContainer
-			? this._getShapesInReadingOrder(filteredShapes)
-			: this.getCurrentPageShapesInReadingOrder()
+		// Locked shapes can't be selected by clicking or select all, so traversal skips them too
+		const filteredShapes = this.getCurrentPageShapes().filter(
+			(shape) =>
+				!shape.isLocked &&
+				(isSelectedWithinContainer ? shape.parentId === firstParentId : isPageId(shape.parentId))
+		)
+		const readingOrderShapes = this._getShapesInReadingOrder(filteredShapes)
 		const currentShapeId: TLShapeId | undefined =
 			selectedShapeIds.length === 1
 				? selectedShapeIds[0]

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2287,10 +2287,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			firstParentId &&
 			selectedShapeIds.every((shapeId) => this.getShape(shapeId)?.parentId === firstParentId) &&
 			!isPageId(firstParentId)
-		// Locked shapes can't be selected by clicking or select all, so traversal skips them too
+		// Locked shapes (and children of locked containers) can't be selected by clicking or
+		// select all, so traversal skips them too
 		const filteredShapes = this.getCurrentPageShapes().filter(
 			(shape) =>
-				!shape.isLocked &&
+				!this.isShapeOrAncestorLocked(shape) &&
 				(isSelectedWithinContainer ? shape.parentId === firstParentId : isPageId(shape.parentId))
 		)
 		const readingOrderShapes = this._getShapesInReadingOrder(filteredShapes)
@@ -2302,6 +2303,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let adjacentShapeId: TLShapeId
 		if (direction === 'next' || direction === 'prev') {
 			const shapeIds = readingOrderShapes.map((shape) => shape.id)
+			// Every candidate can be filtered out (e.g. a locked shape is selected and nothing
+			// else is unlocked); indexing an empty list would hand getShape undefined
+			if (shapeIds.length === 0) return
 
 			const currentIndex = currentShapeId ? shapeIds.indexOf(currentShapeId) : -1
 			const adjacentIndex =

--- a/packages/tldraw/src/test/navigation.test.ts
+++ b/packages/tldraw/src/test/navigation.test.ts
@@ -1005,6 +1005,50 @@ describe('Shape navigation', () => {
 			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		})
 
+		it('keeps a selected locked shape when nothing else is selectable', () => {
+			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, isLocked: true }])
+
+			editor.setSelectedShapes([ids.box1])
+
+			expect(() => editor.selectAdjacentShape('next')).not.toThrow()
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+			expect(() => editor.selectAdjacentShape('right')).not.toThrow()
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		it('skips children of a locked frame when navigating with next and prev', () => {
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.frame1, type: 'frame', x: 200, y: 0, props: { w: 200, h: 200 }, isLocked: true },
+				{ id: ids.box2, type: 'geo', x: 10, y: 10, parentId: ids.frame1 },
+				{ id: ids.box3, type: 'geo', x: 110, y: 10, parentId: ids.frame1 },
+			])
+
+			// A child of the locked frame is selected, e.g. programmatically; the other child is
+			// locked by its ancestor, so traversal has nowhere to go
+			editor.setSelectedShapes([ids.box2])
+
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+			editor.selectAdjacentShape('prev')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+		})
+
+		it('skips children of a locked frame when navigating in a cardinal direction', () => {
+			editor.createShapes([
+				{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 400, h: 200 }, isLocked: true },
+				{ id: ids.box1, type: 'geo', x: 10, y: 10, parentId: ids.frame1 },
+				{ id: ids.box2, type: 'geo', x: 200, y: 10, parentId: ids.frame1 },
+			])
+
+			editor.setSelectedShapes([ids.box1])
+
+			editor.selectAdjacentShape('right')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
 		it('skips locked shapes when navigating within a container', () => {
 			editor.createShapes([
 				{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 400, h: 200 } },

--- a/packages/tldraw/src/test/navigation.test.ts
+++ b/packages/tldraw/src/test/navigation.test.ts
@@ -957,6 +957,72 @@ describe('Shape navigation', () => {
 	})
 
 	// 7. Additional edge cases and regression tests
+	describe('locked shapes', () => {
+		it('skips locked shapes when navigating with next and prev', () => {
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0, isLocked: true },
+				{ id: ids.box3, type: 'geo', x: 200, y: 0 },
+			])
+
+			editor.select(ids.box1)
+
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+
+			editor.selectAdjacentShape('prev')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		it('skips locked shapes when navigating in a cardinal direction', () => {
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0, isLocked: true },
+				{ id: ids.box3, type: 'geo', x: 200, y: 0 },
+			])
+
+			editor.select(ids.box1)
+
+			editor.selectAdjacentShape('right')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+
+			editor.selectAdjacentShape('left')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		it('keeps the current selection when every other shape is locked', () => {
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0, isLocked: true },
+			])
+
+			editor.select(ids.box1)
+
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+			editor.selectAdjacentShape('right')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		it('skips locked shapes when navigating within a container', () => {
+			editor.createShapes([
+				{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 400, h: 200 } },
+				{ id: ids.box1, type: 'geo', x: 10, y: 10, parentId: ids.frame1 },
+				{ id: ids.box2, type: 'geo', x: 120, y: 10, parentId: ids.frame1, isLocked: true },
+				{ id: ids.box3, type: 'geo', x: 230, y: 10, parentId: ids.frame1 },
+			])
+
+			editor.select(ids.box1)
+
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+
+			editor.selectAdjacentShape('left')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+	})
+
 	describe('edge cases and regressions', () => {
 		it('cycles through all shapes when repeatedly tabbing', () => {
 			// Create several shapes with predefined IDs


### PR DESCRIPTION
This PR fixes a bug where Tab / Shift+Tab and Ctrl/Cmd+arrow traversal would land on locked shapes, even though clicking and select all never select them. Closes #10421.

### Before

`Editor.selectAdjacentShape` built its candidate list from every shape at the current level (page or container) with no lock filter, so both the reading-order list used for `next`/`prev` and the list passed to `getNearestAdjacentShape` for cardinal moves included locked shapes. Pressing Tab next to a locked rectangle selected it (outline, no handles), a selection the user could not otherwise reach.

### After

`selectAdjacentShape` drops locked shapes from its candidate list before computing the reading order or the nearest shape in a direction, matching `selectAll`'s use of unlocked shapes. If every other shape at the current level is locked, the current selection stays put.

### Implementation notes

The fix is scoped to `selectAdjacentShape`; `getCurrentPageShapesInReadingOrder` is unchanged because the A11y announcement uses it for the "shape N of M" count, and the issue flagged screen-reader reachability as the open product question. Both branches now go through `_getShapesInReadingOrder` on the filtered list instead of the page-level computed, since that computed cannot apply the lock filter.

### Change type

- [x] `bugfix`

### Test plan

1. Draw two rectangles, lock one, select the other.
2. Press Tab, Shift+Tab, and Ctrl/Cmd+arrow towards the locked shape; selection should skip it (or stay put if it is the only other shape).

- [x] Unit tests — the four new `locked shapes` tests in `navigation.test.ts` fail on `main` and pass with this change

### Release notes

- Fix Tab and Ctrl/Cmd+arrow keyboard traversal selecting locked shapes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -6    |
| Tests     | +66 / -0   |
