### PR TITLE
fix(editor): scale camera coasting and edge scrolling by elapsed time

### DIFF
--- a/packages/editor/src/lib/constants.ts
+++ b/packages/editor/src/lib/constants.ts
@@ -24,6 +24,14 @@ export const INTERNAL_POINTER_IDS = {
 	CAMERA_MOVE: -10,
 } as const
 
+/**
+ * Per-tick tuning constants (`cameraSlideFriction`, `edgeScrollSpeed`) assume a 60 Hz tick. Scaling
+ * motion by `elapsed / FRAME_MS_60HZ` keeps that feel on displays with other refresh rates.
+ *
+ * @internal
+ */
+export const FRAME_MS_60HZ = 1000 / 60
+
 /** @public */
 export const SIDES = ['top', 'right', 'bottom', 'left'] as const
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -110,6 +110,7 @@ import {
 import {
 	DEFAULT_ANIMATION_OPTIONS,
 	DEFAULT_CAMERA_OPTIONS,
+	FRAME_MS_60HZ,
 	INTERNAL_POINTER_IDS,
 	LEFT_MOUSE_BUTTON,
 	MIDDLE_MOUSE_BUTTON,
@@ -4085,8 +4086,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 				newCy += center.y / newCz - center.y / cz
 			}
 
-			// Apply friction
-			currentSpeed *= 1 - friction
+			// Apply friction per unit of elapsed time, not per tick, or a 120 Hz display decays twice as fast
+			currentSpeed *= (1 - friction) ** (elapsed / FRAME_MS_60HZ)
 			if (currentSpeed < speedThreshold) {
 				cancel()
 			} else {

--- a/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.test.ts
@@ -262,15 +262,46 @@ describe('EdgeScrollManager', () => {
 		})
 
 		it('should adjust scroll speed based on zoom level', () => {
-			editor.getZoomLevel.mockReturnValue(2)
 			mockInputs.setCurrentScreenPoint(new Vec(5, 300))
 
 			edgeScrollManager.updateEdgeScrolling(300)
+			const atZoom1 = (editor.setCamera.mock.calls[0][0] as Vec).x
 
-			expect(editor.setCamera).toHaveBeenCalled()
-			const callArgs = editor.setCamera.mock.calls[0][0] as Vec
+			editor.setCamera.mockClear()
+			edgeScrollManager = new EdgeScrollManager(editor)
+			editor.getZoomLevel.mockReturnValue(2)
+			edgeScrollManager.updateEdgeScrolling(300)
+			const atZoom2 = (editor.setCamera.mock.calls[0][0] as Vec).x
+
 			// Higher zoom should result in smaller camera movement
-			expect(Math.abs(callArgs.x)).toBeLessThan(25)
+			expect(atZoom2).toBeCloseTo(atZoom1 / 2)
+		})
+
+		it('should move the same distance per second regardless of tick rate', () => {
+			mockInputs.setCurrentScreenPoint(new Vec(5, 300))
+
+			// Get past the delay and easing ramp so each tick moves at full speed
+			edgeScrollManager.updateEdgeScrolling(1000)
+			editor.setCamera.mockClear()
+
+			// One second of 60 Hz ticks
+			for (let i = 0; i < 60; i++) edgeScrollManager.updateEdgeScrolling(1000 / 60)
+			const at60Hz = editor.setCamera.mock.calls.reduce(
+				(sum, [camera]) => sum + (camera as Vec).x,
+				0
+			)
+
+			editor.setCamera.mockClear()
+
+			// One second of 120 Hz ticks
+			for (let i = 0; i < 120; i++) edgeScrollManager.updateEdgeScrolling(1000 / 120)
+			const at120Hz = editor.setCamera.mock.calls.reduce(
+				(sum, [camera]) => sum + (camera as Vec).x,
+				0
+			)
+
+			expect(at60Hz).toBeGreaterThan(0)
+			expect(at120Hz).toBeCloseTo(at60Hz)
 		})
 
 		it('should add scroll delta to current camera position', () => {

--- a/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.ts
+++ b/packages/editor/src/lib/editor/managers/EdgeScrollManager/EdgeScrollManager.ts
@@ -1,3 +1,4 @@
+import { FRAME_MS_60HZ } from '../../../constants'
 import { EASINGS } from '../../../primitives/easings'
 import { Vec } from '../../../primitives/Vec'
 import type { Editor } from '../../Editor'
@@ -51,10 +52,13 @@ export class EdgeScrollManager {
 								)
 							)
 						: 1
-				this.moveCameraWhenCloseToEdge({
-					x: edgeScrollProximityFactor.x * eased,
-					y: edgeScrollProximityFactor.y * eased,
-				})
+				this.moveCameraWhenCloseToEdge(
+					{
+						x: edgeScrollProximityFactor.x * eased,
+						y: edgeScrollProximityFactor.y * eased,
+					},
+					elapsed
+				)
 			}
 		}
 	}
@@ -112,7 +116,7 @@ export class EdgeScrollManager {
 	 * Moves the camera when the mouse is close to the edge of the screen.
 	 * @public
 	 */
-	private moveCameraWhenCloseToEdge(proximityFactor: { x: number; y: number }) {
+	private moveCameraWhenCloseToEdge(proximityFactor: { x: number; y: number }, elapsed: number) {
 		if (proximityFactor.x === 0 && proximityFactor.y === 0) return
 		const { editor } = this
 
@@ -128,9 +132,11 @@ export class EdgeScrollManager {
 				? EDGE_SCROLL_SMALL_SCREEN_SPEED_FACTOR
 				: 1
 
-		// Determines the base speed of the scroll
+		// Determines the base speed of the scroll. edgeScrollSpeed is px per 60 Hz frame, so scale
+		// by elapsed time or a 120 Hz display scrolls twice as fast.
 		const zoomLevel = editor.getZoomLevel()
-		const pxSpeed = editor.user.getEdgeScrollSpeed() * editor.options.edgeScrollSpeed
+		const pxSpeed =
+			editor.user.getEdgeScrollSpeed() * editor.options.edgeScrollSpeed * (elapsed / FRAME_MS_60HZ)
 		const scrollDeltaX = (pxSpeed * proximityFactor.x * screenSizeFactorX) / zoomLevel
 		const scrollDeltaY = (pxSpeed * proximityFactor.y * screenSizeFactorY) / zoomLevel
 

--- a/packages/tldraw/src/test/commands/setCamera.test.ts
+++ b/packages/tldraw/src/test/commands/setCamera.test.ts
@@ -453,11 +453,13 @@ describe('CameraOptions.panSpeed', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 		// pointerMove calls forceTick() internally, so we don't need an extra forceTick() call
 		editor.pointerDown(shape.x, shape.y, shapeId).forceTick().pointerMove(-5000, -5000)
-		// At maximum speed and a zoom level of 1, the camera should move by 25px per tick if the screen
-		// is wider than 1000 pixels, or by 25 * 0.612px if it is smaller.
-		const newX = viewportScreenBounds.w < 1000 ? 25 * 0.612 : 25
-		const newY = viewportScreenBounds.h < 1000 ? 25 * 0.612 : 25
-		expect(editor.getCamera()).toMatchObject({ x: newX, y: newY, z: 1 })
+		// At maximum speed and a zoom level of 1, the camera should move by 25px per 60 Hz frame if the
+		// screen is wider than 1000 pixels, or by 25 * 0.612px if it is smaller. forceTick emits a 16ms
+		// tick, so scale the expectation to that.
+		const pxPerTick = 25 * (16 / (1000 / 60))
+		const newX = viewportScreenBounds.w < 1000 ? pxPerTick * 0.612 : pxPerTick
+		const newY = viewportScreenBounds.h < 1000 ? pxPerTick * 0.612 : pxPerTick
+		expect(editor.getCamera()).toCloselyMatchObject({ x: newX, y: newY, z: 1 })
 	})
 })
 
@@ -1267,4 +1269,22 @@ test('slideCamera zoom momentum survives a long frame', () => {
 	expect(z).toBeGreaterThan(0)
 	expect(z).toBeLessThan(1)
 	expect(Number.isFinite(x) && Number.isFinite(y)).toBe(true)
+})
+
+test('slideCamera coasts the same distance regardless of tick rate', () => {
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+
+	const coastFor = (ticksPerSecond: number) => {
+		editor.setCamera({ x: 0, y: 0, z: 1 })
+		editor.slideCamera({ speed: 1, direction: { x: 1, y: 0 } })
+		// two seconds of ticks at the given rate, more than enough for the slide to finish
+		for (let i = 0; i < ticksPerSecond * 2; i++) editor.emit('tick', 1000 / ticksPerSecond)
+		return editor.getCamera().x
+	}
+
+	const at60Hz = coastFor(60)
+	const at120Hz = coastFor(120)
+
+	expect(at60Hz).toBeGreaterThan(0)
+	expect(at120Hz / at60Hz).toBeCloseTo(1, 1)
 })

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -2074,6 +2074,9 @@ it('Ignores locked shapes when hovering', () => {
 })
 
 describe('Edge scrolling', () => {
+	// edgeScrollSpeed is px per 60 Hz frame; forceTick emits a 16ms tick
+	const pxPerTick = (editor: TestEditor) => editor.options.edgeScrollSpeed * (16 / (1000 / 60))
+
 	it('moves the camera correctly when delay and duration are zero', () => {
 		editor = new TestEditor({
 			options: {
@@ -2088,16 +2091,16 @@ describe('Edge scrolling', () => {
 		editor.pointerDown()
 		editor.pointerMove(0, 0)
 
-		expect(editor.getCamera()).toMatchObject({
-			x: editor.options.edgeScrollSpeed,
-			y: editor.options.edgeScrollSpeed,
+		expect(editor.getCamera()).toCloselyMatchObject({
+			x: pxPerTick(editor),
+			y: pxPerTick(editor),
 		})
 
 		editor.forceTick()
 
-		expect(editor.getCamera()).toMatchObject({
-			x: editor.options.edgeScrollSpeed * 2,
-			y: editor.options.edgeScrollSpeed * 2,
+		expect(editor.getCamera()).toCloselyMatchObject({
+			x: pxPerTick(editor) * 2,
+			y: pxPerTick(editor) * 2,
 		})
 	})
 
@@ -2116,16 +2119,16 @@ describe('Edge scrolling', () => {
 		editor.pointerMove(0, 0)
 
 		// one tick's length of delay
-		expect(editor.getCamera()).toMatchObject({
+		expect(editor.getCamera()).toCloselyMatchObject({
 			x: 0,
 			y: 0,
 		})
 
 		editor.forceTick()
 
-		expect(editor.getCamera()).toMatchObject({
-			x: editor.options.edgeScrollSpeed,
-			y: editor.options.edgeScrollSpeed,
+		expect(editor.getCamera()).toCloselyMatchObject({
+			x: pxPerTick(editor),
+			y: pxPerTick(editor),
 		})
 	})
 
@@ -2144,16 +2147,16 @@ describe('Edge scrolling', () => {
 		editor.pointerMove(0, 0)
 
 		// one tick's length of delay
-		expect(editor.getCamera()).toMatchObject({
-			x: editor.options.edgeScrollSpeed * 0.125,
-			y: editor.options.edgeScrollSpeed * 0.125,
+		expect(editor.getCamera()).toCloselyMatchObject({
+			x: pxPerTick(editor) * 0.125,
+			y: pxPerTick(editor) * 0.125,
 		})
 
 		editor.forceTick()
 
-		expect(editor.getCamera()).toMatchObject({
-			x: editor.options.edgeScrollSpeed * 1.125,
-			y: editor.options.edgeScrollSpeed * 1.125,
+		expect(editor.getCamera()).toCloselyMatchObject({
+			x: pxPerTick(editor) * 1.125,
+			y: pxPerTick(editor) * 1.125,
 		})
 	})
 })

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -142,6 +142,9 @@ describe('When translating...', () => {
 			.expectShapeToMatch({ id: ids.box1, x: 60, y: 60 })
 	})
 
+	// edgeScrollSpeed is 25px per 60 Hz frame; forceTick emits a 16ms tick
+	const edgeScrollPxPerTick = 25 * (16 / (1000 / 60))
+
 	it('translates a single shape near the top left edge', () => {
 		editor.user.updateUserPreferences({ edgeScrollSpeed: 1 })
 		editor.pointerDown(50, 50, ids.box1).pointerMove(0, 50) // [-50, 0]
@@ -151,7 +154,7 @@ describe('When translating...', () => {
 		editor.forceTick()
 		editor
 			// The change is bigger than expected because the camera moves
-			.expectShapeToMatch({ id: ids.box1, x: -65, y: 10 })
+			.expectShapeToMatch({ id: ids.box1, x: -40 - edgeScrollPxPerTick, y: 10 })
 			// We'll continue moving in the x position, but now we'll also move in the y position.
 			// The speed in the y position is smaller since we are further away from the edge.
 			.pointerMove(0, 25)
@@ -175,16 +178,27 @@ describe('When translating...', () => {
 		editor.forceTick()
 		editor
 			// The change is bigger than expected because the camera moves
-			.expectShapeToMatch({ id: ids.box1, x: 1115, y: 10 })
+			.expectShapeToMatch({ id: ids.box1, x: 1040 + edgeScrollPxPerTick * 3, y: 10 })
 			.pointerMove(1080, 800)
 
+		// The viewport is shorter than 1000px, so vertical scrolling runs at 0.612x, and the pointer
+		// is only 75% of the way into the edge zone
+		const edgeScrollPyPerTick = edgeScrollPxPerTick * 0.612 * 0.75
 		editor.forceTick()
 		editor.forceTick()
 		editor.forceTick()
 		editor
-			.expectShapeToMatch({ id: ids.box1, x: 1215, y: 805.9 })
+			.expectShapeToMatch({
+				id: ids.box1,
+				x: 1040 + edgeScrollPxPerTick * 7,
+				y: 760 + edgeScrollPyPerTick * 4,
+			})
 			.pointerUp()
-			.expectShapeToMatch({ id: ids.box1, x: 1240, y: 821.2 })
+			.expectShapeToMatch({
+				id: ids.box1,
+				x: 1040 + edgeScrollPxPerTick * 8,
+				y: 760 + edgeScrollPyPerTick * 4 + edgeScrollPxPerTick * 0.612,
+			})
 	})
 
 	it('translates multiple shapes', () => {


### PR DESCRIPTION
This PR fixes a bug where camera coasting after a fling decays roughly twice as fast, and edge scrolling moves roughly twice as fast, on a 120 Hz display compared to a 60 Hz one. Closes #10440.

### Before

`Editor.slideCamera` already scaled the per-tick displacement by `elapsed`, but applied friction as a flat `currentSpeed *= 1 - friction` once per tick. With twice as many ticks per second on a 120 Hz display the speed decayed as `0.91^(2n)` instead of `0.91^n` over the same wall-clock time, so the throw stopped sooner.

`EdgeScrollManager.updateEdgeScrolling` received `elapsed` and used it for the delay and easing ramp, but `moveCameraWhenCloseToEdge` moved the camera by a fixed `edgeScrollSpeed` pixels per tick regardless of how long the tick was, so a 120 Hz display scrolled twice as far per second.

### After

Both paths scale by `elapsed / FRAME_MS_60HZ` (a new `@internal` constant, `1000 / 60`), so motion per second is the same at any refresh rate. Friction becomes `(1 - friction) ** (elapsed / FRAME_MS_60HZ)`, and the edge-scroll pixel speed is multiplied by `elapsed / FRAME_MS_60HZ`. The existing `cameraSlideFriction: 0.09` and `edgeScrollSpeed: 25` defaults are unchanged and keep their current feel at 60 Hz.

### Implementation notes

The test `Driver.forceTick` emits a 16 ms tick rather than 16.67 ms, so the existing edge-scroll tests that hardcoded "25 px per tick" now expect `25 * (16 / (1000 / 60))` = 24 px per tick. Those expectations were rewritten as expressions rather than changing the driver's tick length, which would have touched unrelated timing tests.

### Change type

- [x] `bugfix`

### Test plan

1. On a 120 Hz display, fling the canvas with the hand tool and compare the coast distance to a 60 Hz display.
2. Drag a shape to the viewport edge on both displays and compare the scroll rate.

- [x] Unit tests — the new tests (`slideCamera coasts the same distance regardless of tick rate`, `should move the same distance per second regardless of tick rate`) fail on `main` and pass with this change

### Release notes

- Fix camera coasting and edge scrolling running faster on high-refresh displays

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +24 / -9   |
| Tests     | +97 / -29  |
