### PR TITLE
fix(tldraw): remove dead hide-toolbar-while-editing flag from TldrawUi

### DIFF
--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -1,6 +1,6 @@
-import { tlenv, useContainer, useEditor, useReactor, useValue } from '@tldraw/editor'
+import { useContainer, useEditor, useValue } from '@tldraw/editor'
 import classNames from 'classnames'
-import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ReactNode, useEffect, useMemo } from 'react'
 import { TLUiAssetUrlOverrides } from './assetUrls'
 import { SkipToMainContent } from './components/A11y'
 import { TldrawUiButton } from './components/primitives/Button/TldrawUiButton'
@@ -127,43 +127,6 @@ const TldrawUiContent = React.memo(function TldrawUI() {
 
 	useEditorEvents()
 
-	const rIsEditingAnything = useRef(false)
-	const rHidingTimeout = useRef(-1 as any)
-	const [hideToolbarWhileEditing, setHideToolbarWhileEditing] = useState(false)
-
-	useReactor(
-		'update hide toolbar while delayed',
-		() => {
-			const isMobileEnvironment = tlenv.isIos || tlenv.isAndroid
-			if (!isMobileEnvironment) return
-
-			const editingShape = editor.getEditingShapeId()
-			if (editingShape === null) {
-				if (rIsEditingAnything.current) {
-					rIsEditingAnything.current = false
-					clearTimeout(rHidingTimeout.current)
-					if (tlenv.isAndroid) {
-						// On Android, hide it after 150ms
-						rHidingTimeout.current = editor.timers.setTimeout(() => {
-							setHideToolbarWhileEditing(false)
-						}, 150)
-					} else {
-						// On iOS, just hide it immediately
-						setHideToolbarWhileEditing(false)
-					}
-				}
-				return
-			}
-
-			if (!rIsEditingAnything.current) {
-				rIsEditingAnything.current = true
-				clearTimeout(rHidingTimeout.current)
-				setHideToolbarWhileEditing(true)
-			}
-		},
-		[]
-	)
-
 	const { 'toggle-focus-mode': toggleFocus } = useActions()
 
 	const { breakpointsAbove, breakpointsBelow } = useMemo(() => {
@@ -190,9 +153,6 @@ const TldrawUiContent = React.memo(function TldrawUI() {
 			// readers like VoiceOver and TalkBack that do not announce role="application". See
 			// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role
 			role="document"
-			// When the virtual keyboard is opening we want it to hide immediately.
-			// But when the virtual keyboard is closing we want to wait a bit before showing it again.
-			data-iseditinganything={hideToolbarWhileEditing}
 			data-breakpoint={breakpoint}
 			data-breakpoints-above={breakpointsAbove.join(' ')}
 			data-breakpoints-below={breakpointsBelow.join(' ')}


### PR DESCRIPTION
This PR fixes a bug where `TldrawUi` computed a "hide the toolbar while editing" flag on iOS and Android and stamped it on `.tlui-layout` as `data-iseditinganything`, but nothing read it. Closes #10443.

### Before

`TldrawUiContent` ran a reactor on iOS/Android that tracked `editor.getEditingShapeId()` (with a 150 ms delay on Android when editing ended) and set `data-iseditinganything` on the layout element. No selector in `ui.css` matched that attribute, so the state and timer did nothing. The `.tl-canvas[data-iseditinganything]` rules in `editor.css` target a different element set by `DefaultCanvas`, and are unaffected.

### After

The reactor, the timer, the state, and the layout attribute are gone. Nothing user-facing changes.

### Implementation notes

The issue left the decision open between wiring the flag up to hide the toolbar and removing it. I removed it, because the hide rule was disabled deliberately rather than lost by accident: it shipped together with `interactive-widget=resizes-content` in the rich text PR (#4895, commit 2a2b4d2cbf), and when that viewport setting was reverted mid-PR for hampering the keyboard (commit 87ff25e686), the CSS rule was commented out alongside it and later deleted in #5734. Without `resizes-content` the bottom toolbar sits behind the virtual keyboard anyway, and on the mobile layout the toolbar also hosts the mobile style panel, so re-enabling the rule would have taken the style panel away during text editing for no gain.

No test was added: the change only deletes dead state, and there is no behaviour a test could observe differently before and after.

### Change type

- [x] `bugfix`

### Test plan

1. On a phone (or a mobile device emulation with a touch user agent), double-tap a shape to edit its text.
2. The toolbar behaves exactly as before; `.tlui-layout` no longer carries a `data-iseditinganything` attribute.

### Release notes

- Remove an unused `data-iseditinganything` attribute from the `.tlui-layout` element, along with the editing-state reactor that set it on iOS and Android.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -42   |
