### PR TITLE
fix(examples): give examples that shared the 'example' persistence key their own keys

### DIFF
--- a/apps/examples/src/examples/configuration/custom-options/CustomOptionsExample.tsx
+++ b/apps/examples/src/examples/configuration/custom-options/CustomOptionsExample.tsx
@@ -9,7 +9,7 @@ const options: Partial<TldrawOptions> = {
 export default function CustomOptionsExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" options={options} />
+			<Tldraw persistenceKey="custom-options-example" options={options} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/configuration/deep-links/DeepLinksExample.tsx
+++ b/apps/examples/src/examples/configuration/deep-links/DeepLinksExample.tsx
@@ -4,7 +4,7 @@ import 'tldraw/tldraw.css'
 export default function DeepLinksExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" options={{ deepLinks: true }} />
+			<Tldraw persistenceKey="deep-links-example" options={{ deepLinks: true }} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/configuration/persistence-key/PersistenceKeyExample.tsx
+++ b/apps/examples/src/examples/configuration/persistence-key/PersistenceKeyExample.tsx
@@ -4,7 +4,7 @@ import 'tldraw/tldraw.css'
 export default function PersistenceKeyExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" />
+			<Tldraw persistenceKey="persistence-key-example" />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/configuration/readonly/ReadOnlyExample.tsx
+++ b/apps/examples/src/examples/configuration/readonly/ReadOnlyExample.tsx
@@ -5,7 +5,7 @@ export default function ReadOnlyExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				persistenceKey="example"
+				persistenceKey="readonly-example"
 				onMount={(editor) => {
 					editor.updateInstanceState({ isReadonly: true })
 				}}

--- a/apps/examples/src/examples/editor-api/lock-camera-zoom/LockCameraZoomExample.tsx
+++ b/apps/examples/src/examples/editor-api/lock-camera-zoom/LockCameraZoomExample.tsx
@@ -24,7 +24,7 @@ const overrides: TLUiOverrides = {
 export default function LockCameraZoomExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" overrides={overrides} />
+			<Tldraw persistenceKey="lock-camera-zoom-example" overrides={overrides} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/events/event-blocker/EventBlockerExample.tsx
+++ b/apps/examples/src/examples/events/event-blocker/EventBlockerExample.tsx
@@ -31,7 +31,7 @@ const components: TLComponents = {
 export default function EventBlockerExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" components={components} />
+			<Tldraw persistenceKey="event-blocker-example" components={components} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/events/meta-on-create/OnCreateShapeMetaExample.tsx
+++ b/apps/examples/src/examples/events/meta-on-create/OnCreateShapeMetaExample.tsx
@@ -32,7 +32,7 @@ export default function OnCreateShapeMetaExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
-				persistenceKey="example"
+				persistenceKey="meta-on-create-example"
 				components={components}
 				onMount={(editor) => {
 					// [3]

--- a/apps/examples/src/examples/ui/changing-default-colors/ChangingDefaultColorsExample.tsx
+++ b/apps/examples/src/examples/ui/changing-default-colors/ChangingDefaultColorsExample.tsx
@@ -8,7 +8,7 @@ export default function ChangingDefaultColorsExample() {
 		<div className="tldraw__editor">
 			{/* [1] */}
 			<Tldraw
-				persistenceKey="example"
+				persistenceKey="changing-default-colors-example"
 				onMount={(editor) => {
 					const theme = editor.getTheme('default')!
 					editor.updateTheme({

--- a/apps/examples/src/examples/ui/changing-default-style/ChangingDefaultStyleExample.tsx
+++ b/apps/examples/src/examples/ui/changing-default-style/ChangingDefaultStyleExample.tsx
@@ -8,7 +8,7 @@ DefaultSizeStyle.setDefaultValue('s')
 export default function ChangingDefaultStyleExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" />
+			<Tldraw persistenceKey="changing-default-style-example" />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/ui/custom-renderer/CustomRendererExample.tsx
+++ b/apps/examples/src/examples/ui/custom-renderer/CustomRendererExample.tsx
@@ -14,7 +14,7 @@ export default function CustomRendererExample() {
 	return (
 		// [2]
 		<div className="tldraw__editor custom-renderer">
-			<Tldraw persistenceKey="example" components={components} />
+			<Tldraw persistenceKey="custom-renderer-example" components={components} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/ui/force-mobile/ForceBreakpointExample.tsx
+++ b/apps/examples/src/examples/ui/force-mobile/ForceBreakpointExample.tsx
@@ -4,7 +4,7 @@ import 'tldraw/tldraw.css'
 export default function ForceMobileExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" forceMobile />
+			<Tldraw persistenceKey="force-mobile-example" forceMobile />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/use-cases/fog-of-war/FogOfWarExample.tsx
+++ b/apps/examples/src/examples/use-cases/fog-of-war/FogOfWarExample.tsx
@@ -97,7 +97,7 @@ const components: TLComponents = {
 export default function FogOfWarExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example" components={components} />
+			<Tldraw persistenceKey="fog-of-war-example" components={components} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/use-cases/snowstorm/SnowStormExample.tsx
+++ b/apps/examples/src/examples/use-cases/snowstorm/SnowStormExample.tsx
@@ -6,7 +6,7 @@ import './snowstorm.css'
 export default function SnowStormExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="example">
+			<Tldraw persistenceKey="snowstorm-example">
 				{/* Children of Tldraw render inside the editor container, above the canvas */}
 				<SnowStorm />
 			</Tldraw>

--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -143,7 +143,9 @@ export default function Develop() {
 	const debuggingOverrides = useDebugging()
 
 	// The comment records live in the store alongside shapes, so the schema needs them registered
-	// before the persisted document loads.
+	// before the persisted document loads. That makes this schema newer than the default one, so
+	// no other example may share the 'example' persistence key: a newer-schema tab ignores an
+	// older tab's changes and overwrites the shared database with its own copy (#10514).
 	const schema = useMemo(() => createTLSchema({ records: commentSchemaRecords }), [])
 	const store = useLocalStore({ persistenceKey: 'example', schema })
 


### PR DESCRIPTION
This PR fixes a bug where drawing in an example that used `persistenceKey="example"` (`/deep-links/full`, `/readonly/full`, and eleven others) was silently lost while `/develop` was open in another tab. Closes #10514.

### Before

`/develop` registers the comment record types, whose migration sequence is retroactive, so its schema is newer than the one every other `example`-keyed route uses. In `TLLocalSyncClient`, the newer tab treats the older tabs' broadcast messages as out of date: it ignores their diffs, tells them to reload (they don't, since from their side the schemas match), and schedules a full rewrite of the shared IndexedDB document from its own memory. Changes flowed from `/develop` to the other tabs but never back, and the next rewrite erased whatever the other tab had drawn.

### After

`/develop` keeps the `example` key, so existing local dev documents still load. The thirteen examples that shared it now each persist under their own `<example-name>-example` key, matching the convention the rest of the examples already follow, so none of them shares a document or a broadcast channel with `/develop` or with each other.

### Implementation notes

This only separates the documents. The underlying protocol issue remains: when two tabs on the same persistence key run different schema versions, the newer tab discards the older tab's changes and overwrites the database, and the older tab never finds out. That is a `TLLocalSyncClient` change and is out of scope here.

A comment on `/develop`'s store notes that no other example may share its key.

### Change type

- [x] `bugfix`

### Test plan

No unit test: this is a configuration change in the examples app.

1. Open `/develop` and `/deep-links/full` in two tabs.
2. Draw in `/deep-links/full`, then reload it. The drawing is still there.
3. Draw in `/develop`; it does not appear in `/deep-links/full`, and vice versa.

### Release notes

- Fix drawings being lost in examples that shared the `example` persistence key while `/develop` is open in another tab

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -14  |
| Tests     | +0 / -0    |
