### PR TITLE
fix(editor): flush local persistence on pagehide and when the tab is hidden

### DIFF
--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -172,3 +172,59 @@ test('writes that come in during a persist operation will get persisted afterwar
 	await tick()
 	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
 })
+
+test('pagehide flushes pending changes without waiting for the throttle', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'test', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+
+	client.store.put([PageRecordType.create({ name: 'test2', index: 'a1' as IndexKey })])
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+
+	window.dispatchEvent(new Event('pagehide'))
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+})
+
+test('hiding the tab flushes pending changes without waiting for the throttle', async () => {
+	const { client, tick } = testClient()
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'test', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1)
+
+	client.store.put([PageRecordType.create({ name: 'test2', index: 'a1' as IndexKey })])
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+
+	const visibilityState = vi.spyOn(document, 'visibilityState', 'get')
+	try {
+		visibilityState.mockReturnValue('hidden')
+		document.dispatchEvent(new Event('visibilitychange'))
+		expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	} finally {
+		visibilityState.mockRestore()
+	}
+})
+
+test('pagehide does not write before the initial load has completed', async () => {
+	const { client } = testClient()
+	window.dispatchEvent(new Event('pagehide'))
+	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
+	expect(client.db.storeChanges).not.toHaveBeenCalled()
+})
+
+test('pagehide and visibilitychange listeners are removed when the client closes', async () => {
+	const removeWindowListener = vi.spyOn(window, 'removeEventListener')
+	const removeDocumentListener = vi.spyOn(document, 'removeEventListener')
+	try {
+		const { client, tick } = testClient()
+		await tick()
+		client.close()
+		expect(removeWindowListener).toHaveBeenCalledWith('pagehide', expect.any(Function))
+		expect(removeDocumentListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+	} finally {
+		removeWindowListener.mockRestore()
+		removeDocumentListener.mockRestore()
+	}
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -68,6 +68,7 @@ export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
 	private diffQueue: Array<RecordsDiff<UnknownRecord> | typeof UPDATE_INSTANCE_STATE> = []
 	private didDispose = false
+	private didLoad = false
 	private shouldDoFullDBWrite = true
 	private isReloading = false
 	readonly persistenceKey: string
@@ -142,6 +143,28 @@ export class TLLocalSyncClient {
 				{ scope: 'session' }
 			)
 		)
+
+		if (typeof window !== 'undefined') {
+			// Persists are throttled, so without this the last PERSIST_THROTTLE_MS of edits are lost
+			// whenever the tab is closed or reloaded. `pagehide` is the last reliable event before
+			// unload on desktop; on mobile the page can be discarded without it firing, so we also
+			// flush when the tab is hidden.
+			const flush = () => {
+				// Before the initial load completes a full write would overwrite the saved
+				// document with an empty store.
+				if (!this.didLoad) return
+				this.persistIfNeeded()
+			}
+			const onVisibilityChange = () => {
+				if (document.visibilityState === 'hidden') flush()
+			}
+			window.addEventListener('pagehide', flush)
+			document.addEventListener('visibilitychange', onVisibilityChange)
+			this.disposables.add(() => {
+				window.removeEventListener('pagehide', flush)
+				document.removeEventListener('visibilitychange', onVisibilityChange)
+			})
+		}
 
 		this.connect(onLoad, onLoadError)
 
@@ -249,6 +272,7 @@ export class TLLocalSyncClient {
 			this.disposables.add(() => {
 				this.channel.close()
 			})
+			this.didLoad = true
 			onLoad(this)
 		} catch (e: any) {
 			this.debug('error loading data from store', e)


### PR DESCRIPTION
This PR fixes a bug where up to 350 ms of edits were lost when a tab was closed, reloaded, or backgrounded. Closes #10513.

### Before

`TLLocalSyncClient` throttles IndexedDB writes with a 350 ms timer and nothing flushed the queue when the page went away. Any change made inside that window, including the final characters typed into a note or the last slice of a drag, never reached the database.

### After

The client listens for `pagehide` on `window` and for `visibilitychange` → `hidden` on `document`, and on either event calls the persist path immediately, bypassing the throttle timer. The throttle itself is unchanged for normal editing. The listeners are registered in the client's disposables and removed on `close()`.

### Implementation notes

- `visibilitychange` is included because mobile browsers often discard a backgrounded page without firing `pagehide`; it also means switching tabs on desktop flushes early, which is harmless.
- The flush is a no-op until the initial load has finished. The first write after connecting is always a full snapshot, so flushing before load would overwrite the saved document with an empty store (for example, a background tab closed before IndexedDB responded). A `didLoad` flag guards this.
- If a write is already in flight when the event fires, the flush does nothing more; the in-flight transaction is the best we can do at that point. IndexedDB transactions started during `pagehide` generally complete.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `TLLocalSyncClient.test.ts`: `pagehide flushes pending changes without waiting for the throttle` and `hiding the tab flushes pending changes without waiting for the throttle` fail on `main` and pass here; plus tests that nothing is written before the initial load and that listeners are removed on `close()`.
1. Open `/develop`, type into a note, and close the tab within a quarter second. Reopen: the last characters are present.
2. Reload mid-drag: the shape is at its last dragged position rather than an earlier intermediate one.

### Release notes

- Fix edits made in the last 350 ms before closing or reloading a tab being lost from local persistence.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +24 / -0   |
| Tests     | +56 / -0   |
