### PR TITLE
fix(internal): raise AnthropicTokenRateAnomaly thresholds so routine agent sessions don't page

### DIFF
--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: stacks-890472
 spec:
   annotations:
-    description: Token processing rate of {{ $value | humanize }} tokens/sec is 3x
+    description: Token processing rate of {{ $value | humanize }} tokens/sec is 5x
       higher than the 7-day average for job {{ $labels.job }}.
     summary: Anthropic API token rate anomaly detected.
   execErrState: Ok
@@ -57,10 +57,10 @@ spec:
           (
             rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])
             >
-            3 * avg_over_time(rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])[7d:1h])
+            5 * avg_over_time(rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])[7d:1h])
           )
           and
-          rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h]) > 100
+          rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h]) > 1000
         instant: true
         intervalMs: 1000
         maxDataPoints: 43200


### PR DESCRIPTION
## Problem

Since #10579 fixed the flapping, `AnthropicTokenRateAnomaly` fires correctly — but on ordinary agent sessions. A typical cache-heavy session sustains ~750 tokens/sec while daily spend stays flat (under $15/day since Aug 21), because cache reads inflate token counts enormously relative to cost. The 7-day baseline also averages over nights and weekends, so any busy working hour clears 3x. The result is a warning that mostly means "someone is working".

## Fix

Keep the rule as an early-warning for genuinely exceptional bursts only:

- absolute floor: 100 → 1000 tokens/sec (~3.6M tokens/hour)
- baseline multiplier: 3x → 5x

Yesterday's ~750 tokens/sec session no longer fires; an Aug 21-scale runaway (~$360/day) still does within minutes. Cost-denominated protection is unchanged: `AnthropicDailyCostSpike` (>1.5x day-over-day, $50 floor) and `AnthropicHighCostThreshold` ($1000/24h) from #10579.

## Notes

Alert rules show as "skipped: client-side check only" in CI dry-run — expected per `internal/grafana/README.md`. Deploys on merge.