### PR TITLE
fix(select): restore prior selection when cancelling a scribble brush

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -23,9 +23,8 @@ export class ScribbleBrushing extends StateNode {
 	newlySelectedShapeIds = new Set<TLShapeId>()
 
 	override onEnter() {
-		// Always captured, not only when shift is held, so that cancelling can restore
-		// the prior selection the same way a rectangle brush does (#10429). Whether it
-		// is merged into the live selection is decided per-update by the shift key.
+		// Captured regardless of shift so cancel() can restore it like the rectangle
+		// brush does (#10429); shift only decides whether it merges into the live selection.
 		this.initialSelectedShapeIds = new Set<TLShapeId>(this.editor.getSelectedShapeIds())
 		this.newlySelectedShapeIds = new Set<TLShapeId>()
 		this.size = 0

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/ScribbleBrushing.ts
@@ -23,9 +23,10 @@ export class ScribbleBrushing extends StateNode {
 	newlySelectedShapeIds = new Set<TLShapeId>()
 
 	override onEnter() {
-		this.initialSelectedShapeIds = new Set<TLShapeId>(
-			this.editor.inputs.getShiftKey() ? this.editor.getSelectedShapeIds() : []
-		)
+		// Always captured, not only when shift is held, so that cancelling can restore
+		// the prior selection the same way a rectangle brush does (#10429). Whether it
+		// is merged into the live selection is decided per-update by the shift key.
+		this.initialSelectedShapeIds = new Set<TLShapeId>(this.editor.getSelectedShapeIds())
 		this.newlySelectedShapeIds = new Set<TLShapeId>()
 		this.size = 0
 		this.hits.clear()

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1792,6 +1792,33 @@ describe('scribble brushes to add to the selection', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
 	})
 
+	it('restores the prior selection when cancelled without shift', () => {
+		editor.select(ids.box2)
+		editor.pointerMove(-50, -50)
+		editor.keyDown('Alt')
+		// ctrl-press keeps the current selection and starts a brush on drag
+		editor.pointerDown(-50, -50, { target: 'canvas', accelKey: true })
+		editor.pointerMove(50, 50)
+		editor.expectToBeIn('select.scribble_brushing')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.cancel()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+	})
+
+	it('restores the prior selection when cancelled with shift', () => {
+		editor.select(ids.box2)
+		editor.pointerMove(-50, -50)
+		editor.keyDown('Alt')
+		editor.keyDown('Shift')
+		editor.pointerDown(-50, -50, { target: 'canvas', accelKey: true })
+		editor.pointerMove(50, 50)
+		editor.expectToBeIn('select.scribble_brushing')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+		editor.cancel()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+	})
+
 	it('selects when switching between moves', () => {
 		editor.ungroupShapes([ids.group1]) // ungroup boxes 3 and 4
 		editor.pointerMove(650, 0)


### PR DESCRIPTION
This PR fixes a bug where pressing Escape during an alt-drag scribble selection deselected everything instead of restoring the selection from before the drag. Closes #10429.

### Before

`ScribbleBrushing.onEnter` only recorded `initialSelectedShapeIds` when shift was held; otherwise it stored an empty set. `cancel()` restored that set, so Escape during a plain scribble (for example after a Ctrl/Cmd+press on a selected shape) cleared the selection. The rectangle brush (`Brushing`) always records the initial selection and restores it on cancel, so the two brushes diverged.

### After

`ScribbleBrushing` always records the selection at entry. The shift key still decides, per update, whether that set is merged into the live selection during the drag, so the existing "scribble without shift replaces the selection" behavior is unchanged. Escape now restores the pre-drag selection for both brushes.

### Implementation notes

If the user starts a rectangle brush and then presses Alt mid-drag, the scribble state is entered with the rectangle brush's partial selection already applied, so Escape restores that rather than the pre-drag selection. That was already the case with shift held and is out of scope here.

### Change type

- [x] `bugfix`

### Test plan

1. Select a rectangle.
2. Ctrl/Cmd+press on it and drag with Alt held to scribble across other shapes.
3. Press Escape: the original rectangle is selected again.

- [x] Unit tests — the new "restores the prior selection when cancelled without shift" test fails on `main` and passes with this change

### Release notes

- Fix Escape during a scribble selection dropping the prior selection

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -3    |
| Tests     | +27 / -0   |
