### PR TITLE
fix(editor): clear the cropping shape when leaving crop mode by tool switch, page change, or selection change

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -4969,6 +4969,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.stopFollowingUser()
 		// finish off any in-progress interactions
 		this.complete()
+		// Cropping ignores `complete` (undo and menus send it too), and it's per-page state, so
+		// clear it here while the page being left is still current
+		this.setCroppingShape(null)
 
 		return this.run(
 			() => {

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -56,6 +56,16 @@ export function registerDefaultSideEffects(editor: Editor) {
 					}
 				}
 
+				// Duplicate, select all, etc. move the selection off the cropping shape without ending
+				// the crop; left alone, the crop handles and the selection then point at different shapes
+				if (
+					next.croppingShapeId &&
+					prev.selectedShapeIds !== next.selectedShapeIds &&
+					!(next.selectedShapeIds.length === 1 && next.selectedShapeIds[0] === next.croppingShapeId)
+				) {
+					editor.setCroppingShape(null)
+				}
+
 				if (prev.editingShapeId !== next.editingShapeId) {
 					if (!prev.editingShapeId && next.editingShapeId) {
 						if (!editor.isIn('select.editing_shape')) {

--- a/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/SelectTool.ts
@@ -84,5 +84,8 @@ export class SelectTool extends StateNode {
 		if (this.editor.getCurrentPageState().editingShapeId) {
 			this.editor.setEditingShape(null)
 		}
+		if (this.editor.getCroppingShapeId()) {
+			this.editor.setCroppingShape(null)
+		}
 	}
 }

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -297,6 +297,51 @@ describe('When in the crop.idle state', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('switching tools clears the cropping shape id', () => {
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.setCurrentTool('geo')
+		editor.expectToBeIn('geo.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.setCurrentTool('select')
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		expect(editor.getSelectedShapeIds()).toMatchObject([ids.imageB])
+	})
+
+	it('changing page clears the cropping shape id and leaves crop mode', () => {
+		const pageA = editor.getCurrentPageId()
+		editor.createPage({ name: 'page b' })
+		const pageB = editor.getPages().find((p) => p.id !== pageA)!.id
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.setCurrentPage(pageB)
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.setCurrentPage(pageA)
+		editor.expectToBeIn('select.idle')
+		expect(editor.getCroppingShapeId()).toBe(null)
+	})
+
+	it('duplicating the cropping shape clears the cropping shape id and leaves crop mode', () => {
+		editor
+			.expectToBeIn('select.idle')
+			.doubleClick(550, 550, ids.imageB)
+			.expectToBeIn('select.crop.idle')
+		expect(editor.getCroppingShapeId()).toBe(ids.imageB)
+		editor.duplicateShapes([ids.imageB], { x: 100, y: 0 })
+		const duplicateId = editor.getOnlySelectedShapeId()
+		expect(duplicateId).not.toBe(ids.imageB)
+		expect(editor.getCroppingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
 	it('pointing the canvas should point canvas', () => {
 		editor
 			.expectToBeIn('select.idle')


### PR DESCRIPTION
This PR fixes a bug where leaving crop mode by switching tools, changing page, or duplicating the image left the image marked as the cropping shape, so its selection outline stopped being drawn when it was selected or hovered later. Closes #10436.

### Before

Only the explicit cancel/confirm paths inside the crop states called `setCroppingShape(null)`. Pressing a tool key exited the select tool with `croppingShapeId` still set on the page state; `ImageShapeUtil` hides the indicator for that shape, so after `R` then `V` the image had no selection outline until another image was cropped or it was deleted. `setCurrentPage` only sent `complete`, which crop idle ignores, so the select tool stayed in `select.crop.idle` on the new page with the old page's image still marked. Cmd/Ctrl+D in crop idle duplicated the image and selected the copy while the original stayed marked, leaving the crop handles and the selection pointing at different shapes.

### After

Leaving crop mode by any of these routes clears the mark and returns the select tool to `select.idle`:

- `SelectTool.onExit` clears the cropping shape the same way it already clears the editing shape, so a tool switch ends the crop.
- `Editor.setCurrentPage` clears the cropping shape after `complete()`, while the page being left is still current, so the old page's state is cleaned up before the switch.
- The default `instance_page_state` side effect ends the crop when the selection moves off the cropping shape (duplicate, select all, programmatic selection). It only reacts to selection changes, so crop idle's own "set cropping shape, then select it" sequence when clicking a second image is unaffected.

### Implementation notes

The issue suggests clearing in `Crop.onExit`. That state is also exited for the rotate-handle detour (`select.pointing_rotate_handle` with `onInteractionEnd: 'select.crop.idle'`), which must keep the cropping shape, and clearing there re-enters `select.idle` from inside the exit and leaves it orphaned. Clearing in `SelectTool.onExit` instead mirrors the existing editing-shape handling and avoids both problems. The page-change clear lives in the editor rather than a tldraw side effect because a side effect on the instance record only runs after the current page has already changed, by which point the old page's state can no longer be reached through `setCroppingShape`.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev`, drop an image on the canvas and double-click it to enter crop mode.
2. Press `R`, then `V`, then click the image: the selection outline is drawn.
3. Enter crop mode again and switch page: the tool is in `select.idle` and `editor.getCroppingShapeId()` is `null` on both pages.
4. Enter crop mode again and press Cmd/Ctrl+D: the copy is selected, the tool is in `select.idle`, and no crop handles remain on the original.

- [x] Unit tests — the three new tests fail on `main` and pass with this change

### Release notes

- Fix images staying marked as the cropping shape after leaving crop mode by switching tools, changing page, or duplicating.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -0   |
| Tests     | +45 / -0   |
