### PR TITLE
fix(editor): confirm hard reset and close blocked IndexedDB connections

### DIFF
--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -1,5 +1,5 @@
 import { createTLSchema } from '@tldraw/tlschema'
-import { openDB } from 'idb'
+import { deleteDB, openDB } from 'idb'
 import { vi } from 'vitest'
 import { hardReset } from './hardReset'
 import { getAllIndexDbNames, LocalIndexedDb } from './LocalIndexedDb'
@@ -238,5 +238,25 @@ describe('LocalIndexedDb', () => {
 		expect(
 			(await window.indexedDB.databases()).find((db) => db.name === 'TLDRAW_ASSET_STORE_v1test-0')
 		).toBeUndefined()
+	})
+
+	it('closes its connection so another tab can delete the database', async () => {
+		const db = new LocalIndexedDb('test-0')
+		await db.storeSnapshot({ schema, snapshot: {} })
+
+		// Simulates a hard reset from another tab. Without the blocking handler this never
+		// resolves because our open connection blocks the delete.
+		let timeout: ReturnType<typeof setTimeout>
+		const result = await Promise.race([
+			deleteDB('TLDRAW_DOCUMENT_v2test-0').then(() => 'deleted'),
+			new Promise<string>((resolve) => {
+				timeout = setTimeout(() => resolve('blocked'), 1000)
+			}),
+		])
+		clearTimeout(timeout!)
+		expect(result).toBe('deleted')
+
+		// the next write on the closed connection surfaces as an error rather than hanging
+		await expect(db.storeSnapshot({ schema, snapshot: {} })).rejects.toThrow()
 	})
 })

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -25,7 +25,7 @@ async function openLocalDb(persistenceKey: string) {
 
 	addDbName(storeId)
 
-	return await openDB<StoreName>(storeId, 4, {
+	const db = await openDB<StoreName>(storeId, 4, {
 		upgrade(database) {
 			if (!database.objectStoreNames.contains(Table.Records)) {
 				database.createObjectStore(Table.Records)
@@ -40,7 +40,15 @@ async function openLocalDb(persistenceKey: string) {
 				database.createObjectStore(Table.Assets)
 			}
 		},
+		// Another tab is deleting (hard reset) or upgrading this database. Its request waits
+		// until every open connection closes, so holding ours would stall it indefinitely.
+		// Closing here lets it proceed; this tab's next write then fails and goes through
+		// the write-failure alert-and-reload path.
+		blocking() {
+			db.close()
+		},
 	})
+	return db
 }
 
 async function migrateLegacyAssetDbIfNeeded(persistenceKey: string) {
@@ -160,7 +168,9 @@ export class LocalIndexedDb {
 			}
 		})()
 		this.pendingTransactionSet.add(txPromise)
-		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise))
+		// the caller owns the rejection; without the catch a failed tx also surfaces as an
+		// unhandled rejection from this bookkeeping chain
+		txPromise.finally(() => this.pendingTransactionSet.delete(txPromise)).catch(noop)
 		return txPromise
 	}
 

--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -48,7 +48,19 @@ export function DefaultDebugMenuContent({
 	return (
 		<>
 			<TldrawUiMenuGroup id="items">
-				<TldrawUiMenuItem id="hard-reset" onSelect={hardResetEditor} label={'Hard reset'} />
+				<TldrawUiMenuItem
+					id="hard-reset"
+					onSelect={() => {
+						if (
+							window.confirm(
+								'Hard reset will delete all tldraw data stored in this browser, including every document and your preferences. This cannot be undone.'
+							)
+						) {
+							hardResetEditor()
+						}
+					}}
+					label={'Hard reset'}
+				/>
 				<TldrawUiMenuItem
 					id="add-toast"
 					onSelect={() => {


### PR DESCRIPTION
This PR fixes a bug where the debug menu's "Hard reset" wiped every tldraw database on the origin with no confirmation, and silently stalled whenever another tldraw tab was open. Closes #10515.

### Before

The debug menu item called `hardResetEditor()` directly. `hardReset` then awaited `deleteDB` for every known database, but `LocalIndexedDb` opened its connections without a `blocking` handler, so any other open tab kept the delete pending forever. The resetting tab had already cleared session storage and closed its own connection, nothing else was erased, and the page never reloaded; the next edit in that tab failed to save, showed the write-failure alert, and reloaded onto an intact document.

### After

- The debug menu item asks for confirmation via `window.confirm` before resetting (the same file already uses `window.alert` for its "Throw error" item, and the error screen's reset also requires an explicit second step).
- `openLocalDb` passes a `blocking` handler that closes the connection, so a `deleteDB` (or a future version upgrade) from another tab proceeds immediately. The blocked tab's next write throws on the closed connection and goes through the existing write-failure alert-and-reload path, which reloads it onto the freshly reset state.

### Implementation notes

- Only `blocking` was needed; `blocked`/`terminated` are left alone.
- The `tx` helper's `txPromise.finally(...)` bookkeeping chain produced a second, unhandled rejection whenever a transaction failed. The new test hits that path, so the chain now ends in `.catch(noop)`; callers still receive the rejection from `txPromise` itself.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `LocalIndexedDb.test.ts` "closes its connection so another tab can delete the database" (fails on `main`: the delete stays blocked past the timeout; passes with the change).
1. Open `/develop` in two tabs, Debug menu › Hard reset in one, confirm the prompt. The other tab shows the "could not save" alert on its next edit and reloads empty; the resetting tab reloads empty.
2. Cancel the prompt: nothing happens.

### Release notes

- Fix the debug menu's hard reset running without confirmation and stalling when another tldraw tab is open.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -3   |
| Tests     | +21 / -1   |
