### PR TITLE
fix(tldraw): let handle drags yield the grid to the accel key and to shape snaps

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -1133,3 +1133,35 @@ describe('Zero-length arrows', () => {
 		expect(shapesAtPoint.some((s) => s.id === geoId)).toBe(true)
 	})
 })
+
+describe('Grid mode when dragging a terminal handle', () => {
+	it('suspends the grid while the accel key is held', () => {
+		const id = createShapeId('grid-arrow')
+		editor.updateInstanceState({ isGridMode: true })
+		editor.createShapes([
+			{
+				id,
+				type: 'arrow',
+				x: 500,
+				y: 500,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 100 },
+				},
+			},
+		])
+
+		editor.select(id)
+		editor.pointerDown(600, 600, {
+			target: 'handle',
+			shape: arrow(id),
+			handle: editor.getShapeHandles(id)!.find((h) => h.id === 'end')!,
+		})
+
+		editor.pointerMove(633, 627)
+		expect(arrow(id).props.end).toMatchObject({ x: 130, y: 130 })
+
+		editor.pointerMove(633, 627, undefined, { ctrlKey: true })
+		expect(arrow(id).props.end).toMatchObject({ x: 133, y: 127 })
+	})
+})

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -37,7 +37,6 @@ import {
 	invLerp,
 	lerp,
 	mapObjectMapValues,
-	maybeSnapToGrid,
 	structuredClone,
 	toDomPrecision,
 	toRichText,
@@ -60,6 +59,7 @@ import { DEFAULT_FILL_COLOR_NAMES } from '../shared/defaultFills'
 import { getThemeFontFaces } from '../shared/defaultFonts'
 import { getFillDefForCanvas, getFillDefForExport } from '../shared/defaultStyleDefs'
 import { getDisplayValues } from '../shared/getDisplayValues'
+import { maybeSnapHandleToGrid } from '../shared/maybeSnapHandleToGrid'
 import { PathBuilder } from '../shared/PathBuilder'
 import { PatternFill } from '../shared/PatternFill'
 import { RichTextLabel, RichTextSVG } from '../shared/RichTextLabel'
@@ -518,7 +518,7 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 		if (!targetInfo) {
 			// todo: maybe double check that this isn't equal to the other handle too?
 			removeArrowBinding(this.editor, shape, handleId)
-			const newPoint = maybeSnapToGrid(new Vec(handle.x, handle.y), this.editor)
+			const newPoint = maybeSnapHandleToGrid(new Vec(handle.x, handle.y), this.editor)
 			update.props![handleId] = {
 				x: newPoint.x,
 				y: newPoint.y,

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.test.tsx
@@ -503,6 +503,48 @@ describe('Line points: id-mapped object with a decoupled index', () => {
 	})
 })
 
+describe('Grid mode when dragging a handle', () => {
+	beforeEach(() => {
+		editor.updateInstanceState({ isGridMode: true })
+	})
+
+	it('suspends the grid while the accel key is held', () => {
+		editor.select(id)
+		editor.pointerDown(250, 250, {
+			target: 'handle',
+			shape: getShape(),
+			handle: getHandles().find((h) => h.id === 'a2')!,
+		})
+
+		editor.pointerMove(263, 277)
+		expect(getShape().props.points.a2).toMatchObject({ x: 110, y: 130 })
+
+		editor.pointerMove(263, 277, undefined, { ctrlKey: true })
+		expect(editor.snaps.getIndicators()).toHaveLength(0)
+		expect(getShape().props.points.a2).toMatchObject({ x: 113, y: 127 })
+	})
+
+	it('lets a shape snap win over the grid', () => {
+		editor.user.updateUserPreferences({ isSnapMode: true })
+		editor.createShapes([
+			{ id: createShapeId('box'), type: 'geo', x: 203, y: 203, props: { w: 100, h: 100 } },
+		])
+
+		editor.select(id)
+		editor
+			.pointerDown(250, 250, {
+				target: 'handle',
+				shape: getShape(),
+				handle: getHandles().find((h) => h.id === 'a2')!,
+			})
+			.pointerMove(205, 241)
+
+		// the handle snapped to the box's left edge at page (203, 241); the grid must not move it afterwards
+		expect(editor.snaps.getIndicators()).toHaveLength(1)
+		expect(getShape().props.points.a2).toMatchObject({ x: 53, y: 91 })
+	})
+})
+
 function getHandlesFor(shapeId: TLLineShape['id']) {
 	return editor.getShapeHandles<TLLineShape>(shapeId)!
 }

--- a/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/line/LineShapeUtil.tsx
@@ -22,12 +22,12 @@ import {
 	lineShapeMigrations,
 	lineShapeProps,
 	mapObjectMapValues,
-	maybeSnapToGrid,
 	sortByIndex,
 	useColorMode,
 } from '@tldraw/editor'
 import { STROKE_SIZES } from '../shared/default-shape-constants'
 import { ShapeOptionsWithDisplayValues, getDisplayValues } from '../shared/getDisplayValues'
+import { maybeSnapHandleToGrid } from '../shared/maybeSnapHandleToGrid'
 import { PathBuilder, PathBuilderGeometry2d } from '../shared/PathBuilder'
 
 const handlesCache = new WeakCache<TLLineShape['props'], TLHandle[]>()
@@ -179,7 +179,7 @@ export class LineShapeUtil extends ShapeUtil<TLLineShape> {
 	}
 
 	override onHandleDrag(shape: TLLineShape, { handle }: TLHandleDragInfo<TLLineShape>) {
-		const newPoint = maybeSnapToGrid(new Vec(handle.x, handle.y), this.editor)
+		const newPoint = maybeSnapHandleToGrid(new Vec(handle.x, handle.y), this.editor)
 		// handle.id is the point's key (== its id), so we update the point in place.
 		return {
 			...shape,

--- a/packages/tldraw/src/lib/shapes/shared/maybeSnapHandleToGrid.ts
+++ b/packages/tldraw/src/lib/shapes/shared/maybeSnapHandleToGrid.ts
@@ -1,0 +1,14 @@
+import { Editor, Vec, maybeSnapToGrid } from '@tldraw/editor'
+
+/**
+ * Grid-snaps a dragged handle point under the same rules translate and resize use for
+ * shapes: the accel key suspends the grid, and an active shape snap (one with an
+ * indicator showing) wins over it. Without the second rule the grid would pull the
+ * handle off the very point the snap indicator is drawn on.
+ */
+export function maybeSnapHandleToGrid(point: Vec, editor: Editor): Vec {
+	if (editor.inputs.getAccelKey() || editor.snaps.getIndicators().length > 0) {
+		return point.clone()
+	}
+	return maybeSnapToGrid(point, editor)
+}


### PR DESCRIPTION
This PR fixes a bug where dragging a line point or an arrow end with the grid on ignored the Ctrl/Cmd grid override, and could land the point up to half a cell away from a shape it had visibly snapped to. Closes #10425.

### Before

Translating, resizing, and cropping suspend the grid while the accel key is held, and translating also skips the grid when a shape snap is showing its indicator. Handle drags did neither: `DraggingHandle` applied the shape snap, then `LineShapeUtil.onHandleDrag` and `ArrowShapeUtil.onTerminalHandleDrag` called `maybeSnapToGrid`, which checks only `isGridMode`. Holding Ctrl/Cmd had no effect on the grid, and the grid ran after the shape snap, so a line point showing the snap cross on a rectangle's off-grid edge was pulled back onto the grid.

### After

Both utils route the handle point through a new tldraw-internal `maybeSnapHandleToGrid`, which returns the point untouched while the accel key is held or while a snap indicator is showing, and otherwise defers to `maybeSnapToGrid`. Holding Ctrl/Cmd now suspends the grid for handle drags like it does elsewhere, and a shape snap wins over the grid.

### Implementation notes

- `maybeSnapToGrid` itself is left alone: it is also used by the paste and drop handlers, which run while Cmd is held for Cmd+V, so adding the accel-key check there would have stopped pasted content from aligning to the grid.
- The grid stays inside the arrow util rather than moving up into `DraggingHandle`, because the arrow only grid-snaps an unbound terminal. Grid-snapping the handle before target detection would change which shape an arrow binds to and would quantize precise anchors, which the issue does not ask for.
- Arrow handles have no `snapType`, so the indicator check only ever matters for lines; it is harmless for arrows.

### Change type

- [x] `bugfix`

### Test plan

1. Show the grid (Ctrl/Cmd+').
2. Draw a rectangle and nudge it one unit off the grid.
3. Draw a line and drag an end onto the rectangle's edge with snap mode on: the point stays where the snap cross is drawn.
4. Drag a line point or an arrow end while holding Ctrl/Cmd: it follows the pointer instead of the grid.

- [x] Unit tests — the three new tests fail on `main` and pass with this change

### Release notes

- Fix handle drags on lines and arrows ignoring the Ctrl/Cmd grid override and applying the grid after a shape snap.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -4   |
| Tests     | +74 / -0   |
