### PR TITLE
fix(dotcom): bound the source persist wait and report boot stalls in file effects

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -75,7 +75,13 @@ import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom, listAllObjectKeys } from './r2'
-import { RoomNotFoundError, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
+import {
+	BootStallError,
+	RoomNotFoundError,
+	SourcePersistTimeoutError,
+	settleWithin,
+	shouldSkipMissingRoomEffect,
+} from './roomEffectHelpers'
 import { getPublishedRoomSnapshot } from './routes/tla/getPublishedFile'
 import { deleteBoardThumbnails, enqueueOgImageRender } from './routes/tla/ogImageQueue'
 import { generateSnapshotChunks } from './snapshotUtils'
@@ -238,6 +244,7 @@ export class TLFileDurableObject extends DurableObject {
 			throw new Error('documentInfo must be present when accessing room')
 		}
 		if (!this._storage) {
+			this._bootStage = 'storage-load'
 			const promise = retry(() => this.loadStorage(this.documentInfo.slug), {
 				// Allow RoomNotFoundError to bubble up since it means the room doesn't exist
 				// and there's no point in retrying.
@@ -271,6 +278,7 @@ export class TLFileDurableObject extends DurableObject {
 					// Never cache a rejection: the condition may heal, and a cached rejection
 					// makes every later retry fail instantly.
 					if (this._storage === promise) this._storage = null
+					this._bootStage = null
 					throw error
 				})
 			this._storage = promise
@@ -279,6 +287,11 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	_room: Promise<TLSocketRoom<TLRecord, SessionMeta>> | null = null
+
+	// Which boot phase a pending _storage/_room promise last reached. Pending promises are
+	// cached, so when a boot wedges every caller awaits the same stuck await — this names it
+	// (see BootStallError and __admin__getDocumentInfo).
+	_bootStage: string | null = null
 
 	sentry: ReturnType<typeof createSentry> | null = null
 
@@ -289,6 +302,7 @@ export class TLFileDurableObject extends DurableObject {
 		if (!this._room) {
 			const promise = this.getStorage()
 				.then(async (storage) => {
+					this._bootStage = 'room-create'
 					const room = new TLSocketRoom<TLRecord, SessionMeta>({
 						storage,
 						schema: fileSyncSchema,
@@ -369,12 +383,14 @@ export class TLFileDurableObject extends DurableObject {
 					}
 					// Also associate file assets after we load the room
 					setTimeout(this.maybeAssociateFileAssets.bind(this), PERSIST_INTERVAL_MS)
+					this._bootStage = null
 					return room
 				})
 				.catch((error) => {
 					// Never cache a rejection: the condition may heal, and a cached rejection
 					// makes every later retry fail instantly.
 					if (this._room === promise) this._room = null
+					this._bootStage = null
 					throw error
 				})
 			this._room = promise
@@ -1182,6 +1198,7 @@ export class TLFileDurableObject extends DurableObject {
 		const serialized = typeof data === 'string' ? data : JSON.stringify(data)
 		const snapshot = typeof data === 'string' ? JSON.parse(data) : data
 
+		this._bootStage = 'source-r2-put'
 		const putTimer = this.timer()
 		const key = getR2KeyForRoom({ slug: this._fileRecordCache.id, isApp: true })
 		const roomObject = await this.r2.rooms.put(key, serialized)
@@ -1216,9 +1233,21 @@ export class TLFileDurableObject extends DurableObject {
 				// The source file's content is copied verbatim into this (user-owned) room. Read
 				// access to the source `id` is authorized upstream when the file record is created
 				// (see the `createFile` mutator), since that is where the user's identity is known.
+				// Bound the wait: a busy source room can hold its serial persist queue longer than
+				// the outbox drain's 30s effect timeout, wedging this boot and parking the insert
+				// effect (#10541). Its last persisted snapshot is at most one persist throttle
+				// stale, which a duplicate can tolerate.
+				this._bootStage = 'source-await-persist'
 				const awaitPersistTimer = this.timer()
-				await getRoomDurableObject(this.env, id).awaitPersist()
+				const persistWait = await settleWithin(
+					getRoomDurableObject(this.env, id).awaitPersist(),
+					SOURCE_PERSIST_WAIT_TIMEOUT_MS
+				)
+				if (persistWait === 'timeout') {
+					this.reportError(new SourcePersistTimeoutError(id, SOURCE_PERSIST_WAIT_TIMEOUT_MS))
+				}
 				awaitPersistTimer.report('create_from_source_await_persist')
+				this._bootStage = 'source-r2-fetch'
 
 				const r2FetchTimer = this.timer()
 				const text = await this.r2.rooms
@@ -2538,7 +2567,7 @@ export class TLFileDurableObject extends DurableObject {
 			})
 		}
 		try {
-			await this.getRoom()
+			await this.reportIfBootStalls(this.getRoom(), file)
 		} catch (e) {
 			if (shouldSkipMissingRoomEffect(e, file)) {
 				console.error('appFileRecordCreated: room not found for deleted file, skipping', e)
@@ -2564,7 +2593,7 @@ export class TLFileDurableObject extends DurableObject {
 		}
 
 		try {
-			await this.updateRoomForFileRecord(file)
+			await this.reportIfBootStalls(this.updateRoomForFileRecord(file), file)
 		} catch (e) {
 			if (shouldSkipMissingRoomEffect(e, file)) {
 				console.error('appFileRecordDidUpdate: room not found for deleted file, skipping', e)
@@ -2709,6 +2738,20 @@ export class TLFileDurableObject extends DurableObject {
 		await this.persistToDatabase(opts?.throwOnFailure ? { throwOnFailure: true } : undefined)
 	}
 
+	// Report-only watchdog for outbox effect RPCs: fires just under the drain's 30s effect
+	// timeout so Sentry gets the boot stage before the drain bumps the row as a bare timeout.
+	// The outbox owns retry semantics — this never rejects or cancels the work.
+	private async reportIfBootStalls<T>(work: Promise<T>, file: TlaFile): Promise<T> {
+		const timer = setTimeout(() => {
+			this.reportError(new BootStallError(file.id, this._bootStage, BOOT_STALL_REPORT_MS))
+		}, BOOT_STALL_REPORT_MS)
+		try {
+			return await work
+		} finally {
+			clearTimeout(timer)
+		}
+	}
+
 	/**
 	 * Reports this object's stored identity and liveness without booting the room. Reads raw
 	 * storage so rooms with a stale documentInfo version still resolve; null for a
@@ -2724,6 +2767,7 @@ export class TLFileDurableObject extends DurableObject {
 			deleted: !!info.deleted,
 			connectedSockets: this.ctx.getWebSockets().length,
 			roomLoaded: this._room !== null,
+			bootStage: this._bootStage,
 		}
 	}
 
@@ -2831,3 +2875,8 @@ const PERSIST_RETRIES_MAX = 100
 // ~10 attempts * 2s = ~20s of own retries, sized for the 30s outbox effect timeout (see
 // persistToDatabase for why this is not a hard bound).
 const PERSIST_RETRIES_MAX_THROWING = 10
+// Both sized against the outbox drain's 30s EFFECT_TIMEOUT_MS: the persist wait must leave
+// room for the rest of the from-source boot, and the stall report must land before the
+// drain gives up on the attempt.
+const SOURCE_PERSIST_WAIT_TIMEOUT_MS = 10_000
+const BOOT_STALL_REPORT_MS = 25_000

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -269,6 +269,9 @@ export class TLFileDurableObject extends DurableObject {
 					// outbox no-ops after a couple of synchronous SQL statements, so the cost per
 					// room start is trivial.
 					queueMicrotask(() => void this.drainCommentOutbox())
+					// Clear here, not only when the room settles: storage-only callers (restore,
+					// .tldr download) never boot the room and would leave a stale stage behind.
+					this._bootStage = null
 					return storage
 				})
 				.catch((error) => {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -76,7 +76,7 @@ import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom, listAllObjectKeys } from './r2'
 import {
-	BootStallError,
+	FileEffectStallError,
 	RoomNotFoundError,
 	SourcePersistTimeoutError,
 	settleWithin,
@@ -244,7 +244,7 @@ export class TLFileDurableObject extends DurableObject {
 			throw new Error('documentInfo must be present when accessing room')
 		}
 		if (!this._storage) {
-			this._bootStage = 'storage-load'
+			this.setBootStage('storage-load')
 			const promise = retry(() => this.loadStorage(this.documentInfo.slug), {
 				// Allow RoomNotFoundError to bubble up since it means the room doesn't exist
 				// and there's no point in retrying.
@@ -271,7 +271,7 @@ export class TLFileDurableObject extends DurableObject {
 					queueMicrotask(() => void this.drainCommentOutbox())
 					// Clear here, not only when the room settles: storage-only callers (restore,
 					// .tldr download) never boot the room and would leave a stale stage behind.
-					this._bootStage = null
+					this.setBootStage(null)
 					return storage
 				})
 				.catch((error) => {
@@ -281,7 +281,7 @@ export class TLFileDurableObject extends DurableObject {
 					// Never cache a rejection: the condition may heal, and a cached rejection
 					// makes every later retry fail instantly.
 					if (this._storage === promise) this._storage = null
-					this._bootStage = null
+					this.setBootStage(null)
 					throw error
 				})
 			this._storage = promise
@@ -291,10 +291,14 @@ export class TLFileDurableObject extends DurableObject {
 
 	_room: Promise<TLSocketRoom<TLRecord, SessionMeta>> | null = null
 
-	// Which boot phase a pending _storage/_room promise last reached. Pending promises are
-	// cached, so when a boot wedges every caller awaits the same stuck await — this names it
-	// (see BootStallError and __admin__getDocumentInfo).
-	_bootStage: string | null = null
+	// Which boot phase a pending _storage/_room promise last reached, and when it was entered.
+	// Pending promises are cached, so when a boot wedges every caller awaits the same stuck
+	// await — this names it and its age (see FileEffectStallError and __admin__getDocumentInfo).
+	_bootStage: { stage: string; startedAt: number } | null = null
+
+	private setBootStage(stage: string | null) {
+		this._bootStage = stage === null ? null : { stage, startedAt: Date.now() }
+	}
 
 	sentry: ReturnType<typeof createSentry> | null = null
 
@@ -305,7 +309,7 @@ export class TLFileDurableObject extends DurableObject {
 		if (!this._room) {
 			const promise = this.getStorage()
 				.then(async (storage) => {
-					this._bootStage = 'room-create'
+					this.setBootStage('room-create')
 					const room = new TLSocketRoom<TLRecord, SessionMeta>({
 						storage,
 						schema: fileSyncSchema,
@@ -386,14 +390,14 @@ export class TLFileDurableObject extends DurableObject {
 					}
 					// Also associate file assets after we load the room
 					setTimeout(this.maybeAssociateFileAssets.bind(this), PERSIST_INTERVAL_MS)
-					this._bootStage = null
+					this.setBootStage(null)
 					return room
 				})
 				.catch((error) => {
 					// Never cache a rejection: the condition may heal, and a cached rejection
 					// makes every later retry fail instantly.
 					if (this._room === promise) this._room = null
-					this._bootStage = null
+					this.setBootStage(null)
 					throw error
 				})
 			this._room = promise
@@ -1201,7 +1205,7 @@ export class TLFileDurableObject extends DurableObject {
 		const serialized = typeof data === 'string' ? data : JSON.stringify(data)
 		const snapshot = typeof data === 'string' ? JSON.parse(data) : data
 
-		this._bootStage = 'source-r2-put'
+		this.setBootStage('source-r2-put')
 		const putTimer = this.timer()
 		const key = getR2KeyForRoom({ slug: this._fileRecordCache.id, isApp: true })
 		const roomObject = await this.r2.rooms.put(key, serialized)
@@ -1238,9 +1242,10 @@ export class TLFileDurableObject extends DurableObject {
 				// (see the `createFile` mutator), since that is where the user's identity is known.
 				// Bound the wait: a busy source room can hold its serial persist queue longer than
 				// the outbox drain's 30s effect timeout, wedging this boot and parking the insert
-				// effect (#10541). Its last persisted snapshot is at most one persist throttle
-				// stale, which a duplicate can tolerate.
-				this._bootStage = 'source-await-persist'
+				// effect (#10541). Its last persisted snapshot is typically at most one persist
+				// throttle stale — older only when the source's own persists are failing, which
+				// is reported separately.
+				this.setBootStage('source-await-persist')
 				const awaitPersistTimer = this.timer()
 				const persistWait = await settleWithin(
 					getRoomDurableObject(this.env, id).awaitPersist(),
@@ -1250,7 +1255,7 @@ export class TLFileDurableObject extends DurableObject {
 					this.reportError(new SourcePersistTimeoutError(id, SOURCE_PERSIST_WAIT_TIMEOUT_MS))
 				}
 				awaitPersistTimer.report('create_from_source_await_persist')
-				this._bootStage = 'source-r2-fetch'
+				this.setBootStage('source-r2-fetch')
 
 				const r2FetchTimer = this.timer()
 				const text = await this.r2.rooms
@@ -2570,7 +2575,7 @@ export class TLFileDurableObject extends DurableObject {
 			})
 		}
 		try {
-			await this.reportIfBootStalls(this.getRoom(), file)
+			await this.reportIfEffectStalls(this.getRoom(), file, 'insert')
 		} catch (e) {
 			if (shouldSkipMissingRoomEffect(e, file)) {
 				console.error('appFileRecordCreated: room not found for deleted file, skipping', e)
@@ -2596,7 +2601,7 @@ export class TLFileDurableObject extends DurableObject {
 		}
 
 		try {
-			await this.reportIfBootStalls(this.updateRoomForFileRecord(file), file)
+			await this.reportIfEffectStalls(this.updateRoomForFileRecord(file), file, 'update')
 		} catch (e) {
 			if (shouldSkipMissingRoomEffect(e, file)) {
 				console.error('appFileRecordDidUpdate: room not found for deleted file, skipping', e)
@@ -2742,17 +2747,25 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	// Report-only watchdog for outbox effect RPCs: fires just under the drain's 30s effect
-	// timeout so Sentry gets the boot stage before the drain bumps the row as a bare timeout.
-	// The outbox owns retry semantics — this never rejects or cancels the work. A null stage
-	// means the boot already settled and the stall is in work after it (e.g. the per-session
-	// permission refresh in updateRoomForFileRecord) — report that as 'post-boot', not a boot
-	// failure.
-	private async reportIfBootStalls<T>(work: Promise<T>, file: TlaFile): Promise<T> {
+	// timeout so Sentry gets the cause before the drain bumps the row as a bare timeout.
+	// The outbox owns retry semantics — this never rejects or cancels the work.
+	private async reportIfEffectStalls<T>(
+		work: Promise<T>,
+		file: TlaFile,
+		command: 'insert' | 'update'
+	): Promise<T> {
 		const timer = setTimeout(() => {
+			const bootStage = this._bootStage
 			this.reportError(
-				new BootStallError(file.id, this._bootStage ?? 'post-boot', BOOT_STALL_REPORT_MS)
+				new FileEffectStallError(
+					file.id,
+					command,
+					bootStage?.stage ?? null,
+					bootStage ? Date.now() - bootStage.startedAt : null,
+					EFFECT_STALL_REPORT_MS
+				)
 			)
-		}, BOOT_STALL_REPORT_MS)
+		}, EFFECT_STALL_REPORT_MS)
 		try {
 			return await work
 		} finally {
@@ -2775,7 +2788,8 @@ export class TLFileDurableObject extends DurableObject {
 			deleted: !!info.deleted,
 			connectedSockets: this.ctx.getWebSockets().length,
 			roomLoaded: this._room !== null,
-			bootStage: this._bootStage,
+			bootStage: this._bootStage?.stage ?? null,
+			bootStageAgeMs: this._bootStage ? Date.now() - this._bootStage.startedAt : null,
 		}
 	}
 
@@ -2887,4 +2901,4 @@ const PERSIST_RETRIES_MAX_THROWING = 10
 // room for the rest of the from-source boot, and the stall report must land before the
 // drain gives up on the attempt.
 const SOURCE_PERSIST_WAIT_TIMEOUT_MS = 10_000
-const BOOT_STALL_REPORT_MS = 25_000
+const EFFECT_STALL_REPORT_MS = 25_000

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -76,6 +76,7 @@ import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom, listAllObjectKeys } from './r2'
 import {
+	BootStage,
 	FileEffectStallError,
 	RoomNotFoundError,
 	SourcePersistTimeoutError,
@@ -294,9 +295,9 @@ export class TLFileDurableObject extends DurableObject {
 	// Which boot phase a pending _storage/_room promise last reached, and when it was entered.
 	// Pending promises are cached, so when a boot wedges every caller awaits the same stuck
 	// await — this names it and its age (see FileEffectStallError and __admin__getDocumentInfo).
-	_bootStage: { stage: string; startedAt: number } | null = null
+	_bootStage: { stage: BootStage; startedAt: number } | null = null
 
-	private setBootStage(stage: string | null) {
+	private setBootStage(stage: BootStage | null) {
 		this._bootStage = stage === null ? null : { stage, startedAt: Date.now() }
 	}
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2743,10 +2743,15 @@ export class TLFileDurableObject extends DurableObject {
 
 	// Report-only watchdog for outbox effect RPCs: fires just under the drain's 30s effect
 	// timeout so Sentry gets the boot stage before the drain bumps the row as a bare timeout.
-	// The outbox owns retry semantics — this never rejects or cancels the work.
+	// The outbox owns retry semantics — this never rejects or cancels the work. A null stage
+	// means the boot already settled and the stall is in work after it (e.g. the per-session
+	// permission refresh in updateRoomForFileRecord) — report that as 'post-boot', not a boot
+	// failure.
 	private async reportIfBootStalls<T>(work: Promise<T>, file: TlaFile): Promise<T> {
 		const timer = setTimeout(() => {
-			this.reportError(new BootStallError(file.id, this._bootStage, BOOT_STALL_REPORT_MS))
+			this.reportError(
+				new BootStallError(file.id, this._bootStage ?? 'post-boot', BOOT_STALL_REPORT_MS)
+			)
 		}, BOOT_STALL_REPORT_MS)
 		try {
 			return await work

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
@@ -1,6 +1,6 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
-import { describe, expect, it } from 'vitest'
-import { RoomNotFoundError, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomNotFoundError, settleWithin, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
 
 function file(partial: Partial<TlaFile>): TlaFile {
 	return {
@@ -40,5 +40,43 @@ describe('shouldSkipMissingRoomEffect', () => {
 
 	it('does not skip a different error for a deleted file', () => {
 		expect(shouldSkipMissingRoomEffect(new Error('boom'), file({ isDeleted: true }))).toBe(false)
+	})
+})
+
+describe('settleWithin', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('resolves settled when the promise resolves in time', async () => {
+		const result = settleWithin(Promise.resolve('done'), 1000)
+		await expect(result).resolves.toBe('settled')
+	})
+
+	it('resolves settled when the promise rejects in time', async () => {
+		const result = settleWithin(Promise.reject(new Error('boom')), 1000)
+		await expect(result).resolves.toBe('settled')
+	})
+
+	it('resolves timeout when the promise is still pending', async () => {
+		const result = settleWithin(new Promise(() => {}), 1000)
+		vi.advanceTimersByTime(1000)
+		await expect(result).resolves.toBe('timeout')
+	})
+
+	it('swallows a rejection that lands after the timeout', async () => {
+		let reject!: (e: Error) => void
+		const pending = new Promise((_, r) => {
+			reject = r
+		})
+		const result = settleWithin(pending, 1000)
+		vi.advanceTimersByTime(1000)
+		await expect(result).resolves.toBe('timeout')
+		reject(new Error('late'))
+		// A late rejection must not become an unhandled rejection.
+		await vi.runAllTimersAsync()
 	})
 })

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -22,11 +22,18 @@ export function shouldSkipMissingRoomEffect(error: unknown, file: TlaFile): bool
 // that the effect stalled; a boot stage, when present, says where the room boot is stuck —
 // a null stage means the boot settled and the stall is in post-boot work (e.g. the
 // per-session permission refresh).
+export type BootStage =
+	| 'storage-load'
+	| 'source-await-persist'
+	| 'source-r2-fetch'
+	| 'source-r2-put'
+	| 'room-create'
+
 export class FileEffectStallError extends Error {
 	constructor(
 		slug: string,
 		command: 'insert' | 'update',
-		stage: string | null,
+		stage: BootStage | null,
 		stageAgeMs: number | null,
 		ms: number
 	) {

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -15,3 +15,49 @@ export class RoomNotFoundError extends Error {
 export function shouldSkipMissingRoomEffect(error: unknown, file: TlaFile): boolean {
 	return error instanceof RoomNotFoundError && file.isDeleted
 }
+
+// Reported (not thrown) when a room boot is still pending just under the outbox drain's 30s
+// effect timeout, so Sentry names the stage the boot is stuck at before the drain bumps the
+// row. Without it a wedged boot parks a row as a bare EffectTimeoutError with no cause (#10541).
+export class BootStallError extends Error {
+	constructor(slug: string, stage: string | null, ms: number) {
+		super(`room boot for ${slug} still pending after ${ms}ms at stage: ${stage ?? 'unknown'}`)
+		this.name = 'BootStallError'
+	}
+}
+
+// Reported when a duplicate-from-source boot gives up waiting for the source room's persist
+// and proceeds with its last persisted snapshot.
+export class SourcePersistTimeoutError extends Error {
+	constructor(sourceSlug: string, ms: number) {
+		super(
+			`awaitPersist on source ${sourceSlug} did not settle within ${ms}ms; copying its last persisted snapshot`
+		)
+		this.name = 'SourcePersistTimeoutError'
+	}
+}
+
+/**
+ * Await `promise` for at most `ms`; 'timeout' means it was still pending. The promise's
+ * eventual settlement (including rejection) is swallowed — callers use this for best-effort
+ * work they are prepared to proceed without.
+ */
+export async function settleWithin(
+	promise: Promise<unknown>,
+	ms: number
+): Promise<'settled' | 'timeout'> {
+	let timer: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			promise.then(
+				() => 'settled' as const,
+				() => 'settled' as const
+			),
+			new Promise<'timeout'>((resolve) => {
+				timer = setTimeout(() => resolve('timeout'), ms)
+			}),
+		])
+	} finally {
+		clearTimeout(timer)
+	}
+}

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -16,13 +16,27 @@ export function shouldSkipMissingRoomEffect(error: unknown, file: TlaFile): bool
 	return error instanceof RoomNotFoundError && file.isDeleted
 }
 
-// Reported (not thrown) when a room boot is still pending just under the outbox drain's 30s
-// effect timeout, so Sentry names the stage the boot is stuck at before the drain bumps the
-// row. Without it a wedged boot parks a row as a bare EffectTimeoutError with no cause (#10541).
-export class BootStallError extends Error {
-	constructor(slug: string, stage: string | null, ms: number) {
-		super(`room boot for ${slug} still pending after ${ms}ms at stage: ${stage ?? 'unknown'}`)
-		this.name = 'BootStallError'
+// Reported (not thrown) when an outbox file effect is still pending just under the drain's
+// 30s effect timeout, so Sentry names the cause before the drain bumps the row. Without it a
+// wedged effect parks a row as a bare EffectTimeoutError (#10541). The guaranteed fact is
+// that the effect stalled; a boot stage, when present, says where the room boot is stuck —
+// a null stage means the boot settled and the stall is in post-boot work (e.g. the
+// per-session permission refresh).
+export class FileEffectStallError extends Error {
+	constructor(
+		slug: string,
+		command: 'insert' | 'update',
+		stage: string | null,
+		stageAgeMs: number | null,
+		ms: number
+	) {
+		super(
+			`file ${command} effect for ${slug} still pending after ${ms}ms` +
+				(stage !== null
+					? ` at boot stage ${stage} (${stageAgeMs}ms in stage)`
+					: ' in post-boot work')
+		)
+		this.name = 'FileEffectStallError'
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug where duplicating a busy, actively-edited shared file parked its outbox `insert` effect: all 10 drain attempts hit the 30s effect timeout, Sentry showed only a bare `EffectTimeoutError`, and the parked row tripped the outbox health check (twice on 2026-08-23). Closes #10541.

### Before

A duplicate-from-source boot awaited `awaitPersist()` on the source room with no bound. On a busy source (2.2MB snapshot persisting every ~7s), that call queues behind the source's serial persist queue with up to ~200s of its own non-throwing retries — far past the drain's 30s effect timeout. The pending `_storage` promise is cached, so every retry awaited the same wedged boot. Nothing threw, so nothing reached Sentry; a timed-out RPC can't be cancelled, so the first attempt eventually completed and wrote the R2 blob, but by then the row was parked.

This stall predates the outbox: the legacy replicator fired these notifications fire-and-forget, so the same wedge was a silently lost effect, healed invisibly on first user open (`createSource` is never cleared, so opening the duplicate reruns the boot-from-source). The outbox made delivery guaranteed and failures loud — this PR makes the cause visible too.

### After

- The duplication persist wait is capped at 10s (`settleWithin`). On timeout it reports `SourcePersistTimeoutError` and proceeds with the source's last persisted snapshot — typically at most one persist throttle (~8s) stale (older only when the source's own persists are failing, which reports separately), and far fresher than the parked-row alternative, where the copy happens whenever someone first opens the file.
- `_bootStage` tracks the phase a pending boot last reached (`storage-load`, `source-await-persist`, `source-r2-fetch`, `source-r2-put`, `room-create`) with its transition time, cleared when it settles, and is exposed with its age via `__admin__getDocumentInfo` so admin resolve-do-id shows where a live DO is stuck.
- The outbox effect RPCs (`appFileRecordCreated`, `appFileRecordDidUpdate`) run under a 25s report-only watchdog that sends `FileEffectStallError` — landing just under the drain's 30s timeout, so parked rows stop being causeless. It names the stalled command (`insert`/`update`) and, when a boot is pending, the current stage and how long it has sat there; a null stage reads as post-boot work (e.g. the per-session permission refresh), not a boot failure. The watchdog never cancels or retries; the drain keeps owning retry semantics.

### Implementation notes

The stall bound lives on the caller (`settleWithin` racing the RPC), not inside the source DO: a callee-side deadline can't fire when the source DO itself is unresponsive (rebooting, CPU-pinned), which is exactly the wedge being defended against. A callee-side `awaitPersist` deadline with a precise persisted/timed-out/failed verdict was considered and deferred until telemetry shows enough timeouts to justify the extra protocol.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — new coverage for `settleWithin` (settles in time, rejection counts as settled, timeout while pending, late rejection swallowed); the helper is new, so there is no failing-on-main repro
- After deploy: Sentry should show `SourcePersistTimeoutError` / `FileEffectStallError` with a stage instead of bare `EffectTimeoutError` if an effect wedges again

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| tldraw.com | +135 / -4  |
| Tests      | +40 / -2   |


