### PR TITLE
fix(select): reset the cursor when brushing starts from a resize or rotate handle

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Brushing.ts
@@ -36,6 +36,10 @@ export class Brushing extends StateNode {
 
 		this.isWrapMode = editor.user.getIsWrapMode()
 
+		// Accel-pressing a resize or rotate handle brushes instead of resizing or rotating,
+		// and the handle's hover cursor would otherwise stay up for the whole brush.
+		editor.setCursor({ type: 'default', rotation: 0 })
+
 		this.viewportDidChange = false
 
 		let isInitialCheck = true

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3867,6 +3867,33 @@ it('uses the cross cursor when create resizing', () => {
 	expect(editor.getInstanceState().cursor.rotation).toBe(0)
 })
 
+describe('When brushing from a selection handle with the accel key', () => {
+	it('resets the resize cursor when brushing starts from a resize handle', () => {
+		editor.select(ids.boxA)
+		editor.pointerDownOnHandle('bottom_right', { ctrlKey: true })
+		editor.expectToBeIn('select.brushing')
+		expect(editor.getInstanceState().cursor).toMatchObject({ type: 'default', rotation: 0 })
+
+		editor.pointerMoveBy(50, 50)
+		expect(editor.getInstanceState().cursor).toMatchObject({ type: 'default', rotation: 0 })
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getInstanceState().cursor).toMatchObject({ type: 'default', rotation: 0 })
+	})
+
+	it('resets the rotate cursor when brushing starts from a rotate handle', () => {
+		editor.select(ids.boxA)
+		editor.pointerDownOnHandle('top_right_rotate', { ctrlKey: true })
+		editor.expectToBeIn('select.brushing')
+		expect(editor.getInstanceState().cursor).toMatchObject({ type: 'default', rotation: 0 })
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getInstanceState().cursor).toMatchObject({ type: 'default', rotation: 0 })
+	})
+})
+
 describe('Resizing text from the right edge', () => {
 	it('Resizes text from the right edge', () => {
 		const id = createShapeId()


### PR DESCRIPTION
This PR fixes a bug where Ctrl/Cmd+pressing a selection's resize or rotate handle started a brush that ran with the resize or rotate arrow cursor still showing. Closes #10430.

### Before

`Idle.onPointerDown` routes an accel-key press on a resize or rotate handle straight to `brushing` (long-standing behavior from #4570, where Ctrl/Cmd brushes through whatever is under the pointer). The hover cursor for the handle is set by `updateHoveredOverlayId` while idle, but `Brushing` never touched the cursor, so the resize or rotate arrow stayed up for the whole brush until `Idle.onEnter` reset it on pointer up.

### After

`Brushing.onEnter` resets the cursor to `default` before doing anything else, so a brush started from a handle shows the same cursor as one started from the canvas. Because the reset happens before the alt-key hand-off to `scribble_brushing`, Ctrl/Cmd+Alt on a handle gets the right cursor too.

### Implementation notes

The issue flagged this as a product call on whether Ctrl/Cmd on a handle should brush at all. This PR takes the conservative path: it keeps the existing brush routing (which dates back to #4570 and has a test in `rotating.test.ts`) and only fixes the cursor. The zero-size brush on a click without movement is unchanged; with the accel key held it deselects the shape, which matches what Ctrl/Cmd+click on the selected shape itself does.

### Change type

- [x] `bugfix`

### Test plan

1. Select a rectangle.
2. Ctrl/Cmd+press a corner resize handle (or a rotate handle) and drag.
3. The cursor should be the default arrow while brushing, not the resize or rotate arrow.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix the cursor staying as a resize or rotate arrow when Ctrl/Cmd+dragging a selection handle to brush-select.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -0    |
| Tests     | +27 / -0   |