### PR TITLE
fix(editor): stop the storage read-failure alert from promising a reload

### DIFF
--- a/packages/editor/src/lib/utils/sync/alerts.ts
+++ b/packages/editor/src/lib/utils/sync/alerts.ts
@@ -12,7 +12,7 @@ Keep seeing this message?
 /** @internal */
 export function showCantReadFromIndexDbAlert() {
 	window.alert(
-		`Oops! We could not access your browser's storage—and the app won't work correctly without that. We now need to reload the page and try again.
+		`Oops! We could not access your browser's storage—and the app won't work correctly without that. Reload the page to try again.
 
 Keep seeing this message?
 • If you're using tldraw in a private or "incognito" window, try loading tldraw in a regular window or in a different browser.`


### PR DESCRIPTION
This PR fixes a bug where the IndexedDB read-failure alert told the user "We now need to reload the page and try again" but no reload ever happened. Closes #10519.

### Before

`TLLocalSyncClient.connect()` catches the load error, calls `onLoadError`, shows `showCantReadFromIndexDbAlert()`, and returns. The page stays on the error screen, so the alert's promise of a reload was never kept. The write-failure path does reload after its alert, so the two messages looked like they should behave the same.

### After

The read-failure alert describes what happened and tells the user to reload the page to try again. The behaviour is unchanged: the page stays on the error screen until the user reloads.

### Implementation notes

Changed the text rather than adding a reload. In a browser that blocks storage (the main way this path is hit), a read failure is deterministic, so reloading automatically would loop the user through the alert forever. The write-failure alert is left as is because that path really does reload.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests — none; this is a string change in a `window.alert` call.
1. Open the app in a browser with storage blocked (or stub `indexedDB.open` to throw) and confirm the alert no longer says the page will reload.

### Release notes

- Fix the storage read-failure alert promising a reload that never happened

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -1    |
| Tests     | +0 / -0    |
