### PR TITLE
fix(editor): release held keys when the window loses focus

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Editor } from '../editor/Editor'
 import { TLKeyboardEventInfo } from '../editor/types/event-types'
 import { activeElementShouldCaptureKeys, preventDefault } from '../utils/dom'
@@ -13,6 +13,10 @@ export function useDocumentEvents() {
 
 	const isEditing = useValue('isEditing', () => editor.getEditingShapeId(), [editor])
 	const isAppFocused = useValue('isFocused', () => editor.getIsFocused(), [editor])
+
+	// `inputs.keys` only stores codes, but tools match `onKeyUp` on `info.key`, so the window
+	// blur release below needs the key remembered per code.
+	const heldKeysRef = useRef(new Map<string, string>())
 
 	// Prevent the browser's default drag and drop behavior on our container (UI, etc)
 	useEffect(() => {
@@ -212,6 +216,7 @@ export function useDocumentEvents() {
 				accelKey: isAccelKey(e),
 			}
 
+			heldKeysRef.current.set(e.code, e.key)
 			editor.dispatch(info)
 		}
 
@@ -239,6 +244,7 @@ export function useDocumentEvents() {
 				accelKey: isAccelKey(e),
 			}
 
+			heldKeysRef.current.delete(e.code)
 			editor.dispatch(info)
 		}
 
@@ -305,6 +311,36 @@ export function useDocumentEvents() {
 			container.removeEventListener('keyup', handleKeyUp)
 		}
 	}, [editor, container, isAppFocused, isEditing])
+
+	// Alt+Tab / Cmd+Tab away while holding a key delivers the keyup to the other app, so without
+	// this Space-panning (grab cursor, drags pan) stuck until the key was pressed again (#10442).
+	// Replaying a key_up per held key runs the normal release path, including tool onKeyUp.
+	useEffect(() => {
+		const win = editor.getContainerWindow()
+
+		const handleWindowBlur = () => {
+			const heldKeys = heldKeysRef.current
+			for (const code of [...editor.inputs.keys]) {
+				editor.dispatch({
+					type: 'keyboard',
+					name: 'key_up',
+					key: heldKeys.get(code) ?? code,
+					code,
+					shiftKey: false,
+					altKey: false,
+					ctrlKey: false,
+					metaKey: false,
+					accelKey: false,
+				})
+			}
+			heldKeys.clear()
+		}
+
+		win.addEventListener('blur', handleWindowBlur)
+		return () => {
+			win.removeEventListener('blur', handleWindowBlur)
+		}
+	}, [editor])
 }
 
 function areShortcutsDisabled(editor: Editor) {

--- a/packages/editor/src/lib/test/useDocumentEvents.test.tsx
+++ b/packages/editor/src/lib/test/useDocumentEvents.test.tsx
@@ -1,7 +1,9 @@
-import { act, render } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import { vi } from 'vitest'
 import { createTLStore } from '../config/createTLStore'
-import { TldrawEditor } from '../TldrawEditor'
+import { Editor } from '../editor/Editor'
+import { TLKeyboardEventInfo } from '../editor/types/event-types'
+import { TL_CONTAINER_CLASS, TldrawEditor } from '../TldrawEditor'
 
 describe('useDocumentEvents drop handling', () => {
 	// The container's native drop listener used to stop propagation before the event reached
@@ -27,5 +29,79 @@ describe('useDocumentEvents drop handling', () => {
 		expect(onDrop).toHaveBeenCalledTimes(1)
 		// the browser default (navigating to the dropped file) is still prevented
 		expect(event.defaultPrevented).toBe(true)
+	})
+})
+
+describe('useDocumentEvents window blur', () => {
+	async function renderEditor() {
+		let editor!: Editor
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} autoFocus onMount={(e) => void (editor = e)} />)
+		})
+		const container = document.querySelector<HTMLElement>(`.${TL_CONTAINER_CLASS}`)!
+		return { editor, container }
+	}
+
+	function keyDown(container: HTMLElement, init: KeyboardEventInit) {
+		act(() => {
+			container.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }))
+		})
+	}
+
+	function blurWindow() {
+		act(() => {
+			window.dispatchEvent(new Event('blur'))
+		})
+	}
+
+	afterEach(() => {
+		cleanup()
+	})
+
+	// Alt+Tab / Cmd+Tab while holding Space: the keyup goes to the other app, so the editor
+	// used to stay in spacebar panning mode with the grab cursor until Space was pressed again.
+	it('ends spacebar panning and restores the cursor', async () => {
+		const { editor, container } = await renderEditor()
+		editor.setCursor({ type: 'cross', rotation: 0 })
+
+		keyDown(container, { key: ' ', code: 'Space' })
+		expect(editor.inputs.keys.has('Space')).toBe(true)
+		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.getInstanceState().cursor.type).toBe('grab')
+
+		blurWindow()
+		expect(editor.inputs.keys.has('Space')).toBe(false)
+		expect(editor.inputs.getIsSpacebarPanning()).toBe(false)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.getInstanceState().cursor.type).toBe('cross')
+	})
+
+	it('releases every held key through a key_up that tools can match on key', async () => {
+		const { editor, container } = await renderEditor()
+		const keyUps: TLKeyboardEventInfo[] = []
+		editor.on('event', (info) => {
+			if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info)
+		})
+
+		keyDown(container, { key: 'ArrowLeft', code: 'ArrowLeft' })
+		keyDown(container, { key: 'a', code: 'KeyA' })
+		expect([...editor.inputs.keys]).toEqual(['ArrowLeft', 'KeyA'])
+
+		blurWindow()
+		expect(editor.inputs.keys.size).toBe(0)
+		expect(keyUps.map((info) => [info.key, info.code])).toEqual([
+			['ArrowLeft', 'ArrowLeft'],
+			['a', 'KeyA'],
+		])
+	})
+
+	it('does nothing when no keys are held', async () => {
+		const { editor } = await renderEditor()
+		const onEvent = vi.fn()
+		editor.on('event', onEvent)
+		blurWindow()
+		expect(onEvent).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
This PR fixes a bug where switching applications (Alt+Tab / Cmd+Tab) while holding Space left the editor stuck in spacebar panning mode — grab cursor, and drags pan the camera — until Space was pressed and released again. The same applied to any other held key, which stayed in `inputs.keys`. Closes #10442.

### Before

`useDocumentEvents` adds a code to `inputs.keys` on `keydown` and removes it on `keyup`, both listened for on the container. When the window loses focus the `keyup` goes to the other application, so nothing ever cleared the held key or the panning flags that `Editor` sets for `Space`.

### After

`useDocumentEvents` listens for `blur` on the container's window and dispatches a synthetic `key_up` for every code still in `inputs.keys`. That runs the normal release path in `Editor`: the key leaves `inputs.keys`, spacebar panning ends and the previous cursor is restored, and tool `onKeyUp` handlers fire as they would for a real release.

### Implementation notes

- The synthetic `key_up` reports all modifiers as released, which also starts the existing 150ms modifier release debounce for any held Shift/Alt/Ctrl/Meta.
- `inputs.keys` only stores codes, but tools match `onKeyUp` on `info.key`, so the hook keeps a small code → key map from the `keydown` it dispatched and uses it when replaying (falling back to the code).
- Only window `blur` is handled, matching the issue's scope. Focus moving to an element outside the container within the same page (where the container also misses the `keyup`) is left for a follow-up.

### Change type

- [x] `bugfix`

### Test plan

1. Hold Space on the canvas, Cmd+Tab / Alt+Tab to another app, release Space, come back.
2. The cursor is back to normal and dragging no longer pans.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix held keys (including Space panning) staying active after the window loses focus.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +37 / -1   |
| Tests     | +78 / -2   |
