### PR TITLE
fix(arrows): let reordering a bound arrow take effect

### DIFF
--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -68,8 +68,7 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 		// This is a significant performance optimization when moving many bound shapes.
 		//
 		// An index-only change is an explicit reorder of the arrow (send to back, bring
-		// forward, ...). Restacking here would put the arrow straight back above its bound
-		// shapes and make the reorder a no-op (#10433), so only react to parent changes.
+		// forward, ...); restacking it above its bound shapes here would undo that (#10433).
 		if (reason !== 'ancestry' && shapeBefore.parentId === shapeAfter.parentId) {
 			return
 		}

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -66,11 +66,11 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 		// When translating arrows together with their bound shapes, only x/y changes.
 		// In this case, bindings remain valid and no reparenting is needed.
 		// This is a significant performance optimization when moving many bound shapes.
-		if (
-			reason !== 'ancestry' &&
-			shapeBefore.parentId === shapeAfter.parentId &&
-			shapeBefore.index === shapeAfter.index
-		) {
+		//
+		// An index-only change is an explicit reorder of the arrow (send to back, bring
+		// forward, ...). Restacking here would put the arrow straight back above its bound
+		// shapes and make the reorder a no-op (#10433), so only react to parent changes.
+		if (reason !== 'ancestry' && shapeBefore.parentId === shapeAfter.parentId) {
 			return
 		}
 		arrowDidUpdate(this.editor, shapeAfter as TLArrowShape)

--- a/packages/tldraw/src/test/arrows-megabus.test.tsx
+++ b/packages/tldraw/src/test/arrows-megabus.test.tsx
@@ -850,3 +850,72 @@ describe('When the bound shape changes geometry', () => {
 		expect(endBinding().props.normalizedAnchor).toMatchObject(resnapped)
 	})
 })
+
+describe('Reordering a bound arrow', () => {
+	const order = () => editor.getCurrentPageShapesSorted().map((shape) => shape.id)
+
+	beforeEach(() => {
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+			{ id: ids.box2, type: 'geo', x: 300, y: 0, props: { w: 100, h: 100 } },
+		])
+		editor.createShape({
+			id: ids.arrow1,
+			type: 'arrow',
+			x: 50,
+			y: 50,
+			props: { start: { x: 0, y: 0 }, end: { x: 300, y: 0 } },
+		})
+		// exact bindings run the arrow center to center, so its bounds overlap both boxes
+		for (const [terminal, toId] of [
+			['start', ids.box1],
+			['end', ids.box2],
+		] as const) {
+			editor.createBinding({
+				type: 'arrow',
+				fromId: ids.arrow1,
+				toId,
+				props: {
+					terminal,
+					isExact: true,
+					isPrecise: true,
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					snap: 'none',
+				},
+			})
+		}
+		expect(order()).toEqual([ids.box1, ids.box2, ids.arrow1])
+	})
+
+	it('lets send to back move the arrow below its bound shapes', () => {
+		editor.sendToBack([ids.arrow1])
+		expect(order()).toEqual([ids.arrow1, ids.box1, ids.box2])
+	})
+
+	it('lets send backward move the arrow below a bound shape', () => {
+		editor.sendBackward([ids.arrow1])
+		expect(order()).toEqual([ids.box1, ids.arrow1, ids.box2])
+	})
+
+	it('lets bring to front move the arrow above an unrelated shape', () => {
+		editor.createShapes([{ id: ids.box3, type: 'geo', x: 600, y: 0 }])
+		expect(order()).toEqual([ids.box1, ids.box2, ids.arrow1, ids.box3])
+		editor.bringToFront([ids.arrow1])
+		expect(order()).toEqual([ids.box1, ids.box2, ids.box3, ids.arrow1])
+	})
+
+	it('still brings the arrow up with a bound shape that is brought to front', () => {
+		editor.sendToBack([ids.arrow1])
+		editor.bringToFront([ids.box1])
+		expect(order()).toEqual([ids.box2, ids.box1, ids.arrow1])
+	})
+
+	it('restores the stacking order on undo', () => {
+		editor.markHistoryStoppingPoint()
+		editor.sendToBack([ids.arrow1])
+		editor.undo()
+		expect(order()).toEqual([ids.box1, ids.box2, ids.arrow1])
+		editor.redo()
+		expect(order()).toEqual([ids.arrow1, ids.box1, ids.box2])
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where "Send to back" (and every other reorder) had no effect on an arrow bound to a shape: the arrow snapped straight back above its bound shapes on the same keypress. Closes #10433.

### Before

`ArrowBindingUtil.onAfterChangeFromShape` returned early only when both the arrow's `parentId` and `index` were unchanged. A reorder changes only the index, so it fell through to `arrowDidUpdate` → `reparentArrow`, which places a bound arrow just above the highest of its bound shapes. The explicit reorder was undone inside the same transaction, so `[` / `]` and the menu items appeared to do nothing, and `editor.sendToBack([arrow])` was silently reverted too.

### After

`onAfterChangeFromShape` only restacks the arrow when its parent changes (or the change came from its ancestry). An index-only change on the arrow is always an explicit reorder, so it now sticks: the arrow can be sent below its bound shapes or brought above unrelated shapes. The "bound arrow follows its bound shape" rule is unchanged in the other direction: `onAfterChangeToShape` still restacks the arrow when a bound shape is reordered, and binding creation/changes still restack it, so an arrow that was sent to back moves back up when its bound shape is brought to front.

### Implementation notes

The issue marked this as a product call between letting the reorder win and disabling the reorder actions for bound arrows. I went with letting the reorder win: it is a one-condition change at the spot that caused the symptom, it fixes the editor API (`sendToBack`, `sendBackward`, `bringForward`, `bringToFront`) as well as the UI, and disabling the actions would also have had to cover mixed selections where reordering already works fine. Happy to switch to the disable-the-action route if that is the preferred product behaviour.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a rectangle and an arrow bound to it.
2. Select the arrow and press `[`. The arrow is now behind the rectangle.
3. Select the rectangle and press `]`. The arrow comes back up above it.

- [x] Unit tests — four of the five new tests fail on `main` and pass with this change

### Release notes

- Fix "Send to back", "Send backward", "Bring forward" and "Bring to front" having no effect on arrows bound to shapes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -5    |
| Tests     | +69 / -0   |
