### PR TITLE
fix(tldraw): give the debug menu's create 100 shapes fresh ids, a stopping point, and viewport placement

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenuContent.tsx
@@ -294,23 +294,23 @@ const DebugFlagToggle = track(function DebugFlagToggle({
 	)
 })
 
-let t = 0
-
-function createNShapes(editor: Editor, n: number) {
+/** @internal */
+export function createNShapes(editor: Editor, n: number) {
 	const gap = editor.options.adjacentShapeMargin
 	const shapesToCreate: TLShapePartial[] = Array(n)
 	const cols = Math.floor(Math.sqrt(n))
+	const { x, y } = editor.getViewportPageBounds()
 
 	for (let i = 0; i < n; i++) {
-		t++
 		shapesToCreate[i] = {
-			id: createShapeId('box' + t),
+			id: createShapeId(),
 			type: 'geo',
-			x: (i % cols) * (100 + gap),
-			y: Math.floor(i / cols) * (100 + gap),
+			x: x + (i % cols) * (100 + gap),
+			y: y + Math.floor(i / cols) * (100 + gap),
 		}
 	}
 
+	editor.markHistoryStoppingPoint('create n shapes')
 	editor.run(() => {
 		// allow this to trigger the max shapes alert
 		editor.createShapes(shapesToCreate).setSelectedShapes(shapesToCreate.map((s) => s.id))

--- a/packages/tldraw/src/test/createNShapes.test.ts
+++ b/packages/tldraw/src/test/createNShapes.test.ts
@@ -1,0 +1,55 @@
+import { createShapeId } from '@tldraw/editor'
+import { createNShapes } from '../lib/ui/components/DebugMenu/DefaultDebugMenuContent'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+describe('createNShapes (debug menu)', () => {
+	it('creates new shapes after a reload instead of overwriting the earlier ones', async () => {
+		createNShapes(editor, 10)
+		const firstIds = [...editor.getCurrentPageShapeIds()]
+		expect(firstIds).toHaveLength(10)
+		const snapshot = editor.getSnapshot()
+
+		// A reload starts the module over, which is where ids derived from module
+		// state collide with the shapes that survived in the persisted document.
+		vi.resetModules()
+		const fresh = await import('../lib/ui/components/DebugMenu/DefaultDebugMenuContent')
+		const { TestEditor: FreshTestEditor } = await import('./TestEditor')
+		const reloaded = new FreshTestEditor()
+		reloaded.loadSnapshot(snapshot)
+
+		fresh.createNShapes(reloaded, 10)
+		expect(reloaded.getCurrentPageShapeIds().size).toBe(20)
+		for (const id of firstIds) {
+			expect(reloaded.getCurrentPageShapeIds().has(id)).toBe(true)
+		}
+	})
+
+	it('undoes in one step without taking earlier changes with it', () => {
+		const box = createShapeId()
+		editor.createShape({ id: box, type: 'geo', x: 0, y: 0 })
+
+		createNShapes(editor, 10)
+		expect(editor.getCurrentPageShapeIds().size).toBe(11)
+
+		editor.undo()
+		expect(editor.getCurrentPageShapeIds().size).toBe(1)
+		expect(editor.getShape(box)).toBeDefined()
+	})
+
+	it('lays the grid out at the top left of the viewport', () => {
+		editor.setCamera({ x: -1000, y: -2000 })
+		const viewport = editor.getViewportPageBounds()
+
+		createNShapes(editor, 10)
+
+		const bounds = editor.getSelectionPageBounds()!
+		expect(bounds.x).toBe(viewport.x)
+		expect(bounds.y).toBe(viewport.y)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where the debug menu's "Create 100 shapes" item overwrote shapes it had created before a reload, could not be undone on its own, and laid its grid out at the page origin instead of in view. Closes #10516.

### Before

`createNShapes` derived shape ids from a module-level counter (`createShapeId('box' + t)`). The counter restarts on every load, so running the item again after a reload `put` over any surviving `shape:box1…box100`: they snapped back to the grid with default props, and any that had been moved to another page were pulled onto the current one. The item also marked no history stopping point, so one undo removed the hundred shapes together with whatever edit preceded them. And the grid started at `(0, 0)`, so with the camera anywhere else it looked as if nothing had happened.

### After

Each shape gets a fresh `createShapeId()`, the item marks a `'create n shapes'` stopping point before creating, and the grid starts at the top left of `editor.getViewportPageBounds()`.

### Implementation notes

`createNShapes` is now exported (marked `@internal`) so it can be unit tested. `packages/tldraw/src/index.ts` re-exports this module by name, so this does not change the public API report (`yarn api-check` is clean).

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `packages/tldraw/src/test/createNShapes.test.ts` covers the three symptoms (ids survive a simulated module reload, one undo removes only the new shapes, grid starts at the viewport's page bounds). All three fail on `main` and pass with this change.
1. Open the debug menu, "Create 100 shapes", move a few to page 2, reload, run it again: the earlier shapes stay where they were and 100 new ones appear in the current viewport. Undo once removes only the new 100.

### Release notes

- Fix the debug menu's "Create 100 shapes" reusing ids across reloads, undoing together with the previous change, and placing shapes outside the viewport

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -7    |
| Tests     | +55 / -0   |
