### PR TITLE
chore: declare sideEffects for SDK packages and check the consumer bundle in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Code quality:
 - `yarn format` - format the repo
 - `yarn format-current` - format changed files
 - `yarn api-check` - validate public API reports
-- `yarn lazy check-bundle-size` - measure the SDK and worker bundles and fail if the SDK pulls in code a consumer of `<Tldraw />` should not pay for
+- `yarn lazy check-bundle-size` - check SDK and worker bundle sizes
 
 ## Validation workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Code quality:
 - `yarn format` - format the repo
 - `yarn format-current` - format changed files
 - `yarn api-check` - validate public API reports
+- `yarn lazy check-bundle-size` - measure the SDK and worker bundles and fail if the SDK pulls in code a consumer of `<Tldraw />` should not pay for
 
 ## Validation workflow
 

--- a/internal/scripts/check-packages.ts
+++ b/internal/scripts/check-packages.ts
@@ -476,11 +476,79 @@ async function group<T>(name: string, cb: () => Promise<T>) {
 	}
 }
 
+// Published packages are built unbundled (one output file per source module), so a consumer's
+// bundler sees hundreds of modules and, without this flag, must assume every one of them has
+// import-time side effects and keep them all. Only the package entry point (which registers the
+// library version) and stylesheets have side effects worth keeping.
+const expectedSideEffects = [
+	'./src/index.ts',
+	'./dist-esm/index.mjs',
+	'./dist-cjs/index.js',
+	'**/*.css',
+]
+
+async function checkSideEffects({
+	packages,
+	fix,
+}: {
+	packages: Package[]
+	fix: boolean
+}): Promise<boolean> {
+	let errorCount = 0
+	for (const { relativePath, packageJson, name } of packages) {
+		const isPublishedLibrary =
+			relativePath.startsWith('packages/') &&
+			!packageJson.private &&
+			existsSync(join(REPO_ROOT, relativePath, 'src/index.ts'))
+		if (!isPublishedLibrary) continue
+
+		const actual = packageJson.sideEffects
+		const ok =
+			Array.isArray(actual) &&
+			actual.length === expectedSideEffects.length &&
+			actual.every((v, i) => v === expectedSideEffects[i])
+		if (ok) {
+			nicelog(['✅ ', kleur.green(`${name}: `), kleur.grey('sideEffects')].join(''))
+			continue
+		}
+
+		errorCount++
+		nicelog(
+			[
+				'❌ ',
+				kleur.red(`${name}: `),
+				kleur.grey('sideEffects -> '),
+				kleur.red(JSON.stringify(actual ?? null)),
+				kleur.gray(' (expected: '),
+				kleur.green(JSON.stringify(expectedSideEffects)),
+				kleur.gray(')'),
+			].join('')
+		)
+		if (fix) {
+			packageJson.sideEffects = expectedSideEffects
+			await writeJsonFile(join(REPO_ROOT, relativePath, 'package.json'), packageJson)
+		}
+	}
+
+	if (errorCount) {
+		if (fix) {
+			nicelog(kleur.yellow(`Fixed ${errorCount} errors`))
+			return true
+		}
+		nicelog(kleur.red(`Found ${errorCount} errors (run \`yarn check-packages --fix\`)`))
+		return false
+	}
+	return true
+}
+
 async function main({ fix }: { fix: boolean }) {
 	const packages = await getAllWorkspacePackages()
 
 	const scriptsOk = await group('Checking package.json scripts...', () =>
 		checkPackageJsonScripts({ packages, fix })
+	)
+	const sideEffectsOk = await group('Checking package.json sideEffects...', () =>
+		checkSideEffects({ packages, fix })
 	)
 	const tsConfigsOk = await group('Checking tsconfig.json files...', () =>
 		checkTsConfigs({ packages, fix })
@@ -492,7 +560,7 @@ async function main({ fix }: { fix: boolean }) {
 		checkProductMetadata({ packages, fix })
 	)
 
-	if (!scriptsOk || !tsConfigsOk || !libsOk || !productMetadataOk) {
+	if (!scriptsOk || !sideEffectsOk || !tsConfigsOk || !libsOk || !productMetadataOk) {
 		process.exit(1)
 	}
 }

--- a/internal/scripts/check-packages.ts
+++ b/internal/scripts/check-packages.ts
@@ -496,11 +496,11 @@ async function checkSideEffects({
 }): Promise<boolean> {
 	let errorCount = 0
 	for (const { relativePath, packageJson, name } of packages) {
-		const isPublishedLibrary =
-			relativePath.startsWith('packages/') &&
-			!packageJson.private &&
-			existsSync(join(REPO_ROOT, relativePath, 'src/index.ts'))
-		if (!isPublishedLibrary) continue
+		if (!relativePath.startsWith('packages/') || packageJson.private) continue
+		if (!existsSync(join(REPO_ROOT, relativePath, 'src/index.ts'))) {
+			nicelog(['  ⏩ ', kleur.grey(`${name}: skipped (no src/index.ts)`)].join(''))
+			continue
+		}
 
 		const actual = packageJson.sideEffects
 		const ok =
@@ -525,8 +525,15 @@ async function checkSideEffects({
 			].join('')
 		)
 		if (fix) {
-			packageJson.sideEffects = expectedSideEffects
-			await writeJsonFile(join(REPO_ROOT, relativePath, 'package.json'), packageJson)
+			// Keep the key next to "type", where the hand-written manifests put it
+			const fixed: Record<string, unknown> = {}
+			for (const [key, value] of Object.entries(packageJson)) {
+				if (key === 'sideEffects') continue
+				fixed[key] = value
+				if (key === 'type') fixed.sideEffects = expectedSideEffects
+			}
+			if (!('sideEffects' in fixed)) fixed.sideEffects = expectedSideEffects
+			await writeJsonFile(join(REPO_ROOT, relativePath, 'package.json'), fixed)
 		}
 	}
 

--- a/internal/scripts/check-sdk-bundle.ts
+++ b/internal/scripts/check-sdk-bundle.ts
@@ -38,10 +38,15 @@ const TLDRAW_CANARIES = [
 // TldrawEditor uses useLocalStore, never the standalone store hook
 const EDITOR_CANARIES = ['packages/editor/src/lib/hooks/useTLStore.ts']
 
+// Serialized as a JS string literal so a repo path with backslashes or quotes stays a valid specifier
+function specifier(...segments: string[]) {
+	return JSON.stringify(join(REPO_ROOT, ...segments))
+}
+
 const ENTRIES: Entry[] = [
 	{
 		name: "import { Tldraw } from 'tldraw'",
-		source: `export { Tldraw } from '${REPO_ROOT}/packages/tldraw/src/index'`,
+		source: `export { Tldraw } from ${specifier('packages/tldraw/src/index')}`,
 		// Measured at 1,657,637 B when this check was added, and 1,738,900 B with every
 		// sideEffects declaration ignored, so the limit sits between the two. Bump it deliberately
 		// when the SDK legitimately grows; it exists to make growth visible, not to forbid it.
@@ -50,12 +55,12 @@ const ENTRIES: Entry[] = [
 	},
 	{
 		name: "import { TldrawEditor } from '@tldraw/editor'",
-		source: `export { TldrawEditor } from '${REPO_ROOT}/packages/editor/src/index'`,
+		source: `export { TldrawEditor } from ${specifier('packages/editor/src/index')}`,
 		mustNotInclude: EDITOR_CANARIES,
 	},
 	{
 		name: "export * from 'tldraw'",
-		source: `export * from '${REPO_ROOT}/packages/tldraw/src/index'`,
+		source: `export * from ${specifier('packages/tldraw/src/index')}`,
 		mustInclude: [...TLDRAW_CANARIES, ...EDITOR_CANARIES],
 	},
 ]

--- a/internal/scripts/check-sdk-bundle.ts
+++ b/internal/scripts/check-sdk-bundle.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
-import { join, relative } from 'path'
+import { join } from 'path'
 import { gzipSync } from 'zlib'
 import { build } from 'esbuild'
 import kleur from 'kleur'
@@ -12,35 +12,42 @@ import { nicelog } from './lib/nicelog'
 // code only reachable through the package barrel is not dragged in. The canaries are modules that
 // nothing in the default `<Tldraw />` tree imports; if one shows up in the bundle then some package
 // lost its `sideEffects` declaration or a module grew an import-time side effect, and every consumer
-// of the SDK pays for the whole barrel again.
+// of the SDK pays for the whole barrel again. The `export *` entry asserts the opposite so that a
+// renamed or deleted canary fails loudly instead of matching nothing forever.
 
 interface Entry {
 	name: string
 	source: string
 	sizeLimitBytes?: number
 	mustNotInclude?: string[]
+	mustInclude?: string[]
 }
+
+const TLDRAW_CANARIES = [
+	'packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts',
+	'packages/tldraw/src/lib/TldrawImage.tsx',
+	'packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx',
+	'node_modules/@radix-ui/react-select/',
+]
+const EDITOR_CANARIES = ['packages/editor/src/lib/hooks/useTLStore.ts']
 
 const ENTRIES: Entry[] = [
 	{
 		name: "import { Tldraw } from 'tldraw'",
 		source: `export { Tldraw } from '${REPO_ROOT}/packages/tldraw/src/index'`,
+		// Bump deliberately when the SDK legitimately grows; this exists to make growth visible.
 		sizeLimitBytes: 1_800_000,
-		mustNotInclude: [
-			'packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts',
-			'packages/tldraw/src/lib/TldrawImage.tsx',
-			'packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx',
-			'node_modules/@radix-ui/react-select/',
-		],
+		mustNotInclude: [...TLDRAW_CANARIES, ...EDITOR_CANARIES],
 	},
 	{
 		name: "import { TldrawEditor } from '@tldraw/editor'",
 		source: `export { TldrawEditor } from '${REPO_ROOT}/packages/editor/src/index'`,
-		mustNotInclude: ['packages/editor/src/lib/hooks/useTLStore.ts'],
+		mustNotInclude: EDITOR_CANARIES,
 	},
 	{
 		name: "export * from 'tldraw'",
 		source: `export * from '${REPO_ROOT}/packages/tldraw/src/index'`,
+		mustInclude: [...TLDRAW_CANARIES, ...EDITOR_CANARIES],
 	},
 ]
 
@@ -48,6 +55,7 @@ async function measure(entry: Entry, dir: string) {
 	const entryFile = join(dir, 'entry.ts')
 	writeFileSync(entryFile, entry.source)
 	const result = await build({
+		absWorkingDir: REPO_ROOT,
 		entryPoints: [entryFile],
 		bundle: true,
 		minify: true,
@@ -55,28 +63,21 @@ async function measure(entry: Entry, dir: string) {
 		platform: 'browser',
 		target: 'es2022',
 		external: ['react', 'react-dom', 'react/jsx-runtime'],
-		loader: {
-			'.css': 'empty',
-			'.svg': 'dataurl',
-			'.png': 'dataurl',
-			'.woff2': 'dataurl',
-			'.json': 'json',
-		},
+		// Same defines as build-package.ts, so the version-registration code is as small as it is
+		// in a published build
 		define: {
 			'globalThis.TLDRAW_LIBRARY_IS_BUILD': 'true',
 			'globalThis.TLDRAW_LIBRARY_NAME': '"tldraw"',
 			'globalThis.TLDRAW_LIBRARY_VERSION': '"0.0.0"',
 			'globalThis.TLDRAW_LIBRARY_MODULES': '"esm"',
-			'process.env.NODE_ENV': '"production"',
 		},
 		write: false,
 		logLevel: 'silent',
 		metafile: true,
 	})
 	const output = result.outputFiles[0].contents
-	const inputs = Object.keys(Object.values(result.metafile.outputs)[0].inputs).map((file) =>
-		relative(REPO_ROOT, join(dir, file))
-	)
+	// Metafile paths are relative to absWorkingDir, i.e. the repo root
+	const inputs = Object.keys(Object.values(result.metafile.outputs)[0].inputs)
 	return {
 		minified: output.length,
 		gzipped: gzipSync(output, { level: 9 }).length,
@@ -91,7 +92,8 @@ function kb(bytes: number) {
 async function main() {
 	const args = minimist(process.argv.slice(2))
 	const dir = mkdtempSync(join(tmpdir(), 'tldraw-bundle-'))
-	let failed = false
+	let tooBig = false
+	let badInputs = false
 	try {
 		for (const entry of ENTRIES) {
 			const { minified, gzipped, inputs } = await measure(entry, dir)
@@ -100,18 +102,26 @@ async function main() {
 			)
 
 			if (entry.sizeLimitBytes && minified > entry.sizeLimitBytes) {
-				failed = true
+				tooBig = true
 				nicelog(
 					`  ${kleur.red().bold('ERROR')} exceeds the size limit of ${kb(entry.sizeLimitBytes)} minified`
 				)
 			}
 
 			for (const pattern of entry.mustNotInclude ?? []) {
-				const hits = inputs.filter((file) => file.includes(pattern))
-				if (hits.length) {
-					failed = true
+				if (inputs.some((file) => file.includes(pattern))) {
+					badInputs = true
 					nicelog(
 						`  ${kleur.red().bold('ERROR')} includes ${pattern}, which nothing in this entry should need`
+					)
+				}
+			}
+
+			for (const pattern of entry.mustInclude ?? []) {
+				if (!inputs.some((file) => file.includes(pattern))) {
+					badInputs = true
+					nicelog(
+						`  ${kleur.red().bold('ERROR')} does not include ${pattern}; was the canary renamed or removed?`
 					)
 				}
 			}
@@ -124,14 +134,21 @@ async function main() {
 		rmSync(dir, { recursive: true, force: true })
 	}
 
-	if (failed) {
+	if (badInputs) {
 		nicelog(
 			kleur.red(
-				'\nThe SDK bundle includes code that consumers should not pay for. Check that every package in packages/* declares "sideEffects" (yarn check-packages) and that no module runs code at import time.'
+				'\nThe SDK bundle includes code that consumers should not pay for. Check that every package in packages/* declares "sideEffects" (yarn check-packages) and that no module runs code at import time. Canaries live in internal/scripts/check-sdk-bundle.ts.'
 			)
 		)
-		process.exit(1)
 	}
+	if (tooBig) {
+		nicelog(
+			kleur.red(
+				'\nThe SDK bundle has grown past its size limit. If the growth is intended, bump sizeLimitBytes in internal/scripts/check-sdk-bundle.ts.'
+			)
+		)
+	}
+	if (badInputs || tooBig) process.exit(1)
 }
 
 main()

--- a/internal/scripts/check-sdk-bundle.ts
+++ b/internal/scripts/check-sdk-bundle.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, relative } from 'path'
+import { gzipSync } from 'zlib'
+import { build } from 'esbuild'
+import kleur from 'kleur'
+import minimist from 'minimist'
+import { REPO_ROOT } from './lib/file'
+import { nicelog } from './lib/nicelog'
+
+// Bundles what a typical consumer imports from the SDK packages, reports the size, and asserts that
+// code only reachable through the package barrel is not dragged in. The canaries are modules that
+// nothing in the default `<Tldraw />` tree imports; if one shows up in the bundle then some package
+// lost its `sideEffects` declaration or a module grew an import-time side effect, and every consumer
+// of the SDK pays for the whole barrel again.
+
+interface Entry {
+	name: string
+	source: string
+	sizeLimitBytes?: number
+	mustNotInclude?: string[]
+}
+
+const ENTRIES: Entry[] = [
+	{
+		name: "import { Tldraw } from 'tldraw'",
+		source: `export { Tldraw } from '${REPO_ROOT}/packages/tldraw/src/index'`,
+		sizeLimitBytes: 1_800_000,
+		mustNotInclude: [
+			'packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts',
+			'packages/tldraw/src/lib/TldrawImage.tsx',
+			'packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx',
+			'node_modules/@radix-ui/react-select/',
+		],
+	},
+	{
+		name: "import { TldrawEditor } from '@tldraw/editor'",
+		source: `export { TldrawEditor } from '${REPO_ROOT}/packages/editor/src/index'`,
+		mustNotInclude: ['packages/editor/src/lib/hooks/useTLStore.ts'],
+	},
+	{
+		name: "export * from 'tldraw'",
+		source: `export * from '${REPO_ROOT}/packages/tldraw/src/index'`,
+	},
+]
+
+async function measure(entry: Entry, dir: string) {
+	const entryFile = join(dir, 'entry.ts')
+	writeFileSync(entryFile, entry.source)
+	const result = await build({
+		entryPoints: [entryFile],
+		bundle: true,
+		minify: true,
+		format: 'esm',
+		platform: 'browser',
+		target: 'es2022',
+		external: ['react', 'react-dom', 'react/jsx-runtime'],
+		loader: {
+			'.css': 'empty',
+			'.svg': 'dataurl',
+			'.png': 'dataurl',
+			'.woff2': 'dataurl',
+			'.json': 'json',
+		},
+		define: {
+			'globalThis.TLDRAW_LIBRARY_IS_BUILD': 'true',
+			'globalThis.TLDRAW_LIBRARY_NAME': '"tldraw"',
+			'globalThis.TLDRAW_LIBRARY_VERSION': '"0.0.0"',
+			'globalThis.TLDRAW_LIBRARY_MODULES': '"esm"',
+			'process.env.NODE_ENV': '"production"',
+		},
+		write: false,
+		logLevel: 'silent',
+		metafile: true,
+	})
+	const output = result.outputFiles[0].contents
+	const inputs = Object.keys(Object.values(result.metafile.outputs)[0].inputs).map((file) =>
+		relative(REPO_ROOT, join(dir, file))
+	)
+	return {
+		minified: output.length,
+		gzipped: gzipSync(output, { level: 9 }).length,
+		inputs,
+	}
+}
+
+function kb(bytes: number) {
+	return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+async function main() {
+	const args = minimist(process.argv.slice(2))
+	const dir = mkdtempSync(join(tmpdir(), 'tldraw-bundle-'))
+	let failed = false
+	try {
+		for (const entry of ENTRIES) {
+			const { minified, gzipped, inputs } = await measure(entry, dir)
+			nicelog(
+				`${kleur.cyan().bold(entry.name)}  ${kb(minified)} minified, ${kb(gzipped)} gzipped, ${inputs.length} modules`
+			)
+
+			if (entry.sizeLimitBytes && minified > entry.sizeLimitBytes) {
+				failed = true
+				nicelog(
+					`  ${kleur.red().bold('ERROR')} exceeds the size limit of ${kb(entry.sizeLimitBytes)} minified`
+				)
+			}
+
+			for (const pattern of entry.mustNotInclude ?? []) {
+				const hits = inputs.filter((file) => file.includes(pattern))
+				if (hits.length) {
+					failed = true
+					nicelog(
+						`  ${kleur.red().bold('ERROR')} includes ${pattern}, which nothing in this entry should need`
+					)
+				}
+			}
+
+			if (args.verbose) {
+				for (const file of inputs.sort()) nicelog(`    ${file}`)
+			}
+		}
+	} finally {
+		rmSync(dir, { recursive: true, force: true })
+	}
+
+	if (failed) {
+		nicelog(
+			kleur.red(
+				'\nThe SDK bundle includes code that consumers should not pay for. Check that every package in packages/* declares "sideEffects" (yarn check-packages) and that no module runs code at import time.'
+			)
+		)
+		process.exit(1)
+	}
+}
+
+main()

--- a/internal/scripts/check-sdk-bundle.ts
+++ b/internal/scripts/check-sdk-bundle.ts
@@ -23,20 +23,29 @@ interface Entry {
 	mustInclude?: string[]
 }
 
+// Each canary is public API that the default editor never imports. If one of them is ever wired
+// into the default tree on purpose, swap it for another consumer-only module rather than
+// deleting the check.
 const TLDRAW_CANARIES = [
+	// only reachable via parseTldrawJsonFile / parseAndLoadDocument
 	'packages/tldraw/src/lib/utils/tldr/buildFromV1Document.ts',
+	// a standalone component, not rendered by <Tldraw />
 	'packages/tldraw/src/lib/TldrawImage.tsx',
+	// a UI primitive no default menu uses; drags in @radix-ui/react-select via the radix-ui umbrella
 	'packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx',
 	'node_modules/@radix-ui/react-select/',
 ]
+// TldrawEditor uses useLocalStore, never the standalone store hook
 const EDITOR_CANARIES = ['packages/editor/src/lib/hooks/useTLStore.ts']
 
 const ENTRIES: Entry[] = [
 	{
 		name: "import { Tldraw } from 'tldraw'",
 		source: `export { Tldraw } from '${REPO_ROOT}/packages/tldraw/src/index'`,
-		// Bump deliberately when the SDK legitimately grows; this exists to make growth visible.
-		sizeLimitBytes: 1_800_000,
+		// Measured at 1,657,637 B when this check was added, and 1,738,900 B with every
+		// sideEffects declaration ignored, so the limit sits between the two. Bump it deliberately
+		// when the SDK legitimately grows; it exists to make growth visible, not to forbid it.
+		sizeLimitBytes: 1_700_000,
 		mustNotInclude: [...TLDRAW_CANARIES, ...EDITOR_CANARIES],
 	},
 	{

--- a/internal/scripts/lib/types.ts
+++ b/internal/scripts/lib/types.ts
@@ -53,6 +53,7 @@ export const ProductConfig = T.object({
 export type ProductConfig = T.TypeOf<typeof ProductConfig>
 
 export const PackageJson = T.object({
+	sideEffects: T.or(T.boolean, T.arrayOf(T.string)).optional(),
 	name: T.string,
 	private: T.boolean.optional(),
 	workspaces: T.arrayOf(T.string).optional(),

--- a/internal/scripts/lib/types.ts
+++ b/internal/scripts/lib/types.ts
@@ -53,9 +53,9 @@ export const ProductConfig = T.object({
 export type ProductConfig = T.TypeOf<typeof ProductConfig>
 
 export const PackageJson = T.object({
-	sideEffects: T.or(T.boolean, T.arrayOf(T.string)).optional(),
 	name: T.string,
 	private: T.boolean.optional(),
+	sideEffects: T.or(T.boolean, T.arrayOf(T.string)).optional(),
 	workspaces: T.arrayOf(T.string).optional(),
 	[EXPORT_CONFIG_KEY]: TemplateConfig.optional(),
 	[PRODUCT_CONFIG_KEY]: ProductConfig.optional(),

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -135,14 +135,10 @@ const config = {
 		},
 		'check-bundle-size': {
 			execution: 'independent',
-			workspaceOverrides: {
-				// The SDK check bundles packages/tldraw from source, so it depends on every SDK
-				// package's sources and manifests, not just its own workspace.
-				'packages/tldraw': {
-					cache: {
-						inputs: ['<rootDir>/packages/*/src/**/*', '<rootDir>/packages/*/package.json'],
-					},
-				},
+			// Every bundle check pulls in SDK package sources, so a change in packages/* must
+			// invalidate the cache even though it lives outside the checking workspace.
+			cache: {
+				inputs: ['src/**/*', '<rootDir>/packages/*/src/**/*', '<rootDir>/packages/*/package.json'],
 			},
 		},
 		'api-check': {

--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -133,6 +133,18 @@ const config = {
 				outputs: ['<rootDir>/apps/dotcom/client/public/tla/locales-compiled/*.json'],
 			},
 		},
+		'check-bundle-size': {
+			execution: 'independent',
+			workspaceOverrides: {
+				// The SDK check bundles packages/tldraw from source, so it depends on every SDK
+				// package's sources and manifests, not just its own workspace.
+				'packages/tldraw': {
+					cache: {
+						inputs: ['<rootDir>/packages/*/src/**/*', '<rootDir>/packages/*/package.json'],
+					},
+				},
+			},
+		},
 		'api-check': {
 			execution: 'top-level',
 			baseCommand: `tsx <rootDir>/internal/scripts/api-check.ts`,

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -26,6 +26,12 @@
 	"types": "./.tsbuild/index.d.ts",
 	"style": "./collaboration.css",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"files": [
 		"collaboration.css"
 	],

--- a/packages/commenting/package.json
+++ b/packages/commenting/package.json
@@ -27,6 +27,12 @@
 	"types": "./.tsbuild/index.d.ts",
 	"style": "./commenting.css",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"files": [
 		"commenting.css"
 	],

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -33,6 +33,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"scripts": {
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,6 +36,12 @@
 	"types": "./.tsbuild/index.d.ts",
 	"style": "./editor.css",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [
 		"editor.css"

--- a/packages/mentions/package.json
+++ b/packages/mentions/package.json
@@ -27,6 +27,12 @@
 	"types": "./.tsbuild/index.d.ts",
 	"style": "./mentions.css",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"files": [
 		"mentions.css"
 	],

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -33,6 +33,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/namespaced-tldraw/package.json
+++ b/packages/namespaced-tldraw/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"scripts": {
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",

--- a/packages/state-react/package.json
+++ b/packages/state-react/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/sync-collaboration/package.json
+++ b/packages/sync-collaboration/package.json
@@ -26,6 +26,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"scripts": {
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",

--- a/packages/sync-core/package.json
+++ b/packages/sync-core/package.json
@@ -36,6 +36,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -36,6 +36,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -40,6 +40,12 @@
 		"./*.css": "./*.css"
 	},
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"scripts": {
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",
@@ -49,6 +55,7 @@
 		"prebuild": "node ./scripts/copy-css-files.mjs",
 		"build": "yarn run -T tsx ../../internal/scripts/build-package.ts",
 		"build-api": "yarn run -T tsx ../../internal/scripts/build-api.ts",
+		"check-bundle-size": "yarn run -T tsx ../../internal/scripts/check-sdk-bundle.ts",
 		"prepack": "yarn run -T tsx ../../internal/scripts/prepack.ts",
 		"postpack": "../../internal/scripts/postpack.sh",
 		"pack-tarball": "yarn pack",

--- a/packages/tlschema/package.json
+++ b/packages/tlschema/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -35,6 +35,12 @@
 	"main": "./src/index.ts",
 	"types": "./.tsbuild/index.d.ts",
 	"type": "module",
+	"sideEffects": [
+		"./src/index.ts",
+		"./dist-esm/index.mjs",
+		"./dist-cjs/index.js",
+		"**/*.css"
+	],
 	"/* GOTCHA */": "files will include ./dist and index.d.ts by default, add any others you want to include in here",
 	"files": [],
 	"scripts": {


### PR DESCRIPTION
This PR improves the bundle size for consumers of the SDK so that importing `Tldraw` no longer pulls in every module reachable from the package barrel, and adds a CI check that keeps it that way. It is step 1 of the plan in #10572.

### Before

The published packages are built one output file per source module (`bundle: false` in `build-package.ts`), so a consumer's bundler sees hundreds of modules behind `tldraw`'s `index.ts`. No package declared `sideEffects`, so the bundler had to assume every one of those modules might run code at import time and keep them all: `import { Tldraw } from 'tldraw'` cost 1,685,972 B minified / 512,705 B gzipped, only 3% less than `export * from 'tldraw'`, and included things like `@radix-ui/react-select` (18 KB, used only by the unmounted `TldrawUiSelect` primitive), `TldrawImage`, and the v1 `.tldr` importer.

### After

Every published package under `packages/*` declares

```json
"sideEffects": ["./src/index.ts", "./dist-esm/index.mjs", "./dist-cjs/index.js", "**/*.css"]
```

The entry point is the one module with a real import-time effect (`registerTldrawLibraryVersion`), and stylesheets must stay side-effectful or `import 'tldraw/tldraw.css'` gets dropped. `yarn check-packages` now enforces the declaration (and `--fix` adds it), and `yarn lazy check-bundle-size` runs a new `internal/scripts/check-sdk-bundle.ts` alongside the existing worker checks. It bundles `import { Tldraw } from 'tldraw'` and `import { TldrawEditor } from '@tldraw/editor'` from source with esbuild, prints the sizes, fails if modules that nothing in the default editor tree needs show up, and fails above a 1.7 MB minified limit meant to be bumped deliberately (the current build is 1.66 MB; with every declaration ignored it is 1.74 MB, so losing them fails the check). The `export * from 'tldraw'` entry asserts the same canaries *are* present, so a renamed canary fails instead of matching nothing.

Measured with esbuild (minify, ESM, React external):

| Entry | Before | After | Delta |
| --- | --- | --- | --- |
| `import { Tldraw } from 'tldraw'` | 1,685,972 B / 512,705 B gz (741 modules) | 1,657,637 B / 503,417 B gz (728 modules) | **-28.3 KB / -9.3 KB gz** |
| `import { TldrawEditor } from '@tldraw/editor'` | 552,043 B / 169,482 B gz | 549,193 B / 168,686 B gz | -2.9 KB / -0.8 KB gz |
| `export * from 'tldraw'` | 1,743,443 B / 530,878 B gz | unchanged | — |

The remaining 728 modules are all genuinely reachable from `<Tldraw />` through real imports, so module-level tree-shaking is now exhausted; further reductions need the structural changes in the other steps of #10572 (lazy-loading, dependency replacement). One consequence worth knowing about for those: a module that is both dynamically imported *and* re-exported from the package barrel still lands in the consumer's initial chunk in both Rollup and esbuild, because the barrel's static edge counts for chunk assignment even when the export is unused. Lazily loaded implementation modules therefore need to live behind a wrapper that the barrel exports, not be barrel exports themselves.

One pre-existing hazard the review turned up and this PR leaves alone: `packages/tldraw/src/lib/utils/text/richText.ts` mutates tiptap singletons at module scope (`Code.config.excludes`, `Highlight.config.priority`). It is safe because every text path imports that module, but it is the kind of side effect the declaration now says doesn't exist; moving the two assignments into `getTipTapDefaultExtensions()` would remove the hazard.

### Change type

- [x] `improvement`

### Test plan

1. `yarn check-packages` passes; remove a `sideEffects` entry and it fails, `--fix` restores it next to `"type"`.
2. `yarn lazy check-bundle-size` passes; run the script against a tree without the declarations and it reports the canaries.
3. `yarn dev` and the dotcom client still start and render (they consume the packages via `src/index.ts` through Vite, which honours the declaration).

### Release notes

- Declare `sideEffects` in every SDK package so bundlers can drop modules you don't import; `import { Tldraw } from 'tldraw'` is ~28 KB smaller minified.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Documentation  | +1 / -0    |
| Config/tooling | +351 / -1  |
