### PR TITLE
fix(notes): let the note tool snap beside the note it just created

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeTool.test.ts
@@ -204,6 +204,24 @@ describe('Adjacent note position helpers (sticky pits)', () => {
 			})
 	})
 
+	it('Falls into a pit beside the note the tool just created when tool lock is on', () => {
+		editor.updateInstanceState({ isToolLocked: true })
+		editor.setCurrentTool('note').pointerMove(100, 100).click()
+		const first = editor.getLastCreatedShape()
+		expect(first).toMatchObject({ type: 'note', x: 0, y: 0 })
+		expect(editor.getSelectedShapeIds()).toEqual([first.id])
+
+		editor.pointerMove(324, 104).click()
+		const second = editor.getLastCreatedShape()
+		expect(second.id).not.toBe(first.id)
+		editor.expectShapeToMatch({
+			...second,
+			// in the pit to the right of the first note
+			x: 220,
+			y: 0,
+		})
+	})
+
 	it('Does not create a new sticky note in a sticky pit if a note is already there', () => {
 		editor
 			.createShape({ type: 'note', x: 0, y: 0 })

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -3,6 +3,7 @@ import {
 	IndexKey,
 	TLNoteShape,
 	TLShape,
+	TLShapeId,
 	Vec,
 	compact,
 	createShapeId,
@@ -94,29 +95,34 @@ export interface AvailableNoteAdjacentPositionsOpts {
 	extraHeight: number
 	noteWidth: number
 	noteHeight: number
+	/**
+	 * Notes whose adjacent positions should not be offered, e.g. the notes being dragged,
+	 * which would otherwise snap to their own slots.
+	 */
+	excludeShapeIds?: TLShapeId[]
 }
 
 /**
- * Get all of the available note adjacent positions, excluding the selected shapes.
+ * Get all of the available note adjacent positions, excluding those around `excludeShapeIds`.
  *
  * @internal */
 export function getAvailableNoteAdjacentPositions(
 	editor: Editor,
 	opts: AvailableNoteAdjacentPositionsOpts
 ) {
-	const { rotation, scale, extraHeight, noteWidth, noteHeight } = opts
-	const selectedShapeIds = new Set(editor.getSelectedShapeIds())
+	const { rotation, scale, extraHeight, noteWidth, noteHeight, excludeShapeIds = [] } = opts
+	const excludedShapeIds = new Set(excludeShapeIds)
 	const minSize =
 		(Math.max(noteWidth, noteHeight) + editor.options.adjacentShapeMargin + extraHeight) ** 2
 	const allCenters = new Map<TLNoteShape, Vec>()
 	const positions: (Vec | undefined)[] = []
 
-	// Get all the positions that are adjacent to the selected note shapes
+	// Get all the positions that are adjacent to the candidate note shapes
 	for (const shape of editor.getCurrentPageShapes()) {
 		if (
 			!editor.isShapeOfType(shape, 'note') ||
 			scale !== shape.props.scale ||
-			selectedShapeIds.has(shape.id)
+			excludedShapeIds.has(shape.id)
 		) {
 			continue
 		}
@@ -126,7 +132,7 @@ export function getAvailableNoteAdjacentPositions(
 		// If the note has a different rotation, we can't use its adjacent positions
 		if (rotation !== transform.rotation()) continue
 
-		// Save the unselected note shape's center
+		// Save the candidate note shape's center
 		allCenters.set(shape, editor.getShapePageBounds(shape)!.center)
 
 		// And push its position to the positions array

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -439,6 +439,7 @@ function getTranslatingSnapshot(editor: Editor) {
 			extraHeight: noteSnapshot.shape.props.growY ?? 0,
 			noteWidth: dv.noteWidth,
 			noteHeight: dv.noteHeight,
+			excludeShapeIds: selectedShapeIds,
 		})
 		noteCenterOffset = new Vec(dv.noteWidth / 2, dv.noteHeight / 2)
 	}


### PR DESCRIPTION
This PR fixes a bug where the note tool, with tool lock on, would not snap a new note into the slot beside the note it had just created. Closes #10427.

### Before

`getAvailableNoteAdjacentPositions` read `editor.getSelectedShapeIds()` internally and skipped those notes when collecting candidate slots. That exclusion is for the translate gesture, where the notes being dragged must not snap to their own slots. The note tool reuses the helper via `getNoteShapeAdjacentPositionOffset`, but `createNoteShape` selects the note it creates and tool lock keeps the note tool active, so on the next click the previous note was still selected and its slots were never offered. The second note landed wherever the pointer was.

### After

The exclusion is an explicit `excludeShapeIds` option on the helper. The translate gesture passes the ids of the shapes it is dragging, preserving its behaviour exactly; the note tool passes nothing, so every note on the page is a candidate and the new note snaps beside the previous one. This also applies when a note is selected and the user picks the note tool without tool lock.

### Change type

- [x] `bugfix`

### Test plan

1. Pick the note tool and turn tool lock on.
2. Click on the canvas to create a note.
3. Click again just to the right of it, within the snap radius of the adjacent slot.
4. The second note snaps into alignment beside the first.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix the note tool not snapping a new note beside the note it just created when tool lock is on

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -6   |
| Tests     | +18 / -0   |
