### PR TITLE
fix(tldraw): rich text list copy, https links, link shortcut, and RTL lists

### DIFF
--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -801,7 +801,8 @@ input,
 
 .tl-rich-text ul,
 .tl-rich-text ol {
-	text-align: left;
+	/* `start`, not `left`: RTL list items need the marker on the right. */
+	text-align: start;
 	margin: 0;
 	padding-left: 1.625ch;
 	/* Some resets, like Tailwind, nix the list styling. */

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.test.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.test.tsx
@@ -1,0 +1,83 @@
+import { act, waitFor } from '@testing-library/react'
+import { createShapeId, Editor } from '@tldraw/editor'
+import { renderTldrawComponentWithEditor } from '../../../test/testutils/renderTldrawComponent'
+import { Tldraw } from '../../Tldraw'
+
+const id = createShapeId('text')
+
+// ProseMirror scrolls the selection into view after a selection change, which needs layout that
+// jsdom does not provide for ranges.
+beforeAll(() => {
+	Range.prototype.getClientRects = () => [] as unknown as DOMRectList
+	Range.prototype.getBoundingClientRect = () => new DOMRect()
+})
+
+const richText = {
+	type: 'doc',
+	content: [
+		{ type: 'paragraph', content: [{ type: 'text', text: 'Shopping' }] },
+		{
+			type: 'bulletList',
+			content: [
+				{
+					type: 'listItem',
+					content: [{ type: 'paragraph', content: [{ type: 'text', text: 'eggs' }] }],
+				},
+				{
+					type: 'listItem',
+					content: [{ type: 'paragraph', content: [{ type: 'text', text: 'milk' }] }],
+				},
+			],
+		},
+	],
+}
+
+async function startEditing(editor: Editor) {
+	await act(async () => {
+		editor.createShape({ id, type: 'text', x: 0, y: 0, props: { richText } })
+		editor.select(id)
+		editor.setEditingShape(id)
+	})
+	await waitFor(() => expect(editor.getRichTextEditor()).toBeTruthy())
+	return editor.getRichTextEditor()!
+}
+
+// What ProseMirror puts in the `text/plain` clipboard entry for the current selection.
+function copyPlaintext(textEditor: ReturnType<Editor['getRichTextEditor']>) {
+	const { view } = textEditor!
+	return view.someProp('clipboardTextSerializer', (f) => f(view.state.selection.content(), view))
+}
+
+describe('RichTextArea clipboard', () => {
+	it('copies a selected list with markers and no blank lines', async () => {
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => <Tldraw onMount={onMount} />,
+			{ waitForPatterns: false }
+		)
+		const textEditor = await startEditing(editor)
+
+		act(() => {
+			textEditor.commands.selectAll()
+		})
+		expect(copyPlaintext(textEditor)).toBe('Shopping\n- eggs\n- milk')
+	})
+
+	it('copies a partial selection cut to the selected text', async () => {
+		const { editor } = await renderTldrawComponentWithEditor(
+			(onMount) => <Tldraw onMount={onMount} />,
+			{ waitForPatterns: false }
+		)
+		const textEditor = await startEditing(editor)
+
+		// From `ping` in the paragraph to `mi` in the second item.
+		act(() => {
+			textEditor.commands.setTextSelection({ from: 5, to: 23 })
+		})
+		expect(copyPlaintext(textEditor)).toBe('ping\n- eggs\n- mi')
+
+		act(() => {
+			textEditor.commands.setTextSelection({ from: 21, to: 25 })
+		})
+		expect(copyPlaintext(textEditor)).toBe('milk')
+	})
+})

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -16,7 +16,10 @@ import {
 	useUniqueSafeId,
 } from '@tldraw/editor'
 import React, { useLayoutEffect, useRef } from 'react'
-import { isEditingRichTextList } from '../../utils/text/richText'
+import {
+	isEditingRichTextList,
+	renderPlaintextFromRichTextSelection,
+} from '../../utils/text/richText'
 
 /** @public */
 export interface TextAreaProps {
@@ -179,17 +182,17 @@ export const RichTextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(func
 					return false
 				},
 				handleDoubleClick: (_view, _pos, event) => onDoubleClick(event),
+				// tiptap's core clipboardTextSerializer only knows the schema's serializers, so a
+				// copied list would lose its markers and gain blank lines. Use the same list-aware
+				// plaintext as `renderPlaintextFromRichText` so copying while editing matches
+				// copying the shape.
+				clipboardTextSerializer: (_slice, view) => renderPlaintextFromRichTextSelection(view.state),
 				...editorProps,
-			},
-			coreExtensionOptions: {
-				clipboardTextSerializer: {
-					blockSeparator: '\n',
-				},
 			},
 			// N.B. We disable the text direction in the core list here,
 			// but we add it back in again in our own extensions list so that
 			// people can omit/override it if they want to.
-			enableCoreExtensions: { textDirection: false },
+			enableCoreExtensions: { textDirection: false, clipboardTextSerializer: false },
 			textDirection: 'auto',
 			...restOfTipTapConfig,
 			content: rInitialRichText.current as JSONContent,

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbarContent.tsx
@@ -40,7 +40,12 @@ export function DefaultRichTextToolbarContent({
 
 	useEffect(() => {
 		function handleKeyDown(event: KeyboardEvent) {
-			if (onEditLinkStart && isAccelKey(event) && event.shiftKey && event.key === 'k') {
+			if (
+				onEditLinkStart &&
+				isAccelKey(event) &&
+				event.shiftKey &&
+				event.key.toLowerCase() === 'k'
+			) {
 				event.preventDefault()
 				onEditLinkStart()
 			}

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -1,9 +1,12 @@
+import { getSchema } from '@tiptap/core'
+import { Node } from '@tiptap/pm/model'
 import { TLRichText, toRichText } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
 import {
 	isEmptyRichText,
 	renderHtmlFromRichTextWithExtensions,
 	renderPlaintextFromRichText,
+	renderPlaintextFromRichTextRange,
 	renderRichTextFromHTML,
 	tipTapDefaultExtensions,
 } from './richText'
@@ -147,6 +150,68 @@ describe('renderPlaintextFromRichText', () => {
 				},
 			])
 		).toBe('- fruit\n  1. apple\n  2. pear\n- veg')
+	})
+
+	it('keeps a hard break inside a list item', () => {
+		expect(
+			plain([
+				{
+					type: 'bulletList',
+					content: [
+						listItem({
+							type: 'paragraph',
+							content: [text('before'), { type: 'hardBreak' }, text('after')],
+						}),
+						listItem(paragraph('next')),
+					],
+				},
+			])
+		).toBe('- before\nafter\n- next')
+	})
+
+	it('keeps a hard break pasted inside a list item', () => {
+		const richText = renderRichTextFromHTML(
+			editor,
+			'<ul><li>before<br>after</li><li>next</li></ul>'
+		)
+		expect(renderPlaintextFromRichText(editor, richText)).toBe('- before\nafter\n- next')
+	})
+})
+
+describe('renderPlaintextFromRichTextRange', () => {
+	// Positions: `Shopping` occupies 1-9, `eggs` 13-17 and `milk` 21-25.
+	const doc = Node.fromJSON(getSchema(tipTapDefaultExtensions), {
+		type: 'doc',
+		content: [
+			paragraph('Shopping'),
+			{
+				type: 'bulletList',
+				content: [listItem(paragraph('eggs')), listItem(paragraph('milk'))],
+			},
+		],
+	})
+	const between = (from: number, to: number) => renderPlaintextFromRichTextRange(doc, { from, to })
+
+	it('renders the whole document like renderPlaintextFromRichText', () => {
+		expect(between(0, doc.content.size)).toBe('Shopping\n- eggs\n- milk')
+	})
+
+	it('cuts the first and last lines to the selection', () => {
+		expect(between(5, 23)).toBe('ping\n- eggs\n- mi')
+	})
+
+	it('only marks an item when the selection starts at its beginning', () => {
+		expect(between(14, 25)).toBe('ggs\n- milk')
+		expect(between(13, 25)).toBe('- eggs\n- milk')
+	})
+
+	it('renders a selection inside a single item without a marker', () => {
+		expect(between(22, 24)).toBe('il')
+		expect(between(21, 25)).toBe('milk')
+	})
+
+	it('skips items outside the selection', () => {
+		expect(between(1, 17)).toBe('Shopping\n- eggs')
 	})
 })
 

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -1,9 +1,22 @@
 import { TLRichText, toRichText } from '@tldraw/editor'
+import { TestEditor } from '../../../test/TestEditor'
 import {
 	isEmptyRichText,
 	renderHtmlFromRichTextWithExtensions,
+	renderPlaintextFromRichText,
+	renderRichTextFromHTML,
 	tipTapDefaultExtensions,
 } from './richText'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+const text = (t: string) => ({ type: 'text', text: t })
+const paragraph = (t: string) => ({ type: 'paragraph', content: [text(t)] })
+const listItem = (...content: any[]) => ({ type: 'listItem', content })
 
 const render = (content: TLRichText['content']) =>
 	renderHtmlFromRichTextWithExtensions(
@@ -83,5 +96,92 @@ describe('isEmptyRichText', () => {
 			],
 		}
 		expect(isEmptyRichText(richText)).toBe(false)
+	})
+})
+
+describe('renderPlaintextFromRichText', () => {
+	const plain = (content: TLRichText['content']) =>
+		renderPlaintextFromRichText(editor, { type: 'doc', content } as TLRichText)
+
+	it('separates paragraphs with a single newline', () => {
+		expect(plain([paragraph('one'), paragraph('two')])).toBe('one\ntwo')
+	})
+
+	it('renders bullet list items as one dashed line each', () => {
+		expect(
+			plain([
+				paragraph('Shopping'),
+				{
+					type: 'bulletList',
+					content: [listItem(paragraph('eggs')), listItem(paragraph('milk'))],
+				},
+				paragraph('Done'),
+			])
+		).toBe('Shopping\n- eggs\n- milk\nDone')
+	})
+
+	it('numbers ordered list items from the list start', () => {
+		expect(
+			plain([
+				{
+					type: 'orderedList',
+					attrs: { start: 3 },
+					content: [listItem(paragraph('three')), listItem(paragraph('four'))],
+				},
+			])
+		).toBe('3. three\n4. four')
+	})
+
+	it('indents nested lists under their parent item', () => {
+		expect(
+			plain([
+				{
+					type: 'bulletList',
+					content: [
+						listItem(paragraph('fruit'), {
+							type: 'orderedList',
+							content: [listItem(paragraph('apple')), listItem(paragraph('pear'))],
+						}),
+						listItem(paragraph('veg')),
+					],
+				},
+			])
+		).toBe('- fruit\n  1. apple\n  2. pear\n- veg')
+	})
+})
+
+describe('renderRichTextFromHTML', () => {
+	const hrefs = (html: string) => {
+		const found: string[] = []
+		const walk = (node: any) => {
+			for (const mark of node.marks ?? []) if (mark.type === 'link') found.push(mark.attrs.href)
+			for (const child of node.content ?? []) walk(child)
+		}
+		walk(renderRichTextFromHTML(editor, html))
+		return found
+	}
+
+	it('gives a scheme-less href a scheme so it does not resolve against the host page', () => {
+		expect(
+			hrefs(
+				'<p><a href="example.com">a</a> <a href="www.example.com?q=1">b</a> <a href="//example.com/path">c</a></p>'
+			)
+		).toEqual(['https://example.com', 'https://www.example.com?q=1', 'https://example.com/path'])
+	})
+
+	it('leaves hrefs that already have a scheme alone', () => {
+		expect(
+			hrefs(
+				'<p><a href="http://example.com">a</a> <a href="https://example.com">b</a> <a href="mailto:hi@example.com">c</a></p>'
+			)
+		).toEqual(['http://example.com', 'https://example.com', 'mailto:hi@example.com'])
+	})
+
+	it('leaves explicitly relative hrefs alone', () => {
+		expect(
+			hrefs(
+				'<p><a href="/docs">a</a> <a href="./docs">b</a> <a href="#top">c</a> <a href="?q=1">d</a></p>'
+			)
+		).toEqual(['/docs', './docs', '#top', '?q=1'])
 	})
 })

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -5,7 +5,9 @@ import {
 	generateHTML,
 	generateJSON,
 	generateText,
+	getText,
 	JSONContent,
+	TextSerializer,
 } from '@tiptap/core'
 import { Code } from '@tiptap/extension-code'
 import { Highlight } from '@tiptap/extension-highlight'
@@ -62,6 +64,9 @@ export function getTipTapDefaultExtensions(
 			link: {
 				openOnClick: false,
 				autolink: true,
+				// The link editor prefixes a bare address with `https://`, so autolinking a typed one
+				// must do the same rather than tiptap's `http` default.
+				defaultProtocol: 'https',
 			},
 			// Prevent trailing paragraph insertion after lists (fixes #7641)
 			trailingNode: {
@@ -165,8 +170,44 @@ export function isEditingRichTextList(editor: Editor) {
 	return !!(textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList'))
 }
 
+function isListNode(node: Node) {
+	return node.type.name === 'bulletList' || node.type.name === 'orderedList'
+}
+
+// Without a serializer, tiptap's `getText` treats a list, each of its items, and each item's
+// paragraph as separate blocks, so the block separator lands three times between items and the
+// markers are lost. This renders one `- ` / `1. ` line per item (nested lists indented) instead.
+function renderListToText(
+	list: Node,
+	textSerializers: Record<string, TextSerializer>,
+	indent = ''
+): string {
+	const isOrdered = list.type.name === 'orderedList'
+	const start: number = list.attrs.start ?? 1
+	const lines: string[] = []
+	list.forEach((item, _offset, index) => {
+		const marker = isOrdered ? `${start + index}. ` : '- '
+		const continuation = ' '.repeat(marker.length)
+		item.forEach((child, _childOffset, childIndex) => {
+			if (isListNode(child)) {
+				lines.push(renderListToText(child, textSerializers, indent + continuation))
+			} else {
+				const prefix = childIndex === 0 ? marker : continuation
+				lines.push(indent + prefix + getText(child, { blockSeparator: '\n', textSerializers }))
+			}
+		})
+	})
+	return lines.join('\n')
+}
+
+const listTextSerializers: Record<string, TextSerializer> = {
+	bulletList: ({ node }) => renderListToText(node, listTextSerializers),
+	orderedList: ({ node }) => renderListToText(node, listTextSerializers),
+}
+
 /**
- * Renders plaintext from a rich text string.
+ * Renders plaintext from a rich text string. Each block renders on its own line, and list items
+ * are prefixed with `- ` or `1. ` markers.
  * @param editor - The editor instance.
  * @param richText - The rich text content.
  *
@@ -180,6 +221,7 @@ export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText
 			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
 		return generateText(richText as JSONContent, tipTapExtensions, {
 			blockSeparator: '\n',
+			textSerializers: listTextSerializers,
 		})
 	})
 }
@@ -194,7 +236,32 @@ export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText
 export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText {
 	const tipTapExtensions =
 		editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-	return generateJSON(html, tipTapExtensions) as TLRichText
+	const richText = generateJSON(html, tipTapExtensions)
+	normalizeLinkHrefs(richText)
+	return richText as TLRichText
+}
+
+// Pasted HTML can carry an `href` like `example.com`, which the browser would resolve
+// relative to the host page. Give it a scheme so the link opens where the author meant. Anything
+// that already has a scheme, or is explicitly relative (`/`, `./`, `#`, `?`), is left alone.
+function normalizeLinkHrefs(node: JSONContent) {
+	if (node.marks) {
+		for (const mark of node.marks) {
+			if (mark.type !== 'link' || typeof mark.attrs?.href !== 'string') continue
+			mark.attrs.href = normalizeHref(mark.attrs.href)
+		}
+	}
+	if (node.content) {
+		for (const child of node.content) normalizeLinkHrefs(child)
+	}
+}
+
+function normalizeHref(href: string) {
+	const trimmed = href.trim()
+	if (trimmed === '' || /^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return href
+	if (trimmed.startsWith('//')) return `https:${trimmed}`
+	if (/^[/.#?]/.test(trimmed)) return href
+	return `https://${trimmed}`
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -4,14 +4,17 @@ import {
 	extensions,
 	generateHTML,
 	generateJSON,
-	generateText,
-	getText,
+	getSchema,
+	getTextBetween,
+	getTextSerializersFromSchema,
 	JSONContent,
+	Range,
 	TextSerializer,
 } from '@tiptap/core'
 import { Code } from '@tiptap/extension-code'
 import { Highlight } from '@tiptap/extension-highlight'
 import { Node } from '@tiptap/pm/model'
+import { EditorState } from '@tiptap/pm/state'
 import { StarterKit, type StarterKitOptions } from '@tiptap/starter-kit'
 import {
 	Editor,
@@ -177,32 +180,82 @@ function isListNode(node: Node) {
 // Without a serializer, tiptap's `getText` treats a list, each of its items, and each item's
 // paragraph as separate blocks, so the block separator lands three times between items and the
 // markers are lost. This renders one `- ` / `1. ` line per item (nested lists indented) instead.
+//
+// `range` is the selection being serialized, in document positions: blocks outside it are
+// skipped, blocks straddling its edges are cut to it, and a line only gets its marker when the
+// selection begins at or before the line's first character.
 function renderListToText(
 	list: Node,
+	listPos: number,
+	range: Range,
 	textSerializers: Record<string, TextSerializer>,
 	indent = ''
 ): string {
 	const isOrdered = list.type.name === 'orderedList'
 	const start: number = list.attrs.start ?? 1
 	const lines: string[] = []
-	list.forEach((item, _offset, index) => {
+	list.forEach((item, itemOffset, index) => {
 		const marker = isOrdered ? `${start + index}. ` : '- '
 		const continuation = ' '.repeat(marker.length)
-		item.forEach((child, _childOffset, childIndex) => {
+		const itemPos = listPos + 1 + itemOffset
+		item.forEach((child, childOffset, childIndex) => {
+			const childPos = itemPos + 1 + childOffset
+			if (childPos >= range.to || childPos + child.nodeSize <= range.from) return
 			if (isListNode(child)) {
-				lines.push(renderListToText(child, textSerializers, indent + continuation))
-			} else {
-				const prefix = childIndex === 0 ? marker : continuation
-				lines.push(indent + prefix + getText(child, { blockSeparator: '\n', textSerializers }))
+				lines.push(renderListToText(child, childPos, range, textSerializers, indent + continuation))
+				return
 			}
+			const contentStart = childPos + 1
+			const prefix =
+				range.from <= contentStart ? indent + (childIndex === 0 ? marker : continuation) : ''
+			const text = getTextBetween(
+				child,
+				{
+					from: Math.max(0, range.from - contentStart),
+					to: Math.min(child.content.size, range.to - contentStart),
+				},
+				{ blockSeparator: '\n', textSerializers }
+			)
+			lines.push(prefix + text)
 		})
 	})
 	return lines.join('\n')
 }
 
-const listTextSerializers: Record<string, TextSerializer> = {
-	bulletList: ({ node }) => renderListToText(node, listTextSerializers),
-	orderedList: ({ node }) => renderListToText(node, listTextSerializers),
+/**
+ * Renders plaintext from a range of a ProseMirror document, with list items marked the same way
+ * as {@link renderPlaintextFromRichText}. Used for the `text/plain` clipboard entry while editing,
+ * where the range is the current selection. The schema's own serializers (e.g. `hardBreak` ->
+ * `\n`) must reach the recursive list calls, so the list serializers are layered onto them rather
+ * than replacing them.
+ *
+ * @internal
+ */
+export function renderPlaintextFromRichTextRange(doc: Node, range: Range): string {
+	const textSerializers = getTextSerializersFromSchema(doc.type.schema)
+	const $from = doc.resolve(range.from)
+	// A selection inside one block is a run of text, not a list: copying a word (or a whole
+	// single item) out of a list item should paste as just that text, without a marker.
+	if ($from.parent.isTextblock && $from.sameParent(doc.resolve(range.to))) {
+		return getTextBetween(doc, range, { blockSeparator: '\n', textSerializers })
+	}
+	const list: TextSerializer = ({ node, pos, range }) =>
+		renderListToText(node, pos, range, textSerializers)
+	textSerializers.bulletList = list
+	textSerializers.orderedList = list
+	return getTextBetween(doc, range, { blockSeparator: '\n', textSerializers })
+}
+
+/**
+ * Renders plaintext for the selection of a rich text editor's state.
+ *
+ * @internal
+ */
+export function renderPlaintextFromRichTextSelection(state: EditorState): string {
+	const { doc, selection } = state
+	const from = Math.min(...selection.ranges.map((range) => range.$from.pos))
+	const to = Math.max(...selection.ranges.map((range) => range.$to.pos))
+	return renderPlaintextFromRichTextRange(doc, { from, to })
 }
 
 /**
@@ -219,10 +272,8 @@ export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText
 	return plainTextFromRichTextCache.get(richText, () => {
 		const tipTapExtensions =
 			editor.getTextOptions().tipTapConfig?.extensions ?? tipTapDefaultExtensions
-		return generateText(richText as JSONContent, tipTapExtensions, {
-			blockSeparator: '\n',
-			textSerializers: listTextSerializers,
-		})
+		const doc = Node.fromJSON(getSchema(tipTapExtensions), richText as JSONContent)
+		return renderPlaintextFromRichTextRange(doc, { from: 0, to: doc.content.size })
 	})
 }
 


### PR DESCRIPTION
This PR fixes a set of small rich text inconsistencies around copying, pasting, and links: copied lists lose their markers and gain blank lines, a typed bare address links as `http://`, the link shortcut does nothing on Windows and Linux, lists are forced left-aligned in RTL text, and a scheme-less `href` pasted from HTML opens relative to the host page. Closes #10525.

### Before

- `renderPlaintextFromRichText` ran tiptap's `generateText` with only a block separator. A list, each item, and each item's paragraph all count as blocks, so the separator landed three times between a paragraph and a list and twice between items, and the bullets and numbers were dropped.
- The Link extension used tiptap's `defaultProtocol` of `http`, while the link editor prefixes `https://`.
- The rich text toolbar's link shortcut compared `event.key === 'k'`; with Shift held, Windows and Linux report `K`.
- `.tl-rich-text ul, ol { text-align: left }` put the marker on the wrong side of Hebrew or Arabic items.
- `renderRichTextFromHTML` kept an `href` like `example.com` as-is, so the link resolved against the current site.

### After

- Plain text renders every block on its own line, with list items as `- ` / `1. ` lines (numbering honours the list's `start`) and nested lists indented under their parent item. `Shopping` + bullets `eggs`, `milk` copies as `Shopping\n- eggs\n- milk`.
- Autolinked addresses get `https://`, matching the link editor.
- The link shortcut matches `k` case-insensitively.
- Lists use `text-align: start`.
- Scheme-less hrefs from pasted HTML get `https://` (protocol-relative `//host` gets `https:`). Hrefs with a scheme, and explicitly relative ones (`/`, `./`, `#`, `?`), are left alone.

### Implementation notes

- Item (2) from the issue (markdown shortcuts like `**bold**` not converting when pasted onto the canvas) is a feature decision and is not addressed here.
- Top-level blocks stay separated by a single newline rather than a blank line. tldraw has no soft breaks, so every Enter is a new paragraph; a blank line between blocks would double-space every multi-line shape on copy. The change only collapses the extra separators inside lists and adds markers.
- tiptap's own `isAllowedUri` rejects hrefs such as `example.com/path` (the `/` trips its scheme check) and drops the link before we see it, so the normalisation applies to what does get through: `example.com`, `www.example.com?q=1`, `//example.com/path`. Loosening `isAllowedUri` would also loosen its `javascript:` guard, so it was left as is.
- `renderPlaintextFromRichText` also backs `ShapeUtil.getText`, so shape text used for search and the `text/plain` clipboard entry now carries list markers.
- The rich text editor's `text/plain` clipboard entry (copying a selection while editing) goes through the same list-aware serializer instead of tiptap's core `clipboardTextSerializer`, so it matches copying the shape. It is range-aware: lines outside the selection are skipped, edge lines are cut to it, an item only gets its marker when the selection starts at its beginning, and a selection inside a single block copies as bare text.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `richText.test.ts`: `renderPlaintextFromRichText` (list markers, ordered start, nested indentation, single-newline paragraphs, hard breaks inside items), `renderPlaintextFromRichTextRange` (partial selections) and `renderRichTextFromHTML` (scheme-less, scheme-bearing, and relative hrefs). The list and href tests fail on `main`.
- [x] Integration test — `RichTextArea.test.tsx`: the clipboard plaintext for a whole and a partial list selection while editing.
1. Type `example.com ` in a text shape and check the link is `https://example.com`.
2. On Windows or Linux, select text while editing and press Ctrl+Shift+K; the link editor opens.
3. Paste a right-to-left bulleted list and check the markers sit on the right.

### Release notes

- Fix copied lists losing their bullets and gaining blank lines, bare addresses linking as `http://`, the link shortcut on Windows and Linux, list alignment in RTL text, and scheme-less links pasted from HTML.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +77 / -4   |
| Tests     | +100 / -0  |

