### PR TITLE
docs: fix tldraw.dev page errors caught by the dotdev smoke test

### DIFF
--- a/apps/docs/components/common/tldraw-link.tsx
+++ b/apps/docs/components/common/tldraw-link.tsx
@@ -6,13 +6,22 @@ import { useEffect, useState } from 'react'
 export function TldrawLink(props: React.ComponentProps<'a'>) {
 	const { href, children } = props
 	const windowObject = typeof window !== 'undefined' ? window : null
-	const [sessionId, setSessionId] = useState(windowObject?.posthog?.get_session_id())
-	const [distinctId, setDistinctId] = useState(windowObject?.posthog?.get_distinct_id())
+	// Start empty so the first client render matches the server HTML — reading
+	// posthog during render appends `#session_id` to hrefs before hydration and
+	// causes a hydration mismatch whenever posthog loads first.
+	const [sessionId, setSessionId] = useState<string | undefined>(undefined)
+	const [distinctId, setDistinctId] = useState<string | undefined>(undefined)
 
 	useEffect(() => {
 		// Note this href check is intentionally loose, just to avoid
 		// doing this setInterval for every link. We do the real check below.
 		if (sessionId || !href?.includes('tldraw.com')) return
+
+		if (windowObject?.posthog) {
+			setSessionId(windowObject.posthog.get_session_id())
+			setDistinctId(windowObject.posthog.get_distinct_id())
+			return
+		}
 
 		// XXX: have to wait a bit for posthog to be ready.
 		// there's unfortunately no event callback for this.

--- a/apps/docs/components/content/feature.tsx
+++ b/apps/docs/components/content/feature.tsx
@@ -16,7 +16,8 @@ export function Feature({
 				<Icon icon={icon} className="h-5 w-5 text-zinc-900 dark:text-zinc-100" />
 				<h3 className="font-bold text-zinc-900 dark:text-zinc-100">{title}</h3>
 			</div>
-			<p className="leading-relaxed text-zinc-600 dark:text-zinc-400">{children}</p>
+			{/* MDX renders block children as their own `<p>`s, so this wrapper must not be a `<p>` — nested `<p>`s break hydration. */}
+			<div className="leading-relaxed text-zinc-600 dark:text-zinc-400">{children}</div>
 		</div>
 	)
 }

--- a/apps/docs/content/starter-kits/agent.mdx
+++ b/apps/docs/content/starter-kits/agent.mdx
@@ -59,11 +59,7 @@ With its default configuration, the agent can perform the following actions:
 
 ### Architecture
 
-<img
-	src="/images/starter-kits/chart-agent.png"
-	alt="Flowchart showing how user input is processed by an agent, which gathers a canvas screenshot, analyzes shapes, and builds context. These feed into an AI model, which performs further shape analysis, updates the canvas, and produces results that go back to the user as feedback."
-	style={{ maxWidth: '400px', height: 'auto', display: 'block', margin: '0 auto' }}
-/>
+![Flowchart showing how user input is processed by an agent, which gathers a canvas screenshot, analyzes shapes, and builds context. These feed into an AI model, which performs further shape analysis, updates the canvas, and produces results that go back to the user as feedback.](/images/starter-kits/chart-agent.png)
 
 ### 1. User input
 

--- a/apps/docs/scripts/lib/getApiMarkdown.ts
+++ b/apps/docs/scripts/lib/getApiMarkdown.ts
@@ -303,7 +303,9 @@ function getItemTitle(item: ApiItem) {
 		return 'Constructor'
 	}
 
-	const name = item.displayName
+	// Escape square brackets so a name like `[Symbol.iterator]` followed by the
+	// `(\u00A0)` call parens below doesn't parse as a markdown link.
+	const name = item.displayName.replaceAll('[', '\\[').replaceAll(']', '\\]')
 	if (item.kind === ApiItemKind.Method || item.kind === ApiItemKind.Function) {
 		return `${name}(\u00A0)`
 	}

--- a/apps/examples/src/examples/ui/custom-theme/CustomThemeExample.tsx
+++ b/apps/examples/src/examples/ui/custom-theme/CustomThemeExample.tsx
@@ -79,7 +79,9 @@ const pixelFont: TLThemeFont = {
 	],
 }
 
-// Custom font — use a Google Font loaded via full URLs.
+// Custom font — use a Google Font loaded via full URLs. These versioned
+// gstatic URLs expire when Google revs the font; refresh them from
+// https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700 if they 404.
 const cursiveFont: TLThemeFont = {
 	fontFamily: "'Comic Neue', cursive",
 	icon: <div style={{ fontFamily: "'Comic Neue', cursive", fontSize: 16, lineHeight: 1 }}>Aa</div>,
@@ -87,7 +89,7 @@ const cursiveFont: TLThemeFont = {
 		{
 			family: 'Comic Neue',
 			src: {
-				url: 'https://fonts.gstatic.com/s/comicneue/v8/4UaErEJDsxBrF37olUeD_wHLwpteLwtHJlc.woff2',
+				url: 'https://fonts.gstatic.com/s/comicneue/v9/4UaHrEJDsxBrF37olUeD96rp57F2IwM.woff2',
 				format: 'woff2',
 			},
 			weight: 'normal',
@@ -96,7 +98,7 @@ const cursiveFont: TLThemeFont = {
 		{
 			family: 'Comic Neue',
 			src: {
-				url: 'https://fonts.gstatic.com/s/comicneue/v8/4UaFrEJDsxBrF37olUeD96_RTplUKylCNlcw_Q.woff2',
+				url: 'https://fonts.gstatic.com/s/comicneue/v9/4UaErEJDsxBrF37olUeD_xHM8pxULilENlY.woff2',
 				format: 'woff2',
 			},
 			weight: 'bold',


### PR DESCRIPTION
Our internal tldraw.dev smoke test (tldraw-internal "Dotdev test") crawls the live site and has been red for days on several docs-owned pages. This fixes the four docs-side causes.

- **`/starter-kits/overview` hydration failure (React #418):** `Feature` wrapped its MDX children in a `<p>`, but MDX renders block children as their own `<p>`s — the nested `<p><p>` gets flattened by the HTML parser and hydration mismatches. The wrapper is now a `<div>`.
- **Intermittent hydration failure on any page with a tldraw.com link (seen on `/starter-kits/shader`):** `TldrawLink` read posthog's session/distinct ids during the first client render, so when posthog loaded before hydration the client href already had `#session_id=…` appended while the server HTML didn't. The ids now start empty and are read in an effect.
- **`Invalid URL: %C2%A0` console errors on `/reference/store/AtomMap`, `AtomSet`, `ReadonlySharedStyleMap`:** `getApiMarkdown` emits method headings as `name( )`, and for `[Symbol.iterator]` that produces `[Symbol.iterator]( )` — which markdown parses as a *link* whose href is a non-breaking space. Square brackets in member names are now escaped. (Note: these pages' member heading anchors change slightly since the heading text changes.)
- **404 on `/starter-kits/agent`:** the architecture diagram used a literal JSX `<img src="/images/…">`, which bypasses the MDX `img → Image` mapping and its `assetUrl` prefixing, so behind the tldraw.dev proxy it resolved against the marketing app and 404'd. Converted to a markdown image like the sibling starter-kit chart diagrams (it now gets the standard full-width image plate instead of the 400px centered styling).
- **404 fonts on `/examples/custom-theme`:** the example hardcoded Comic Neue **v8** gstatic URLs, which Google retired. Bumped to the current v9 URLs (both verified 200) and left a comment on how to refresh them next time they rot.

### Change type

- [x] `bugfix`

### Release notes

- Fixed hydration errors, broken reference-page member links, a missing starter-kit image, and stale font URLs on tldraw.dev docs pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)