### PR TITLE
fix(debug): remove dead flags, fix slow-fps threshold, and gate hideShapes and edit-on-type

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -668,7 +668,6 @@ export interface DebugFlagDefaults<T> {
 // @internal (undocumented)
 export const debugFlags: {
     readonly a11y: DebugFlag<boolean>;
-    readonly debugCursors: DebugFlag<boolean>;
     readonly debugElbowArrows: DebugFlag<boolean>;
     readonly debugGeometry: DebugFlag<boolean>;
     readonly debugSvg: DebugFlag<boolean>;
@@ -679,7 +678,6 @@ export const debugFlags: {
     readonly logPointerCaptures: DebugFlag<boolean>;
     readonly logPreventDefaults: DebugFlag<boolean>;
     readonly measurePerformance: DebugFlag<boolean>;
-    readonly reconnectOnPing: DebugFlag<boolean>;
     readonly showFps: DebugFlag<boolean>;
     readonly throwToBlob: DebugFlag<boolean>;
 };

--- a/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultCanvas.tsx
@@ -119,7 +119,13 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps) {
 		[editor]
 	)
 
-	const hideShapes = useValue('debug_shapes', () => debugFlags.hideShapes.get(), [debugFlags])
+	// Gated on debug mode so a flag left on can't strand the user on a blank canvas with no
+	// debug menu to turn it back off.
+	const hideShapes = useValue(
+		'debug_shapes',
+		() => debugFlags.hideShapes.get() && editor.getInstanceState().isDebugMode,
+		[editor]
+	)
 
 	const isGridMode = useValue('isGridMode', () => editor.getInstanceState().isGridMode, [editor])
 	const { Grid } = useEditorComponents()

--- a/packages/editor/src/lib/utils/debug-flags.ts
+++ b/packages/editor/src/lib/utils/debug-flags.ts
@@ -43,12 +43,6 @@ export const debugFlags = {
 	throwToBlob: createDebugValue('throwToBlob', {
 		defaults: { all: false },
 	}),
-	reconnectOnPing: createDebugValue('reconnectOnPing', {
-		defaults: { all: false },
-	}),
-	debugCursors: createDebugValue('debugCursors', {
-		defaults: { all: false },
-	}),
 	forceSrgb: createDebugValue('forceSrgbColors', { defaults: { all: false } }),
 	debugGeometry: createDebugValue('debugGeometry', { defaults: { all: false } }),
 	hideShapes: createDebugValue('hideShapes', { defaults: { all: false } }),

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -598,7 +598,15 @@ export class Idle extends StateNode {
 			// This feature flag lets us start editing a note shape's label when a key is pressed.
 			// We exclude certain keys to avoid conflicting with modifiers, but there are conflicts
 			// with other action kbds, hence why this is kept behind a feature flag.
-			if (!SKIPPED_KEYS_FOR_AUTO_EDITING.includes(info.key) && !info.altKey && !info.ctrlKey) {
+			// Only printable single characters count: named keys (F1, CapsLock, Escape, ...) have
+			// multi-character `key` values and must not start editing.
+			if (
+				info.key.length === 1 &&
+				!SKIPPED_KEYS_FOR_AUTO_EDITING.includes(info.key) &&
+				!info.altKey &&
+				!info.ctrlKey &&
+				!info.metaKey
+			) {
 				// If the only selected shape is editable, then begin editing it
 				const onlySelectedShape = this.editor.getOnlySelectedShape()
 				if (

--- a/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
+++ b/packages/tldraw/src/lib/ui/components/DefaultDebugPanel.tsx
@@ -24,6 +24,11 @@ const CurrentState = track(function CurrentState() {
 	return <div className="tlui-debug-panel__current-state">{`${path}`}</div>
 })
 
+// Fixed rather than relative to the highest rate seen: displays with adaptive refresh (and
+// browsers that switch rAF cadence) can peak at 120 Hz and then settle at a healthy 60, which a
+// relative threshold would flag as slow.
+const SLOW_FPS = 60 * 0.75
+
 function FPS() {
 	const editor = useEditor()
 	const showFps = useValue('show_fps', () => debugFlags.showFps.get(), [debugFlags])
@@ -66,8 +71,7 @@ function FPS() {
 					maxKnownFps = fps
 				}
 
-				const slowFps = maxKnownFps * 0.75
-				if ((fps < slowFps && !isSlow) || (fps >= slowFps && isSlow)) {
+				if ((fps < SLOW_FPS && !isSlow) || (fps >= SLOW_FPS && isSlow)) {
 					isSlow = !isSlow
 				}
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -4,6 +4,7 @@ import {
 	TLArrowShape,
 	TLFrameShape,
 	createShapeId,
+	debugFlags,
 	toRichText,
 } from '@tldraw/editor'
 import { vi } from 'vitest'
@@ -59,7 +60,15 @@ describe('TLSelectTool.Idle', () => {
 })
 
 // todo: turn on feature flag for these tests or remove them
-describe.skip('Edit on type', () => {
+describe('Edit on type', () => {
+	beforeEach(() => {
+		debugFlags.editOnType.set(true)
+	})
+
+	afterEach(() => {
+		debugFlags.editOnType.reset()
+	})
+
 	it('Starts editing shape on key down if shape does auto-edit on key stroke', () => {
 		const id = createShapeId()
 		editor.createShapes([
@@ -118,8 +127,30 @@ describe.skip('Edit on type', () => {
 		editor.keyDown('a', { altKey: true })
 		// Simulate ctrlKey being pressed
 		editor.keyDown('a', { ctrlKey: true })
+		// Simulate metaKey being pressed
+		editor.keyDown('a', { metaKey: true })
 		expect(editor.getEditingShapeId()).not.toBe(shape.id)
 	})
+
+	it.each(['F1', 'CapsLock', 'Escape', 'ArrowLeft', 'Home'])(
+		'Does not start editing on non-printable key %s',
+		(key) => {
+			const id = createShapeId()
+			editor.createShapes([
+				{
+					id,
+					type: 'note',
+					x: 100,
+					y: 100,
+					props: { richText: toRichText('hello') },
+				},
+			])!
+			const shape = editor.getShape(id)!
+			editor.select(shape.id)
+			editor.keyDown(key)
+			expect(editor.getEditingShapeId()).toBe(null)
+		}
+	)
 })
 
 describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () => {


### PR DESCRIPTION
This PR fixes four slips in the debug tooling: two dead debug flags, an FPS "slow" threshold that tracked the highest rate ever seen, a `hideShapes` flag that kept hiding the canvas after debug mode was turned off, and "edit on type" starting editing on non-printable keys. Closes #10522.

### Before

- `reconnectOnPing` and `debugCursors` were declared in `debug-flags.ts` and rendered as toggles in the Debug flags submenu, but nothing in the repo read either value.
- The FPS counter raised `maxKnownFps` to the highest rate observed and turned red below 0.75 × that. On a display with adaptive refresh (or a browser that switches rAF cadence) a 120 Hz peak made the threshold 90, so a healthy steady 60 fps showed as slow.
- `DefaultCanvas` read `debugFlags.hideShapes` regardless of `isDebugMode`. Turning debug mode off with the flag on left an empty canvas and no debug menu to turn it back off.
- `Idle.onKeyDown` started editing a selected note on any key not in the skip list, so `F1`, `CapsLock`, `Escape`, arrow keys with no accel, etc. all began editing.

### After

- The two dead flags are removed (and from the editor API report; they were `@internal`).
- The slow threshold is a fixed 45 fps (0.75 × 60). The `max` readout stays for information but no longer drives the colour.
- `hideShapes` only hides the shapes layer while debug mode is on. The flag value itself is untouched, so turning debug mode back on restores the previous state.
- Edit-on-type only fires for printable single-character keys (`key.length === 1`) with no alt/ctrl/meta, keeping the existing skip list.

### Implementation notes

- Fixed threshold rather than a measured refresh rate: on ProMotion-style displays the refresh rate itself moves between 120 and 60, so any threshold derived from an observed rate flags the idle state as slow.
- Gating `hideShapes` in the consumer was chosen over resetting all flags in `toggle-debug-mode`, since the other flags are harmless when debug mode is off and resetting would lose the user's session flag state.
- The triggering key is still not inserted into the label. The editing entry path (`select-all-text` event after the rich text editor mounts) has no hook for seeding text, and the key event has already been consumed by the time the editor exists, so that is left as is.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — un-skipped the `Edit on type` block in `packages/tldraw/src/test/SelectTool.test.ts` (it was skipped because the flag defaults to off; it now sets the flag in `beforeEach`) and added `Does not start editing on non-printable key` cases for `F1`, `CapsLock`, `Escape`, `ArrowLeft`, `Home`. The new cases fail on `main`.
1. Turn on debug mode, enable `hideShapes`, turn debug mode off: shapes reappear. Turn it back on: shapes hide again.
2. Enable `showFps` on a 120 Hz display: a steady 60 fps is not red.
3. The Debug flags submenu no longer lists `reconnectOnPing` or `debugCursors`.

### Release notes

- Fix debug tooling: remove dead `reconnectOnPing` and `debugCursors` flags, stop flagging a steady 60 fps as slow, stop `hideShapes` from hiding the canvas once debug mode is off, and limit edit-on-type to printable keys.

### API changes

- Removed the unused `debugFlags.debugCursors` and `debugFlags.reconnectOnPing` flags; nothing in the repo read them

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +22 / -12  |
| Tests     | +32 / -1   |