### PR TITLE
fix(notes): pan to the adjacent note after selecting it

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -32,7 +32,6 @@ import {
 	useValue,
 } from '@tldraw/editor'
 import { useCallback, useContext } from 'react'
-import { startEditingShapeWithRichText } from '../../tools/SelectTool/selectHelpers'
 import { TldrawUiTooltip } from '../../ui/components/primitives/TldrawUiTooltip'
 import { TranslationsContext } from '../../ui/hooks/useTranslation/useTranslation'
 import {
@@ -54,7 +53,11 @@ import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { RichTextLabel, RichTextSVG } from '../shared/RichTextLabel'
 import { useIsReadyForEditing } from '../shared/useEditablePlainText'
 import { useEfficientZoomThreshold } from '../shared/useEfficientZoomThreshold'
-import { CLONE_HANDLE_MARGIN, getNoteShapeForAdjacentPosition } from './noteHelpers'
+import {
+	CLONE_HANDLE_MARGIN,
+	getNoteShapeForAdjacentPosition,
+	startEditingAdjacentNote,
+} from './noteHelpers'
 
 const NOTE_SHAPE_HORIZONTAL_ALIGNS = Object.freeze({
 	start: 'start',
@@ -749,7 +752,7 @@ function useNoteKeydownHandler(id: TLShapeId) {
 				})
 
 				if (newNote) {
-					startEditingShapeWithRichText(editor, newNote, { selectAll: true })
+					startEditingAdjacentNote(editor, newNote)
 				}
 			}
 		},

--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -366,3 +366,65 @@ it('Puts the new shape into a rotated frame and keeps the source page rotation',
 	testNoteShapeFrameRotations(0.01, 0)
 	testNoteShapeFrameRotations(0.01, 0.01)
 })
+
+describe('Bringing the adjacent note on screen', () => {
+	beforeEach(() => {
+		editor.user.updateUserPreferences({ animationSpeed: 0 })
+	})
+
+	it('Pans to a new note created off screen by clicking the clone handle', () => {
+		// Fully on screen, with the slot to its right hanging off the edge of the 2000px viewport
+		editor.createShape({ type: 'note', x: 1700, y: 1000 })
+		const shape = editor.getLastCreatedShape()!
+		const viewportBefore = editor.getViewportPageBounds().clone()
+		expect(viewportBefore.contains(editor.getShapePageBounds(shape)!)).toBe(true)
+
+		const handle = editor.getShapeHandles(shape.id)![1]
+		editor
+			.select(shape.id)
+			.pointerDown(handle.x, handle.y, { target: 'handle', shape, handle })
+			.expectToBeIn('select.pointing_handle')
+			.pointerUp()
+
+		const newShape = editor.getLastCreatedShape()
+		expect(newShape.id).not.toBe(shape.id)
+		expect(editor.getSelectedShapeIds()).toEqual([newShape.id])
+		expect(viewportBefore.contains(editor.getShapePageBounds(newShape)!)).toBe(false)
+		expect(editor.getViewportPageBounds().contains(editor.getShapePageBounds(newShape)!)).toBe(true)
+	})
+
+	it('Pans to an existing off screen note reached by clicking the clone handle', () => {
+		editor.createShape({ type: 'note', x: 1920, y: 1000 })
+		const offscreenNote = editor.getLastCreatedShape()!
+		editor.createShape({ type: 'note', x: 1700, y: 1000 })
+		const shape = editor.getLastCreatedShape()!
+
+		const handle = editor.getShapeHandles(shape.id)![1]
+		editor
+			.select(shape.id)
+			.pointerDown(handle.x, handle.y, { target: 'handle', shape, handle })
+			.expectToBeIn('select.pointing_handle')
+			.pointerUp()
+
+		expect(editor.getSelectedShapeIds()).toEqual([offscreenNote.id])
+		expect(editor.getViewportPageBounds().contains(editor.getShapePageBounds(offscreenNote)!)).toBe(
+			true
+		)
+	})
+
+	it('Does not move the camera when the new note is already on screen', () => {
+		editor.createShape({ type: 'note', x: 1000, y: 1000 })
+		const shape = editor.getLastCreatedShape()!
+		const cameraBefore = { ...editor.getCamera() }
+
+		const handle = editor.getShapeHandles(shape.id)![1]
+		editor
+			.select(shape.id)
+			.pointerDown(handle.x, handle.y, { target: 'handle', shape, handle })
+			.expectToBeIn('select.pointing_handle')
+			.pointerUp()
+
+		expect(editor.getLastCreatedShape().id).not.toBe(shape.id)
+		expect(editor.getCamera()).toMatchObject(cameraBefore)
+	})
+})

--- a/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteHelpers.ts
@@ -8,6 +8,7 @@ import {
 	createShapeId,
 	toRichText,
 } from '@tldraw/editor'
+import { startEditingShapeWithRichText } from '../../tools/SelectTool/selectHelpers'
 
 /** @internal */
 export const CLONE_HANDLE_MARGIN = 0
@@ -263,11 +264,21 @@ export function getNoteShapeForAdjacentPosition(
 		nextNote = editor.getShape(id)!
 	}
 
+	return nextNote
+}
+
+/**
+ * Start editing a note reached via Tab, Ctrl/Cmd+Enter, or a clone handle, and bring it on
+ * screen if it landed outside the viewport.
+ *
+ * @internal */
+export function startEditingAdjacentNote(editor: Editor, note: TLShape) {
+	startEditingShapeWithRichText(editor, note, { selectAll: true })
+	// Zooming before the note is selected pans to the source note instead (#10428).
 	editor.zoomToSelectionIfOffscreen(16, {
 		animation: {
 			duration: editor.options.animationMediumMs,
 		},
 		inset: 0,
 	})
-	return nextNote
 }

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -12,6 +12,7 @@ import { getArrowBindings } from '../../../shapes/arrow/shared'
 import {
 	getNoteAdjacentPositions,
 	getNoteShapeForAdjacentPosition,
+	startEditingAdjacentNote,
 } from '../../../shapes/note/noteHelpers'
 import type { NoteShapeUtil } from '../../../shapes/note/NoteShapeUtil'
 import { getDisplayValues } from '../../../shapes/shared/getDisplayValues'
@@ -76,7 +77,7 @@ export class PointingHandle extends StateNode {
 			const { editor } = this
 			const nextNote = getNoteForAdjacentPosition(editor, shape, handle, false)
 			if (nextNote) {
-				startEditingShapeWithRichText(editor, nextNote, { selectAll: true })
+				startEditingAdjacentNote(editor, nextNote)
 				return
 			}
 		}


### PR DESCRIPTION
This PR fixes a bug where the camera did not pan to a note created with Tab, Ctrl/Cmd+Enter, or a note's clone handle when the new note landed outside the viewport. Closes #10428.

### Before

`getNoteShapeForAdjacentPosition` called `editor.zoomToSelectionIfOffscreen` as its last step, before returning the new note. At that point the source note was still the selection, so the pan only fired when the *source* note was partly off screen, and framed the source note rather than the new one. Pressing Tab on a note near the edge of the viewport walked the row of new notes off screen without the camera following.

### After

The zoom is moved out of the helper into a new `startEditingAdjacentNote` helper, which calls `startEditingShapeWithRichText` (which selects the note) and then `zoomToSelectionIfOffscreen`. The Tab / Ctrl/Cmd+Enter handler and the clone-handle click path both go through it, so the camera now pans to bring the new (or existing adjacent) note into view.

### Implementation notes

The clone-handle *drag* path no longer zooms at all. It repositions the new note under the pointer, which is already on screen, and then hands off to `select.translating`, which edge-scrolls as needed. Animating the camera at the start of a drag would move the canvas under the pointer, so that path deliberately skips the zoom.

### Change type

- [x] `bugfix`

### Test plan

1. Create a note near the right edge of the viewport.
2. Press Tab repeatedly, or click its right clone handle.
3. The camera pans so each new note is on screen.

- [x] Unit tests — the two "pans to ..." tests in `noteCloning.test.ts` fail on `main` and pass with this change

### Release notes

- Fix the camera not panning to a note created with Tab, Ctrl/Cmd+Enter, or the clone handle when it lands off screen

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +20 / -5   |
| Tests     | +62 / -0   |
