### PR TITLE
fix(tldraw): fix follow tooltip, Windows Shift label, and Delete with shortcuts off

### DIFF
--- a/apps/docs/content/sdk-features/accessibility.mdx
+++ b/apps/docs/content/sdk-features/accessibility.mdx
@@ -182,7 +182,7 @@ editor.user.updateUserPreferences({
 })
 ```
 
-When disabled, tldraw's keyboard shortcuts don't interfere with assistive technology shortcuts. Basic navigation with Tab and arrow keys still works for shape selection.
+When disabled, tool keys and action shortcuts like `R` or `Ctrl/Cmd+D` stop firing, so they don't interfere with assistive technology shortcuts. The keys that operate a selection still work: Tab and the arrow keys for navigation, Enter to edit, Escape to cancel, and Delete or Backspace to delete. So do the accessibility shortcuts that move focus to the style panel (Ctrl/Cmd+Enter), open the context menu (Ctrl/Cmd+Shift+Enter), and repeat the selection's description (Alt+R).
 
 ## Accessibility menu
 

--- a/assets/translations/main.json
+++ b/assets/translations/main.json
@@ -366,7 +366,7 @@
 	"people-menu.change-name": "Change name",
 	"people-menu.avatar-color": "Avatar color",
 	"people-menu.change-color": "Change color",
-	"people-menu.follow": "Following",
+	"people-menu.follow": "Follow",
 	"people-menu.following": "Following",
 	"people-menu.leading": "Following you",
 	"people-menu.user": "(You)",

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -32,6 +32,12 @@ const SKIP_KBDS = [
 	'asset',
 ]
 
+// Actions whose kbd still fires with the keyboard shortcuts preference off. The preference
+// silences tldraw's shortcuts, not the keys that operate a selection: the select tool handles
+// Enter, Tab, Escape, and the arrows outside this registry, so Delete would otherwise be the
+// one selection key the preference took away.
+const KBDS_IGNORING_SHORTCUTS_PREFERENCE = ['delete']
+
 /** @public */
 export function useKeyboardShortcuts() {
 	const editor = useEditor()
@@ -60,8 +66,13 @@ export function useKeyboardShortcuts() {
 			if (isReadonlyMode && !action.readonlyOk) continue
 			if (SKIP_KBDS.includes(action.id)) continue
 
+			const ignoresPreference = KBDS_IGNORING_SHORTCUTS_PREFERENCE.includes(action.id)
 			register(getHotkeysStringFromKbd(action.kbd), (event) => {
-				if (areShortcutsDisabled(editor) && !action.isRequiredA11yAction) return
+				if (!action.isRequiredA11yAction) {
+					if (ignoresPreference ? isShortcutContextBlocked(editor) : areShortcutsDisabled(editor)) {
+						return
+					}
+				}
 				preventDefault(event)
 				action.onSelect('kbd')
 			})
@@ -211,11 +222,14 @@ export function useKeyboardShortcuts() {
 }
 
 export function areShortcutsDisabled(editor: Editor) {
+	return isShortcutContextBlocked(editor) || !editor.user.getAreKeyboardShortcutsEnabled()
+}
+
+function isShortcutContextBlocked(editor: Editor) {
 	return (
 		editor.menus.hasAnyOpenMenus() ||
 		editor.getEditingShapeId() !== null ||
-		editor.getCrashingError() ||
-		!editor.user.getAreKeyboardShortcutsEnabled()
+		editor.getCrashingError()
 	)
 }
 

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/defaultTranslation.ts
@@ -373,7 +373,7 @@ export const DEFAULT_TRANSLATION = {
 	'people-menu.change-name': 'Change name',
 	'people-menu.avatar-color': 'Avatar color',
 	'people-menu.change-color': 'Change color',
-	'people-menu.follow': 'Following',
+	'people-menu.follow': 'Follow',
 	'people-menu.following': 'Following',
 	'people-menu.leading': 'Following you',
 	'people-menu.user': '(You)',

--- a/packages/tldraw/src/lib/ui/kbd-utils.test.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.test.ts
@@ -1,11 +1,30 @@
+import { tlenv } from '@tldraw/editor'
 import { kbd } from './kbd-utils'
 
 describe('kbd', () => {
+	const isDarwin = tlenv.isDarwin
+	afterEach(() => {
+		tlenv.isDarwin = isDarwin
+	})
+
 	it('displays a comma key with modifiers', () => {
 		expect(kbd('shift+,,shift+alt+,')).toEqual([...kbd('shift+.').slice(0, -1), ','])
 	})
 
 	it('preserves spaces in atomic key labels', () => {
 		expect(kbd('[[Page Up]]')).toEqual(['Page Up'])
+	})
+
+	it('renders modifiers as glyphs on mac', () => {
+		tlenv.isDarwin = true
+		expect(kbd('cmd+shift+z')).toEqual(['⌘', '⇧', 'Z'])
+		expect(kbd('$!z')).toEqual(['⌘', '⇧', 'Z'])
+	})
+
+	it('writes every modifier out as a word on windows', () => {
+		tlenv.isDarwin = false
+		expect(kbd('cmd+shift+z')).toEqual(['Ctrl', '+', 'Shift', '+', 'Z'])
+		expect(kbd('shift+alt+.')).toEqual(['Shift', '+', 'Alt', '+', '.'])
+		expect(kbd('$!z')).toEqual(['Ctrl', '+', 'Shift', '+', 'Z'])
 	})
 })

--- a/packages/tldraw/src/lib/ui/kbd-utils.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.ts
@@ -9,13 +9,14 @@ import { tlenv } from '@tldraw/editor'
  * Source: https://github.com/jaywcjlove/hotkeys-js
  */
 
-// N.B. We rework these Windows placeholders down below.
-const cmdKey = tlenv.isDarwin ? '⌘' : '__CTRL__'
-const ctrlKey = tlenv.isDarwin ? '⌃' : '__CTRL__'
-const altKey = tlenv.isDarwin ? '⌥' : '__ALT__'
-
 /** @public */
 export function kbd(str: string) {
+	// N.B. We rework these Windows placeholders down below.
+	const cmdKey = tlenv.isDarwin ? '⌘' : '__CTRL__'
+	const ctrlKey = tlenv.isDarwin ? '⌃' : '__CTRL__'
+	const altKey = tlenv.isDarwin ? '⌥' : '__ALT__'
+	const shiftKey = tlenv.isDarwin ? '⇧' : '__SHIFT__'
+
 	return (
 		(splitKbd(str)[0] ?? '')
 			// If the string contains [[Tab]], we don't split these up
@@ -28,12 +29,12 @@ export function kbd(str: string) {
 							.replace(/cmd\+/g, cmdKey)
 							.replace(/ctrl\+/g, ctrlKey)
 							.replace(/alt\+/g, altKey)
-							.replace(/shift\+/g, '⇧')
+							.replace(/shift\+/g, shiftKey)
 							// Backwards compatibility with the old system.
 							.replace(/\$/g, cmdKey)
 							.replace(/\?/g, altKey)
-							.replace(/!/g, '⇧')
-							.match(/__CTRL__|__ALT__|./g) || []
+							.replace(/!/g, shiftKey)
+							.match(/__CTRL__|__ALT__|__SHIFT__|./g) || []
 			)
 			.flat()
 			.map((sub, index) => {
@@ -44,6 +45,8 @@ export function kbd(str: string) {
 					modifiedKey = 'Ctrl'
 				} else if (sub === '__ALT__') {
 					modifiedKey = 'Alt'
+				} else if (sub === '__SHIFT__') {
+					modifiedKey = 'Shift'
 				} else {
 					modifiedKey = sub[0].toUpperCase() + sub.slice(1)
 				}

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -341,3 +341,52 @@ describe('frame selection shortcut', () => {
 		expect(editor.getShape(b)?.parentId).toBe(frame!.id)
 	})
 })
+
+describe('the keyboard shortcuts preference', () => {
+	function createSelectedShape(editor: Editor) {
+		const id = createShapeId()
+		act(() => {
+			editor.createShape({ id, type: 'geo', x: 0, y: 0 })
+			editor.select(id)
+		})
+		return id
+	}
+
+	async function setupWithShortcutsOff() {
+		const { editor } = await setupFocusedEditor()
+		act(() => {
+			editor.user.updateUserPreferences({ areKeyboardShortcutsEnabled: false })
+		})
+		return { editor }
+	}
+
+	it('silences tool keys and action chords', async () => {
+		const { editor } = await setupWithShortcutsOff()
+		const id = createSelectedShape(editor)
+
+		keydown(editor, { key: 'r', code: 'KeyR' })
+		expect(editor.getCurrentToolId()).toBe('select')
+
+		keydown(editor, { key: 'd', code: 'KeyD', metaKey: true })
+		expect(editor.getCurrentPageShapeIds()).toEqual(new Set([id]))
+	})
+
+	it('keeps Delete working on a selection, like the keys the select tool handles itself', async () => {
+		const { editor } = await setupWithShortcutsOff()
+		const id = createSelectedShape(editor)
+
+		keydown(editor, { key: 'Delete', code: 'Delete' })
+		expect(editor.getCurrentPageShapeIds().has(id)).toBe(false)
+	})
+
+	it('still blocks Delete while a menu is open', async () => {
+		const { editor } = await setupWithShortcutsOff()
+		const id = createSelectedShape(editor)
+
+		act(() => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		keydown(editor, { key: 'Delete', code: 'Delete' })
+		expect(editor.getCurrentPageShapeIds().has(id)).toBe(true)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where the people menu's follow button said "Following" before the user followed anyone, the shortcuts dialog on Windows mixed a word and a glyph (`Ctrl+⇧+Z`), and turning the "Enable keyboard shortcuts" preference off silenced Delete while Enter, Tab, and the arrows kept working. Closes #10452.

### Before

- `people-menu.follow` and `people-menu.following` were both "Following" in `assets/translations/main.json`, so the button's tooltip read "Following" in both states.
- `kbd()` rendered `cmd+` and `alt+` as `Ctrl` and `Alt` on Windows but always replaced `shift+` with `⇧`, so redo showed as `Ctrl+⇧+Z`.
- `useKeyboardShortcuts` gated every registered action on `areShortcutsDisabled`, which folds the preference in with "a menu is open / a shape is being edited / the editor crashed". Delete is a registered action, so the preference silenced it; Enter, Tab, Escape, and the arrows are handled by the select tool and never pass through the registry, so they kept working. Which selection keys survived depended on where they happened to be implemented.

### After

- The follow string is "Follow"; "Following" is only shown while following.
- On Windows and Linux `kbd()` writes `Shift` out like the other modifiers: `Ctrl+Shift+Z`, `Shift+Alt+.`. macOS is unchanged (`⌘⇧Z`). The modifier lookup now happens at call time so the platform can be flipped in tests.
- The preference follows one rule: it silences tldraw's shortcuts (tool keys and action chords, other than the three `isRequiredA11yAction` shortcuts) and leaves the keys that operate a selection alone — Tab, arrows, Enter, Escape, and now Delete/Backspace. Delete still respects the open-menu, editing, and crash checks. The accessibility docs state the rule.

### Implementation notes

The issue asked for one rule without saying which way to resolve it. Gating the select tool's Enter/Tab/arrow handling on the preference would contradict the documented accessibility promise that navigation keeps working, so Delete was brought in line with the other selection keys instead. It is done with a small `KBDS_IGNORING_SHORTCUTS_PREFERENCE` list in `useKeyboardShortcuts` (same shape as the existing `SKIP_KBDS`) rather than `isRequiredA11yAction`, because that flag also bypasses the open-menu and editing checks.

The commenting package hardcodes a `⇧C` hint that does not go through `kbd()`; it is left as is.

### Change type

- [x] `bugfix`

### Test plan

1. Open a synced room with a second user and hover the follow button in the people menu: it reads "Follow", and "Following" once clicked.
2. On Windows, open the keyboard shortcuts dialog: redo reads `Ctrl+Shift+Z`.
3. Turn off Preferences > Accessibility > Keyboard shortcuts, select a shape, press Delete: the shape is deleted. `R` and `Ctrl/Cmd+D` still do nothing.

- [x] Unit tests — the new kbd and Delete tests fail on `main` and pass with this change

### Release notes

- Fix the follow button's tooltip saying "Following" before following anyone
- Fix Windows and Linux shortcut labels showing `⇧` instead of `Shift`
- Fix Delete not working when the keyboard shortcuts preference is off, matching Enter, Tab, and the arrows

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +29 / -12  |
| Tests           | +68 / -0   |
| Automated files | +1 / -1    |
| Documentation   | +1 / -1    |
