### PR TITLE
feat(dotcom): report create-file for imported .tldr files

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -64,7 +64,7 @@ import { trackEvent } from '../../utils/analytics'
 import { ZERO_SERVER } from '../../utils/config'
 import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
 import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
-import { TLAppUiContextType } from '../utils/app-ui-events'
+import { TLAppUiContextType, TLAppUiEventSource } from '../utils/app-ui-events'
 import { getDateFormat } from '../utils/dates'
 import { FeatureFlags } from '../utils/FeatureFlagPoller'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
@@ -1091,10 +1091,16 @@ export class TldrawApp {
 
 	async uploadTldrFiles(
 		files: File[],
-		onFirstFileUploaded?: (fileId: string) => void,
-		workspaceId?: string,
-		onUploadError?: () => void
+		opts: {
+			/** Where the import started; reported as the `create-file` source for each file. */
+			source: TLAppUiEventSource
+			onFirstFileUploaded?(fileId: string): void
+			workspaceId?: string
+			onUploadError?(): void
+		}
 	) {
+		let { onFirstFileUploaded } = opts
+		const { source, workspaceId, onUploadError } = opts
 		const totalFiles = files.length
 		let uploadedFiles = 0
 		if (totalFiles === 0) return
@@ -1172,6 +1178,8 @@ export class TldrawApp {
 					uploaded: ++uploadedFiles + 1,
 				}),
 			})
+
+			this.trackEvent('create-file', { source })
 
 			if (onFirstFileUploaded) {
 				onFirstFileUploaded(res.value.fileId)

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
@@ -25,13 +25,13 @@ export const SneakyTldrawFileDropHandler = memo(function SneakyTldrawFileDropHan
 			if (tldrawFiles.length > 0) {
 				const currentFile = fileId ? app.getFile(fileId) : null
 				const workspaceId = currentFile?.owningGroupId ?? undefined
-				await app.uploadTldrFiles(
-					tldrawFiles,
-					(fileId) => {
+				await app.uploadTldrFiles(tldrawFiles, {
+					source: 'file-drop',
+					onFirstFileUploaded: (fileId) => {
 						navigate(routes.tlaFile(fileId), { state: { mode: 'create' } })
 					},
-					workspaceId
-				)
+					workspaceId,
+				})
 			} else if (files.length > 0) {
 				await defaultHandleExternalFileContent(editor, { ...content, files }, { toasts, msg })
 			}

--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -365,8 +365,11 @@ export function ImportFileActionItem() {
 					const tldrawFiles = rejectTldrawOfflineFiles(pickedFiles)
 					if (!tldrawFiles.length) return
 
-					app.uploadTldrFiles(tldrawFiles, (fileId) => {
-						navigate(routes.tlaFile(fileId), { state: { mode: 'create' } })
+					app.uploadTldrFiles(tldrawFiles, {
+						source: 'account-menu',
+						onFirstFileUploaded: (fileId) => {
+							navigate(routes.tlaFile(fileId), { state: { mode: 'create' } })
+						},
 					})
 				} catch {
 					// user cancelled

--- a/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
+++ b/apps/dotcom/client/src/tla/hooks/useTldrFileDrop.ts
@@ -26,8 +26,11 @@ export function useTldrFileDrop() {
 			if (!tldrawFiles.length) {
 				return
 			}
-			app.uploadTldrFiles(tldrawFiles, (fileId) => {
-				navigate(routes.tlaFile(fileId))
+			app.uploadTldrFiles(tldrawFiles, {
+				source: 'file-drop',
+				onFirstFileUploaded: (fileId) => {
+					navigate(routes.tlaFile(fileId))
+				},
 			})
 		},
 		[app, auth, navigate, rejectTldrawOfflineFiles]

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -18,6 +18,8 @@ export type TLAppUiEventSource =
 	| 'account-menu'
 	| 'top-bar'
 	| 'legacy-import-button'
+	| 'file-drop'
+	| 'import-url'
 	| 'new-page'
 	| 'app'
 	| 'cookie-settings'

--- a/apps/dotcom/client/src/tla/utils/importFromUrl.ts
+++ b/apps/dotcom/client/src/tla/utils/importFromUrl.ts
@@ -31,12 +31,12 @@ export async function importFromUrl(
 		return new Promise<
 			{ ok: true; fileId: string } | { ok: false; error: string; toastAlreadyShown?: boolean }
 		>((resolve) => {
-			app.uploadTldrFiles(
-				[file],
-				(fileId) => resolve({ ok: true, fileId }),
-				undefined,
-				() => resolve({ ok: false, error: 'Upload failed', toastAlreadyShown: true })
-			)
+			app.uploadTldrFiles([file], {
+				source: 'import-url',
+				onFirstFileUploaded: (fileId) => resolve({ ok: true, fileId }),
+				onUploadError: () =>
+					resolve({ ok: false, error: 'Upload failed', toastAlreadyShown: true }),
+			})
 		})
 	} catch (e) {
 		return {


### PR DESCRIPTION
Files created by importing a `.tldr` file never showed up in the `create-file` analytics event, so the "files created by source" breakdown in PostHog undercounted and could not say how many files arrive by import. Only the account-menu path fired anything (`import-tldr-file`, and that fires when the picker opens, before a file is chosen); drag-and-drop and import-from-URL fired nothing.

`TldrawApp.uploadTldrFiles` now takes an options object with a required `source` and fires `create-file` once per file that actually uploads, so every import path is counted in the same event as the sidebar button. Sources: `account-menu` (Import file menu item), `file-drop` (drop onto the editor or the app), `import-url` (`?import=` flow). Two of those are new `TLAppUiEventSource` values.

The positional parameters became an options object because the call sites were already passing `undefined` to reach the later ones; there are four callers, all updated here. `import-tldr-file` is left as-is since it still measures intent (picker opened) rather than outcome.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On tldraw.com, import a `.tldr` file from the account menu, drop one onto the editor, and open `/?import=<url-to-a-tldr>`.
2. In PostHog, each should produce a `create-file` event with source `account-menu`, `file-drop` or `import-url`.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Importing a `.tldr` file now reports a `create-file` analytics event with the import source.
