### PR TITLE
test(editor): add unit tests for the geometry primitives

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
@@ -1,5 +1,228 @@
-describe('Arc2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { Arc2d } from './Arc2d'
+
+// A quarter circle of radius 10 centred at the origin, from (10, 0) clockwise (in screen
+// space, i.e. with increasing angle) to (0, 10).
+const quarter = () =>
+	new Arc2d({
+		center: new Vec(0, 0),
+		start: new Vec(10, 0),
+		end: new Vec(0, 10),
+		sweepFlag: 1,
+		largeArcFlag: 0,
+	})
+
+// The complementary three-quarter arc between the same points, going the other way round.
+const threeQuarter = () =>
+	new Arc2d({
+		center: new Vec(0, 0),
+		start: new Vec(10, 0),
+		end: new Vec(0, 10),
+		sweepFlag: 0,
+		largeArcFlag: 1,
+	})
+
+function expectVec(actual: Vec, expected: { x: number; y: number }) {
+	expect(actual.x).toBeCloseTo(expected.x)
+	expect(actual.y).toBeCloseTo(expected.y)
+}
+
+describe('Arc2d construction', () => {
+	it('is never closed or filled', () => {
+		expect(quarter()).toMatchObject({ isClosed: false, isFilled: false })
+	})
+
+	it('throws when start and end are the same point', () => {
+		expect(
+			() =>
+				new Arc2d({
+					center: new Vec(0, 0),
+					start: new Vec(10, 0),
+					end: new Vec(10, 0),
+					sweepFlag: 1,
+					largeArcFlag: 0,
+				})
+		).toThrow('Arc must have different start and end points.')
+	})
+})
+
+describe('Arc2d.getLength', () => {
+	it('is the arc measure times the radius', () => {
+		expect(quarter().length).toBeCloseTo((Math.PI / 2) * 10)
+		expect(threeQuarter().length).toBeCloseTo(((3 * Math.PI) / 2) * 10)
+	})
+
+	it('is half a circumference for a semicircle in either direction', () => {
+		const semi = new Arc2d({
+			center: new Vec(25, 25),
+			start: new Vec(25, 50),
+			end: new Vec(25, 0),
+			sweepFlag: 1,
+			largeArcFlag: 1,
+		})
+		expect(semi.length).toBeCloseTo(Math.PI * 25)
+	})
+})
+
+describe('Arc2d.getVertices', () => {
+	it('samples at least eight segments from start to end', () => {
+		const { vertices } = quarter()
+		expect(vertices.length).toBe(9)
+		expectVec(vertices[0], { x: 10, y: 0 })
+		expectVec(vertices[4], { x: 10 / Math.SQRT2, y: 10 / Math.SQRT2 })
+		expectVec(vertices[8], { x: 0, y: 10 })
+	})
+
+	it('keeps every vertex on the circle', () => {
+		for (const v of quarter().vertices) {
+			expect(Vec.Dist(v, new Vec(0, 0))).toBeCloseTo(10)
+		}
+	})
+
+	it('walks the long way round for a large arc', () => {
+		const { vertices } = threeQuarter()
+		expect(vertices.length).toBe(9)
+		expectVec(vertices[0], { x: 10, y: 0 })
+		// the midpoint of the long arc is opposite the midpoint of the short arc
+		expectVec(vertices[4], { x: -10 / Math.SQRT2, y: -10 / Math.SQRT2 })
+		expectVec(vertices[8], { x: 0, y: 10 })
+	})
+
+	it('samples more vertices for longer arcs', () => {
+		const big = new Arc2d({
+			center: new Vec(0, 0),
+			start: new Vec(100, 0),
+			end: new Vec(0, 100),
+			sweepFlag: 1,
+			largeArcFlag: 0,
+		})
+		// length is 50π ≈ 157, one vertex per 20 units -> 8 segments
+		expect(big.vertices.length).toBe(9)
+		const bigger = new Arc2d({
+			center: new Vec(0, 0),
+			start: new Vec(200, 0),
+			end: new Vec(0, 200),
+			sweepFlag: 1,
+			largeArcFlag: 0,
+		})
+		// length is 100π ≈ 314 -> 16 segments
+		expect(bigger.vertices.length).toBe(17)
+	})
+})
+
+describe('Arc2d.bounds', () => {
+	it('is the box around the sampled vertices', () => {
+		const { bounds } = quarter()
+		expect(bounds.x).toBeCloseTo(0)
+		expect(bounds.y).toBeCloseTo(0)
+		expect(bounds.w).toBeCloseTo(10)
+		expect(bounds.h).toBeCloseTo(10)
+	})
+})
+
+describe('Arc2d.nearestPoint', () => {
+	it('projects radially onto the arc when the angle is within the sweep', () => {
+		expectVec(quarter().nearestPoint(new Vec(5, 5)), { x: 10 / Math.SQRT2, y: 10 / Math.SQRT2 })
+		expectVec(quarter().nearestPoint(new Vec(20, 20)), {
+			x: 10 / Math.SQRT2,
+			y: 10 / Math.SQRT2,
+		})
+	})
+
+	it('returns the start point for angles before the arc', () => {
+		expect(quarter().nearestPoint(new Vec(20, -5))).toMatchObject({ x: 10, y: 0 })
+		expect(quarter().nearestPoint(new Vec(20, 0))).toMatchObject({ x: 10, y: 0 })
+	})
+
+	it('returns the end point for angles after the arc', () => {
+		expect(quarter().nearestPoint(new Vec(-5, 20))).toMatchObject({ x: 0, y: 10 })
+		expect(quarter().nearestPoint(new Vec(0, 20))).toMatchObject({ x: 0, y: 10 })
+	})
+
+	it('returns the start point for the centre itself', () => {
+		expect(quarter().nearestPoint(new Vec(0, 0))).toMatchObject({ x: 10, y: 0 })
+	})
+
+	it('projects onto the long arc', () => {
+		expectVec(threeQuarter().nearestPoint(new Vec(-20, 0)), { x: -10, y: 0 })
+		expectVec(threeQuarter().nearestPoint(new Vec(0, -3)), { x: 0, y: -10 })
+		// a point in the gap of the long arc snaps to the nearer end point
+		expect(threeQuarter().nearestPoint(new Vec(20, 5))).toMatchObject({ x: 10, y: 0 })
+	})
+})
+
+describe('Arc2d.distanceToPoint', () => {
+	it('measures to the arc or its end points', () => {
+		expect(quarter().distanceToPoint(new Vec(20, 20))).toBeCloseTo(Math.hypot(20, 20) - 10)
+		expect(quarter().distanceToPoint(new Vec(20, 0))).toBe(10)
+		expect(quarter().distanceToPoint(new Vec(0, 0))).toBe(10)
+	})
+
+	it('is never negative because an arc has no interior', () => {
+		expect(quarter().distanceToPoint(new Vec(1, 1), true)).toBeGreaterThan(0)
+	})
+})
+
+describe('Arc2d.hitTestPoint', () => {
+	it('hits points on the arc within the margin', () => {
+		expect(quarter().hitTestPoint(new Vec(10 / Math.SQRT2, 10 / Math.SQRT2), 0.001)).toBe(true)
+		expect(quarter().hitTestPoint(new Vec(10, 0))).toBe(true)
+		expect(quarter().hitTestPoint(new Vec(5, 5), 3)).toBe(true)
+		expect(quarter().hitTestPoint(new Vec(5, 5), 2)).toBe(false)
+	})
+
+	it('does not hit the sector inside the arc even with hitInside', () => {
+		expect(quarter().hitTestPoint(new Vec(5, 5), 0, true)).toBe(false)
+	})
+})
+
+describe('Arc2d.hitTestLineSegment', () => {
+	it('hits a segment crossing the arc', () => {
+		expect(quarter().hitTestLineSegment(new Vec(5, 0), new Vec(5, 20))).toBe(true)
+	})
+
+	it('misses a segment crossing the circle outside the arc', () => {
+		// crosses the circle at (-5, 8.66), which is at 120° and not on the quarter arc
+		expect(quarter().hitTestLineSegment(new Vec(-5, 0), new Vec(-5, 20))).toBe(false)
+		// but it is on the complementary arc
+		expect(threeQuarter().hitTestLineSegment(new Vec(-5, 0), new Vec(-5, 20))).toBe(true)
+	})
+
+	it('misses a segment that does not reach the circle', () => {
+		expect(quarter().hitTestLineSegment(new Vec(20, 20), new Vec(30, 30))).toBe(false)
+		expect(quarter().hitTestLineSegment(new Vec(1, 1), new Vec(2, 2))).toBe(false)
+	})
+
+	// Locks in current behaviour, see #10555.
+	it('hits crossings just beyond the end points (known quirk)', () => {
+		// (5, -8.66) is at -60°, off the quarter arc, but getPointInArcT clamps it to the start
+		expect(quarter().hitTestLineSegment(new Vec(5, -20), new Vec(5, 0))).toBe(true)
+	})
+
+	it('checks both directions of the long arc', () => {
+		expect(threeQuarter().hitTestLineSegment(new Vec(5, -20), new Vec(5, 0))).toBe(true)
+		expect(threeQuarter().hitTestLineSegment(new Vec(5, 0), new Vec(5, 20))).toBe(false)
+	})
+})
+
+describe('Arc2d.getSvgPathData', () => {
+	it('emits a move and an arc command with the flags', () => {
+		expect(quarter().getSvgPathData()).toBe('M10, 0 A10 10 0 0 1 0, 10')
+		expect(threeQuarter().getSvgPathData()).toBe('M10, 0 A10 10 0 1 0 0, 10')
+	})
+
+	it('omits the move command when not first', () => {
+		expect(quarter().getSvgPathData(false)).toBe(' A10 10 0 0 1 0, 10')
+	})
+
+	it('rounds coordinates to two decimals', () => {
+		const arc = new Arc2d({
+			center: new Vec(0, 0),
+			start: new Vec(10, 0),
+			end: new Vec(10 / Math.SQRT2, 10 / Math.SQRT2),
+			sweepFlag: 1,
+			largeArcFlag: 0,
+		})
+		expect(arc.getSvgPathData()).toBe('M10, 0 A10 10 0 0 1 7.07, 7.07')
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/CubicBezier2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicBezier2d.test.ts
@@ -1,5 +1,175 @@
-describe('CubicBezier2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { CubicBezier2d } from './CubicBezier2d'
+import { Polyline2d } from './Polyline2d'
+
+// A symmetric arch from (0, 0) to (100, 0) whose control points pull it up to y = 75 at t = 0.5
+const arch = (resolution?: number) =>
+	new CubicBezier2d({
+		start: new Vec(0, 0),
+		cp1: new Vec(0, 100),
+		cp2: new Vec(100, 100),
+		end: new Vec(100, 0),
+		resolution,
+	})
+
+// Control points on the line y = x, so the curve is the straight segment (0,0) -> (30,30)
+const straight = () =>
+	new CubicBezier2d({
+		start: new Vec(0, 0),
+		cp1: new Vec(10, 10),
+		cp2: new Vec(20, 20),
+		end: new Vec(30, 30),
+	})
+
+describe('CubicBezier2d construction', () => {
+	it('is an open, unfilled polyline', () => {
+		const b = arch()
+		expect(b).toBeInstanceOf(Polyline2d)
+		expect(b).toMatchObject({ isClosed: false, isFilled: false })
+	})
+})
+
+describe('CubicBezier2d.GetAtT', () => {
+	it('returns the end points at t = 0 and t = 1', () => {
+		expect(CubicBezier2d.GetAtT(arch(), 0)).toMatchObject({ x: 0, y: 0 })
+		expect(CubicBezier2d.GetAtT(arch(), 1)).toMatchObject({ x: 100, y: 0 })
+	})
+
+	it('returns the weighted control point average in between', () => {
+		// 0.125 a + 0.375 b + 0.375 c + 0.125 d
+		expect(CubicBezier2d.GetAtT(arch(), 0.5)).toMatchObject({ x: 50, y: 75 })
+		const p = CubicBezier2d.GetAtT(arch(), 0.4)
+		expect(p.x).toBeCloseTo(35.2)
+		expect(p.y).toBeCloseTo(72)
+	})
+})
+
+describe('CubicBezier2d.getVertices', () => {
+	it('samples resolution + 1 points along the curve', () => {
+		const { vertices } = arch()
+		expect(vertices.length).toBe(11)
+		expect(vertices[0]).toMatchObject({ x: 0, y: 0 })
+		expect(vertices[5]).toMatchObject({ x: 50, y: 75 })
+		expect(vertices[10]).toMatchObject({ x: 100, y: 0 })
+	})
+
+	it('honours a custom resolution', () => {
+		const { vertices } = arch(4)
+		expect(vertices.length).toBe(5)
+		expect(vertices[2]).toMatchObject({ x: 50, y: 75 })
+	})
+
+	it('is symmetric for symmetric control points', () => {
+		const { vertices } = arch()
+		for (let i = 0; i < 5; i++) {
+			expect(vertices[i].x).toBeCloseTo(100 - vertices[10 - i].x)
+			expect(vertices[i].y).toBeCloseTo(vertices[10 - i].y)
+		}
+	})
+})
+
+describe('CubicBezier2d.bounds', () => {
+	it('spans the sampled vertices', () => {
+		expect(arch().bounds).toMatchObject({ x: 0, y: 0, w: 100, h: 75 })
+		expect(arch().center).toMatchObject({ x: 50, y: 37.5 })
+	})
+})
+
+describe('CubicBezier2d.getLength', () => {
+	it('equals the chord for a straight curve', () => {
+		expect(straight().length).toBeCloseTo(Math.hypot(30, 30))
+	})
+
+	it('sums sampled chords at the given precision', () => {
+		const b = arch()
+		expect(b.getLength(undefined, 1)).toBe(100)
+		expect(b.getLength(undefined, 2)).toBeCloseTo(2 * Math.hypot(50, 75))
+	})
+
+	it('gets longer with finer sampling of a curved path', () => {
+		const b = arch()
+		expect(b.getLength(undefined, 2)).toBeLessThan(b.getLength(undefined, 32))
+		expect(b.length).toBe(b.getLength(undefined, 32))
+	})
+})
+
+describe('CubicBezier2d.nearestPoint', () => {
+	it('returns the peak vertex for a point above the arch', () => {
+		expect(arch().nearestPoint(new Vec(50, 100))).toMatchObject({ x: 50, y: 75 })
+	})
+
+	it('clamps to the end points', () => {
+		expect(arch().nearestPoint(new Vec(-10, 0))).toMatchObject({ x: 0, y: 0 })
+		expect(arch().nearestPoint(new Vec(110, 0))).toMatchObject({ x: 100, y: 0 })
+	})
+
+	it('projects onto the straight curve', () => {
+		const p = straight().nearestPoint(new Vec(20, 10))
+		expect(p.x).toBeCloseTo(15)
+		expect(p.y).toBeCloseTo(15)
+	})
+})
+
+describe('CubicBezier2d.distanceToPoint', () => {
+	it('measures to the sampled polyline', () => {
+		expect(arch().distanceToPoint(new Vec(50, 100))).toBe(25)
+		expect(arch().distanceToPoint(new Vec(-10, 0))).toBe(10)
+		expect(straight().distanceToPoint(new Vec(20, 10))).toBeCloseTo(Math.hypot(5, 5))
+	})
+
+	it('is always positive, even under the arch with hitInside', () => {
+		expect(arch().distanceToPoint(new Vec(50, 30), true)).toBeGreaterThan(0)
+	})
+})
+
+describe('CubicBezier2d.hitTestPoint', () => {
+	it('hits points on the curve', () => {
+		expect(arch().hitTestPoint(new Vec(50, 75))).toBe(true)
+		expect(arch().hitTestPoint(new Vec(0, 0))).toBe(true)
+	})
+
+	it('respects the margin', () => {
+		expect(arch().hitTestPoint(new Vec(50, 80), 5)).toBe(true)
+		expect(arch().hitTestPoint(new Vec(50, 80), 4)).toBe(false)
+	})
+
+	it('does not hit the area under the arch', () => {
+		expect(arch().hitTestPoint(new Vec(50, 30))).toBe(false)
+		expect(arch().hitTestPoint(new Vec(50, 30), 0, true)).toBe(false)
+	})
+})
+
+describe('CubicBezier2d.hitTestLineSegment', () => {
+	it('hits a segment crossing the curve', () => {
+		expect(arch().hitTestLineSegment(new Vec(50, 0), new Vec(50, 100))).toBe(true)
+	})
+
+	it('misses a segment away from the curve', () => {
+		expect(arch().hitTestLineSegment(new Vec(200, 0), new Vec(200, 100))).toBe(false)
+	})
+
+	it('respects the distance', () => {
+		expect(arch().hitTestLineSegment(new Vec(0, 80), new Vec(100, 80), 5)).toBe(true)
+		expect(arch().hitTestLineSegment(new Vec(0, 80), new Vec(100, 80), 4)).toBe(false)
+	})
+})
+
+describe('CubicBezier2d.getSvgPathData', () => {
+	it('emits a move and a cubic command', () => {
+		expect(arch().getSvgPathData()).toBe('M 0, 0  C0, 100 100, 100 100, 0')
+	})
+
+	it('omits the move command when not first', () => {
+		expect(arch().getSvgPathData(false)).toBe(' C0, 100 100, 100 100, 0')
+	})
+
+	it('rounds coordinates to two decimals', () => {
+		const b = new CubicBezier2d({
+			start: new Vec(0.123, 0),
+			cp1: new Vec(1.006, 2),
+			cp2: new Vec(3, 4.999),
+			end: new Vec(10, 10),
+		})
+		expect(b.getSvgPathData()).toBe('M 0.12, 0  C1.01, 2 3, 5 10, 10')
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/CubicSpline2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicSpline2d.test.ts
@@ -1,5 +1,162 @@
-describe('CubicSpline2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { CubicBezier2d } from './CubicBezier2d'
+import { CubicSpline2d } from './CubicSpline2d'
+
+// Three collinear points: the spline is the straight line from (0, 0) to (200, 0)
+const line = () => new CubicSpline2d({ points: [new Vec(0, 0), new Vec(100, 0), new Vec(200, 0)] })
+
+// A symmetric peak: (0, 0) up to (100, 100) and back down to (200, 0)
+const peak = () =>
+	new CubicSpline2d({ points: [new Vec(0, 0), new Vec(100, 100), new Vec(200, 0)] })
+
+function expectVec(actual: Vec, expected: { x: number; y: number }) {
+	expect(actual.x).toBeCloseTo(expected.x)
+	expect(actual.y).toBeCloseTo(expected.y)
+}
+
+describe('CubicSpline2d construction', () => {
+	it('is never closed or filled', () => {
+		expect(line()).toMatchObject({ isClosed: false, isFilled: false })
+	})
+})
+
+describe('CubicSpline2d.segments', () => {
+	it('creates one bezier per pair of consecutive points', () => {
+		const { segments } = line()
+		expect(segments.length).toBe(2)
+		expect(segments[0]).toBeInstanceOf(CubicBezier2d)
+		expect(segments[0].vertices[0]).toMatchObject({ x: 0, y: 0 })
+		expect(segments[0].vertices[10]).toMatchObject({ x: 100, y: 0 })
+		expect(segments[1].vertices[0]).toMatchObject({ x: 100, y: 0 })
+		expect(segments[1].vertices[10]).toMatchObject({ x: 200, y: 0 })
+	})
+
+	it('uses the end points as control points at the ends and Catmull-Rom style tangents between', () => {
+		const { segments } = peak()
+		// cp1 of the first segment is the first point; cp2 is pulled back from the second point
+		// along the chord (p3 - p1) / 6 * 1.25
+		expect(segments[0].getSvgPathData()).toBe('M 0, 0  C0, 0 58.33, 100 100, 100')
+		expect(segments[1].getSvgPathData()).toBe('M 100, 100  C141.67, 100 200, 0 200, 0')
+	})
+
+	it('caches the segments', () => {
+		const s = line()
+		expect(s.segments).toBe(s.segments)
+	})
+
+	it('creates a single straight segment for two points', () => {
+		const s = new CubicSpline2d({ points: [new Vec(0, 0), new Vec(100, 0)] })
+		expect(s.segments.length).toBe(1)
+		expect(s.segments[0].getSvgPathData()).toBe('M 0, 0  C0, 0 100, 0 100, 0')
+		expect(s.length).toBeCloseTo(100)
+	})
+
+	it('has no segments for a single point', () => {
+		const s = new CubicSpline2d({ points: [new Vec(5, 5)] })
+		expect(s.segments).toEqual([])
+		expect(s.vertices).toEqual([new Vec(5, 5)])
+		expect(s.length).toBe(0)
+		expect(() => s.nearestPoint(new Vec(0, 0))).toThrow('nearest point not found')
+	})
+})
+
+describe('CubicSpline2d.getVertices', () => {
+	it('concatenates the segment vertices and appends the final point', () => {
+		const { vertices } = line()
+		expect(vertices.length).toBe(11 + 11 + 1)
+		expect(vertices[0]).toMatchObject({ x: 0, y: 0 })
+		expect(vertices[10]).toMatchObject({ x: 100, y: 0 })
+		expect(vertices[11]).toMatchObject({ x: 100, y: 0 })
+		expect(vertices[22]).toMatchObject({ x: 200, y: 0 })
+		for (const v of vertices) expect(v.y).toBe(0)
+	})
+
+	it('passes through every control point', () => {
+		const { vertices } = peak()
+		expect(vertices[0]).toMatchObject({ x: 0, y: 0 })
+		expect(vertices[10]).toMatchObject({ x: 100, y: 100 })
+		expect(vertices[22]).toMatchObject({ x: 200, y: 0 })
+	})
+})
+
+describe('CubicSpline2d.bounds', () => {
+	it('spans the vertices', () => {
+		expect(line().bounds).toMatchObject({ x: 0, y: 0, w: 200, h: 0 })
+		expect(peak().bounds).toMatchObject({ x: 0, y: 0, w: 200, h: 100 })
+		expect(peak().center).toMatchObject({ x: 100, y: 50 })
+	})
+})
+
+describe('CubicSpline2d.getLength', () => {
+	it('sums the segment lengths', () => {
+		const s = line()
+		expect(s.length).toBeCloseTo(200)
+		expect(s.length).toBeCloseTo(s.segments[0].length + s.segments[1].length)
+	})
+
+	it('is longer than the chord for a curved spline', () => {
+		expect(peak().length).toBeGreaterThan(2 * Math.hypot(100, 100))
+	})
+})
+
+describe('CubicSpline2d.nearestPoint', () => {
+	it('projects onto the nearest segment', () => {
+		expectVec(line().nearestPoint(new Vec(50, 10)), { x: 50, y: 0 })
+		expectVec(line().nearestPoint(new Vec(150, -10)), { x: 150, y: 0 })
+	})
+
+	it('clamps to the end points', () => {
+		expect(line().nearestPoint(new Vec(-10, 0))).toMatchObject({ x: 0, y: 0 })
+		expect(line().nearestPoint(new Vec(210, 5))).toMatchObject({ x: 200, y: 0 })
+	})
+
+	it('returns the shared point where two segments meet', () => {
+		expect(peak().nearestPoint(new Vec(100, 120))).toMatchObject({ x: 100, y: 100 })
+	})
+})
+
+describe('CubicSpline2d.distanceToPoint', () => {
+	it('is the distance to the nearest segment', () => {
+		expect(line().distanceToPoint(new Vec(50, 10))).toBeCloseTo(10)
+		expect(line().distanceToPoint(new Vec(150, -10))).toBeCloseTo(10)
+		expect(peak().distanceToPoint(new Vec(100, 120))).toBe(20)
+	})
+
+	it('is never negative', () => {
+		expect(peak().distanceToPoint(new Vec(100, 50), true)).toBeGreaterThan(0)
+	})
+})
+
+describe('CubicSpline2d.hitTestPoint', () => {
+	it('hits points on the spline within the margin', () => {
+		expect(line().hitTestPoint(new Vec(50, 0), 0.001)).toBe(true)
+		expect(line().hitTestPoint(new Vec(50, 10), 10)).toBe(true)
+		expect(line().hitTestPoint(new Vec(50, 10), 9)).toBe(false)
+	})
+
+	it('does not hit the area under a peak', () => {
+		expect(peak().hitTestPoint(new Vec(100, 50), 0, true)).toBe(false)
+	})
+})
+
+describe('CubicSpline2d.hitTestLineSegment', () => {
+	it('hits a segment crossing either bezier', () => {
+		expect(line().hitTestLineSegment(new Vec(50, -10), new Vec(50, 10))).toBe(true)
+		expect(line().hitTestLineSegment(new Vec(150, -10), new Vec(150, 10))).toBe(true)
+	})
+
+	it('misses a segment that does not reach the spline', () => {
+		expect(line().hitTestLineSegment(new Vec(150, 5), new Vec(150, 10))).toBe(false)
+		expect(line().hitTestLineSegment(new Vec(250, -10), new Vec(250, 10))).toBe(false)
+	})
+})
+
+describe('CubicSpline2d.getSvgPathData', () => {
+	it('chains the segment paths with a single move command', () => {
+		expect(line().getSvgPathData()).toBe('M 0, 0  C0, 0 58.33, 0 100, 0 C141.67, 0 200, 0 200, 0')
+	})
+
+	it('is empty for a single point', () => {
+		expect(new CubicSpline2d({ points: [new Vec(5, 5)] }).getSvgPathData()).toBe('')
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Ellipse2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Ellipse2d.test.ts
@@ -1,5 +1,245 @@
-describe('Ellipse2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { perimeterOfEllipse } from '../utils'
+import { Vec } from '../Vec'
+import { Edge2d } from './Edge2d'
+import { Ellipse2d } from './Ellipse2d'
+import { getVerticesCountForArcLength } from './geometry-constants'
+
+// A 100x50 ellipse: centre (50, 25), rx = 50, ry = 25
+const ellipse = () => new Ellipse2d({ width: 100, height: 50, isFilled: false })
+const filled = () => new Ellipse2d({ width: 100, height: 50, isFilled: true })
+
+function expectOnEllipse(p: Vec, cx: number, cy: number, rx: number, ry: number) {
+	const dx = (p.x - cx) / rx
+	const dy = (p.y - cy) / ry
+	expect(dx * dx + dy * dy).toBeCloseTo(1, 6)
+}
+
+describe('Ellipse2d construction', () => {
+	it('is always closed and keeps the fill flag from config', () => {
+		expect(ellipse()).toMatchObject({ isClosed: true, isFilled: false })
+		expect(filled()).toMatchObject({ isClosed: true, isFilled: true })
+	})
+
+	it('passes through the other geometry options', () => {
+		const e = new Ellipse2d({
+			width: 10,
+			height: 10,
+			isFilled: true,
+			isLabel: true,
+			isInternal: true,
+			debugColor: 'red',
+			ignore: true,
+			excludeFromShapeBounds: true,
+		})
+		expect(e).toMatchObject({
+			isLabel: true,
+			isInternal: true,
+			debugColor: 'red',
+			ignore: true,
+			excludeFromShapeBounds: true,
+		})
+	})
+})
+
+describe('Ellipse2d.getVertices', () => {
+	it('samples one vertex per 20 units of perimeter, starting at the rightmost point', () => {
+		const e = ellipse()
+		const { vertices } = e
+		expect(vertices.length).toBe(getVerticesCountForArcLength(perimeterOfEllipse(50, 25)))
+		expect(vertices.length).toBe(13)
+		expect(vertices[0]).toMatchObject({ x: 100, y: 25 })
+	})
+
+	it('places every vertex on the ellipse and inside the bounds', () => {
+		const { vertices, bounds } = ellipse()
+		for (const v of vertices) {
+			expectOnEllipse(v, 50, 25, 50, 25)
+			expect(bounds.containsPoint(v)).toBe(true)
+		}
+	})
+
+	it('walks the ellipse in the positive angular direction', () => {
+		const { vertices } = ellipse()
+		// second vertex is one step (2π/13) clockwise in screen space, so below the first
+		expect(vertices[1].x).toBeLessThan(100)
+		expect(vertices[1].y).toBeGreaterThan(25)
+	})
+
+	it('falls back to the minimum vertex count for a tiny ellipse', () => {
+		const { vertices } = new Ellipse2d({ width: 1, height: 1, isFilled: false })
+		expect(vertices.length).toBe(8)
+	})
+
+	it('does not produce NaNs for a zero size ellipse', () => {
+		const e = new Ellipse2d({ width: 0, height: 0, isFilled: false })
+		expect(e.vertices.length).toBe(8)
+		for (const v of e.vertices) {
+			expect(Number.isFinite(v.x)).toBe(true)
+			expect(Number.isFinite(v.y)).toBe(true)
+		}
+		expect(e.bounds).toMatchObject({ x: 0, y: 0, w: 0, h: 0 })
+	})
+
+	it('has a NaN length for a zero size ellipse (known quirk)', () => {
+		// perimeterOfEllipse divides by (rx + ry) ** 2, which is zero here
+		expect(new Ellipse2d({ width: 0, height: 0, isFilled: false }).getLength()).toBeNaN()
+	})
+})
+
+describe('Ellipse2d.edges', () => {
+	it('connects consecutive vertices and closes back to the first', () => {
+		const e = ellipse()
+		const { edges, vertices } = e
+		expect(edges.length).toBe(vertices.length)
+		expect(edges[0]).toBeInstanceOf(Edge2d)
+		expect(edges[0].vertices).toEqual([vertices[0], vertices[1]])
+		expect(edges[edges.length - 1].vertices).toEqual([vertices[vertices.length - 1], vertices[0]])
+	})
+
+	it('caches the edges', () => {
+		const e = ellipse()
+		expect(e.edges).toBe(e.edges)
+	})
+})
+
+describe('Ellipse2d.bounds', () => {
+	it('is the width by height box at the origin', () => {
+		expect(ellipse().bounds).toMatchObject({ x: 0, y: 0, w: 100, h: 50 })
+		expect(ellipse().center).toMatchObject({ x: 50, y: 25 })
+	})
+
+	it('is not affected by the polygon approximation', () => {
+		// the bounds come from the config, not from the sampled vertices
+		const e = new Ellipse2d({ width: 3, height: 7, isFilled: false })
+		expect(e.bounds).toMatchObject({ x: 0, y: 0, w: 3, h: 7 })
+	})
+})
+
+describe('Ellipse2d.getLength', () => {
+	it("uses Ramanujan's perimeter approximation", () => {
+		expect(ellipse().length).toBeCloseTo(242.21, 1)
+		expect(ellipse().length).toBeCloseTo(perimeterOfEllipse(50, 25))
+	})
+
+	it('matches a circle circumference when width equals height', () => {
+		expect(new Ellipse2d({ width: 100, height: 100, isFilled: false }).length).toBeCloseTo(
+			Math.PI * 100
+		)
+	})
+})
+
+describe('Ellipse2d.area', () => {
+	it('is the area of the inscribed polygon', () => {
+		const e = ellipse()
+		const n = e.vertices.length
+		expect(e.area).toBeCloseTo((n / 2) * 50 * 25 * Math.sin((2 * Math.PI) / n), 5)
+		expect(e.area).toBeLessThan(Math.PI * 50 * 25)
+	})
+})
+
+describe('Ellipse2d.nearestPoint', () => {
+	it('returns the vertex when it is the nearest point', () => {
+		expect(ellipse().nearestPoint(new Vec(150, 25))).toMatchObject({ x: 100, y: 25 })
+	})
+
+	it('returns a point on the edge polygon nearest to the point', () => {
+		const e = ellipse()
+		const p = e.nearestPoint(new Vec(50, -10))
+		expect(Vec.Dist(p, new Vec(50, 0))).toBeLessThan(1.5)
+		expect(e.hitTestPoint(p, 0.001)).toBe(true)
+	})
+
+	it('accepts plain objects', () => {
+		expect(ellipse().nearestPoint({ x: 150, y: 25 })).toMatchObject({ x: 100, y: 25 })
+	})
+})
+
+describe('Ellipse2d.distanceToPoint', () => {
+	it('is positive outside', () => {
+		expect(ellipse().distanceToPoint(new Vec(150, 25))).toBe(50)
+		expect(filled().distanceToPoint(new Vec(150, 25))).toBe(50)
+	})
+
+	it('is zero on a vertex', () => {
+		expect(ellipse().distanceToPoint(new Vec(100, 25))).toBe(0)
+	})
+
+	it('is negative inside only when filled or hitInside', () => {
+		const unfilledDist = ellipse().distanceToPoint(new Vec(50, 25))
+		expect(unfilledDist).toBeGreaterThan(0)
+		expect(filled().distanceToPoint(new Vec(50, 25))).toBe(-unfilledDist)
+		expect(ellipse().distanceToPoint(new Vec(50, 25), true)).toBe(-unfilledDist)
+	})
+})
+
+describe('Ellipse2d.hitTestPoint', () => {
+	it('hits the interior only when filled or hitInside', () => {
+		expect(filled().hitTestPoint(new Vec(50, 25))).toBe(true)
+		expect(ellipse().hitTestPoint(new Vec(50, 25))).toBe(false)
+		expect(ellipse().hitTestPoint(new Vec(50, 25), 0, true)).toBe(true)
+	})
+
+	it('misses points outside', () => {
+		expect(filled().hitTestPoint(new Vec(150, 25))).toBe(false)
+		expect(ellipse().hitTestPoint(new Vec(150, 25))).toBe(false)
+	})
+
+	it('misses the bounding box corners, which are outside the ellipse', () => {
+		expect(filled().hitTestPoint(new Vec(1, 1))).toBe(false)
+		expect(filled().hitTestPoint(new Vec(99, 49))).toBe(false)
+	})
+
+	it('hits the edge', () => {
+		expect(ellipse().hitTestPoint(new Vec(100, 25))).toBe(true)
+	})
+
+	it('respects the margin', () => {
+		expect(ellipse().hitTestPoint(new Vec(105, 25), 5)).toBe(true)
+		expect(ellipse().hitTestPoint(new Vec(105, 25), 4)).toBe(false)
+		expect(ellipse().hitTestPoint(new Vec(95, 25), 5)).toBe(true)
+	})
+})
+
+describe('Ellipse2d.hitTestLineSegment', () => {
+	it('hits a segment crossing the edge', () => {
+		expect(ellipse().hitTestLineSegment(new Vec(50, -10), new Vec(50, 60))).toBe(true)
+		expect(ellipse().hitTestLineSegment(new Vec(90, 25), new Vec(110, 25))).toBe(true)
+	})
+
+	it('misses a segment entirely outside', () => {
+		expect(ellipse().hitTestLineSegment(new Vec(150, 0), new Vec(150, 50))).toBe(false)
+	})
+
+	it('misses a segment entirely inside, even when filled', () => {
+		expect(ellipse().hitTestLineSegment(new Vec(40, 25), new Vec(60, 25))).toBe(false)
+		expect(filled().hitTestLineSegment(new Vec(40, 25), new Vec(60, 25))).toBe(false)
+	})
+
+	it('misses a segment that cuts through a bounding box corner only', () => {
+		expect(ellipse().hitTestLineSegment(new Vec(0, 0), new Vec(5, 5))).toBe(false)
+	})
+})
+
+describe('Ellipse2d.intersectLineSegment', () => {
+	it('returns both crossings of a horizontal line through the centre', () => {
+		const hits = ellipse().intersectLineSegment(new Vec(-10, 25), new Vec(110, 25))
+		expect(hits.length).toBe(2)
+		expect(hits.map((h) => h.y)).toEqual([25, 25])
+		const xs = hits.map((h) => h.x).sort((a, b) => a - b)
+		// the leftmost point is not a vertex, so the polygon edge sits slightly inside the ellipse
+		expect(xs[0]).toBeGreaterThanOrEqual(0)
+		expect(xs[0]).toBeLessThan(2)
+		expect(xs[1]).toBe(100)
+	})
+})
+
+describe('Ellipse2d.getSvgPathData', () => {
+	it('draws two arcs starting from the leftmost point', () => {
+		expect(ellipse().getSvgPathData(true)).toBe('M0,25 a50,25,0,1,1,100,0a50,25,0,1,1,-100,0')
+	})
+
+	it('omits the move command when not first', () => {
+		expect(ellipse().getSvgPathData()).toBe(' a50,25,0,1,1,100,0a50,25,0,1,1,-100,0')
+		expect(ellipse().getSvgPathData(false)).toBe(ellipse().getSvgPathData())
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Geometry2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Geometry2d.test.ts
@@ -1,7 +1,12 @@
 import { Mat } from '../Mat'
 import { Vec, VecLike } from '../Vec'
 import { Edge2d } from './Edge2d'
-import { Geometry2dFilters } from './Geometry2d'
+import {
+	Geometry2d,
+	Geometry2dFilters,
+	Geometry2dOptions,
+	TransformedGeometry2d,
+} from './Geometry2d'
 import { Group2d } from './Group2d'
 import { Rectangle2d } from './Rectangle2d'
 
@@ -481,3 +486,550 @@ function expectApproxMatch(a: VecLike, b: VecLike) {
 	expect(a.x).toBeCloseTo(b.x, 0.0001)
 	expect(a.y).toBeCloseTo(b.y, 0.0001)
 }
+
+// A minimal concrete geometry so the base class implementations can be exercised directly,
+// without the overrides that the built-in shapes add.
+class TestPolygon extends Geometry2d {
+	constructor(
+		private points: Vec[],
+		opts: Partial<Geometry2dOptions> = {}
+	) {
+		super({ isFilled: false, isClosed: true, ...opts })
+	}
+
+	getVertices() {
+		return this.points
+	}
+
+	nearestPoint(point: VecLike): Vec {
+		const { points } = this
+		if (points.length === 0) return new Vec(0, 0)
+		let nearest = points[0]
+		let dist = Infinity
+		const limit = this.isClosed ? points.length : points.length - 1
+		for (let i = 0; i < limit; i++) {
+			const p = Vec.NearestPointOnLineSegment(points[i], points[(i + 1) % points.length], point)
+			const d = Vec.Dist2(p, point)
+			if (d < dist) {
+				dist = d
+				nearest = p
+			}
+		}
+		return nearest
+	}
+
+	getSvgPathData() {
+		return ''
+	}
+}
+
+// A 100x100 square at the origin
+const squarePoints = () => [new Vec(0, 0), new Vec(100, 0), new Vec(100, 100), new Vec(0, 100)]
+const square = (opts: Partial<Geometry2dOptions> = {}) => new TestPolygon(squarePoints(), opts)
+const filledSquare = () => square({ isFilled: true })
+// An open L shape: along the top of the square and down its right side
+const openL = (opts: Partial<Geometry2dOptions> = {}) =>
+	new TestPolygon([new Vec(0, 0), new Vec(100, 0), new Vec(100, 100)], { isClosed: false, ...opts })
+
+function sortPoints(points: VecLike[]) {
+	const round = (n: number) => Math.round(n * 1e6) / 1e6
+	return [...points]
+		.map((p) => ({ x: round(p.x), y: round(p.y) }))
+		.sort((a, b) => a.x - b.x || a.y - b.y)
+}
+
+describe('Geometry2d construction', () => {
+	it('defaults the optional flags', () => {
+		expect(square()).toMatchObject({
+			isFilled: false,
+			isClosed: true,
+			isLabel: false,
+			isEmptyLabel: false,
+			isInternal: false,
+			excludeFromShapeBounds: false,
+			debugColor: undefined,
+			ignore: undefined,
+		})
+	})
+
+	it('keeps the provided flags', () => {
+		expect(
+			square({
+				isFilled: true,
+				isLabel: true,
+				isEmptyLabel: true,
+				isInternal: true,
+				excludeFromShapeBounds: true,
+				debugColor: 'red',
+				ignore: true,
+			})
+		).toMatchObject({
+			isFilled: true,
+			isLabel: true,
+			isEmptyLabel: true,
+			isInternal: true,
+			excludeFromShapeBounds: true,
+			debugColor: 'red',
+			ignore: true,
+		})
+	})
+})
+
+describe('Geometry2d.isExcludedByFilter', () => {
+	it('is never excluded without filters', () => {
+		expect(square({ isLabel: true }).isExcludedByFilter()).toBe(false)
+		expect(square({ isInternal: true }).isExcludedByFilter(undefined)).toBe(false)
+	})
+
+	it('excludes labels and internal geometry according to the filter', () => {
+		const plain = square()
+		const label = square({ isLabel: true })
+		const internal = square({ isInternal: true })
+		const both = square({ isLabel: true, isInternal: true })
+		const { INCLUDE_ALL, EXCLUDE_LABELS, EXCLUDE_INTERNAL, EXCLUDE_NON_STANDARD } =
+			Geometry2dFilters
+
+		expect([plain, label, internal, both].map((g) => g.isExcludedByFilter(INCLUDE_ALL))).toEqual([
+			false,
+			false,
+			false,
+			false,
+		])
+		expect([plain, label, internal, both].map((g) => g.isExcludedByFilter(EXCLUDE_LABELS))).toEqual(
+			[false, true, false, true]
+		)
+		expect(
+			[plain, label, internal, both].map((g) => g.isExcludedByFilter(EXCLUDE_INTERNAL))
+		).toEqual([false, false, true, true])
+		expect(
+			[plain, label, internal, both].map((g) => g.isExcludedByFilter(EXCLUDE_NON_STANDARD))
+		).toEqual([false, true, true, true])
+	})
+})
+
+describe('Geometry2d.hitTestPoint', () => {
+	it('hits the interior only when filled or hitInside', () => {
+		expect(filledSquare().hitTestPoint(new Vec(50, 50))).toBe(true)
+		expect(square().hitTestPoint(new Vec(50, 50))).toBe(false)
+		expect(square().hitTestPoint(new Vec(50, 50), 0, true)).toBe(true)
+	})
+
+	it('hits the edge and respects the margin outside', () => {
+		expect(square().hitTestPoint(new Vec(100, 50))).toBe(true)
+		expect(square().hitTestPoint(new Vec(150, 50))).toBe(false)
+		expect(square().hitTestPoint(new Vec(150, 50), 50)).toBe(true)
+		expect(square().hitTestPoint(new Vec(150, 50), 49)).toBe(false)
+	})
+
+	it('respects the margin inside an unfilled shape', () => {
+		expect(square().hitTestPoint(new Vec(90, 50), 10)).toBe(true)
+		expect(square().hitTestPoint(new Vec(90, 50), 9)).toBe(false)
+	})
+
+	it('ignores hitInside for open geometry', () => {
+		expect(openL().hitTestPoint(new Vec(90, 10), 0, true)).toBe(false)
+		expect(openL({ isFilled: true }).hitTestPoint(new Vec(90, 10))).toBe(false)
+	})
+})
+
+describe('Geometry2d.distanceToPoint', () => {
+	it('is negative inside only when filled or hitInside', () => {
+		expect(filledSquare().distanceToPoint(new Vec(50, 50))).toBe(-50)
+		expect(square().distanceToPoint(new Vec(50, 50))).toBe(50)
+		expect(square().distanceToPoint(new Vec(50, 50), true)).toBe(-50)
+	})
+
+	it('is positive outside', () => {
+		expect(filledSquare().distanceToPoint(new Vec(150, 50))).toBe(50)
+		expect(square().distanceToPoint(new Vec(-3, -4))).toBe(5)
+	})
+
+	it('is never negative for open geometry', () => {
+		expect(openL({ isFilled: true }).distanceToPoint(new Vec(90, 10), true)).toBe(10)
+	})
+})
+
+describe('Geometry2d.distanceToLineSegment', () => {
+	it('falls back to distanceToPoint for a degenerate segment', () => {
+		expect(square().distanceToLineSegment(new Vec(150, 50), new Vec(150, 50))).toBe(50)
+		expect(filledSquare().distanceToLineSegment(new Vec(50, 50), new Vec(50, 50))).toBe(-50)
+	})
+
+	it('is zero when the segment crosses an edge', () => {
+		expect(square().distanceToLineSegment(new Vec(50, -10), new Vec(50, 110))).toBe(0)
+		expect(openL().distanceToLineSegment(new Vec(50, -10), new Vec(50, 10))).toBe(0)
+	})
+
+	it('does not count the closing segment of open geometry', () => {
+		// the segment crosses the line from (100, 100) back to (0, 0)
+		const closedL = new TestPolygon([new Vec(0, 0), new Vec(100, 0), new Vec(100, 100)])
+		expect(closedL.distanceToLineSegment(new Vec(20, 30), new Vec(30, 20))).toBe(0)
+		expect(openL().distanceToLineSegment(new Vec(20, 30), new Vec(30, 20))).toBeGreaterThan(0)
+	})
+
+	it('measures from the nearest vertex to the segment', () => {
+		expect(square().distanceToLineSegment(new Vec(150, -50), new Vec(150, 50))).toBe(50)
+	})
+
+	// Locks in current behaviour, see #10556.
+	it('measures from the polygon vertices, not its edges', () => {
+		// the segment is 5 units above the middle of the top edge, but 50.25 from the nearest vertex
+		expect(square().distanceToLineSegment(new Vec(50, -10), new Vec(50, -5))).toBeCloseTo(
+			Math.hypot(50, 5)
+		)
+	})
+
+	it('is negative when the nearest point lies inside a filled shape', () => {
+		const d = square().distanceToLineSegment(new Vec(40, 50), new Vec(60, 50))
+		expect(d).toBeCloseTo(Math.hypot(40, 50))
+		expect(filledSquare().distanceToLineSegment(new Vec(40, 50), new Vec(60, 50))).toBe(-d)
+	})
+
+	it('handles degenerate vertex lists', () => {
+		expect(() => new TestPolygon([]).distanceToLineSegment(new Vec(0, 0), new Vec(10, 0))).toThrow(
+			'nearest point not found'
+		)
+		expect(
+			new TestPolygon([new Vec(3, 4)]).distanceToLineSegment(new Vec(0, 0), new Vec(10, 0))
+		).toBe(5)
+	})
+})
+
+describe('Geometry2d.hitTestLineSegment', () => {
+	it('hits when the segment is within the distance', () => {
+		expect(square().hitTestLineSegment(new Vec(50, -10), new Vec(50, 110))).toBe(true)
+		expect(square().hitTestLineSegment(new Vec(150, -50), new Vec(150, 50))).toBe(false)
+		expect(square().hitTestLineSegment(new Vec(150, -50), new Vec(150, 50), 50)).toBe(true)
+		expect(square().hitTestLineSegment(new Vec(150, -50), new Vec(150, 50), 49)).toBe(false)
+	})
+})
+
+describe('Geometry2d.intersectLineSegment', () => {
+	it('intersects closed geometry as a polygon', () => {
+		expect(sortPoints(square().intersectLineSegment(new Vec(-10, 50), new Vec(110, 50)))).toEqual([
+			{ x: 0, y: 50 },
+			{ x: 100, y: 50 },
+		])
+	})
+
+	it('intersects open geometry as a polyline', () => {
+		expect(sortPoints(openL().intersectLineSegment(new Vec(-10, 50), new Vec(110, 50)))).toEqual([
+			{ x: 100, y: 50 },
+		])
+	})
+
+	it('returns an empty array when there is no intersection', () => {
+		expect(square().intersectLineSegment(new Vec(150, 0), new Vec(150, 100))).toEqual([])
+	})
+})
+
+describe('Geometry2d.intersectCircle', () => {
+	it('intersects closed geometry as a polygon', () => {
+		expect(sortPoints(square().intersectCircle(new Vec(0, 50), 10))).toEqual([
+			{ x: 0, y: 40 },
+			{ x: 0, y: 60 },
+		])
+	})
+
+	it('intersects open geometry as a polyline', () => {
+		expect(openL().intersectCircle(new Vec(0, 50), 10)).toEqual([])
+		expect(sortPoints(openL().intersectCircle(new Vec(100, 50), 10))).toEqual([
+			{ x: 100, y: 40 },
+			{ x: 100, y: 60 },
+		])
+	})
+
+	it('returns an empty array when there is no intersection', () => {
+		expect(square().intersectCircle(new Vec(50, 50), 10)).toEqual([])
+	})
+})
+
+describe('Geometry2d.intersectPolygon and intersectPolyline', () => {
+	const strip = [new Vec(40, -10), new Vec(60, -10), new Vec(60, 110), new Vec(40, 110)]
+
+	it('finds where a polygon crosses the edges', () => {
+		expect(sortPoints(square().intersectPolygon(strip))).toEqual([
+			{ x: 40, y: 0 },
+			{ x: 40, y: 100 },
+			{ x: 60, y: 0 },
+			{ x: 60, y: 100 },
+		])
+		expect(sortPoints(openL().intersectPolygon(strip))).toEqual([
+			{ x: 40, y: 0 },
+			{ x: 60, y: 0 },
+		])
+	})
+
+	it('finds where a polyline crosses the edges, without closing it', () => {
+		// only the x = 60 side of the strip is a polyline segment; x = 40 would be the closing side
+		expect(sortPoints(square().intersectPolyline(strip))).toEqual([
+			{ x: 60, y: 0 },
+			{ x: 60, y: 100 },
+		])
+		expect(sortPoints(square().intersectPolyline([new Vec(40, -10), new Vec(40, 110)]))).toEqual([
+			{ x: 40, y: 0 },
+			{ x: 40, y: 100 },
+		])
+	})
+
+	it('returns an empty array when there is no intersection', () => {
+		const far = [new Vec(200, 0), new Vec(300, 0), new Vec(300, 100)]
+		expect(square().intersectPolygon(far)).toEqual([])
+		expect(square().intersectPolyline(far)).toEqual([])
+	})
+})
+
+describe('Geometry2d.interpolateAlongEdge', () => {
+	it('walks around closed geometry and back to the start', () => {
+		const s = square()
+		expect(s.interpolateAlongEdge(0)).toMatchObject({ x: 0, y: 0 })
+		expect(s.interpolateAlongEdge(0.125)).toMatchObject({ x: 50, y: 0 })
+		expect(s.interpolateAlongEdge(0.5)).toMatchObject({ x: 100, y: 100 })
+		expect(s.interpolateAlongEdge(0.875)).toMatchObject({ x: 0, y: 50 })
+		expect(s.interpolateAlongEdge(1)).toMatchObject({ x: 0, y: 0 })
+	})
+
+	it('stops at the last vertex of open geometry', () => {
+		const l = openL()
+		expect(l.interpolateAlongEdge(0.25)).toMatchObject({ x: 50, y: 0 })
+		expect(l.interpolateAlongEdge(1)).toMatchObject({ x: 100, y: 100 })
+		expect(l.interpolateAlongEdge(2)).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('clamps negative values to the first vertex', () => {
+		expect(square().interpolateAlongEdge(-1)).toMatchObject({ x: 0, y: 0 })
+	})
+
+	it('handles degenerate vertex lists', () => {
+		expect(new TestPolygon([]).interpolateAlongEdge(0.5)).toMatchObject({ x: 0, y: 0 })
+		expect(new TestPolygon([new Vec(3, 4)]).interpolateAlongEdge(0.5)).toMatchObject({ x: 3, y: 4 })
+	})
+})
+
+describe('Geometry2d.uninterpolateAlongEdge', () => {
+	it('is the inverse of interpolateAlongEdge', () => {
+		const s = square()
+		expect(s.uninterpolateAlongEdge(new Vec(0, 0))).toBe(0)
+		expect(s.uninterpolateAlongEdge(new Vec(50, 0))).toBe(0.125)
+		expect(s.uninterpolateAlongEdge(new Vec(100, 50))).toBe(0.375)
+		expect(s.uninterpolateAlongEdge(new Vec(50, 100))).toBe(0.625)
+		expect(s.uninterpolateAlongEdge(new Vec(0, 50))).toBe(0.875)
+	})
+
+	it('snaps points off the edge to the nearest segment', () => {
+		expect(square().uninterpolateAlongEdge(new Vec(50, -20))).toBe(0.125)
+		expect(openL().uninterpolateAlongEdge(new Vec(120, 50))).toBe(0.75)
+	})
+
+	it('handles degenerate vertex lists', () => {
+		expect(new TestPolygon([]).uninterpolateAlongEdge(new Vec(1, 1))).toBe(0)
+		expect(new TestPolygon([new Vec(3, 4)]).uninterpolateAlongEdge(new Vec(1, 1))).toBe(0)
+	})
+})
+
+describe('Geometry2d.overlapsPolygon', () => {
+	const inside = [new Vec(40, 40), new Vec(60, 40), new Vec(60, 60), new Vec(40, 60)]
+	const corner = [new Vec(10, 10), new Vec(20, 10), new Vec(20, 20), new Vec(10, 20)]
+	const strip = [new Vec(40, -10), new Vec(60, -10), new Vec(60, 110), new Vec(40, 110)]
+	const around = [new Vec(-10, -10), new Vec(110, -10), new Vec(110, 110), new Vec(-10, 110)]
+	const far = [new Vec(200, 0), new Vec(300, 0), new Vec(300, 100), new Vec(200, 100)]
+
+	it('overlaps when a vertex is inside the polygon', () => {
+		expect(square().overlapsPolygon(around)).toBe(true)
+		expect(openL().overlapsPolygon(around)).toBe(true)
+	})
+
+	it('overlaps a polygon inside a filled shape, but not inside a hollow one', () => {
+		expect(filledSquare().overlapsPolygon(inside)).toBe(true)
+		expect(filledSquare().overlapsPolygon(corner)).toBe(true)
+		expect(square().overlapsPolygon(inside)).toBe(false)
+		expect(square().overlapsPolygon(corner)).toBe(false)
+	})
+
+	it('overlaps when the edges cross', () => {
+		expect(square().overlapsPolygon(strip)).toBe(true)
+		expect(openL().overlapsPolygon(strip)).toBe(true)
+	})
+
+	it('does not overlap a polygon that is far away', () => {
+		expect(filledSquare().overlapsPolygon(far)).toBe(false)
+		expect(openL().overlapsPolygon(far)).toBe(false)
+	})
+
+	it('never overlaps for empty labels', () => {
+		expect(filledSquare().overlapsPolygon(around)).toBe(true)
+		expect(square({ isFilled: true, isEmptyLabel: true }).overlapsPolygon(around)).toBe(false)
+	})
+
+	it('accepts plain objects', () => {
+		expect(square().overlapsPolygon(around.map((v) => ({ x: v.x, y: v.y })))).toBe(true)
+	})
+})
+
+describe('Geometry2d.isPointInBounds', () => {
+	it('checks the bounds with an optional margin', () => {
+		expect(openL().isPointInBounds(new Vec(10, 90))).toBe(true)
+		expect(openL().isPointInBounds(new Vec(-5, 50))).toBe(false)
+		expect(openL().isPointInBounds(new Vec(-5, 50), 5)).toBe(true)
+		expect(openL().isPointInBounds(new Vec(105, 105), 5)).toBe(true)
+		expect(openL().isPointInBounds(new Vec(105, 106), 5)).toBe(false)
+	})
+})
+
+describe('Geometry2d measurements', () => {
+	it('derives the center from the bounds', () => {
+		expect(square().center).toMatchObject({ x: 50, y: 50 })
+		expect(new TestPolygon([new Vec(10, 20), new Vec(30, 60)]).center).toMatchObject({
+			x: 20,
+			y: 40,
+		})
+	})
+
+	it('computes a signed shoelace area for closed geometry', () => {
+		expect(square().area).toBe(10000)
+		expect(new TestPolygon(squarePoints().reverse()).area).toBe(-10000)
+		expect(new TestPolygon([new Vec(0, 0), new Vec(10, 0), new Vec(0, 10)]).area).toBe(50)
+	})
+
+	it('has zero area for open geometry', () => {
+		expect(openL().area).toBe(0)
+		expect(openL({ isFilled: true }).area).toBe(0)
+	})
+
+	it('caches the area', () => {
+		const s = square()
+		expect(s.area).toBe(10000)
+		s['points'].push(new Vec(-100, 50))
+		expect(s.area).toBe(10000)
+	})
+
+	it('computes the length, closing the path only for closed geometry', () => {
+		expect(square().length).toBe(400)
+		expect(openL().length).toBe(200)
+		expect(openL().getLength()).toBe(200)
+		expect(new TestPolygon([]).getLength()).toBe(0)
+		expect(new TestPolygon([new Vec(3, 4)]).getLength()).toBe(0)
+	})
+})
+
+describe('Geometry2d.toSimpleSvgPath', () => {
+	it('draws straight lines through the vertices', () => {
+		expect(square().toSimpleSvgPath()).toBe('M0,0L100,0L100,100L0,100Z')
+		expect(openL().toSimpleSvgPath()).toBe('M0,0L100,0L100,100')
+		expect(new TestPolygon([]).toSimpleSvgPath()).toBe('')
+	})
+})
+
+describe('Geometry2d.ignoreHit', () => {
+	it('never rejects hits by default', () => {
+		expect(square().ignoreHit(new Vec(50, 50))).toBe(false)
+		expect(square().ignoreHit(new Vec(500, 500))).toBe(false)
+	})
+})
+
+describe('TransformedGeometry2d delegation', () => {
+	// 100x50 rect translated to (50, 100) and scaled by 2: occupies (50, 100) to (250, 200)
+	const matrix = Mat.Translate(50, 100).scale(2, 2)
+	const rect = () => new Rectangle2d({ width: 100, height: 50, isFilled: true }).transform(matrix)
+
+	it('copies the flags of the wrapped geometry and applies the overrides', () => {
+		const inner = new Rectangle2d({
+			width: 100,
+			height: 50,
+			isFilled: true,
+			isLabel: true,
+			isInternal: true,
+			excludeFromShapeBounds: true,
+		})
+		expect(inner.transform(matrix)).toMatchObject({
+			isFilled: true,
+			isClosed: true,
+			isLabel: true,
+			isInternal: true,
+			excludeFromShapeBounds: true,
+		})
+		expect(
+			inner.transform(matrix, {
+				isLabel: false,
+				isInternal: false,
+				debugColor: 'red',
+				ignore: true,
+			})
+		).toMatchObject({ isLabel: false, isInternal: false, debugColor: 'red', ignore: true })
+	})
+
+	it('rejects non-uniform scaling', () => {
+		expect(() =>
+			new Rectangle2d({ width: 10, height: 10, isFilled: true }).transform(Mat.Scale(2, 3))
+		).toThrow('non-uniform scaling is not yet supported')
+	})
+
+	it('scales distances back into the outer space', () => {
+		expect(rect().distanceToPoint(new Vec(350, 150))).toBe(100)
+		expect(rect().distanceToPoint(new Vec(150, 150))).toBe(-50)
+		expect(rect().distanceToLineSegment(new Vec(350, 100), new Vec(350, 200))).toBe(100)
+	})
+
+	it('scales the hit test distance into the inner space', () => {
+		expect(rect().hitTestLineSegment(new Vec(350, 100), new Vec(350, 200), 100)).toBe(true)
+		expect(rect().hitTestLineSegment(new Vec(350, 100), new Vec(350, 200), 99)).toBe(false)
+		expect(rect().hitTestLineSegment(new Vec(150, 50), new Vec(150, 250))).toBe(true)
+	})
+
+	it('maps intersections back into the outer space', () => {
+		expect(sortPoints(rect().intersectLineSegment(new Vec(0, 150), new Vec(400, 150)))).toEqual([
+			{ x: 50, y: 150 },
+			{ x: 250, y: 150 },
+		])
+		expect(sortPoints(rect().intersectCircle(new Vec(50, 150), 20))).toEqual([
+			{ x: 50, y: 130 },
+			{ x: 50, y: 170 },
+		])
+		const polygon = [new Vec(0, 120), new Vec(100, 120), new Vec(100, 180), new Vec(0, 180)]
+		expect(sortPoints(rect().intersectPolygon(polygon))).toEqual([
+			{ x: 50, y: 120 },
+			{ x: 50, y: 180 },
+		])
+		expect(sortPoints(rect().intersectPolyline([new Vec(0, 120), new Vec(100, 120)]))).toEqual([
+			{ x: 50, y: 120 },
+		])
+	})
+
+	it('hit tests rotated geometry', () => {
+		// rotate the 100x50 rect a quarter turn about the origin: it now spans x in [-50, 0]
+		const rotated = new Rectangle2d({ width: 100, height: 50, isFilled: true }).transform(
+			Mat.Rotate(Math.PI / 2)
+		)
+		expect(rotated.hitTestPoint(new Vec(-25, 50))).toBe(true)
+		expect(rotated.hitTestPoint(new Vec(25, 50))).toBe(false)
+		expect(rotated.bounds.x).toBeCloseTo(-50)
+		expect(rotated.bounds.w).toBeCloseTo(50)
+		expect(rotated.bounds.h).toBeCloseTo(100)
+	})
+
+	it('delegates ignoreHit in the inner space', () => {
+		class RightHalfIgnored extends TestPolygon {
+			override ignoreHit(point: VecLike) {
+				return point.x > 50
+			}
+		}
+		const g = new RightHalfIgnored(squarePoints()).transform(matrix)
+		expect(g.ignoreHit(new Vec(100, 150))).toBe(false)
+		expect(g.ignoreHit(new Vec(200, 150))).toBe(true)
+	})
+
+	it('composes nested transforms and carries the flags forward', () => {
+		const g = rect()
+			.transform(Mat.Translate(-50, -100), { debugColor: 'red' })
+			.transform(Mat.Scale(0.5, 0.5))
+		expect(g).toBeInstanceOf(TransformedGeometry2d)
+		expect(g.bounds).toMatchObject({ x: 0, y: 0, w: 100, h: 50 })
+		expect(g).toMatchObject({ debugColor: 'red', isFilled: true })
+	})
+
+	it('cannot produce svg path data', () => {
+		expect(() => rect().getSvgPathData(true)).toThrow(
+			'Cannot get SVG path data for transformed geometry.'
+		)
+	})
+})

--- a/packages/editor/src/lib/primitives/geometry/Group2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.test.ts
@@ -1,5 +1,400 @@
-describe('Group2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Mat } from '../Mat'
+import { Vec, VecLike } from '../Vec'
+import { Edge2d } from './Edge2d'
+import { Geometry2dFilters, TransformedGeometry2d } from './Geometry2d'
+import { Group2d } from './Group2d'
+import { Rectangle2d } from './Rectangle2d'
+
+// Two rectangles side by side with a gap between them
+const rectA = () => new Rectangle2d({ width: 100, height: 50, isFilled: true })
+const rectB = () => new Rectangle2d({ x: 200, width: 50, height: 50, isFilled: false })
+// A small filled label to the right of both, and an internal geometry further right
+const label = () =>
+	new Rectangle2d({ x: 300, width: 20, height: 20, isFilled: true, isLabel: true })
+const internal = () =>
+	new Rectangle2d({ x: 400, width: 10, height: 10, isFilled: true, isInternal: true })
+
+const group = () => new Group2d({ children: [rectA(), rectB()] })
+const groupWithLabel = () => new Group2d({ children: [rectA(), label(), rectB()] })
+
+// An L shaped path made of two edges, 200 units long in total
+const path = () =>
+	new Group2d({
+		children: [
+			new Edge2d({ start: new Vec(0, 0), end: new Vec(100, 0) }),
+			new Edge2d({ start: new Vec(100, 0), end: new Vec(100, 100) }),
+		],
+	})
+
+function sortByX(points: VecLike[]) {
+	const round = (n: number) => Math.round(n * 1e6) / 1e6
+	return [...points]
+		.map((p) => ({ x: round(p.x), y: round(p.y) }))
+		.sort((a, b) => a.x - b.x || a.y - b.y)
+}
+
+describe('Group2d construction', () => {
+	it('is closed and unfilled and passes through the other options', () => {
+		const g = new Group2d({
+			children: [rectA()],
+			isLabel: true,
+			debugColor: 'red',
+			excludeFromShapeBounds: true,
+		})
+		expect(g).toMatchObject({
+			isClosed: true,
+			isFilled: false,
+			isLabel: true,
+			debugColor: 'red',
+			excludeFromShapeBounds: true,
+		})
+	})
+
+	it('keeps the children in order', () => {
+		const a = rectA()
+		const b = rectB()
+		const g = new Group2d({ children: [a, b] })
+		expect(g.children).toEqual([a, b])
+		expect(g.ignoredChildren).toEqual([])
+	})
+
+	it('flattens nested groups', () => {
+		const a = rectA()
+		const b = rectB()
+		const c = label()
+		const g = new Group2d({ children: [a, new Group2d({ children: [b, c] })] })
+		expect(g.children).toEqual([a, b, c])
+	})
+
+	it('separates ignored children', () => {
+		const a = rectA()
+		const ignored = new Rectangle2d({ width: 10, height: 10, isFilled: true, ignore: true })
+		const g = new Group2d({ children: [a, ignored] })
+		expect(g.children).toEqual([a])
+		expect(g.ignoredChildren).toEqual([ignored])
+	})
+
+	it('throws without any non-ignored children', () => {
+		expect(() => new Group2d({ children: [] })).toThrow('Group2d must have at least one child')
+		expect(
+			() =>
+				new Group2d({
+					children: [new Rectangle2d({ width: 10, height: 10, isFilled: true, ignore: true })],
+				})
+		).toThrow('Group2d must have at least one child')
+	})
+})
+
+describe('Group2d.getVertices', () => {
+	it('concatenates the vertices of the children', () => {
+		expect(group().vertices).toMatchObject([
+			{ x: 0, y: 0 },
+			{ x: 100, y: 0 },
+			{ x: 100, y: 50 },
+			{ x: 0, y: 50 },
+			{ x: 200, y: 0 },
+			{ x: 250, y: 0 },
+			{ x: 250, y: 50 },
+			{ x: 200, y: 50 },
+		])
+	})
+
+	it('excludes labels by default but keeps internal geometry', () => {
+		const g = new Group2d({ children: [rectA(), label(), internal()] })
+		expect(g.vertices.length).toBe(8)
+		expect(g.getVertices(Geometry2dFilters.EXCLUDE_LABELS).length).toBe(8)
+		expect(g.getVertices(Geometry2dFilters.INCLUDE_ALL).length).toBe(12)
+		expect(g.getVertices(Geometry2dFilters.EXCLUDE_INTERNAL).length).toBe(8)
+		expect(g.getVertices(Geometry2dFilters.EXCLUDE_NON_STANDARD).length).toBe(4)
+	})
+
+	it('returns nothing when the group itself is excluded by the filter', () => {
+		const g = new Group2d({ children: [rectA()], isLabel: true })
+		expect(g.getVertices(Geometry2dFilters.EXCLUDE_LABELS)).toEqual([])
+		expect(g.getVertices(Geometry2dFilters.INCLUDE_ALL).length).toBe(4)
+	})
+
+	it('ignores ignored children', () => {
+		const ignored = new Rectangle2d({ x: 500, width: 10, height: 10, isFilled: true, ignore: true })
+		const g = new Group2d({ children: [rectA(), ignored] })
+		expect(g.getVertices(Geometry2dFilters.INCLUDE_ALL).length).toBe(4)
+	})
+})
+
+describe('Group2d.bounds', () => {
+	it('is the union of the children bounds', () => {
+		expect(group().bounds).toMatchObject({ x: 0, y: 0, w: 250, h: 50 })
+		expect(group().center).toMatchObject({ x: 125, y: 25 })
+	})
+
+	it('includes labels', () => {
+		expect(groupWithLabel().bounds).toMatchObject({ x: 0, y: 0, w: 320, h: 50 })
+	})
+})
+
+describe('Group2d.getLength', () => {
+	it('sums the child lengths, excluding labels by default', () => {
+		expect(group().length).toBe(500)
+		expect(groupWithLabel().length).toBe(500)
+		expect(groupWithLabel().getLength(Geometry2dFilters.INCLUDE_ALL)).toBe(580)
+		expect(groupWithLabel().getLength(Geometry2dFilters.EXCLUDE_LABELS)).toBe(500)
+	})
+})
+
+describe('Group2d.getArea', () => {
+	it('uses the area of the first child', () => {
+		expect(group().area).toBe(5000)
+		expect(new Group2d({ children: [rectB(), rectA()] }).area).toBe(2500)
+	})
+})
+
+describe('Group2d.nearestPoint', () => {
+	it('returns the nearest point across the children, preferring earlier children on ties', () => {
+		expect(group().nearestPoint(new Vec(190, 25))).toMatchObject({ x: 200, y: 25 })
+		expect(group().nearestPoint(new Vec(50, -10))).toMatchObject({ x: 50, y: 0 })
+		expect(group().nearestPoint(new Vec(150, 25))).toMatchObject({ x: 100, y: 25 })
+	})
+
+	it('respects the filters', () => {
+		const g = groupWithLabel()
+		expect(g.nearestPoint(new Vec(310, 30), Geometry2dFilters.INCLUDE_ALL)).toMatchObject({
+			x: 310,
+			y: 20,
+		})
+		expect(g.nearestPoint(new Vec(310, 30), Geometry2dFilters.EXCLUDE_LABELS)).toMatchObject({
+			x: 250,
+			y: 30,
+		})
+	})
+
+	it('uses the label when no filters are given', () => {
+		expect(groupWithLabel().nearestPoint(new Vec(310, 30))).toMatchObject({ x: 310, y: 20 })
+	})
+})
+
+describe('Group2d.distanceToPoint', () => {
+	it('is the smallest child distance, negative inside a filled child', () => {
+		expect(group().distanceToPoint(new Vec(50, 25))).toBe(-25)
+		expect(group().distanceToPoint(new Vec(225, 25))).toBe(25)
+		expect(group().distanceToPoint(new Vec(225, 25), true)).toBe(-25)
+		expect(group().distanceToPoint(new Vec(150, 25))).toBe(50)
+	})
+
+	it('respects the filters', () => {
+		const g = groupWithLabel()
+		expect(g.distanceToPoint(new Vec(310, 10), false, Geometry2dFilters.INCLUDE_ALL)).toBe(-10)
+		expect(g.distanceToPoint(new Vec(310, 10), false, Geometry2dFilters.EXCLUDE_LABELS)).toBe(60)
+	})
+})
+
+describe('Group2d.hitTestPoint', () => {
+	it('hits when any child hits', () => {
+		expect(group().hitTestPoint(new Vec(50, 25), 0, false)).toBe(true)
+		expect(group().hitTestPoint(new Vec(225, 25), 0, false)).toBe(false)
+		expect(group().hitTestPoint(new Vec(225, 25), 0, true)).toBe(true)
+		expect(group().hitTestPoint(new Vec(150, 25), 0, true)).toBe(false)
+		expect(group().hitTestPoint(new Vec(150, 25), 50, false)).toBe(true)
+	})
+
+	it('excludes labels by default', () => {
+		const g = groupWithLabel()
+		expect(g.hitTestPoint(new Vec(310, 10), 0, false)).toBe(false)
+		expect(g.hitTestPoint(new Vec(310, 10), 0, false, Geometry2dFilters.INCLUDE_ALL)).toBe(true)
+	})
+
+	it('never hits ignored children', () => {
+		const ignored = new Rectangle2d({ x: 500, width: 10, height: 10, isFilled: true, ignore: true })
+		const g = new Group2d({ children: [rectA(), ignored] })
+		expect(g.hitTestPoint(new Vec(505, 5), 0, true)).toBe(false)
+	})
+})
+
+describe('Group2d.hitTestLineSegment', () => {
+	it('hits when any child hits', () => {
+		expect(group().hitTestLineSegment(new Vec(90, 25), new Vec(110, 25), 0)).toBe(true)
+		expect(group().hitTestLineSegment(new Vec(240, 25), new Vec(260, 25), 0)).toBe(true)
+		expect(group().hitTestLineSegment(new Vec(150, -10), new Vec(150, 60), 0)).toBe(false)
+	})
+
+	it('passes the distance to the children', () => {
+		expect(group().hitTestLineSegment(new Vec(150, 0), new Vec(150, 50), 50)).toBe(true)
+		expect(group().hitTestLineSegment(new Vec(150, 0), new Vec(150, 50), 49)).toBe(false)
+	})
+
+	it('excludes labels by default', () => {
+		const g = groupWithLabel()
+		expect(g.hitTestLineSegment(new Vec(310, -10), new Vec(310, 30), 0)).toBe(false)
+		expect(
+			g.hitTestLineSegment(new Vec(310, -10), new Vec(310, 30), 0, Geometry2dFilters.INCLUDE_ALL)
+		).toBe(true)
+	})
+})
+
+describe('Group2d.intersectLineSegment', () => {
+	it('collects the intersections from every child', () => {
+		const hits = group().intersectLineSegment(new Vec(-10, 25), new Vec(300, 25))
+		expect(sortByX(hits)).toEqual([
+			{ x: 0, y: 25 },
+			{ x: 100, y: 25 },
+			{ x: 200, y: 25 },
+			{ x: 250, y: 25 },
+		])
+	})
+
+	it('respects the filters', () => {
+		const g = groupWithLabel()
+		const A = new Vec(-10, 10)
+		const B = new Vec(400, 10)
+		expect(g.intersectLineSegment(A, B).length).toBe(6)
+		expect(g.intersectLineSegment(A, B, Geometry2dFilters.EXCLUDE_LABELS).length).toBe(4)
+	})
+
+	it('returns an empty array when nothing is hit', () => {
+		expect(group().intersectLineSegment(new Vec(150, -10), new Vec(150, 60))).toEqual([])
+	})
+})
+
+describe('Group2d.intersectCircle', () => {
+	it('collects the intersections from every child', () => {
+		const hits = group().intersectCircle(new Vec(0, 25), 10)
+		expect(sortByX(hits)).toEqual([
+			{ x: 0, y: 15 },
+			{ x: 0, y: 35 },
+		])
+	})
+
+	it('respects the filters', () => {
+		const g = groupWithLabel()
+		expect(g.intersectCircle(new Vec(300, 10), 5).length).toBe(2)
+		expect(g.intersectCircle(new Vec(300, 10), 5, Geometry2dFilters.EXCLUDE_LABELS)).toEqual([])
+	})
+})
+
+describe('Group2d.intersectPolygon and intersectPolyline', () => {
+	const polygon = [new Vec(50, -10), new Vec(110, -10), new Vec(110, 60), new Vec(50, 60)]
+
+	it('collects polygon intersections from every child', () => {
+		expect(sortByX(group().intersectPolygon(polygon))).toEqual([
+			{ x: 50, y: 0 },
+			{ x: 50, y: 50 },
+		])
+	})
+
+	it('collects polyline intersections from every child', () => {
+		const polyline = [new Vec(50, -10), new Vec(50, 60)]
+		expect(sortByX(group().intersectPolyline(polyline))).toEqual([
+			{ x: 50, y: 0 },
+			{ x: 50, y: 50 },
+		])
+	})
+
+	it('respects the filters', () => {
+		const g = groupWithLabel()
+		const labelPolygon = [new Vec(310, -10), new Vec(330, -10), new Vec(330, 30), new Vec(310, 30)]
+		expect(g.intersectPolygon(labelPolygon).length).toBe(2)
+		expect(g.intersectPolygon(labelPolygon, Geometry2dFilters.EXCLUDE_LABELS)).toEqual([])
+		const labelPolyline = [new Vec(310, -10), new Vec(310, 30)]
+		expect(g.intersectPolyline(labelPolyline).length).toBe(2)
+		expect(g.intersectPolyline(labelPolyline, Geometry2dFilters.EXCLUDE_LABELS)).toEqual([])
+	})
+})
+
+describe('Group2d.interpolateAlongEdge', () => {
+	it('walks through the children in order', () => {
+		const p = path()
+		expect(p.interpolateAlongEdge(0)).toMatchObject({ x: 0, y: 0 })
+		expect(p.interpolateAlongEdge(0.25)).toMatchObject({ x: 50, y: 0 })
+		expect(p.interpolateAlongEdge(0.5)).toMatchObject({ x: 100, y: 0 })
+		expect(p.interpolateAlongEdge(0.75)).toMatchObject({ x: 100, y: 50 })
+		expect(p.interpolateAlongEdge(1)).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('clamps to the end of the last child', () => {
+		expect(path().interpolateAlongEdge(1.5)).toMatchObject({ x: 100, y: 100 })
+	})
+})
+
+describe('Group2d.uninterpolateAlongEdge', () => {
+	it('is the inverse of interpolateAlongEdge', () => {
+		const p = path()
+		expect(p.uninterpolateAlongEdge(new Vec(0, 0))).toBe(0)
+		expect(p.uninterpolateAlongEdge(new Vec(50, 0))).toBe(0.25)
+		expect(p.uninterpolateAlongEdge(new Vec(100, 0))).toBe(0.5)
+		expect(p.uninterpolateAlongEdge(new Vec(100, 50))).toBe(0.75)
+		expect(p.uninterpolateAlongEdge(new Vec(100, 100))).toBe(1)
+	})
+
+	it('snaps points off the path to the nearest child', () => {
+		expect(path().uninterpolateAlongEdge(new Vec(50, -20))).toBe(0.25)
+		expect(path().uninterpolateAlongEdge(new Vec(120, 50))).toBe(0.75)
+	})
+})
+
+describe('Group2d.transform', () => {
+	it('transforms every child', () => {
+		const t = group().transform(Mat.Translate(10, 20))
+		expect(t).toBeInstanceOf(Group2d)
+		expect((t as Group2d).children.every((c) => c instanceof TransformedGeometry2d)).toBe(true)
+		expect(t.bounds).toMatchObject({ x: 10, y: 20, w: 250, h: 50 })
+		expect(t.vertices[0]).toMatchObject({ x: 10, y: 20 })
+		expect(t.vertices.length).toBe(8)
+	})
+
+	it('carries the label, debug colour and ignore flags forward', () => {
+		const g = new Group2d({
+			children: [rectA()],
+			isLabel: true,
+			debugColor: 'red',
+			ignore: true,
+		})
+		expect(g.transform(Mat.Identity())).toMatchObject({
+			isLabel: true,
+			debugColor: 'red',
+			ignore: true,
+		})
+	})
+
+	it('scales hit testing with the transform', () => {
+		const t = group().transform(Mat.Scale(2, 2))
+		expect(t.hitTestPoint(new Vec(100, 50), 0, false)).toBe(true)
+		expect(t.hitTestPoint(new Vec(300, 50), 0, false)).toBe(false)
+		expect(t.distanceToPoint(new Vec(300, 50))).toBe(100)
+	})
+
+	// Locks in current behaviour, see #10562.
+	it('drops the ignored children', () => {
+		const ignored = new Rectangle2d({ x: 500, width: 10, height: 10, isFilled: true, ignore: true })
+		const g = new Group2d({ children: [rectA(), ignored] })
+		expect(g.ignoredChildren.length).toBe(1)
+		expect((g.transform(Mat.Identity()) as Group2d).ignoredChildren).toEqual([])
+	})
+})
+
+describe('Group2d.overlapsPolygon', () => {
+	it('overlaps when any child overlaps', () => {
+		const aroundB = [new Vec(190, -10), new Vec(260, -10), new Vec(260, 60), new Vec(190, 60)]
+		expect(group().overlapsPolygon(aroundB)).toBe(true)
+		const gap = [new Vec(120, 10), new Vec(180, 10), new Vec(180, 40), new Vec(120, 40)]
+		expect(group().overlapsPolygon(gap)).toBe(false)
+	})
+})
+
+describe('Group2d svg output', () => {
+	it('joins the children paths and skips labels', () => {
+		expect(group().getSvgPathData()).toBe('M0,0 h100 v50 h-100z M200,0 h50 v50 h-50z')
+		expect(groupWithLabel().getSvgPathData()).toBe('M0,0 h100 v50 h-100z  M200,0 h50 v50 h-50z')
+	})
+
+	it('draws the children plus a small corner mark at each bounds corner', () => {
+		const g = new Group2d({
+			children: [new Rectangle2d({ width: 128, height: 64, isFilled: true })],
+		})
+		expect(g.toSimpleSvgPath()).toBe(
+			'M0,0L128,0L128,64L0,64Z' +
+				'M0,4 L0,0 L4,0 ' +
+				'M124,0 L128,0 L128,4 ' +
+				'M128,60 L128,64 L124,64 ' +
+				'M4,64 L0,64 L0,60 '
+		)
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Polyline.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Polyline.test.ts
@@ -1,5 +1,0 @@
-describe('Polyline2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
-	})
-})

--- a/packages/editor/src/lib/primitives/geometry/Polyline2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Polyline2d.test.ts
@@ -1,0 +1,207 @@
+import { Vec } from '../Vec'
+import { Polygon2d } from './Polygon2d'
+import { Polyline2d } from './Polyline2d'
+
+// An L shape: right along the top for 100, then down for 100
+const points = () => [new Vec(0, 0), new Vec(100, 0), new Vec(100, 100)]
+const polyline = () => new Polyline2d({ points: points() })
+
+describe('Polyline2d construction', () => {
+	it('is open and unfilled', () => {
+		expect(polyline()).toMatchObject({ isClosed: false, isFilled: false })
+	})
+
+	it('passes through the other options', () => {
+		const p = new Polyline2d({ points: points(), isLabel: true, debugColor: 'red', ignore: true })
+		expect(p).toMatchObject({ isLabel: true, debugColor: 'red', ignore: true })
+	})
+
+	it('throws with fewer than two points', () => {
+		expect(() => new Polyline2d({ points: [] })).toThrow(
+			'Polyline2d: points must be an array of at least 2 points'
+		)
+		expect(() => new Polyline2d({ points: [new Vec(0, 0)] })).toThrow(
+			'Polyline2d: points must be an array of at least 2 points'
+		)
+	})
+})
+
+describe('Polyline2d.getVertices', () => {
+	it('returns the points as given', () => {
+		const pts = points()
+		expect(new Polyline2d({ points: pts }).vertices).toBe(pts)
+	})
+})
+
+describe('Polyline2d.bounds', () => {
+	it('spans the points', () => {
+		expect(polyline().bounds).toMatchObject({ x: 0, y: 0, w: 100, h: 100 })
+		expect(polyline().center).toMatchObject({ x: 50, y: 50 })
+	})
+
+	it('handles offset points', () => {
+		const p = new Polyline2d({ points: [new Vec(10, 20), new Vec(30, -5)] })
+		expect(p.bounds).toMatchObject({ x: 10, y: -5, w: 20, h: 25 })
+	})
+})
+
+describe('Polyline2d.getLength', () => {
+	it('sums the segment lengths without closing', () => {
+		expect(polyline().length).toBe(200)
+	})
+
+	it('is zero for coincident points', () => {
+		expect(new Polyline2d({ points: [new Vec(5, 5), new Vec(5, 5)] }).length).toBe(0)
+	})
+})
+
+describe('Polyline2d.area', () => {
+	it('is zero because the shape is open', () => {
+		expect(polyline().area).toBe(0)
+	})
+})
+
+describe('Polyline2d.nearestPoint', () => {
+	it('projects onto the nearest segment', () => {
+		expect(polyline().nearestPoint(new Vec(50, 10))).toMatchObject({ x: 50, y: 0 })
+		expect(polyline().nearestPoint(new Vec(110, 50))).toMatchObject({ x: 100, y: 50 })
+		expect(polyline().nearestPoint(new Vec(90, 50))).toMatchObject({ x: 100, y: 50 })
+	})
+
+	it('clamps to the end points', () => {
+		expect(polyline().nearestPoint(new Vec(-10, -10))).toMatchObject({ x: 0, y: 0 })
+		expect(polyline().nearestPoint(new Vec(150, 150))).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('prefers the earlier segment on a tie', () => {
+		expect(polyline().nearestPoint(new Vec(50, 50))).toMatchObject({ x: 50, y: 0 })
+	})
+
+	it('does not use the closing segment', () => {
+		// the closing segment (100, 100) -> (0, 0) would pass through (25, 25)
+		expect(polyline().nearestPoint(new Vec(20, 30))).toMatchObject({ x: 20, y: 0 })
+	})
+
+	it('handles zero length segments', () => {
+		const p = new Polyline2d({ points: [new Vec(5, 5), new Vec(5, 5)] })
+		expect(p.nearestPoint(new Vec(10, 10))).toMatchObject({ x: 5, y: 5 })
+	})
+
+	it('returns a new vector rather than one of the points', () => {
+		const pts = points()
+		const p = new Polyline2d({ points: pts })
+		const nearest = p.nearestPoint(new Vec(-10, -10))
+		expect(nearest).toEqual(pts[0])
+		expect(nearest).not.toBe(pts[0])
+	})
+})
+
+describe('Polyline2d.distanceToPoint', () => {
+	it('is the distance to the nearest segment', () => {
+		expect(polyline().distanceToPoint(new Vec(50, 10))).toBe(10)
+		expect(polyline().distanceToPoint(new Vec(50, 50))).toBe(50)
+		expect(polyline().distanceToPoint(new Vec(-3, -4))).toBe(5)
+	})
+
+	it('is never negative for an open polyline, even with hitInside', () => {
+		expect(polyline().distanceToPoint(new Vec(90, 10), true)).toBe(10)
+	})
+})
+
+describe('Polyline2d.hitTestPoint', () => {
+	it('hits points on the line', () => {
+		expect(polyline().hitTestPoint(new Vec(50, 0))).toBe(true)
+		expect(polyline().hitTestPoint(new Vec(100, 100))).toBe(true)
+	})
+
+	it('respects the margin', () => {
+		expect(polyline().hitTestPoint(new Vec(50, 10), 10)).toBe(true)
+		expect(polyline().hitTestPoint(new Vec(50, 10), 9)).toBe(false)
+	})
+
+	it('ignores hitInside because the shape is open', () => {
+		expect(polyline().hitTestPoint(new Vec(90, 10), 0, true)).toBe(false)
+	})
+})
+
+describe('Polyline2d.hitTestLineSegment', () => {
+	it('hits a segment crossing the line', () => {
+		expect(polyline().hitTestLineSegment(new Vec(50, -10), new Vec(50, 10))).toBe(true)
+		expect(polyline().hitTestLineSegment(new Vec(90, 50), new Vec(110, 50))).toBe(true)
+	})
+
+	it('misses a segment inside the corner that does not cross', () => {
+		expect(polyline().hitTestLineSegment(new Vec(50, 10), new Vec(90, 90))).toBe(false)
+	})
+
+	it('misses a segment crossing only the closing segment', () => {
+		expect(polyline().hitTestLineSegment(new Vec(20, 30), new Vec(30, 20))).toBe(false)
+	})
+
+	it('respects the distance from a vertex', () => {
+		expect(polyline().hitTestLineSegment(new Vec(100, -10), new Vec(120, -10), 10)).toBe(true)
+		expect(polyline().hitTestLineSegment(new Vec(100, -10), new Vec(120, -10), 9)).toBe(false)
+	})
+
+	// Locks in current behaviour, see #10556.
+	it('measures the distance from the vertices, not the edges (known quirk)', () => {
+		// the segment is 10 units from the middle of the top edge but 41 from the nearest vertex
+		expect(polyline().hitTestLineSegment(new Vec(40, 10), new Vec(60, 10), 10)).toBe(false)
+		expect(polyline().hitTestLineSegment(new Vec(40, 10), new Vec(60, 10), 42)).toBe(true)
+	})
+})
+
+describe('Polyline2d.intersectLineSegment', () => {
+	it('does not intersect the closing segment', () => {
+		expect(polyline().intersectLineSegment(new Vec(50, -10), new Vec(50, 10))).toEqual([
+			{ x: 50, y: 0, z: 1 },
+		])
+		expect(polyline().intersectLineSegment(new Vec(20, 30), new Vec(30, 20))).toEqual([])
+	})
+})
+
+describe('Polyline2d.interpolateAlongEdge', () => {
+	it('walks along the segments', () => {
+		expect(polyline().interpolateAlongEdge(0)).toMatchObject({ x: 0, y: 0 })
+		expect(polyline().interpolateAlongEdge(0.25)).toMatchObject({ x: 50, y: 0 })
+		expect(polyline().interpolateAlongEdge(0.75)).toMatchObject({ x: 100, y: 50 })
+		expect(polyline().interpolateAlongEdge(1)).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('is inverted by uninterpolateAlongEdge', () => {
+		expect(polyline().uninterpolateAlongEdge(new Vec(50, 0))).toBe(0.25)
+		expect(polyline().uninterpolateAlongEdge(new Vec(100, 50))).toBe(0.75)
+		expect(polyline().uninterpolateAlongEdge(new Vec(120, 50))).toBe(0.75)
+	})
+})
+
+describe('Polyline2d.getSvgPathData', () => {
+	it('emits a move followed by line commands', () => {
+		expect(polyline().getSvgPathData()).toBe('M 0 0 L 100 0 L 100 100')
+	})
+})
+
+describe('Polyline2d when closed (via Polygon2d)', () => {
+	const closed = (isFilled = false) => new Polygon2d({ points: points(), isFilled })
+
+	it('uses the closing segment for the nearest point', () => {
+		expect(closed().nearestPoint(new Vec(20, 30))).toMatchObject({ x: 25, y: 25 })
+		expect(closed().length).toBeCloseTo(200 + Math.hypot(100, 100))
+	})
+
+	it('returns a negative distance inside when filled or hitInside', () => {
+		expect(closed().distanceToPoint(new Vec(90, 10))).toBe(10)
+		expect(closed().distanceToPoint(new Vec(90, 10), true)).toBe(-10)
+		expect(closed(true).distanceToPoint(new Vec(90, 10))).toBe(-10)
+	})
+
+	it('hits the interior when filled', () => {
+		expect(closed(true).hitTestPoint(new Vec(90, 10))).toBe(true)
+		expect(closed().hitTestPoint(new Vec(90, 10))).toBe(false)
+		expect(closed().hitTestPoint(new Vec(90, 10), 0, true)).toBe(true)
+	})
+
+	it('hits segments crossing the closing segment', () => {
+		expect(closed().hitTestLineSegment(new Vec(20, 30), new Vec(30, 20))).toBe(true)
+	})
+})

--- a/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
@@ -1,5 +1,193 @@
-describe('Stadium2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { Stadium2d } from './Stadium2d'
+
+// A wide 100x50 stadium: semicircles of radius 25 centred at (25, 25) and (75, 25)
+const wide = () => new Stadium2d({ width: 100, height: 50, isFilled: false })
+const wideFilled = () => new Stadium2d({ width: 100, height: 50, isFilled: true })
+// A tall 50x100 stadium: semicircles of radius 25 centred at (25, 25) and (25, 75)
+const tall = () => new Stadium2d({ width: 50, height: 100, isFilled: false })
+
+function expectVec(actual: Vec, expected: { x: number; y: number }) {
+	expect(actual.x).toBeCloseTo(expected.x)
+	expect(actual.y).toBeCloseTo(expected.y)
+}
+
+describe('Stadium2d construction', () => {
+	it('is always closed and keeps the fill flag from config', () => {
+		expect(wide()).toMatchObject({ isClosed: true, isFilled: false })
+		expect(wideFilled()).toMatchObject({ isClosed: true, isFilled: true })
+	})
+})
+
+describe('Stadium2d.bounds', () => {
+	it('is the width by height box at the origin', () => {
+		expect(wide().bounds).toMatchObject({ x: 0, y: 0, w: 100, h: 50 })
+		expect(wide().center).toMatchObject({ x: 50, y: 25 })
+		expect(tall().bounds).toMatchObject({ x: 0, y: 0, w: 50, h: 100 })
+	})
+})
+
+describe('Stadium2d.getLength', () => {
+	it('is two straight sides plus a full circle', () => {
+		expect(wide().length).toBeCloseTo(2 * 50 + Math.PI * 50)
+		expect(tall().length).toBeCloseTo(2 * 50 + Math.PI * 50)
+	})
+
+	it('is a circle circumference when width equals height', () => {
+		expect(new Stadium2d({ width: 50, height: 50, isFilled: false }).length).toBeCloseTo(
+			Math.PI * 50
+		)
+	})
+})
+
+describe('Stadium2d.getVertices', () => {
+	it('concatenates the vertices of the two arcs and two edges', () => {
+		const { vertices } = wide()
+		// each semicircle samples the minimum 8 segments (9 vertices), each edge has 2
+		expect(vertices.length).toBe(9 + 2 + 9 + 2)
+		// left arc runs from the bottom to the top through the leftmost point
+		expectVec(vertices[0], { x: 25, y: 50 })
+		expectVec(vertices[4], { x: 0, y: 25 })
+		expectVec(vertices[8], { x: 25, y: 0 })
+		// top edge
+		expect(vertices[9]).toMatchObject({ x: 25, y: 0 })
+		expect(vertices[10]).toMatchObject({ x: 75, y: 0 })
+		// right arc runs from the top to the bottom through the rightmost point
+		expectVec(vertices[11], { x: 75, y: 0 })
+		expectVec(vertices[15], { x: 100, y: 25 })
+		expectVec(vertices[19], { x: 75, y: 50 })
+		// bottom edge
+		expect(vertices[20]).toMatchObject({ x: 75, y: 50 })
+		expect(vertices[21]).toMatchObject({ x: 25, y: 50 })
+	})
+
+	it('keeps every vertex inside the bounds', () => {
+		for (const s of [wide(), tall()]) {
+			for (const v of s.vertices) {
+				expect(v.x).toBeGreaterThanOrEqual(-1e-9)
+				expect(v.y).toBeGreaterThanOrEqual(-1e-9)
+				expect(v.x).toBeLessThanOrEqual(s.bounds.w + 1e-9)
+				expect(v.y).toBeLessThanOrEqual(s.bounds.h + 1e-9)
+			}
+		}
+	})
+
+	it('starts a tall stadium with the top arc from left to right', () => {
+		const { vertices } = tall()
+		expectVec(vertices[0], { x: 0, y: 25 })
+		expectVec(vertices[4], { x: 25, y: 0 })
+		expectVec(vertices[8], { x: 50, y: 25 })
+		expect(vertices[10]).toMatchObject({ x: 50, y: 75 })
+		expectVec(vertices[15], { x: 25, y: 100 })
+		expect(vertices[21]).toMatchObject({ x: 0, y: 25 })
+	})
+})
+
+describe('Stadium2d.nearestPoint', () => {
+	it('projects onto the straight edges', () => {
+		expect(wide().nearestPoint(new Vec(50, -10))).toMatchObject({ x: 50, y: 0 })
+		expect(wide().nearestPoint(new Vec(50, 60))).toMatchObject({ x: 50, y: 50 })
+		expect(tall().nearestPoint(new Vec(-10, 50))).toMatchObject({ x: 0, y: 50 })
+	})
+
+	it('projects radially onto the arcs', () => {
+		expectVec(wide().nearestPoint(new Vec(-10, 25)), { x: 0, y: 25 })
+		expectVec(wide().nearestPoint(new Vec(110, 25)), { x: 100, y: 25 })
+		expectVec(tall().nearestPoint(new Vec(25, -10)), { x: 25, y: 0 })
+		// towards the top-left corner of the bounds the nearest point is on the arc, not the corner
+		const p = wide().nearestPoint(new Vec(0, 0))
+		expectVec(p, { x: 25 - 25 / Math.SQRT2, y: 25 - 25 / Math.SQRT2 })
+	})
+
+	it('projects from inside', () => {
+		expect(wide().nearestPoint(new Vec(50, 20))).toMatchObject({ x: 50, y: 0 })
+	})
+})
+
+describe('Stadium2d.distanceToPoint', () => {
+	it('is positive outside', () => {
+		expect(wide().distanceToPoint(new Vec(50, -10))).toBe(10)
+		expect(wide().distanceToPoint(new Vec(-10, 25))).toBeCloseTo(10)
+		expect(wideFilled().distanceToPoint(new Vec(50, -10))).toBe(10)
+	})
+
+	it('is negative inside only when filled or hitInside', () => {
+		expect(wide().distanceToPoint(new Vec(50, 25))).toBe(25)
+		expect(wideFilled().distanceToPoint(new Vec(50, 25))).toBe(-25)
+		expect(wide().distanceToPoint(new Vec(50, 25), true)).toBe(-25)
+	})
+
+	it('measures to the arc inside the rounded corners', () => {
+		// (5, 5) is inside the bounds but outside the left semicircle
+		expect(wide().distanceToPoint(new Vec(5, 5))).toBeCloseTo(Math.hypot(20, 20) - 25)
+		expect(wideFilled().distanceToPoint(new Vec(5, 5))).toBeCloseTo(Math.hypot(20, 20) - 25)
+	})
+})
+
+describe('Stadium2d.hitTestPoint', () => {
+	it('hits the interior only when filled or hitInside', () => {
+		expect(wideFilled().hitTestPoint(new Vec(50, 25))).toBe(true)
+		expect(wide().hitTestPoint(new Vec(50, 25))).toBe(false)
+		expect(wide().hitTestPoint(new Vec(50, 25), 0, true)).toBe(true)
+	})
+
+	it('misses the rounded corners even when filled', () => {
+		expect(wideFilled().hitTestPoint(new Vec(5, 5))).toBe(false)
+		expect(wideFilled().hitTestPoint(new Vec(95, 45))).toBe(false)
+	})
+
+	it('hits the rounded corners within the margin', () => {
+		const d = Math.hypot(20, 20) - 25 // ≈ 3.28
+		expect(wide().hitTestPoint(new Vec(5, 5), d + 0.01)).toBe(true)
+		expect(wide().hitTestPoint(new Vec(5, 5), d - 0.01)).toBe(false)
+	})
+
+	it('hits the straight edge and respects the margin', () => {
+		expect(wide().hitTestPoint(new Vec(50, 0))).toBe(true)
+		expect(wide().hitTestPoint(new Vec(50, -5), 5)).toBe(true)
+		expect(wide().hitTestPoint(new Vec(50, -5), 4)).toBe(false)
+	})
+})
+
+describe('Stadium2d.hitTestLineSegment', () => {
+	it('hits a segment crossing a straight edge', () => {
+		expect(wide().hitTestLineSegment(new Vec(50, -10), new Vec(50, 60))).toBe(true)
+	})
+
+	it('hits a segment crossing an arc', () => {
+		expect(wide().hitTestLineSegment(new Vec(-10, 25), new Vec(10, 25))).toBe(true)
+		// the diagonal from the bounds corner reaches the arc at t ≈ 7.3
+		expect(wide().hitTestLineSegment(new Vec(0, 0), new Vec(10, 10))).toBe(true)
+	})
+
+	it('misses a segment that stays within a rounded corner gap', () => {
+		expect(wide().hitTestLineSegment(new Vec(0, 0), new Vec(5, 5))).toBe(false)
+	})
+
+	it('misses segments entirely outside or entirely inside', () => {
+		expect(wide().hitTestLineSegment(new Vec(110, 0), new Vec(110, 50))).toBe(false)
+		expect(wideFilled().hitTestLineSegment(new Vec(40, 25), new Vec(45, 25))).toBe(false)
+		expect(wideFilled().hitTestLineSegment(new Vec(45, 2), new Vec(55, 2))).toBe(false)
+	})
+
+	// Locks in current behaviour, see #10555.
+	it('hits an interior segment that crosses the far side of an arc circle (known quirk)', () => {
+		// (50, 25) is on the left arc's circle but opposite the arc itself; Arc2d clamps points on
+		// the complementary arc to the nearest end point, so the crossing counts as a hit
+		expect(wideFilled().hitTestLineSegment(new Vec(30, 25), new Vec(70, 25))).toBe(true)
+	})
+})
+
+describe('Stadium2d.getSvgPathData', () => {
+	it('draws arc, line, arc, line and closes', () => {
+		expect(wide().getSvgPathData()).toBe(
+			'M25, 50 A25 25 0 1 1 25, 0  L75, 0  A25 25 0 1 1 75, 50  L25, 50 Z'
+		)
+	})
+
+	it('draws a tall stadium starting from the left of the top arc', () => {
+		expect(tall().getSvgPathData()).toBe(
+			'M0, 25 A25 25 0 1 1 50, 25  L50, 75  A25 25 0 1 1 0, 75  L0, 25 Z'
+		)
 	})
 })


### PR DESCRIPTION
In order to catch regressions in the geometry primitives without relying on the shape tests in `packages/tldraw`, this PR gives `packages/editor/src/lib/primitives/geometry/` a real unit test suite. Five of the classes (`Ellipse2d`, `Stadium2d`, `Arc2d`, `CubicBezier2d`, `CubicSpline2d`) only had five-line placeholder tests; `Group2d` and `Polyline2d` had next to nothing; and most of the `Geometry2d` base class implementations were only reached through subclasses that override them. Line coverage of the folder goes from 31% to 97%, with every class except `Point2d` and the already-tested `Circle2d`/`Polygon2d` at or near 100%.

`Geometry2d.test.ts` gains a minimal concrete subclass so the base-class `nearestPoint`, `distanceToPoint`, `distanceToLineSegment`, hit testing, bounds and filter handling run unshadowed. The misnamed `Polyline.test.ts` stub is replaced by `Polyline2d.test.ts`.

Writing these surfaced three behaviours that look like bugs, filed as #10555 (`Arc2d.hitTestLineSegment` hits crossings outside the arc), #10556 (`distanceToLineSegment` measures from vertices rather than edges) and #10562 (`Group2d.transform` drops ignored children and options). The tests lock in the current behaviour with a comment pointing at the issue, so each fix is a deliberate one-line test flip. Relates to #10555, #10556, #10562.

Split out of #10563, which covers the rest of the editor package.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests — `cd packages/editor && yarn test run src/lib/primitives/geometry`

### Code changes

| Section | LOC change   |
| ------- | ------------ |
| Tests   | +2151 / -24  |
