### PR TITLE
fix(editor): keep locked descendants when deleting their parent shape

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9162,18 +9162,47 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapeIdsToDelete.length === 0) return this
 
-		// We also need to delete these shapes' descendants
+		// We also need to delete these shapes' descendants. Locked descendants survive (with their
+		// own subtrees) and move to the nearest ancestor that isn't being deleted; otherwise
+		// deleting a frame or group would silently take its locked contents with it.
 		const allShapeIdsToDelete = new Set<TLShapeId>(shapeIdsToDelete)
+		const lockedDescendantIds: TLShapeId[] = []
 
 		for (const id of shapeIdsToDelete) {
 			this.visitDescendants(id, (childId) => {
+				if (!this._shouldIgnoreShapeLock && this.getShape(childId)?.isLocked) {
+					lockedDescendantIds.push(childId)
+					return false
+				}
 				allShapeIdsToDelete.add(childId)
 			})
 		}
 
 		this.emit('deleted-shapes', [...allShapeIdsToDelete])
 		this.emit('edit')
-		return this.run(() => this.store.remove([...allShapeIdsToDelete]))
+		return this.run(() => {
+			// Batch survivors by their outermost deleted ancestor and insert them at its index so
+			// they keep their z-order among the ancestor's siblings.
+			const survivorsByAncestorId = new Map<TLShapeId, TLShapeId[]>()
+			for (const id of lockedDescendantIds) {
+				let ancestor = this.getShape(this.getShape(id)!.parentId as TLShapeId)!
+				while (isShapeId(ancestor.parentId) && allShapeIdsToDelete.has(ancestor.parentId)) {
+					ancestor = this.getShape(ancestor.parentId)!
+				}
+				const survivors = survivorsByAncestorId.get(ancestor.id)
+				if (survivors) {
+					survivors.push(id)
+				} else {
+					survivorsByAncestorId.set(ancestor.id, [id])
+				}
+			}
+			for (const [ancestorId, survivors] of survivorsByAncestorId) {
+				const ancestor = this.getShape(ancestorId)!
+				this.reparentShapes(survivors, ancestor.parentId, ancestor.index)
+			}
+
+			this.store.remove([...allShapeIdsToDelete])
+		})
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9181,24 +9181,58 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.emit('deleted-shapes', [...allShapeIdsToDelete])
 		this.emit('edit')
 		return this.run(() => {
-			// Batch survivors by their outermost deleted ancestor and insert them at its index so
-			// they keep their z-order among the ancestor's siblings.
-			const survivorsByAncestorId = new Map<TLShapeId, TLShapeId[]>()
-			for (const id of lockedDescendantIds) {
-				let ancestor = this.getShape(this.getShape(id)!.parentId as TLShapeId)!
-				while (isShapeId(ancestor.parentId) && allShapeIdsToDelete.has(ancestor.parentId)) {
-					ancestor = this.getShape(ancestor.parentId)!
-				}
-				const survivors = survivorsByAncestorId.get(ancestor.id)
-				if (survivors) {
-					survivors.push(id)
-				} else {
-					survivorsByAncestorId.set(ancestor.id, [id])
-				}
-			}
-			for (const [ancestorId, survivors] of survivorsByAncestorId) {
-				const ancestor = this.getShape(ancestorId)!
-				this.reparentShapes(survivors, ancestor.parentId, ancestor.index)
+			if (lockedDescendantIds.length) {
+				this.run(
+					() => {
+						// Drop bindings between a survivor's subtree and the shapes being deleted before
+						// reparenting anything. A binding util reacting to the survivor's ancestry change
+						// can otherwise move it back under a deleted ancestor (an arrow bound to two
+						// deleted siblings gets reparented to their common ancestor, the deleted frame)
+						// and the survivor is orphaned once that ancestor is removed.
+						const survivingIds = new Set(lockedDescendantIds)
+						for (const id of lockedDescendantIds) {
+							this.visitDescendants(id, (childId) => {
+								survivingIds.add(childId)
+							})
+						}
+						const bindingIdsToDelete: TLBindingId[] = []
+						for (const id of survivingIds) {
+							for (const binding of this.getBindingsInvolvingShape(id)) {
+								const otherId = binding.fromId === id ? binding.toId : binding.fromId
+								if (allShapeIdsToDelete.has(otherId)) bindingIdsToDelete.push(binding.id)
+							}
+						}
+						this.deleteBindings(bindingIdsToDelete, { isolateShapes: true })
+
+						// Batch survivors by their outermost deleted ancestor and insert them at its index so
+						// they keep their z-order among the ancestor's siblings.
+						const survivorsByAncestorId = new Map<TLShapeId, TLShapeId[]>()
+						for (const id of lockedDescendantIds) {
+							let ancestor = this.getShape(this.getShape(id)!.parentId as TLShapeId)!
+							while (isShapeId(ancestor.parentId) && allShapeIdsToDelete.has(ancestor.parentId)) {
+								ancestor = this.getShape(ancestor.parentId)!
+							}
+							const survivors = survivorsByAncestorId.get(ancestor.id)
+							if (survivors) {
+								survivors.push(id)
+							} else {
+								survivorsByAncestorId.set(ancestor.id, [id])
+							}
+						}
+						for (const [ancestorId, survivors] of survivorsByAncestorId) {
+							const ancestor = this.getShape(ancestorId)!
+							// Reparent one at a time, each above the previous one. `lockedDescendantIds` is
+							// in tree order, but `reparentShapes` sorts a batch by local index, which is
+							// meaningless across different intermediate parents.
+							let insertIndex = ancestor.index
+							for (const id of survivors) {
+								this.reparentShapes([id], ancestor.parentId, insertIndex)
+								insertIndex = this.getShape(id)!.index
+							}
+						}
+					},
+					{ ignoreShapeLock: true }
+				)
 			}
 
 			this.store.remove([...allShapeIdsToDelete])

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1314,6 +1314,127 @@ describe('When deleting/removing a frame', () => {
 		expect(editor.getShape(frame1Id)).toBeDefined()
 		expect(editor.getShape(rectId)).toBeDefined()
 	})
+
+	describe('with locked children', () => {
+		const frameId = createShapeId('frame')
+		const lockedId = createShapeId('locked')
+		const unlockedId = createShapeId('unlocked')
+
+		beforeEach(() => {
+			editor.createShapes([
+				{ id: frameId, type: 'frame', x: 100, y: 100, props: { w: 200, h: 200 } },
+				{ id: lockedId, type: 'geo', parentId: frameId, x: 10, y: 20, isLocked: true },
+				{ id: unlockedId, type: 'geo', parentId: frameId, x: 50, y: 50 },
+			])
+		})
+
+		it('keeps a locked child on the page at the same position when the frame is deleted', () => {
+			editor.deleteShape(frameId)
+
+			expect(editor.getShape(frameId)).toBeUndefined()
+			expect(editor.getShape(unlockedId)).toBeUndefined()
+			expect(editor.getShape(lockedId)).toMatchObject({
+				parentId: editor.getCurrentPageId(),
+				x: 110,
+				y: 120,
+				isLocked: true,
+			})
+		})
+
+		it('does not report the locked child as deleted', () => {
+			const deleted: TLShapeId[][] = []
+			editor.on('deleted-shapes', (ids) => deleted.push(ids))
+
+			editor.deleteShape(frameId)
+
+			expect(deleted).toEqual([expect.arrayContaining([frameId, unlockedId])])
+			expect(deleted[0]).not.toContain(lockedId)
+		})
+
+		it('restores the locked child to the frame on undo', () => {
+			editor.markHistoryStoppingPoint('before delete')
+			editor.deleteShape(frameId)
+			editor.undo()
+
+			expect(editor.getShape(frameId)).toBeDefined()
+			expect(editor.getShape(unlockedId)).toMatchObject({ parentId: frameId })
+			expect(editor.getShape(lockedId)).toMatchObject({ parentId: frameId, x: 10, y: 20 })
+		})
+
+		it('reparents the locked child to the nearest surviving ancestor', () => {
+			const outerId = createShapeId('outer')
+			editor.createShape({
+				id: outerId,
+				type: 'frame',
+				x: 1000,
+				y: 1000,
+				props: { w: 500, h: 500 },
+			})
+			editor.reparentShapes([frameId], outerId)
+
+			editor.deleteShape(frameId)
+
+			expect(editor.getShape(lockedId)).toMatchObject({ parentId: outerId })
+			expect(editor.getShapePageBounds(lockedId)).toMatchObject({ x: 110, y: 120 })
+		})
+
+		it('keeps a locked descendant of a deleted nested frame', () => {
+			const innerId = createShapeId('inner')
+			editor.createShapes([
+				{ id: innerId, type: 'frame', parentId: frameId, x: 100, y: 100, props: { w: 50, h: 50 } },
+			])
+			editor.reparentShapes([lockedId], innerId)
+
+			editor.deleteShape(frameId)
+
+			expect(editor.getShape(innerId)).toBeUndefined()
+			expect(editor.getShape(lockedId)).toMatchObject({ parentId: editor.getCurrentPageId() })
+		})
+
+		it('keeps the unlocked children of a surviving locked child', () => {
+			const lockedFrameId = createShapeId('lockedFrame')
+			const grandchildId = createShapeId('grandchild')
+			editor.createShapes([
+				{
+					id: lockedFrameId,
+					type: 'frame',
+					parentId: frameId,
+					x: 0,
+					y: 0,
+					isLocked: true,
+					props: { w: 100, h: 100 },
+				},
+				{ id: grandchildId, type: 'geo', parentId: lockedFrameId, x: 5, y: 5 },
+			])
+
+			editor.deleteShape(frameId)
+
+			expect(editor.getShape(lockedFrameId)).toMatchObject({ parentId: editor.getCurrentPageId() })
+			expect(editor.getShape(grandchildId)).toMatchObject({ parentId: lockedFrameId, x: 5, y: 5 })
+		})
+
+		it('keeps a locked child of a deleted group', () => {
+			const groupId = createShapeId('group')
+			editor.updateShape({ id: lockedId, type: 'geo', isLocked: false })
+			editor.groupShapes([lockedId, unlockedId], { groupId })
+			editor.updateShape({ id: lockedId, type: 'geo', isLocked: true })
+			expect(editor.getShape(groupId)).toMatchObject({ parentId: frameId })
+
+			editor.deleteShape(groupId)
+
+			expect(editor.getShape(groupId)).toBeUndefined()
+			expect(editor.getShape(unlockedId)).toBeUndefined()
+			expect(editor.getShape(lockedId)).toMatchObject({ parentId: frameId, x: 10, y: 20 })
+		})
+
+		it('deletes locked children when shape locks are ignored', () => {
+			editor.run(() => editor.deleteShape(frameId), { ignoreShapeLock: true })
+
+			expect(editor.getShape(frameId)).toBeUndefined()
+			expect(editor.getShape(lockedId)).toBeUndefined()
+			expect(editor.getShape(unlockedId)).toBeUndefined()
+		})
+	})
 })
 
 describe('When dragging a shape', () => {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1427,6 +1427,85 @@ describe('When deleting/removing a frame', () => {
 			expect(editor.getShape(lockedId)).toMatchObject({ parentId: frameId, x: 10, y: 20 })
 		})
 
+		it('keeps a locked arrow bound to deleted siblings on the page', () => {
+			const arrowId = createShapeId('arrow')
+			editor.createShape({
+				id: arrowId,
+				type: 'arrow',
+				parentId: frameId,
+				x: 0,
+				y: 0,
+				props: { start: { x: 20, y: 30 }, end: { x: 60, y: 60 } },
+			})
+			editor.createBindings([
+				{
+					fromId: arrowId,
+					toId: lockedId,
+					type: 'arrow',
+					props: {
+						terminal: 'start',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+				{
+					fromId: arrowId,
+					toId: unlockedId,
+					type: 'arrow',
+					props: {
+						terminal: 'end',
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+						isExact: false,
+						isPrecise: false,
+					},
+				},
+			])
+			// Both bound shapes are unlocked so the frame takes them with it; only the arrow survives.
+			editor.updateShapes([
+				{ id: lockedId, type: 'geo', isLocked: false },
+				{ id: arrowId, type: 'arrow', isLocked: true },
+			])
+			expect(editor.getShape(arrowId)).toMatchObject({ parentId: frameId })
+
+			editor.deleteShape(frameId)
+
+			expect(editor.getShape(frameId)).toBeUndefined()
+			expect(editor.getShape(lockedId)).toBeUndefined()
+			expect(editor.getShape(unlockedId)).toBeUndefined()
+			expect(editor.getShape(arrowId)).toMatchObject({
+				parentId: editor.getCurrentPageId(),
+				isLocked: true,
+			})
+			expect(editor.getBindingsInvolvingShape(arrowId)).toEqual([])
+			expect(editor.getCurrentPageShapeIds().has(arrowId)).toBe(true)
+		})
+
+		it('keeps the relative z-order of locked descendants from different intermediate parents', () => {
+			const inner1Id = createShapeId('inner1')
+			const inner2Id = createShapeId('inner2')
+			const locked1Id = createShapeId('locked1')
+			const locked2Id = createShapeId('locked2')
+			// locked1 sits above an unlocked sibling in inner1, so its local index is higher than
+			// locked2's in inner2 even though locked2 is above it in the tree.
+			editor.createShapes([
+				{ id: inner1Id, type: 'frame', parentId: frameId, x: 0, y: 0, props: { w: 100, h: 100 } },
+				{ id: inner2Id, type: 'frame', parentId: frameId, x: 0, y: 0, props: { w: 100, h: 100 } },
+			])
+			editor.reparentShapes([unlockedId], inner1Id)
+			editor.createShapes([
+				{ id: locked1Id, type: 'geo', parentId: inner1Id, x: 0, y: 0, isLocked: true },
+				{ id: locked2Id, type: 'geo', parentId: inner2Id, x: 0, y: 0, isLocked: true },
+			])
+			expect(editor.getShape(locked1Id)!.index > editor.getShape(locked2Id)!.index).toBe(true)
+
+			editor.deleteShape(frameId)
+
+			const pageOrder = editor.getSortedChildIdsForParent(editor.getCurrentPageId())
+			expect(pageOrder.indexOf(lockedId)).toBeLessThan(pageOrder.indexOf(locked1Id))
+			expect(pageOrder.indexOf(locked1Id)).toBeLessThan(pageOrder.indexOf(locked2Id))
+		})
+
 		it('deletes locked children when shape locks are ignored', () => {
 			editor.run(() => editor.deleteShape(frameId), { ignoreShapeLock: true })
 


### PR DESCRIPTION
This PR fixes a bug where deleting a frame (or group) also deleted its locked children, even though locked shapes survive deletion everywhere else. Closes #10437.

### Before

`Editor.deleteShapes` filtered locked shapes out of the ids it was given, then collected every descendant of the remaining shapes with `visitDescendants` and removed them all. The lock check never ran on the descendants, so a locked rectangle inside an unlocked frame went away with the frame. Any parent shape took the same path, so groups behaved the same way, and the UI delete/cut actions inherited it.

### After

While collecting descendants, `deleteShapes` stops at any locked descendant and leaves its subtree alone. Before removing the rest, it reparents those locked shapes to the nearest ancestor that is not being deleted (usually the page), at the deleted ancestor's index, using `reparentShapes` so their page position and rotation are preserved. The reparent and the removal happen in one `run`, so undo puts the locked shape back inside the frame. The `deleted-shapes` event only lists the shapes that were actually removed. `run(..., { ignoreShapeLock: true })` still deletes everything, as before.

### Implementation notes

The issue flagged this as a product call between refusing the delete and keeping the locked child on the page. I went with keeping it, because that is what `ungroupShapes` already does for locked children (#2070), and the comment on `reparentShapes` explicitly anticipates "when a locked shape's parent is deleted". Refusing would also have left a frame that cannot be deleted without any visible reason.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame with a rectangle inside; lock the rectangle.
2. Select the frame and press Delete.
3. The frame is gone and the locked rectangle is still on the canvas in the same place; undo restores the frame with the rectangle inside it.

- [x] Unit tests — the new tests in `frames.test.ts` fail on `main` and pass with this change

### Release notes

- Fix a bug where deleting a frame or group also deleted its locked children; locked shapes now stay on the canvas.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +31 / -2   |
| Tests     | +121 / -0  |
