### PR TITLE
fix(editor): clear laser trails when the current page changes

### DIFF
--- a/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
+++ b/packages/editor/src/lib/editor/managers/ScribbleManager/ScribbleManager.ts
@@ -1,4 +1,4 @@
-import { TLScribble, VecModel } from '@tldraw/tlschema'
+import { TLPageId, TLScribble, VecModel } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
 import { Vec } from '../../../primitives/Vec'
 import type { Editor } from '../../Editor'
@@ -47,6 +47,7 @@ export interface ScribbleSessionOptions {
 // Internal session state (not exported)
 interface Session {
 	id: string
+	pageId: TLPageId
 	items: ScribbleItem[]
 	state: 'active' | 'stopping' | 'complete'
 	options: Required<Omit<ScribbleSessionOptions, 'id'>>
@@ -75,6 +76,7 @@ export class ScribbleManager {
 		const id = options.id ?? uniqueId()
 		const session: Session = {
 			id,
+			pageId: this.editor.getCurrentPageId(),
 			items: [],
 			state: 'active',
 			options: {
@@ -357,6 +359,15 @@ export class ScribbleManager {
 		if (this.sessions.size === 0 && currentScribbles.length === 0) return
 
 		this.editor.run(() => {
+			// Drop sessions from other pages, otherwise a still-fading laser trail
+			// keeps playing out over the page the user switched to (#10449).
+			const currentPageId = this.editor.getCurrentPageId()
+			for (const session of this.sessions.values()) {
+				if (session.pageId !== currentPageId) {
+					this.clearSession(session.id)
+				}
+			}
+
 			// Tick all sessions
 			for (const session of this.sessions.values()) {
 				this.tickSession(session, elapsed)

--- a/packages/tldraw/src/test/LaserTool.test.ts
+++ b/packages/tldraw/src/test/LaserTool.test.ts
@@ -1,3 +1,4 @@
+import { PageRecordType } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from './TestEditor'
 
@@ -382,6 +383,51 @@ describe('LaserTool', () => {
 
 			// Should have scribbles from both (before first fades)
 			expect(editor.getInstanceState().scribbles.length).toBeGreaterThan(initialScribbleCount)
+		})
+	})
+
+	describe('Page changes', () => {
+		it('clears the trail when the current page changes', () => {
+			editor.setCurrentTool('laser')
+
+			editor.pointerDown(0, 0)
+			for (let i = 1; i <= 10; i++) {
+				editor.pointerMove(i * 5, i * 5)
+				vi.advanceTimersByTime(16)
+			}
+			editor.pointerUp()
+			expect(editor.getInstanceState().scribbles.length).toBeGreaterThan(0)
+
+			const page2Id = PageRecordType.createId('page2')
+			editor.createPage({ id: page2Id, name: 'Page 2' })
+			editor.setCurrentPage(page2Id)
+			vi.advanceTimersByTime(16)
+
+			expect(editor.getInstanceState().scribbles).toEqual([])
+		})
+
+		it('starts a fresh session on the new page after a page change', () => {
+			editor.setCurrentTool('laser')
+
+			editor.pointerDown(0, 0)
+			editor.pointerMove(10, 10)
+			vi.advanceTimersByTime(16)
+			editor.pointerUp()
+
+			const page2Id = PageRecordType.createId('page2')
+			editor.createPage({ id: page2Id, name: 'Page 2' })
+			editor.setCurrentPage(page2Id)
+			vi.advanceTimersByTime(16)
+
+			editor.pointerDown(0, 50)
+			for (let i = 1; i <= 10; i++) {
+				editor.pointerMove(i * 5, 50 + i * 5)
+				vi.advanceTimersByTime(16)
+			}
+			editor.pointerUp()
+
+			// Only the stroke drawn on the new page is visible
+			expect(editor.getInstanceState().scribbles.length).toBe(1)
 		})
 	})
 

--- a/packages/tldraw/src/test/ScribbleManager.test.ts
+++ b/packages/tldraw/src/test/ScribbleManager.test.ts
@@ -1,3 +1,4 @@
+import { PageRecordType } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from './TestEditor'
 
@@ -339,6 +340,24 @@ describe('ScribbleManager', () => {
 					editor.scribbles.tick(16)
 				}
 
+				expect(editor.scribbles.isSessionActive(sessionId)).toBe(false)
+			})
+
+			it('clears sessions started on another page when the current page changes', () => {
+				const sessionId = editor.scribbles.startSession({ selfConsume: false })
+				const item = editor.scribbles.addScribbleToSession(sessionId, {})
+				for (let i = 0; i < 10; i++) {
+					editor.scribbles.addPointToSession(sessionId, item.id, i * 5, i * 5)
+					editor.scribbles.tick(16)
+				}
+				expect(editor.getInstanceState().scribbles.length).toBe(1)
+
+				const page2Id = PageRecordType.createId('page2')
+				editor.createPage({ id: page2Id, name: 'Page 2' })
+				editor.setCurrentPage(page2Id)
+				editor.scribbles.tick(16)
+
+				expect(editor.getInstanceState().scribbles).toEqual([])
 				expect(editor.scribbles.isSessionActive(sessionId)).toBe(false)
 			})
 		})


### PR DESCRIPTION
This PR fixes a bug where a laser trail drawn on one page kept fading out over the new page after switching pages. Closes #10449.

### Before

`ScribbleManager` sessions had no notion of which page they were drawn on. `Editor.setCurrentPage()` completes the in-progress stroke, but the laser session itself stays alive through its idle timeout and grouped fade, and `tick()` kept publishing its scribbles to instance state, so the trail continued to render over whichever page was current.


https://github.com/user-attachments/assets/2882b0ed-4737-4b26-8c0f-86fd33afd86f

### After

A session records the current page id when it starts. On each tick, sessions whose page is not the current page are cleared before the remaining sessions are ticked, so the trail disappears on the first frame after the page change. The laser tool sees the old session as inactive and starts a fresh one for the next stroke on the new page.


https://github.com/user-attachments/assets/73ae990c-057a-4678-ac2b-9edd680ac1fa

### Implementation notes

Stale sessions are cleared rather than hidden: scribbles are transient and would have faded anyway, so there is nothing worth showing again on returning to the original page. The check lives in `tick()` (which already runs every frame before overlays render) rather than in a page-change reaction, so it also covers page changes that bypass `setCurrentPage`, such as undo/redo and following a collaborator.

### Change type

- [x] `bugfix`

### Test plan

1. Select the laser tool, draw a stroke, and switch to another page before it fades.
2. The trail should not appear on the new page.

- [x] Unit tests — the new tests fail on `main` and pass with this change

### Release notes

- Fix laser trails staying visible after changing page.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +12 / -1   |
| Tests     | +65 / -0   |


