### PR TITLE
fix(editor): prune stale session state rows after loading from IndexedDB

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2502,8 +2502,9 @@ export class LocalIndexedDb {
         sessionStateSnapshot: TLSessionStateSnapshot | undefined;
     }>;
     pending(): Promise<void>;
-    // (undocumented)
-    pruneSessions(): Promise<void>;
+    pruneSessions({ keepSessionId }?: {
+        keepSessionId?: string;
+    }): Promise<void>;
     // (undocumented)
     removeAssets(assetId: string[]): Promise<void>;
     // (undocumented)

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.test.ts
@@ -10,6 +10,7 @@ describe('LocalIndexedDb', () => {
 		vi.useRealTimers()
 	})
 	afterEach(async () => {
+		vi.restoreAllMocks()
 		await hardReset({ shouldReload: false })
 	})
 	describe('#storeSnapshot', () => {
@@ -171,6 +172,72 @@ describe('LocalIndexedDb', () => {
 					version: 1,
 				},
 			])
+		})
+	})
+
+	describe('#pruneSessions', () => {
+		it('keeps the 10 most recent session rows and the current session', async () => {
+			const db = new LocalIndexedDb('test-0')
+			let now = 1000
+			vi.spyOn(Date, 'now').mockImplementation(() => now++)
+
+			// the current session is the oldest row of 14
+			const sessionIds = ['current', ...Array.from({ length: 13 }, (_, i) => `other-${i}`)]
+			for (const sessionId of sessionIds) {
+				await db.storeChanges({
+					schema,
+					changes: { added: {}, updated: {}, removed: {} },
+					sessionId,
+					sessionStateSnapshot: { sessionId } as any,
+				})
+			}
+
+			await db.pruneSessions({ keepSessionId: 'current' })
+
+			const remaining = await Promise.all(
+				sessionIds.map(async (sessionId) => [
+					sessionId,
+					((await db.load({ sessionId })).sessionStateSnapshot as any)?.sessionId === sessionId,
+				])
+			)
+			expect(Object.fromEntries(remaining)).toEqual({
+				current: true,
+				'other-0': false,
+				'other-1': false,
+				'other-2': false,
+				'other-3': true,
+				'other-4': true,
+				'other-5': true,
+				'other-6': true,
+				'other-7': true,
+				'other-8': true,
+				'other-9': true,
+				'other-10': true,
+				'other-11': true,
+				'other-12': true,
+			})
+
+			await db.close()
+		})
+
+		it('is a no-op when there are at most 10 rows', async () => {
+			const db = new LocalIndexedDb('test-0')
+			for (let i = 0; i < 10; i++) {
+				await db.storeChanges({
+					schema,
+					changes: { added: {}, updated: {}, removed: {} },
+					sessionId: `session-${i}`,
+					sessionStateSnapshot: { i } as any,
+				})
+			}
+
+			await db.pruneSessions()
+
+			for (let i = 0; i < 10; i++) {
+				expect((await db.load({ sessionId: `session-${i}` })).sessionStateSnapshot).toEqual({ i })
+			}
+
+			await db.close()
 		})
 	})
 

--- a/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
+++ b/packages/editor/src/lib/utils/sync/LocalIndexedDb.ts
@@ -9,6 +9,9 @@ const STORE_PREFIX = 'TLDRAW_DOCUMENT_v2'
 const LEGACY_ASSET_STORE_PREFIX = 'TLDRAW_ASSET_STORE_v1'
 const dbNameIndexKey = 'TLDRAW_DB_NAME_INDEX_v2'
 
+/** How many session state rows (one per tab) to keep per document when pruning. */
+const MAX_SESSION_STATE_ROWS = 10
+
 /** @internal */
 export const Table = {
 	Records: 'records',
@@ -275,15 +278,18 @@ export class LocalIndexedDb {
 		})
 	}
 
-	async pruneSessions() {
+	/**
+	 * Drop all but the most recently updated session state rows. The row for `keepSessionId` is never
+	 * deleted: it may be an old row that this tab restored its state from and has not rewritten yet,
+	 * and deleting it would make a later reload fall back to another tab's session state.
+	 */
+	async pruneSessions({ keepSessionId }: { keepSessionId?: string } = {}) {
 		await this.tx('readwrite', [Table.SessionState], async (tx) => {
 			const sessionStateStore = tx.objectStore(Table.SessionState)
-			const all = (await sessionStateStore.getAll()).sort((a, b) => a.updatedAt - b.updatedAt)
-			if (all.length < 10) {
-				await tx.done
-				return
-			}
-			const toDelete = all.slice(0, all.length - 10)
+			const all = ((await sessionStateStore.getAll()) as SessionStateSnapshotRow[])
+				.filter((row) => row.id !== keepSessionId)
+				.sort((a, b) => a.updatedAt - b.updatedAt)
+			const toDelete = all.slice(0, Math.max(0, all.length - MAX_SESSION_STATE_ROWS))
 			for (const { id } of toDelete) {
 				await sessionStateStore.delete(id)
 			}

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -38,9 +38,12 @@ function testClient(channel = new BroadcastChannelMock('test')) {
 
 	client.db.storeSnapshot = vi.fn(() => Promise.resolve())
 	client.db.storeChanges = vi.fn(() => Promise.resolve())
+	client.db.pruneSessions = vi.fn(() => Promise.resolve())
 
 	return {
-		client: client as { db: { storeSnapshot: Mock; storeChanges: Mock } } & typeof client,
+		client: client as {
+			db: { storeSnapshot: Mock; storeChanges: Mock; pruneSessions: Mock }
+		} & typeof client,
 		store,
 		onLoad,
 		onLoadError,
@@ -81,6 +84,23 @@ test('the client connects on instantiation, announcing its schema', async () => 
 	const [msg] = channel.postMessage.mock.calls[0]
 
 	expect(msg).toMatchObject({ type: 'announce', schema: {} })
+})
+
+test('the client prunes stale session state rows after loading, keeping its own', async () => {
+	const { client, onLoad, tick } = testClient()
+	expect(client.db.pruneSessions).not.toHaveBeenCalled()
+	await tick()
+	expect(onLoad).toHaveBeenCalledTimes(1)
+	expect(client.db.pruneSessions).toHaveBeenCalledTimes(1)
+	expect(client.db.pruneSessions).toHaveBeenCalledWith({ keepSessionId: client.sessionId })
+})
+
+test('a failed session prune does not fail the load', async () => {
+	const { client, onLoad, onLoadError, tick } = testClient()
+	client.db.pruneSessions.mockImplementation(() => Promise.reject(new Error('nope')))
+	await tick()
+	expect(onLoad).toHaveBeenCalledTimes(1)
+	expect(onLoadError).not.toHaveBeenCalled()
 })
 
 test('when a client receives an announce with a newer schema version it reloads itself', async () => {

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -250,6 +250,12 @@ export class TLLocalSyncClient {
 				this.channel.close()
 			})
 			onLoad(this)
+
+			// Session state rows accumulate one per tab, so trim them on load. Pruning is best-effort
+			// and must never turn a successful load into a failure.
+			this.db.pruneSessions({ keepSessionId: this.sessionId }).catch((e: unknown) => {
+				this.debug('failed to prune session state rows', e)
+			})
 		} catch (e: any) {
 			this.debug('error loading data from store', e)
 			if (this.didDispose) return


### PR DESCRIPTION
This PR fixes a bug where session state rows in IndexedDB were never pruned, so every tab that ever opened a locally persisted document left a row in the `session_state` store forever. Closes #10520.

### Before

`LocalIndexedDb.pruneSessions()` existed (keep the 10 most recently updated rows) but nothing called it. `TLLocalSyncClient` is the only consumer of `LocalIndexedDb` and never invoked it, so the rows accumulated one per tab with no upper bound.

### After

`TLLocalSyncClient.connect()` calls `pruneSessions()` after a successful load, fire-and-forget. A prune failure is logged via the client's debug path and never turns a successful load into a load error.

`pruneSessions` now takes an optional `keepSessionId` and never deletes that row. The client passes its own session id so the row it just restored its state from survives even when it is older than the 10 most recent rows from other tabs; otherwise a reload with no intervening writes would fall back to another tab's session state.

### Implementation notes

The keep-10-most-recent policy is unchanged. The signature change is on an `@internal` class, so the API report update is the only public-surface effect.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `LocalIndexedDb.test.ts` `#pruneSessions` (keeps the 10 most recent rows plus the current session; no-op at 10 or fewer rows) and `TLLocalSyncClient.test.ts` ("prunes stale session state rows after loading, keeping its own"; "a failed session prune does not fail the load"). The client tests fail on `main` because `pruneSessions` is never called.

### Release notes

- Fix IndexedDB session state rows accumulating forever; stale rows are now pruned on load.

### API changes

- Changed `LocalIndexedDb.pruneSessions()` (`@internal`) to accept an optional `{ keepSessionId }` so the current tab's row is never pruned

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +20 / -8   |
| Tests     | +87 / -2   |