### PR TITLE
fix(editor): keep spacebar panning active through cancel while Space is held

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10996,7 +10996,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 			if (info.name === 'cancel' || info.name === 'complete') {
 				this.inputs.setIsDragging(false)
 
-				if (this.inputs.getIsPanning()) {
+				// A pan owned by a held spacebar outlives the cancelled interaction;
+				// key_up ends it. Otherwise Escape mid-pan stops the camera until
+				// the user releases and re-presses Space (#10446).
+				if (this.inputs.getIsPanning() && !this.inputs.keys.has('Space')) {
 					this.inputs.setIsPanning(false)
 					this.inputs.setIsSpacebarPanning(false)
 					this.setCursor({ type: this._prevCursor, rotation: 0 })

--- a/packages/tldraw/src/test/spacebarPanning.test.ts
+++ b/packages/tldraw/src/test/spacebarPanning.test.ts
@@ -80,3 +80,61 @@ it('When holding spacebar, pressing the arrow keys moves over by one viewport', 
 	expect(editor.getViewportPageBounds()).toEqual({ x: 1080, y: 720, w: 1080, h: 720 })
 	editor.keyUp(' ')
 })
+
+describe('When cancelling while spacebar is held', () => {
+	it('keeps panning through a cancel while the pointer is down', () => {
+		editor.keyDown(' ')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(50, 50)
+		editor.expectCameraToBe(50, 50, 1)
+
+		editor.cancel()
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
+		expect(editor.getInstanceState().cursor.type).toBe('grabbing')
+
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+
+		editor.pointerUp(100, 100)
+		editor.keyUp(' ')
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.getInstanceState().cursor.type).toBe('default')
+	})
+
+	it('keeps panning through a cancel while the pointer is up', () => {
+		editor.keyDown(' ')
+		editor.cancel()
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.getInstanceState().cursor.type).toBe('grab')
+
+		editor.pointerDown(0, 0)
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+		editor.pointerUp(100, 100)
+		editor.keyUp(' ')
+		expect(editor.inputs.getIsPanning()).toBe(false)
+	})
+
+	it('keeps panning through a complete while spacebar is held', () => {
+		editor.keyDown(' ')
+		editor.pointerDown(0, 0)
+		editor.complete()
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.getInstanceState().cursor.type).toBe('grabbing')
+
+		editor.pointerMove(100, 100)
+		editor.expectCameraToBe(100, 100, 1)
+		editor.pointerUp(100, 100)
+		editor.keyUp(' ')
+		expect(editor.inputs.getIsPanning()).toBe(false)
+	})
+
+	it('still ends a middle mouse pan on cancel when spacebar is not held', () => {
+		editor.pointerDown(0, 0, { button: 1 })
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		editor.cancel()
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.getInstanceState().cursor.type).toBe('default')
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where pressing Escape while holding Space and dragging ended the pan even though Space was still held, so the camera stopped moving and the cursor reverted until the user released and re-pressed Space. Closes #10446.

### Before

`Editor._flushEventForTick` cleared `isPanning` and `isSpacebarPanning` and restored the previous cursor on every `cancel` or `complete` event, without checking whether Space was still down. Escape dispatches `cancel`, so a held-Space pan died mid-drag.


https://github.com/user-attachments/assets/abc0b467-c5a0-4c59-b910-71a88416b2f1

### After

The `cancel` / `complete` handler leaves the pan alone while `inputs.keys` still contains `Space`, matching the existing `pointer_up` logic, which already keeps panning while Space is held. The pan ends on Space `key_up` as before. Panning that is not backed by a held Space (middle mouse, right-click drag) still ends on `cancel` / `complete`.


https://github.com/user-attachments/assets/6031ec16-2635-45c8-a495-3782da0637be

### Implementation notes

The issue also notes that Escape with the hand tool active switches to the select tool. That is the hand tool's own `Idle.onCancel`, the same Escape-returns-to-select behavior every tool has, so it is left unchanged here.

### Change type

- [x] `bugfix`

### Test plan

1. Hold Space, drag the canvas, press Escape, keep dragging: the camera keeps panning and the cursor stays `grabbing`.
2. Release the pointer and Space: panning ends and the cursor returns to normal.
3. Middle-mouse drag, press Escape: the pan still ends.

- [x] Unit tests — the three new spacebar tests fail on `main` and pass with this change

### Release notes

- Fix Escape ending a spacebar pan while Space is still held

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |
| Tests     | +58 / -0   |


