### PR TITLE
fix(editor): honour system color scheme on the loading screen and follow OS reduce motion live

### DIFF
--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -55,7 +55,7 @@ import { LicenseProvider, useLicenseContext } from './license/LicenseProvider'
 import { Watermark } from './license/Watermark'
 import { TldrawOptions } from './options'
 import { TLDeepLinkOptions } from './utils/deepLinks'
-import { getGlobalDocument } from './utils/dom'
+import { getGlobalDocument, getGlobalWindow } from './utils/dom'
 import { TLTextOptions } from './utils/richText'
 import { TLStoreWithStatus } from './utils/sync/StoreWithStatus'
 
@@ -433,11 +433,20 @@ const TldrawEditorWithLoadingStore = memo(function TldrawEditorBeforeLoading({
 	const container = useContainer()
 
 	useLayoutEffect(() => {
-		if (user.userPreferences.get().colorScheme === 'dark') {
+		// Resolve the scheme the same way UserPreferencesManager.getIsDarkMode will once the
+		// editor mounts, so a 'system' user on a dark OS doesn't get a light loading screen that
+		// flips dark on mount.
+		const scheme = user.userPreferences.get().colorScheme ?? rest.colorScheme ?? 'light'
+		const isDark =
+			scheme === 'dark' ||
+			(scheme === 'system' &&
+				typeof window !== 'undefined' &&
+				!!getGlobalWindow().matchMedia?.('(prefers-color-scheme: dark)').matches)
+		if (isDark) {
 			container.classList.remove('tl-theme__light')
 			container.classList.add('tl-theme__dark')
 		}
-	}, [container, user])
+	}, [container, user, rest.colorScheme])
 
 	const { LoadingScreen } = useEditorComponents()
 

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.test.ts
@@ -113,16 +113,16 @@ describe('UserPreferencesManager', () => {
 			const mockAddEventListener = vi.fn()
 			let changeHandler: (e: MediaQueryListEvent) => void
 
-			mockMatchMedia.mockReturnValue({
+			mockMatchMedia.mockImplementation((query: string) => ({
 				matches: false,
 				addEventListener: (event: string, handler: any) => {
-					if (event === 'change') {
+					if (event === 'change' && query === '(prefers-color-scheme: dark)') {
 						changeHandler = handler
 					}
 					mockAddEventListener(event, handler)
 				},
 				removeEventListener: vi.fn(),
-			})
+			}))
 
 			userPreferencesManager = new UserPreferencesManager(mockUser, 'system')
 
@@ -366,6 +366,67 @@ describe('UserPreferencesManager', () => {
 				expect(userPreferencesManager.getAnimationSpeed()).toBe(
 					defaultUserPreferences.animationSpeed
 				)
+			})
+
+			describe('following the OS reduce-motion setting', () => {
+				let reducedMotionChangeHandler: ((e: MediaQueryListEvent) => void) | undefined
+				let osPrefersReducedMotion: boolean
+
+				const mountWithOs = (prefersReducedMotion: boolean) => {
+					osPrefersReducedMotion = prefersReducedMotion
+					reducedMotionChangeHandler = undefined
+					mockMatchMedia.mockImplementation((query: string) => {
+						const isReducedMotion = query === '(prefers-reduced-motion: reduce)'
+						return {
+							matches: isReducedMotion ? osPrefersReducedMotion : false,
+							addEventListener: (event: string, handler: any) => {
+								if (isReducedMotion && event === 'change') reducedMotionChangeHandler = handler
+							},
+							removeEventListener: vi.fn(),
+						}
+					})
+					userPreferencesManager = new UserPreferencesManager(mockUser, 'light')
+				}
+
+				it('resolves an unset speed to 0 when the OS prefers reduced motion', () => {
+					userPreferencesAtom.set({ ...mockUserPreferences, animationSpeed: null })
+					mountWithOs(true)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(0)
+				})
+
+				it('tracks a live OS change while the speed is unset', () => {
+					userPreferencesAtom.set({ ...mockUserPreferences, animationSpeed: null })
+					mountWithOs(false)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(1)
+
+					reducedMotionChangeHandler!({ matches: true } as MediaQueryListEvent)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(0)
+
+					reducedMotionChangeHandler!({ matches: false } as MediaQueryListEvent)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(1)
+				})
+
+				it('ignores the OS once the user has set a speed explicitly', () => {
+					userPreferencesAtom.set({ ...mockUserPreferences, animationSpeed: 1 })
+					mountWithOs(true)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(1)
+
+					userPreferencesAtom.set({ ...mockUserPreferences, animationSpeed: 0 })
+					reducedMotionChangeHandler!({ matches: false } as MediaQueryListEvent)
+					expect(userPreferencesManager.getAnimationSpeed()).toBe(0)
+				})
+
+				it('removes the reduce-motion listener on dispose', () => {
+					const removeEventListener = vi.fn()
+					mockMatchMedia.mockReturnValue({
+						matches: false,
+						addEventListener: vi.fn(),
+						removeEventListener,
+					})
+					userPreferencesManager = new UserPreferencesManager(mockUser, 'light')
+					userPreferencesManager.dispose()
+					expect(removeEventListener).toHaveBeenCalledTimes(2)
+				})
 			})
 		})
 

--- a/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
+++ b/packages/editor/src/lib/editor/managers/UserPreferencesManager/UserPreferencesManager.ts
@@ -7,6 +7,7 @@ import { getGlobalWindow } from '../../../utils/dom'
 /** @public */
 export class UserPreferencesManager {
 	systemColorScheme = atom<'dark' | 'light'>('systemColorScheme', 'light')
+	private readonly systemPrefersReducedMotion = atom('systemPrefersReducedMotion', false)
 	disposables = new Set<() => void>()
 	dispose() {
 		this.disposables.forEach((d) => d())
@@ -31,6 +32,16 @@ export class UserPreferencesManager {
 		}
 		darkModeMediaQuery?.addEventListener('change', handleChange)
 		this.disposables.add(() => darkModeMediaQuery?.removeEventListener('change', handleChange))
+
+		const reducedMotionMediaQuery = getGlobalWindow().matchMedia('(prefers-reduced-motion: reduce)')
+		this.systemPrefersReducedMotion.set(!!reducedMotionMediaQuery?.matches)
+		const handleReducedMotionChange = (e: MediaQueryListEvent) => {
+			this.systemPrefersReducedMotion.set(e.matches)
+		}
+		reducedMotionMediaQuery?.addEventListener('change', handleReducedMotionChange)
+		this.disposables.add(() =>
+			reducedMotionMediaQuery?.removeEventListener('change', handleReducedMotionChange)
+		)
 	}
 
 	updateUserPreferences(userPreferences: Partial<TLUserPreferences>) {
@@ -81,7 +92,12 @@ export class UserPreferencesManager {
 	}
 
 	@computed getAnimationSpeed() {
-		return this.user.userPreferences.get().animationSpeed ?? defaultUserPreferences.animationSpeed
+		// Until the user explicitly sets a speed, follow the OS reduce-motion setting live rather
+		// than the value `defaultUserPreferences` captured at module load.
+		return (
+			this.user.userPreferences.get().animationSpeed ??
+			(this.systemPrefersReducedMotion.get() ? 0 : 1)
+		)
 	}
 
 	@computed getAreKeyboardShortcutsEnabled() {


### PR DESCRIPTION
This PR fixes a bug where the loading screen ignored Theme › System on a dark OS, and where Reduce motion only read the OS setting once at page load. Closes #10518.

### Before

The pre-mount color scheme shim in `TldrawEditor.tsx` only added `tl-theme__dark` when the stored preference was literally `'dark'`, so a `'system'` user on a dark OS saw a light loading screen that flipped dark once the editor mounted. It also ignored the `colorScheme` prop, which `UserPreferencesManager.getIsDarkMode` uses as the fallback.

`defaultUserPreferences.animationSpeed` evaluated `userPrefersReducedMotion()` once at module load, and `getAnimationSpeed()` fell back to that frozen value. Changing the OS reduce-motion setting with tldraw open had no effect until a reload.

### After

The shim resolves the scheme the same way `getIsDarkMode` will after mount: stored preference, then the `colorScheme` prop, then `'light'`; `'system'` is resolved through `matchMedia('(prefers-color-scheme: dark)')`, guarded for environments without `matchMedia`.

`UserPreferencesManager` now tracks `(prefers-reduced-motion: reduce)` with a `matchMedia` change listener, mirroring the existing `systemColorScheme` listener, and `getAnimationSpeed()` resolves an unset (`null`/`undefined`) `animationSpeed` from that live signal. Once the user toggles Reduce motion, the stored explicit value wins, as before. The listener is removed in `dispose()`.

### Implementation notes

- `defaultUserPreferences.animationSpeed` is left as-is: it is `@public` and frozen, and nothing in the repo reads it any more besides tests. Changing it to a getter would change the API report for no runtime benefit.
- The new `systemPrefersReducedMotion` atom is private so the public API report is unchanged.
- The existing "should handle media query change events" test captured the last registered `change` handler regardless of query; it now keys on the color scheme query so the new reduce-motion listener does not shadow it.
- Part (3) of the issue (`toggle-dark-mode` replacing System with an explicit Light/Dark) is a product call and is deliberately not changed here.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `UserPreferencesManager.test.ts` › `getAnimationSpeed` › "following the OS reduce-motion setting" (unset speed resolves to 0 under reduced motion, tracks live OS changes, explicit value wins, listener removed on dispose). The "resolves an unset speed to 0" and "tracks a live OS change" cases fail on `main`.
1. Dark OS, Theme › System, hard reload with throttling: the loading screen is dark and does not flip.
2. Reduce motion never toggled, toggle the OS setting with tldraw open: Zoom to fit stops/starts animating without a reload; the Reduce motion menu item's check follows.
3. Toggle Reduce motion in the menu, then change the OS setting: the menu value sticks.

### Release notes

- Fix the loading screen not honouring Theme › System on a dark OS, and Reduce motion not following the OS setting until a reload

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +27 / -4   |
| Tests     | +66 / -3   |
