### PR TITLE
fix(tldraw): paste from the context menu at the point where it was opened

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
@@ -6,7 +6,8 @@ import {
 	useValue,
 } from '@tldraw/editor'
 import { ContextMenu as _ContextMenu } from 'radix-ui'
-import { ReactNode, memo, useCallback, useEffect, useRef } from 'react'
+import { ReactNode, memo, useCallback, useContext, useEffect, useRef } from 'react'
+import { ContextMenuPagePointContext } from '../../context/actions'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
@@ -74,9 +75,14 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 	// interacts again.
 	const suppressDismissUntilRef = useRef(0)
 
+	const rContextMenuPagePoint = useContext(ContextMenuPagePointContext)
+
 	const cb = useCallback(
 		(isOpen: boolean) => {
 			const body = editor.getContainerDocument().body
+			if (rContextMenuPagePoint) {
+				rContextMenuPagePoint.current = isOpen ? editor.inputs.getCurrentPagePoint().clone() : null
+			}
 			if (!isOpen) {
 				const onlySelectedShape = editor.getOnlySelectedShape()
 
@@ -121,7 +127,7 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 				}
 			}
 		},
-		[editor, preventEscapeFromLosingShapeFocus]
+		[editor, preventEscapeFromLosingShapeFocus, rContextMenuPagePoint]
 	)
 
 	const container = useContainer()

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -63,6 +63,15 @@ export type TLUiActionsContextType = Record<string, TLUiActionItem>
 /** @internal */
 export const ActionsContext = React.createContext<TLUiActionsContextType | null>(null)
 
+/**
+ * The page point the context menu opened at, or null while it is closed. The context menu
+ * writes it; actions that place content (paste) read it, since the pointer keeps moving
+ * over the menu after it opens (#10423).
+ *
+ * @internal
+ */
+export const ContextMenuPagePointContext = React.createContext<{ current: Vec | null } | null>(null)
+
 /** @public */
 export interface ActionsProviderProps {
 	overrides?(
@@ -108,6 +117,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 	const msg = useTranslation()
 
 	const defaultDocumentName = helpers.msg('document.default-name')
+
+	const rContextMenuPagePoint = React.useRef<Vec | null>(null)
 
 	// should this be a useMemo? looks like it doesn't actually deref any reactive values
 	const actions = React.useMemo<TLUiActionsContextType>(() => {
@@ -1051,14 +1062,16 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.paste',
 				kbd: 'cmd+v,ctrl+v',
 				onSelect(source) {
+					// Resolve the point before the clipboard read: the menu closes, and clears
+					// its point, before the read settles.
+					const point =
+						source === 'context-menu'
+							? (rContextMenuPagePoint.current ?? editor.inputs.getCurrentPagePoint())
+							: undefined
 					navigator.clipboard
 						?.read()
 						.then((clipboardItems) => {
-							helpers.paste(
-								clipboardItems,
-								source,
-								source === 'context-menu' ? editor.inputs.getCurrentPagePoint() : undefined
-							)
+							helpers.paste(clipboardItems, source, point)
 						})
 						.catch(() => {
 							helpers.addToast({
@@ -1977,7 +1990,11 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 		components,
 	])
 
-	return <ActionsContext.Provider value={asActions(actions)}>{children}</ActionsContext.Provider>
+	return (
+		<ContextMenuPagePointContext.Provider value={rContextMenuPagePoint}>
+			<ActionsContext.Provider value={asActions(actions)}>{children}</ActionsContext.Provider>
+		</ContextMenuPagePointContext.Provider>
+	)
 }
 
 /** @public */

--- a/packages/tldraw/src/test/ui/ContextMenu.test.tsx
+++ b/packages/tldraw/src/test/ui/ContextMenu.test.tsx
@@ -1,5 +1,6 @@
-import { act, fireEvent, screen } from '@testing-library/react'
-import { createShapeId, Editor, tlenvReactive } from '@tldraw/editor'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { createShapeId, Editor, TldrawOptions, tlenvReactive } from '@tldraw/editor'
+import { vi } from 'vitest'
 import { TLComponents, Tldraw } from '../../lib/Tldraw'
 import { DefaultContextMenu } from '../../lib/ui/components/ContextMenu/DefaultContextMenu'
 import { TLUiOverrides } from '../../lib/ui/overrides'
@@ -7,6 +8,16 @@ import {
 	renderTldrawComponent,
 	renderTldrawComponentWithEditor,
 } from '../testutils/renderTldrawComponent'
+
+// The paste item only renders when the clipboard API exists at module load, so the
+// stub has to be in place before the menu modules are imported.
+const clipboard = vi.hoisted(() => {
+	const clipboard = { read: vi.fn(), write: vi.fn() }
+	Object.assign(navigator, { clipboard })
+	// @ts-expect-error jsdom has no ClipboardItem
+	window.ClipboardItem = class {}
+	return clipboard
+})
 
 it('opens on right-click', async () => {
 	await renderTldrawComponent(
@@ -165,6 +176,54 @@ it('right-click in a shape tool reveals shape actions (rightClickPanning off)', 
 	await screen.findByTestId('context-menu.cut')
 	await screen.findByTestId('context-menu.copy')
 	await screen.findByTestId('context-menu.delete')
+})
+
+it('pastes at the point where the menu was opened, not where the item was chosen', async () => {
+	// Regression for #10423: the pointer keeps moving (over the menu) between the
+	// right-click and choosing Paste, and the pasted content used to follow it.
+	const onClipboardPasteRaw = vi.fn<NonNullable<TldrawOptions['onClipboardPasteRaw']>>(() => false)
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw options={{ onClipboardPasteRaw }} onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+	clipboard.read.mockResolvedValue([new window.ClipboardItem({})])
+
+	function movePointerTo(x: number, y: number) {
+		act(() => {
+			editor.dispatch({
+				type: 'pointer',
+				name: 'pointer_move',
+				target: 'canvas',
+				point: { x, y, z: 0.5 },
+				pointerId: 1,
+				button: 0,
+				isPen: false,
+				shiftKey: false,
+				altKey: false,
+				ctrlKey: false,
+				metaKey: false,
+				accelKey: false,
+			})
+			// pointer moves are batched until the next tick
+			editor.emit('tick', 16)
+		})
+	}
+
+	const canvas = await screen.findByTestId('canvas')
+	movePointerTo(100, 200)
+	fireEvent.contextMenu(canvas)
+	const pasteItem = await screen.findByTestId('context-menu.paste')
+
+	// travel down the menu before choosing the item
+	movePointerTo(300, 400)
+	expect(editor.inputs.getCurrentPagePoint()).toMatchObject({ x: 300, y: 400 })
+
+	fireEvent.click(pasteItem)
+	await waitFor(() => expect(onClipboardPasteRaw).toHaveBeenCalled())
+	expect(onClipboardPasteRaw.mock.calls[0][0]).toMatchObject({
+		source: 'clipboard-read',
+		point: { x: 100, y: 200 },
+	})
 })
 
 it('tunnels context menu', async () => {


### PR DESCRIPTION
This PR fixes a bug where choosing Paste from the context menu placed the content under the pointer's position at the moment the item was clicked (somewhere over the menu) instead of at the point that was right-clicked. Closes #10423.

### Before

The `paste` action in `packages/tldraw/src/lib/ui/context/actions.tsx` passed `editor.inputs.getCurrentPagePoint()` as the paste point for the `context-menu` source, and read it inside the `clipboard.read()` `.then`. The editor tracks pointer moves document-wide (so the pointer position keeps updating while it travels down the menu), which meant the content was centered wherever the pointer ended up when the item was chosen, not where the menu was opened.

### After

`DefaultContextMenu` records `editor.inputs.getCurrentPagePoint()` when the menu opens (and clears it on close) into a ref that `ActionsProvider` owns and shares through an internal `ContextMenuPagePointContext`. The `paste` action reads that point synchronously, before the async clipboard read, so the content lands at the right-click (or long-press) point.

### Implementation notes

- If the context menu is a fully custom component that does not render `DefaultContextMenu`, no point is recorded and the action falls back to the previous behaviour (the current pointer position).
- The menu opened via the keyboard shortcut (`a11y-open-context-menu`) still uses the pointer's position at open time, as it did before; no change there.

### Change type

- [x] `bugfix`

### Test plan

1. Copy a shape.
2. Right-click far from it, move the pointer down the menu, choose Paste.
3. The pasted shape is centered on the right-click point.

- [x] Unit tests — the new test in `ContextMenu.test.tsx` fails on `main` (paste point follows the pointer to `300,400`) and passes with this change (`100,200`).

### Release notes

- Fix context-menu paste landing under the pointer instead of at the right-click point.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +31 / -8   |
| Tests     | +61 / -2   |
