### PR TITLE
fix(tldraw): select pasted text shapes and bookmarks

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
@@ -9,6 +9,7 @@ import {
 import { TestEditor } from '../test/TestEditor'
 import { defaultAssetUtils } from './defaultAssetUtils'
 import {
+	defaultHandleExternalTextContent,
 	defaultHandleExternalUrlContent,
 	notifyIfFileNotAllowed,
 	registerDefaultExternalContentHandlers,
@@ -201,6 +202,21 @@ describe('defaultHandleExternalUrlContent', () => {
 		expect(addToast).not.toHaveBeenCalled()
 	})
 
+	it('selects the created bookmark', async () => {
+		editor = new TestEditor()
+		const { opts } = makeOpts()
+
+		await defaultHandleExternalUrlContent(
+			editor,
+			{ url: 'https://example.com', point: { x: 0, y: 0 } },
+			opts
+		)
+
+		const [bookmark] = editor.getCurrentPageShapes()
+		expect(bookmark.type).toBe('bookmark')
+		expect(editor.getSelectedShapeIds()).toEqual([bookmark.id])
+	})
+
 	it('shows a toast and logs the url for a url with an invalid protocol', async () => {
 		// Regression test for #8097: dragging content from a browser tab in Chrome
 		// with an ad blocker active supplies a DataTransfer url rewritten to
@@ -229,5 +245,32 @@ describe('defaultHandleExternalUrlContent', () => {
 		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('about:blank#blocked'))
 
 		consoleWarn.mockRestore()
+	})
+})
+
+describe('defaultHandleExternalTextContent', () => {
+	let editor: TestEditor
+
+	afterEach(() => {
+		editor?.dispose()
+	})
+
+	it('selects the created text shape', async () => {
+		editor = new TestEditor()
+
+		await defaultHandleExternalTextContent(editor, { text: 'hello', point: { x: 0, y: 0 } })
+
+		const [text] = editor.getCurrentPageShapes()
+		expect(text.type).toBe('text')
+		expect(editor.getSelectedShapeIds()).toEqual([text.id])
+	})
+
+	it('does not select anything when the page is full and no shape is created', async () => {
+		editor = new TestEditor({ options: { maxShapesPerPage: 0 } })
+
+		await defaultHandleExternalTextContent(editor, { text: 'hello', point: { x: 0, y: 0 } })
+
+		expect(editor.getCurrentPageShapes()).toEqual([])
+		expect(editor.getSelectedShapeIds()).toEqual([])
 	})
 })

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -554,22 +554,30 @@ export async function defaultHandleExternalTextContent(
 	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)
 	const shapeId = createShapeId()
 
-	// Allow this to trigger the max shapes reached alert
-	editor.createShapes([
-		{
-			id: shapeId,
-			type: 'text',
-			x: newPoint.x,
-			y: newPoint.y,
-			props: {
-				richText: richTextToPaste,
-				// if the text has more than one line, align it to the left
-				textAlign: align,
-				autoSize,
-				w,
+	editor.run(() => {
+		// Allow this to trigger the max shapes reached alert
+		editor.createShapes([
+			{
+				id: shapeId,
+				type: 'text',
+				x: newPoint.x,
+				y: newPoint.y,
+				props: {
+					richText: richTextToPaste,
+					// if the text has more than one line, align it to the left
+					textAlign: align,
+					autoSize,
+					w,
+				},
 			},
-		},
-	])
+		])
+
+		// createShapes silently creates nothing when the page is full, so only
+		// select the shape if it actually exists
+		if (editor.getShape(shapeId)) {
+			editor.select(shapeId)
+		}
+	})
 }
 
 /** @public */
@@ -623,6 +631,8 @@ export async function defaultHandleExternalUrlContent(
 		})
 		return
 	}
+
+	editor.select(result.value.id)
 }
 
 /** @public */


### PR DESCRIPTION
This PR fixes a bug where pasting plain text, or a URL that becomes a bookmark, left the new shape unselected while every other kind of pasted content (shapes, images, embeds) ends up selected. Closes #10424.

### Before

`defaultHandleExternalTextContent` called `editor.createShapes` and returned, and `defaultHandleExternalUrlContent` returned right after `createBookmarkFromUrl` succeeded. Neither path touched the selection, so the previous selection (or nothing) stayed selected after the paste.

### After

Both handlers select the shape they create. The text handler only selects when the shape actually exists, since `createShapes` silently creates nothing when the page is at `maxShapesPerPage`. The URL handler selects the bookmark returned by `createBookmarkFromUrl`.

### Implementation notes

The selection is applied in the external content handlers rather than inside `createBookmarkFromUrl`. That helper is also used by the convert-to-bookmark action, which loops over several shapes; selecting inside the helper would leave only the last bookmark selected there, so that path is left unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Copy some text in another app and paste onto the canvas: the new text shape is selected.
2. Copy a URL (one that does not become an embed) and paste: the new bookmark is selected.

- [x] Unit tests — the two new selection tests fail on `main` and pass with this change

### Release notes

- Fix pasted text shapes and bookmarks not being selected after paste

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -15  |
| Tests     | +43 / -0   |
