### PR TITLE
perf: lazy-load local persistence, hard reset and the Excalidraw importer

### DIFF
--- a/internal/scripts/build-package.ts
+++ b/internal/scripts/build-package.ts
@@ -109,6 +109,10 @@ async function buildLibrary({
 		outdir,
 		format: info.moduleSystem,
 		outExtension: info.moduleSystem === 'esm' ? { '.js': '.mjs' } : undefined,
+		// Lower `import()` to `require()` in the CJS build. A bare import() of an extensionless
+		// path fails under Jest and other CJS loaders without a dynamic-import hook, which would
+		// put <Tldraw persistenceKey /> straight into the error fallback.
+		supported: info.moduleSystem === 'cjs' ? { 'dynamic-import': false } : undefined,
 		bundle: false,
 		platform: 'neutral',
 		sourcemap: true,

--- a/internal/scripts/build-package.ts
+++ b/internal/scripts/build-package.ts
@@ -14,6 +14,14 @@ interface LibraryInfo {
 	moduleSystem: 'esm' | 'cjs'
 }
 
+// Packages whose CJS build lowers `import()` to `require()`. A bare import() of an extensionless
+// relative path fails under Jest and other CJS loaders without a dynamic-import hook, which would
+// put <Tldraw persistenceKey /> straight into the error fallback. This is opt-in per package
+// because it is only correct for imports of our own modules: @tldraw/mermaid's `import('mermaid')`
+// must stay a native import() since mermaid is ESM-only and `require('mermaid')` throws
+// ERR_REQUIRE_ESM (#9100).
+const PACKAGES_LOWERING_DYNAMIC_IMPORT_IN_CJS = new Set(['@tldraw/editor', 'tldraw'])
+
 /** Prepares the package for publishing. the tarball in case it will be written to disk. */
 async function buildPackage({ sourcePackageDir }: { sourcePackageDir: string }) {
 	// this depends on `build-types` being run first, but we'll rely on turbo to
@@ -109,10 +117,10 @@ async function buildLibrary({
 		outdir,
 		format: info.moduleSystem,
 		outExtension: info.moduleSystem === 'esm' ? { '.js': '.mjs' } : undefined,
-		// Lower `import()` to `require()` in the CJS build. A bare import() of an extensionless
-		// path fails under Jest and other CJS loaders without a dynamic-import hook, which would
-		// put <Tldraw persistenceKey /> straight into the error fallback.
-		supported: info.moduleSystem === 'cjs' ? { 'dynamic-import': false } : undefined,
+		supported:
+			info.moduleSystem === 'cjs' && PACKAGES_LOWERING_DYNAMIC_IMPORT_IN_CJS.has(info.name)
+				? { 'dynamic-import': false }
+				: undefined,
 		bundle: false,
 		platform: 'neutral',
 		sourcemap: true,

--- a/packages/editor/src/lib/hooks/useLocalStore.ts
+++ b/packages/editor/src/lib/hooks/useLocalStore.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { TLStoreOptions, createTLStore } from '../config/createTLStore'
 import { TLEditorSnapshot } from '../config/TLEditorSnapshot'
 import { TLStoreWithStatus } from '../utils/sync/StoreWithStatus'
-import { TLLocalSyncClient } from '../utils/sync/TLLocalSyncClient'
+import type { TLLocalSyncClient } from '../utils/sync/TLLocalSyncClient'
 import { useShallowObjectIdentity } from './useIdentity'
 import { useRefState } from './useRefState'
 
@@ -38,6 +38,7 @@ export function useLocalStore(
 		const objectURLCache = new Map<TLAssetId, Promise<string | null>>()
 		const assets: TLAssetStore = {
 			upload: async (asset, file) => {
+				const client = await clientPromise
 				await client.db.storeAsset(asset.id, file)
 				return { src: asset.id }
 			},
@@ -47,8 +48,8 @@ export function useLocalStore(
 				if (asset.props.src.startsWith('asset:')) {
 					let objectURL = objectURLCache.get(asset.id)
 					if (!objectURL) {
-						objectURL = client.db
-							.getAsset(asset.id)
+						objectURL = clientPromise
+							.then((client) => client.db.getAsset(asset.id))
 							.then((blob) => (blob ? URL.createObjectURL(blob) : null))
 						objectURLCache.set(asset.id, objectURL)
 					}
@@ -58,6 +59,7 @@ export function useLocalStore(
 				return asset.props.src
 			},
 			remove: async (assetIds) => {
+				const client = await clientPromise
 				await client.db.removeAssets(assetIds)
 			},
 			...rest.assets,
@@ -67,22 +69,33 @@ export function useLocalStore(
 
 		let isClosed = false
 
-		const client = new TLLocalSyncClient(store, {
-			sessionId,
-			persistenceKey,
-			onLoad() {
-				if (isClosed) return
-				setState({ store, status: 'synced-local' })
-			},
-			onLoadError(err: any) {
-				if (isClosed) return
-				setState({ status: 'error', error: err })
-			},
+		// The IndexedDB client (and the idb library under it) is only needed when a persistence key
+		// is set, so consumers that never persist locally don't ship it. The store stays in the
+		// 'loading' state until the client has loaded anyway, so the extra await is invisible.
+		const clientPromise: Promise<TLLocalSyncClient> =
+			import('../utils/sync/TLLocalSyncClient').then(
+				({ TLLocalSyncClient }) =>
+					new TLLocalSyncClient(store, {
+						sessionId,
+						persistenceKey,
+						onLoad() {
+							if (isClosed) return
+							setState({ store, status: 'synced-local' })
+						},
+						onLoadError(err: any) {
+							if (isClosed) return
+							setState({ status: 'error', error: err })
+						},
+					})
+			)
+		clientPromise.catch((err) => {
+			if (isClosed) return
+			setState({ status: 'error', error: err })
 		})
 
 		return () => {
 			isClosed = true
-			client.close()
+			clientPromise.then((client) => client.close(), noop)
 			for (const objectURL of objectURLCache.values()) {
 				objectURL.then((url) => url && URL.revokeObjectURL(url), noop)
 			}

--- a/packages/editor/src/lib/utils/runtime.ts
+++ b/packages/editor/src/lib/utils/runtime.ts
@@ -1,5 +1,3 @@
-import { hardReset } from './sync/hardReset'
-
 /** @public */
 export const runtime: {
 	openWindow(url: string, target: string, allowReferrer?: boolean): void
@@ -13,6 +11,8 @@ export const runtime: {
 		window.location.reload()
 	},
 	async hardReset() {
+		// Only reached from the error fallback, so don't make every consumer ship the IndexedDB code
+		const { hardReset } = await import('./sync/hardReset')
 		return await hardReset({ shouldReload: true })
 	},
 }

--- a/packages/editor/src/lib/utils/runtime.ts
+++ b/packages/editor/src/lib/utils/runtime.ts
@@ -44,5 +44,10 @@ export function refreshPage() {
 
 /** @public */
 export function hardResetEditor() {
-	runtime.hardReset()
+	runtime.hardReset().catch((err) => {
+		// The reset code is loaded on demand; if that load fails (the user is likely already on
+		// the error fallback, possibly offline) at least get them a fresh page.
+		console.error(err)
+		runtime.refreshPage()
+	})
 }

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -71,7 +71,6 @@
 		"@tldraw/store": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",
 		"classnames": "^2.5.1",
-		"idb": "^7.1.1",
 		"lz-string": "^1.5.0",
 		"radix-ui": "^1.4.2"
 	},

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -34,7 +34,6 @@ import { getCroppedImageDataForReplacedImage } from './shapes/shared/crop'
 import { FONT_SIZES, TEXT_PROPS, getFontFamily } from './shapes/shared/default-shape-constants'
 import { TLUiToastsContextType } from './ui/context/toasts'
 import { useTranslation } from './ui/hooks/useTranslation/useTranslation'
-import { putExcalidrawContent } from './utils/excalidraw/putExcalidrawContent'
 import { renderHtmlFromRichTextForMeasurement, renderRichTextFromHTML } from './utils/text/richText'
 import { cleanupText, isRightToLeftLanguage } from './utils/text/text'
 
@@ -706,6 +705,7 @@ export async function defaultHandleExternalExcalidrawContent(
 	editor: Editor,
 	{ point, content }: { point?: VecLike; content: any }
 ) {
+	const { putExcalidrawContent } = await import('./utils/excalidraw/putExcalidrawContent')
 	editor.run(() => {
 		putExcalidrawContent(editor, content, point)
 	})

--- a/yarn.lock
+++ b/yarn.lock
@@ -31952,7 +31952,6 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     chokidar-cli: "npm:^3.0.0"
     classnames: "npm:^2.5.1"
-    idb: "npm:^7.1.1"
     jest-diff: "npm:^30.4.1"
     lazyrepo: "npm:0.0.0-alpha.27"
     lz-string: "npm:^1.5.0"


### PR DESCRIPTION
This PR loads three cold paths on demand instead of shipping them in every consumer's initial bundle: the IndexedDB persistence client, the hard-reset helper, and the Excalidraw paste importer. It is step 3 of the plan in #10572, and the measurements below show it delivers much less than the step promised; see "What this does not achieve" before reviewing.

### Before

`useLocalStore`, `runtime.hardReset` and `defaultHandleExternalExcalidrawContent` imported `TLLocalSyncClient` (→ `LocalIndexedDb` → the `idb` library), `hardReset` and `putExcalidrawContent` statically, so they were in the initial bundle even though they only run when a `persistenceKey` is set, when the error fallback's reset button is pressed, or when Excalidraw content is pasted. `packages/tldraw` also declared an `idb` dependency that nothing in the package imports.

### After

Each site loads its dependency with a dynamic `import()` at the point it is needed, following the precedent of `sanitizeSvg` in `defaultExternalContentHandlers.ts`. `useLocalStore` keeps the store in the `loading` state until the client has loaded anyway, so the extra `await` is not observable; the asset store callbacks and the effect cleanup await the same promise, so `close()` runs exactly once on the eventual client even if the effect is torn down before the import resolves, and a failed chunk load surfaces as the existing `error` state. The unused `idb` dependency is removed from `packages/tldraw`.

### What this does not achieve

Measured with Vite 8 (Rollup) on top of #10574, counting the entry chunk plus everything it imports statically:

| | Initial load (minified, gz) | Lazy chunks |
| --- | --- | --- |
| `sideEffects` only | 627,548 B gz | — |
| `sideEffects` + this PR | 630,120 B gz (+2.5 KB) | `TLLocalSyncClient` (7.5 KB), `hardReset` |

Only `TLLocalSyncClient` actually moves to a lazy chunk. `LocalIndexedDb` + `idb`, `putExcalidrawContent` and `hardReset`'s dependencies stay in the initial load because they are also re-exported from the package barrel, and both Rollup and esbuild assign a module that is statically reachable from the entry (even through an unused re-export) to the initial chunk. The extra chunk boundaries cost more in gzip than the 7.5 KB that moved. esbuild without splitting shows the same: 1,657,341 B → 1,654,160 B minified.

The same is true of the existing `sanitizeSvg` lazy import on `main`: it is a barrel export, so it has never actually split. For lazy loading to pay off in this codebase, the implementation module must not be a barrel export: the public export has to be a thin wrapper (or an async API) and the code it loads must live in a module only the wrapper imports. That is a design change to the public surface (`LocalIndexedDb`, `hardReset`, `putExcalidrawContent`, `sanitizeSvg` are all `@public`), so it is not done here.

### Implementation notes

- The CJS build now lowers `import()` to `require()` (`supported: { 'dynamic-import': false }` in `build-package.ts`). A bare `import()` of an extensionless path rejects under Jest and other CJS loaders without a dynamic-import hook, which would have sent every `<Tldraw persistenceKey />` test straight into the error fallback; the pre-existing `sanitizeSvg` import had the same problem. `hardResetEditor` falls back to a page refresh if its chunk fails to load.
- `lz-string` (clipboard), `PerformanceManager` (`editor.performance` is public and synchronous) and `DEFAULT_EMBED_DEFINITIONS` (a synchronous `EmbedShapeUtil` option) were considered and left alone: each would need an API change to load lazily.

### Change type

- [x] `improvement`

### Test plan

1. Mount `<Tldraw persistenceKey="x" />`, draw, reload; the document persists.
2. Trigger the error fallback (debug menu → "Hard reset") and confirm the page resets.
3. Paste an Excalidraw selection onto the canvas.

- [x] Unit tests

### Release notes

- Load the local persistence client on demand so it no longer ships in the initial bundle when no `persistenceKey` is set.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +37 / -19 |
| Config/tooling | +4 / -2 |
