### PR TITLE
fix(tlschema): make exportBackground default to true in one place

### DIFF
--- a/packages/tlschema/src/TLStore.test.ts
+++ b/packages/tlschema/src/TLStore.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTLSchema } from './createTLSchema'
 import { CameraRecordType } from './records/TLCamera'
 import { TLDOCUMENT_ID } from './records/TLDocument'
-import { TLINSTANCE_ID } from './records/TLInstance'
+import { createInstanceRecordType, TLINSTANCE_ID } from './records/TLInstance'
 import { PageRecordType, TLPageId } from './records/TLPage'
 import { InstancePageStateRecordType } from './records/TLPageState'
 import { TLPOINTER_ID } from './records/TLPointer'
@@ -437,6 +437,14 @@ describe('createIntegrityChecker', () => {
 			expect(instance).toBeDefined()
 			expect(instance!.currentPageId).toBeDefined()
 			expect(instance!.exportBackground).toBe(true)
+		})
+
+		it('should default exportBackground to true when the instance omits it', () => {
+			const instance = createInstanceRecordType(new Map()).create({
+				id: TLINSTANCE_ID,
+				currentPageId: 'page:whatever' as TLPageId,
+			})
+			expect(instance.exportBackground).toBe(true)
 		})
 
 		it('should update instance to reference valid page when current page is invalid', () => {

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -491,7 +491,6 @@ export function createIntegrityChecker(store: Store<TLRecord, TLStoreProps>): ()
 				store.schema.types.instance.create({
 					id: TLINSTANCE_ID,
 					currentPageId: getFirstPageId(),
-					exportBackground: true,
 				}),
 			])
 

--- a/packages/tlschema/src/records/TLInstance.ts
+++ b/packages/tlschema/src/records/TLInstance.ts
@@ -296,7 +296,7 @@ export function createInstanceRecordType(stylesById: Map<string, StyleProp<unkno
 				rotation: 0,
 			},
 			isFocusMode: false,
-			exportBackground: false,
+			exportBackground: true,
 			isDebugMode: false,
 			isToolLocked: false,
 			screenBounds: { x: 0, y: 0, w: 1080, h: 720 },


### PR DESCRIPTION
This PR makes `exportBackground` default to `true` in a single place. Closes #10521.

### Before

`TLInstance`'s `withDefaultProperties` declared `exportBackground: false`, while `createIntegrityChecker` in `TLStore.ts` passed an explicit `exportBackground: true` when it created the instance record for a fresh tab. The explicit value won, so every fresh tab started with the background on ("Transparent" unchecked), but any other caller that created the instance record without the field would have started with the opposite value.

### After

The record type's default is `exportBackground: true`, and the integrity checker no longer passes the field. `RecordType.create` spreads `createDefaultProperties()` first and only overrides keys whose value is not `undefined`, so the fresh-tab behavior is unchanged; the default now just lives in one place.

### Implementation notes

Background on (Transparent unchecked) was chosen as the intended default because it is what every fresh tab already gets today. The legacy snapshot path in `extractSessionStateFromLegacySnapshot` still coerces a missing field with `!!`, which is untouched here because old snapshots always carried the field after the `AddExportBackground` migration.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests — new `should default exportBackground to true when the instance omits it` in `packages/tlschema/src/TLStore.test.ts` fails on `main` (`false`) and passes here. The existing `should create missing instance state` test now exercises the record default instead of the explicit value and still passes.
1. Open a fresh tab, open the export menu, and confirm "Transparent" is unchecked.

### Release notes

- Make `exportBackground` default to `true` in one place in `@tldraw/tlschema`

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -2    |
| Tests     | +9 / -1    |
