### PR TITLE
fix(draw): scale shift segment threshold with zoom in draw and highlight tools

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -349,7 +349,7 @@ export class Drawing extends StateNode {
 
 				const hasMovedFarEnough =
 					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
-					this.editor.options.dragDistanceSquared
+					this.editor.options.dragDistanceSquared / this.editor.getZoomLevel() ** 2
 
 				// Find the distance from where the pointer was when shift was released and
 				// where it is now; if it's far enough away, then update the page point where
@@ -416,7 +416,7 @@ export class Drawing extends StateNode {
 
 				const hasMovedFarEnough =
 					Vec.Dist2(pagePointWhereNextSegmentChanged, inputs.getCurrentPagePoint()) >
-					this.editor.options.dragDistanceSquared
+					this.editor.options.dragDistanceSquared / this.editor.getZoomLevel() ** 2
 
 				// Find the distance from where the pointer was when shift was released and
 				// where it is now; if it's far enough away, then update the page point where

--- a/packages/tldraw/src/test/drawing.test.ts
+++ b/packages/tldraw/src/test/drawing.test.ts
@@ -121,6 +121,56 @@ for (const toolType of ['draw', 'highlight'] as const) {
 			expect(shape.props.segments[2].type).toBe('straight')
 		})
 
+		it('Starts a new segment after moving a screen-space distance when zoomed in', () => {
+			// At 8x zoom, 5 screen pixels is 0.625 page units, below the page-space threshold
+			editor.setCamera({ x: 0, y: 0, z: 8 })
+			editor
+				.setCurrentTool(toolType)
+				.pointerDown(100, 100)
+				.pointerMove(120, 120)
+				.keyDown('Shift')
+				.pointerMove(125, 125)
+
+			let shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight'])
+
+			editor.keyUp('Shift').pointerMove(130, 130)
+
+			shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight', 'free'])
+			editor.pointerUp()
+		})
+
+		it('Does not start a new segment before moving a screen-space distance when zoomed out', () => {
+			// At 0.1x zoom, 2 screen pixels is 20 page units, above the page-space threshold
+			editor.setCamera({ x: 0, y: 0, z: 0.1 })
+			editor
+				.setCurrentTool(toolType)
+				.pointerDown(100, 100)
+				.pointerMove(120, 120)
+				.keyDown('Shift')
+				.pointerMove(122, 122)
+
+			let shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free'])
+
+			editor.pointerMove(130, 130)
+
+			shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight'])
+
+			editor.keyUp('Shift').pointerMove(132, 132)
+
+			shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight'])
+
+			editor.pointerMove(140, 140)
+
+			shape = editor.getCurrentPageShapes()[0] as DrawableShape
+			expect(shape.props.segments.map((s) => s.type)).toEqual(['free', 'straight', 'free'])
+			editor.pointerUp()
+		})
+
 		it('Extends previously drawn line when shift is held', () => {
 			editor
 				.setCurrentTool(toolType)


### PR DESCRIPTION
This PR fixes a bug where pressing or releasing Shift mid-stroke in the draw and highlight tools started the new straight or free segment after a distance that scaled with zoom: 4 screen pixels at 100%, 32 at 800%, and under one at 10%. Closes #10426.

### Before

`Drawing.updateDrawingShape()` compared the page-space `Vec.Dist2` between the pointer position when Shift changed and the current pointer position against `options.dragDistanceSquared`, which is a screen-space threshold. At high zoom the straight segment started late; at low zoom it started almost immediately.

### After

Both `starting_straight` and `starting_free` compare against `dragDistanceSquared / zoomLevel ** 2`, so the new segment begins after 4 screen pixels of movement at any zoom, matching the drag threshold used elsewhere in the editor.

### Change type

- [x] `bugfix`

### Test plan

1. Zoom to 800%, pick the draw tool, start a stroke, press Shift and move a few pixels: the straight segment starts right away.
2. Zoom to 10% and repeat: the straight segment does not start until the pointer has moved a few screen pixels.

- [x] Unit tests — the new tests in `drawing.test.ts` fail on `main` and pass with this change, for both the draw and highlight tools

### Release notes

- Fix the shift-to-draw-straight segment threshold in the draw and highlight tools scaling with zoom level

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -2    |
| Tests     | +50 / -0   |
