### PR TITLE
fix(tldraw): hide the actions menu in readonly mode for every tool

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
@@ -1,4 +1,3 @@
-import { useEditor, useValue } from '@tldraw/editor'
 import { ReactNode, memo } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
@@ -29,19 +28,14 @@ export const DefaultActionsMenu = memo(function DefaultActionsMenu({
 	const isReadonlyMode = useReadonly()
 	const { orientation } = useTldrawUiOrientation()
 
-	const editor = useEditor()
-	const isInAcceptableReadonlyState = useValue(
-		'should display quick actions when in readonly',
-		() => editor.isInAny('hand', 'zoom'),
-		[editor]
-	)
-
 	// Get the actions menu content, either the default component or the user's
 	// override. If there's no menu content, then the user has set it to null,
 	// so skip rendering the menu.
 
 	const content = children ?? <DefaultActionsMenuContent />
-	if (isReadonlyMode && !isInAcceptableReadonlyState) return
+
+	// Every default action edits shapes, so in readonly mode the menu would open empty
+	if (isReadonlyMode) return
 
 	return (
 		<TldrawUiPopover id="actions-menu">

--- a/packages/tldraw/src/test/actions-menu-readonly.test.tsx
+++ b/packages/tldraw/src/test/actions-menu-readonly.test.tsx
@@ -1,0 +1,37 @@
+import { act } from '@testing-library/react'
+import { Editor } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+let editor: Editor
+let rendered: Awaited<ReturnType<typeof renderTldrawComponentWithEditor>>['rendered']
+
+beforeEach(async () => {
+	// Pin the quick actions into the menu panel so the test does not depend on jsdom's viewport width
+	;({ editor, rendered } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} options={{ actionShortcutsLocation: 'menu' }} />,
+		{ waitForPatterns: true }
+	))
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+describe('actions menu in readonly mode', () => {
+	it('shows the actions menu button when not readonly', async () => {
+		expect(await rendered.findByTestId('actions-menu.button')).toBeTruthy()
+	})
+
+	it.each(['select', 'hand', 'zoom', 'eraser'])(
+		'hides the actions menu button in readonly mode with the %s tool',
+		async (toolId) => {
+			act(() => {
+				editor.updateInstanceState({ isReadonly: true })
+				editor.setCurrentTool(toolId)
+			})
+			expect(editor.getCurrentToolId()).toBe(toolId)
+			expect(rendered.queryByTestId('actions-menu.button')).toBeNull()
+		}
+	)
+})


### PR DESCRIPTION
This PR fixes a bug where, in a readonly room at tablet width or wider, the actions menu "..." button appeared while the hand or zoom tool was active, and clicking it opened an empty grid. Closes #10445.

### Before

`DefaultActionsMenu` returned early in readonly mode only when the current tool was *not* hand or zoom (`editor.isInAny('hand', 'zoom')`). The pre-composable-UI `MenuZone` hid the whole quick-actions block with `!isReadonly && !editor.isInAny('hand', 'zoom')`; the refactor in #2796 dropped the `!isReadonly` guard and the negation, so the readonly check ended up inverted. The button was hidden with select but shown with hand and zoom, and since every item in `DefaultActionsMenuContent` is an editing action without `readonlyOk`, `TldrawUiMenuItem` filtered them all out and the popover rendered blank.

### After

`DefaultActionsMenu` renders nothing in readonly mode regardless of the current tool, matching the select-tool behaviour and the original pre-refactor behaviour. The `useValue` on the tool state is removed since nothing else in the component depends on it.

### Implementation notes

The issue offered two acceptable outcomes (hide the button for every tool, or keep it and show a usable item). I took the conservative one: the default content has no readonly-usable items at the widths where the menu panel shows the button, so there is nothing to show. A custom `ActionsMenu` override that wants readonly items can still render its own trigger; only the default component hides itself.

### Change type

- [x] `bugfix`

### Test plan

1. Open a readonly room at tablet width or wider.
2. Press `H` (hand) or `Z` (zoom).
3. The "..." actions menu button in the menu panel should not appear.

- [x] Unit tests — `actions-menu-readonly.test.tsx` fails on `main` for the hand and zoom cases and passes with this change

### Release notes

- Fix the actions menu button appearing, and opening empty, in readonly mode with the hand and zoom tools

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -9    |
| Tests     | +37 / -0   |
