### PR TITLE
fix(select): move non-resizable shapes with the selection when resizing

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -133,6 +133,7 @@ export class Resizing extends StateNode {
 			const current = this.editor.getShape(shape.id)
 			if (current) {
 				const util = this.editor.getShapeUtil(shape)
+				if (!util.canResize(shape)) return
 				util.onResizeCancel?.(shape, current)
 			}
 		})
@@ -178,12 +179,15 @@ export class Resizing extends StateNode {
 	}
 
 	private handleResizeStart() {
+		// Non-resizable shapes are in the snapshot only to be repositioned, so they don't get the
+		// resize lifecycle callbacks (matching Editor.resizeShape).
 		const { shapeSnapshots } = this.snapshot
 
 		const changes: TLShapePartial[] = []
 
 		shapeSnapshots.forEach(({ shape }) => {
 			const util = this.editor.getShapeUtil(shape)
+			if (!util.canResize(shape)) return
 			const change = util.onResizeStart?.(shape)
 			if (change) {
 				changes.push(change)
@@ -203,6 +207,7 @@ export class Resizing extends StateNode {
 		shapeSnapshots.forEach(({ shape }) => {
 			const current = this.editor.getShape(shape.id)!
 			const util = this.editor.getShapeUtil(shape)
+			if (!util.canResize(shape)) return
 			const change = util.onResizeEnd?.(shape, current)
 			if (change) {
 				changes.push(change)
@@ -582,17 +587,16 @@ export class Resizing extends StateNode {
 
 			const util = editor.getShapeUtil(shape)
 
-			// If the shape can resize, add it to the resizing shapes snapshots
-			if (util.canResize(shape)) {
-				const pageTransform = editor.getShapePageTransform(shape)!
-				shapeSnapshots.set(shape.id, {
-					shape,
-					bounds: editor.getShapeGeometry(shape).bounds,
-					pageTransform,
-					pageRotation: Mat.Decompose(pageTransform).rotation,
-					isAspectRatioLocked: util.isAspectRatioLocked(shape),
-				})
-			}
+			// Shapes that can't resize are snapshotted too: getResizeShapePartial repositions them
+			// so they keep their place in the selection instead of being left behind.
+			const pageTransform = editor.getShapePageTransform(shape)!
+			shapeSnapshots.set(shape.id, {
+				shape,
+				bounds: editor.getShapeGeometry(shape).bounds,
+				pageTransform,
+				pageRotation: Mat.Decompose(pageTransform).rotation,
+				isAspectRatioLocked: util.isAspectRatioLocked(shape),
+			})
 
 			// Special case:
 			// For frames, we don't want to resize children but we DO want to get a snapshot of their children so that we can restore their

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3582,6 +3582,25 @@ describe('shapes that have do not resize', () => {
 		expect(editor.getShapePageBounds(noteBId)).toMatchObject({ x: 100, y: 110, w: 200, h: 200 })
 	})
 
+	it('are still translated if part of a selection when canResize is false', () => {
+		const bookmarkId = createShapeId('bookmark')
+		editor.createShapes([
+			box(ids.boxA, 0, 0, 200, 320),
+			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
+		])
+
+		// a bookmark without an asset is 320 tall
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 0, y: 0, w: 200, h: 320 })
+
+		editor.select(ids.boxA, bookmarkId)
+
+		editor.resizeSelection({ scaleX: 2, scaleY: 2.1 }, 'bottom_right')
+
+		expect(editor.getShapePageBounds(ids.boxA)).toMatchObject({ x: 0, y: 0, w: 400, h: 672 })
+		// the bookmark keeps its size but moves so its center scales with the selection
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 176, w: 200, h: 320 })
+	})
+
 	it('can flip', () => {
 		const noteBId = createShapeId('noteB')
 		const noteCId = createShapeId('noteC')


### PR DESCRIPTION
This PR fixes a bug where a bookmark (or a fixed-size embed) selected together with other shapes stayed put while the rest of the selection was resized from a handle. Closes #10431.

### Before

`Resizing._createSnapshot` only added a shape to the resize snapshot when `util.canResize(shape)` returned true. `BookmarkShapeUtil.canResize` returns false, so the bookmark was never part of the gesture and was left behind while the other shapes scaled. A note, whose `canResize` is true, is repositioned by `getResizeShapePartial` because its `onResize` returns nothing in `none` mode, which is why the two fixed-size shapes behaved differently.

### After

Every selected shape (and resizable descendant) is snapshotted regardless of `canResize`. `getResizeShapePartial` already skips `onResize` for non-resizable shapes and falls through to repositioning them by their scaled center, so the bookmark now moves with the selection the same way a note does. Single-shape selections are unaffected: the overlay still hides resize handles for shapes that can't resize.

### Implementation notes

The `onResizeStart` / `onResizeEnd` / `onResizeCancel` loops in `Resizing` now skip non-resizable shapes, matching `Editor.resizeShape`, which only runs those callbacks under the same `canResize` check. Those shapes are in the snapshot to be moved, not resized, so they should not see resize lifecycle callbacks.

### Change type

- [x] `bugfix`

### Test plan

1. Paste a URL to create a bookmark and draw a rectangle next to it.
2. Select both and drag a corner handle away.
3. The bookmark keeps its size but moves so it stays in the same relative place within the selection.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix bookmarks and other non-resizable shapes being left behind when resizing a multi-selection.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +15 / -11  |
| Tests     | +19 / -0   |
