### PR TITLE
fix(tldraw): open the link editor from a tap on touch devices

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbar.tsx
@@ -37,7 +37,11 @@ function ContextualToolbarInner({
 	textEditor: TiptapEditor
 }) {
 	const editor = useEditor()
-	const { isEditingLink, onEditLinkStart, onEditLinkClose } = useEditingLinkBehavior(textEditor)
+	const {
+		isEditingLink,
+		onEditLinkStart: startEditingLink,
+		onEditLinkClose,
+	} = useEditingLinkBehavior(textEditor)
 	const [currentSelection, setCurrentSelection] = useState<Range | null>(null)
 	const previousSelectionBounds = useRef<Box | undefined>(undefined)
 	const isMousingDown = useIsMousingDownOnTextEditor(textEditor)
@@ -47,6 +51,15 @@ function ContextualToolbarInner({
 		[editor]
 	)
 	const msg = useTranslation()
+
+	const onEditLinkStart = useCallback(() => {
+		// On touch the formatting toolbar never measures a selection, so a new link started from
+		// the Ctrl/Cmd+Shift+K shortcut would have nothing to anchor to: the link editor would stay
+		// at its hidden position while its input took focus and swallowed typing. Only an existing
+		// link (which anchors to the link mark) can open the editor there.
+		if (isCoarsePointer && !textEditor.isActive('link')) return
+		startEditingLink()
+	}, [isCoarsePointer, textEditor, startEditingLink])
 
 	const getSelectionBounds = useCallback(() => {
 		if (isEditingLink) {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultRichTextToolbar.tsx
@@ -24,7 +24,7 @@ export const DefaultRichTextToolbar = track(function DefaultRichTextToolbar({
 
 	const textEditor = useValue('textEditor', () => editor.getRichTextEditor(), [editor])
 
-	if (editor.getInstanceState().isCoarsePointer || !textEditor) return null
+	if (!textEditor) return null
 
 	return <ContextualToolbarInner textEditor={textEditor}>{children}</ContextualToolbarInner>
 })
@@ -41,13 +41,25 @@ function ContextualToolbarInner({
 	const [currentSelection, setCurrentSelection] = useState<Range | null>(null)
 	const previousSelectionBounds = useRef<Box | undefined>(undefined)
 	const isMousingDown = useIsMousingDownOnTextEditor(textEditor)
+	const isCoarsePointer = useValue(
+		'isCoarsePointer',
+		() => editor.getInstanceState().isCoarsePointer,
+		[editor]
+	)
 	const msg = useTranslation()
 
 	const getSelectionBounds = useCallback(() => {
 		if (isEditingLink) {
-			// If we're editing a link we don't have selection bounds temporarily.
-			return previousSelectionBounds.current
+			// The link input takes focus, so the DOM selection is gone; anchor to the link itself.
+			// There is no link yet when creating one from a plain selection, so fall back to the
+			// bounds the toolbar had before the input took focus.
+			return getLinkBounds(textEditor) ?? previousSelectionBounds.current
 		}
+
+		// On touch, the floating toolbar competes with the native selection menu and handles,
+		// so it only appears for the link editor (reached by tapping a link).
+		if (isCoarsePointer) return
+
 		// Get the text selection rects as a box. This will be undefined if there are no selections.
 		const selection = editor.getContainerWindow().getSelection()
 
@@ -65,7 +77,7 @@ function ContextualToolbarInner({
 		const bounds = Box.Common(rangeBoxes)
 		previousSelectionBounds.current = bounds
 		return bounds
-	}, [editor, currentSelection, isEditingLink])
+	}, [editor, textEditor, currentSelection, isEditingLink, isCoarsePointer])
 
 	useEffect(() => {
 		const handleSelectionUpdate = ({ editor: textEditor }: TextEditorEvents['selectionUpdate']) =>
@@ -101,7 +113,28 @@ function ContextualToolbarInner({
 	)
 }
 
+function getLinkBounds(textEditor: TiptapEditor): Box | undefined {
+	const { state, view } = textEditor
+	try {
+		const range = getMarkRange(
+			state.doc.resolve(state.selection.from),
+			state.schema.marks.link as MarkType
+		)
+		if (!range) return
+		const start = view.coordsAtPos(range.from)
+		const end = view.coordsAtPos(range.to)
+		return Box.Common([
+			new Box(start.left, start.top, start.right - start.left, start.bottom - start.top),
+			new Box(end.left, end.top, end.right - end.left, end.bottom - end.top),
+		])
+	} catch {
+		// getMarkRange can throw when the selection spans the whole document.
+		return
+	}
+}
+
 function useEditingLinkBehavior(textEditor?: TiptapEditor) {
+	const editor = useEditor()
 	const [isEditingLink, setIsEditingLink] = useState(false)
 
 	// Set up text editor event listeners.
@@ -112,8 +145,13 @@ function useEditingLinkBehavior(textEditor?: TiptapEditor) {
 		}
 
 		const handleClick = () => {
-			const isLinkActive = textEditor.isActive('link')
-			setIsEditingLink(isLinkActive)
+			// The browser places the caret as the click's default action and ProseMirror only
+			// reads it back on the following selectionchange task, so checking synchronously
+			// here sees the caret from before the click (and a tap on a link does nothing).
+			editor.timers.setTimeout(() => {
+				if (textEditor.isDestroyed) return
+				setIsEditingLink(textEditor.isActive('link'))
+			}, 0)
 		}
 
 		textEditor.view.dom.addEventListener('click', handleClick)
@@ -122,7 +160,7 @@ function useEditingLinkBehavior(textEditor?: TiptapEditor) {
 				textEditor.view.dom.removeEventListener('click', handleClick)
 			}
 		}
-	}, [textEditor, isEditingLink])
+	}, [editor, textEditor, isEditingLink])
 
 	// If we're editing a link, select the entire link.
 	// This can happen via a click or via keyboarding over to the link and then

--- a/packages/tldraw/src/test/ui/RichTextToolbar.test.tsx
+++ b/packages/tldraw/src/test/ui/RichTextToolbar.test.tsx
@@ -1,0 +1,113 @@
+import { act, waitFor } from '@testing-library/react'
+import { createShapeId, Editor, TiptapEditor, toRichText } from '@tldraw/editor'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+const LINK_INPUT = '.tlui-rich-text__toolbar input'
+
+// ProseMirror measures the caret with getClientRects when the selection moves; jsdom has no layout.
+const emptyRect = () => ({ x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 })
+beforeAll(() => {
+	for (const proto of [Text.prototype, Range.prototype, Element.prototype] as any[]) {
+		proto.getClientRects = () => [emptyRect()]
+		proto.getBoundingClientRect = emptyRect
+	}
+})
+
+async function setup({ withLink }: { withLink: boolean }) {
+	const id = createShapeId('text')
+	const { editor, rendered } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+
+	await act(async () => {
+		editor.createShape({
+			id,
+			type: 'text',
+			x: 0,
+			y: 0,
+			props: {
+				richText: withLink
+					? {
+							type: 'doc',
+							content: [
+								{
+									type: 'paragraph',
+									content: [
+										{
+											type: 'text',
+											text: 'hello',
+											marks: [{ type: 'link', attrs: { href: 'https://tldraw.com' } }],
+										},
+									],
+								},
+							],
+						}
+					: toRichText('hello'),
+			},
+		})
+		editor.select(id)
+		editor.setEditingShape(id)
+	})
+
+	let textEditor: TiptapEditor | null = null
+	await waitFor(() => {
+		textEditor = editor.getRichTextEditor()
+		expect(textEditor).toBeTruthy()
+	})
+	// Put the caret inside the text so `isActive('link')` reflects the link mark (if any)
+	await act(async () => {
+		textEditor!.commands.setTextSelection(2)
+	})
+
+	return { editor, rendered, textEditor: textEditor! }
+}
+
+function pressLinkShortcut(editor: Editor) {
+	act(() => {
+		editor
+			.getContainerDocument()
+			.dispatchEvent(
+				new KeyboardEvent('keydown', { key: 'k', metaKey: true, shiftKey: true, bubbles: true })
+			)
+	})
+}
+
+describe('rich text toolbar link shortcut', () => {
+	it('opens the link editor on a fine pointer', async () => {
+		const { editor, rendered } = await setup({ withLink: false })
+		act(() => editor.updateInstanceState({ isCoarsePointer: false }))
+
+		pressLinkShortcut(editor)
+
+		await waitFor(() => {
+			expect(rendered.container.querySelector(LINK_INPUT)).not.toBeNull()
+		})
+	})
+
+	it('does not open the link editor on a coarse pointer when there is no link to anchor to', async () => {
+		const { editor, rendered } = await setup({ withLink: false })
+		act(() => editor.updateInstanceState({ isCoarsePointer: true }))
+
+		pressLinkShortcut(editor)
+
+		// The formatting toolbar is hidden on touch, so a link editor with nothing to anchor to
+		// would stay off-screen while its input captured typing.
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 20))
+		})
+		expect(rendered.container.querySelector(LINK_INPUT)).toBeNull()
+	})
+
+	it('opens the link editor on a coarse pointer when the caret is inside a link', async () => {
+		const { editor, rendered } = await setup({ withLink: true })
+		act(() => editor.updateInstanceState({ isCoarsePointer: true }))
+
+		pressLinkShortcut(editor)
+
+		await waitFor(() => {
+			expect(rendered.container.querySelector(LINK_INPUT)).not.toBeNull()
+		})
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where links could not be edited, visited, or removed on touch devices. Closes #10524.

### Before

`DefaultRichTextToolbar` returned `null` whenever `isCoarsePointer` was set, so the link editor (which only renders inside that toolbar) was unreachable on phones and tablets. Tapping a link while editing only placed the caret. The toolbar was hidden on touch deliberately: a floating bar above the selection fights with the native selection menu and handles.

Two further problems in the same path meant that just lifting the gate would not have been enough:

- `useEditingLinkBehavior` checked `textEditor.isActive('link')` synchronously in its `click` handler. The browser places the caret as the click's default action and ProseMirror reads it back on the following `selectionchange` task, so the check saw the caret from before the click. On desktop this is why the first click into a link never opened the editor and a second click did; on touch a single tap would have done nothing.
- While editing a link the toolbar was positioned from `previousSelectionBounds`, which is only set when a non-collapsed DOM selection has been measured. Entering the link editor from a collapsed caret left it undefined, so the editor rendered at the hidden off-screen position.

### After

The toolbar mounts on coarse pointers, but `getSelectionBounds` returns nothing there unless the link editor is open, so the formatting bar stays hidden on touch as before. Tapping a link opens the link editor (address input, visit, remove) anchored to the link.

The click handler now evaluates `isActive('link')` on a zero-delay timer so the caret has settled, and the link editor is positioned from the link mark's range via `view.coordsAtPos`, falling back to the previous selection bounds when creating a link from a plain selection. Both fixes also apply on desktop: one click into a link now opens the editor.

### Implementation notes

The original PR briefly showed the full toolbar on coarse pointers and then removed it ("gets in the way"), so this keeps the bold/italic/etc. bar off touch and only surfaces the link editor. Adding a link to arbitrary selected text on touch is therefore still not possible from the toolbar; typing an address still autolinks. Showing the full bar on touch is a product call that can be made separately by removing the `isCoarsePointer` early return in `getSelectionBounds`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `packages/tldraw/src/test/ui/RichTextToolbar.test.tsx` covers the link shortcut on fine and coarse pointers. The tap and positioning paths still depend on live DOM layout and ProseMirror selection timing, which jsdom does not reproduce.
1. In Chrome DevTools, enable device emulation (e.g. iPhone) and open `/develop`.
2. Create a text shape containing a link, double-tap to edit, tap the link: the link editor appears above the link with the address filled in.
3. Tap the trash button: the link is removed and the editor hides. Tap the link again, change the address, press Return: the link updates.
4. Select plain text on the emulated device: no formatting toolbar appears.
5. Without emulation, double-click into a text shape and single-click a link: the link editor opens on the first click. Select a word, click the link button, type an address, press Return: the link is created as before.

### Release notes

- Fix links not being editable or removable on touch devices; tapping a link while editing text now opens the link editor.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +45 / -7   |
| Tests     | +0 / -0    |

