### PR TITLE
fix(select): keep arrow label drag on complete instead of reverting it

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -148,7 +148,7 @@ export class PointingArrowLabel extends StateNode {
 	}
 
 	override onComplete() {
-		this.cancel()
+		this.complete()
 	}
 
 	override onInterrupt() {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -501,6 +501,42 @@ describe('PointingLabel', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('Keeps the dragged label position on complete', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: {
+					richText: toRichText('Test Label'),
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 0 },
+				},
+			},
+		])
+		const shape = editor.getShape<TLArrowShape>(ids.arrow1)!
+		const initialLabelPosition = shape.props.labelPosition
+
+		editor.pointerDown(150, 100, {
+			target: 'shape',
+			shape,
+		})
+		editor.pointerMove(160, 100)
+		editor.expectToBeIn('select.pointing_arrow_label')
+		editor.pointerMove(190, 100)
+
+		const draggedLabelPosition = editor.getShape<TLArrowShape>(ids.arrow1)!.props.labelPosition
+		expect(draggedLabelPosition).not.toBe(initialLabelPosition)
+
+		// A menu opening or an undo keypress mid-drag completes the interaction
+		editor.complete()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getShape<TLArrowShape>(ids.arrow1)!.props.labelPosition).toBe(
+			draggedLabelPosition
+		)
+	})
+
 	it('Doesnt go into pointing_arrow_label mode if not selecting the arrow shape', () => {
 		editor.createShapes([
 			{


### PR DESCRIPTION
This PR fixes a bug where dragging an arrow's label along the arrow and then opening a menu or pressing Ctrl/Cmd+Z mid-drag snapped the label back to where it started. Closes #10434.

### Before

`PointingArrowLabel.onComplete` called `this.cancel()`, which bails to the history mark set at drag start and discards the new `labelPosition`. Every other drag state in the select tool (`Translating`, `Rotating`, `Resizing`, `DraggingHandle`) keeps the change on `complete` and only reverts on `cancel`; the label drag was the odd one out because it does its pointing and dragging in a single state, so it had copied the pointing states' "cancel on complete" behavior.

### After

`onComplete` calls `this.complete()`, so the dragged label position is kept and the state returns to idle (or the `onInteractionEnd` tool) like the other drags. `onCancel` and `onInterrupt` still revert.

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow with a label.
2. Drag the label along the arrow and, mid-drag, press Ctrl/Cmd+Z or open a menu.
3. The label stays where it was dragged to.

- [x] Unit tests — the new test fails on `main` and passes with this change

### Release notes

- Fix arrow label drag reverting when a menu opens or undo is pressed mid-drag

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1    |
| Tests     | +36 / -0   |
