### PR TITLE
feat(sync): add TLSyncClient.flush() to settle pending changes without a frame

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -200,6 +200,30 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **CR6** Applying a network diff is value-aware: a `put` equal to the stored record is a no-op for listeners, a `patch` for a missing record is skipped, and a `remove` of a missing record is skipped.
 - **CR7** `custom` events invoke `onCustomMessageReceived(data)` with `this` bound to null.
 
+## 21a. `TLSyncClient` — flush (CF)
+
+`flush()` exists because both the sending and the receiving side of the client ride the network
+throttle, which is frame-scheduled — a client whose page gets no frames (a minimized or occluded
+window, a background tab) neither sends its pushes nor processes their results. Callers that need
+a durability guarantee (a desktop save barrier) must be able to get one without a frame.
+
+- **CF1** `flush()` first delivers the store's batched listener notifications, then sends any
+  unsent changes immediately — neither step waits for the network throttle.
+- **CF2** The returned promise covers exactly the changes that existed at the moment of the call:
+  it resolves once the server has settled every push in flight at call time (through the client
+  clock captured at the call). Edits made after the call are not waited for, so a busy client can
+  never starve a flush; they may still ride along in the same push.
+- **CF3** A flush with nothing unsettled resolves immediately.
+- **CF4** A flush rejects immediately, naming the reason, when the store is possibly corrupted
+  (the silent push stop of CP7 must not read as "settled") or when the client is not connected and
+  changes remain unsent.
+- **CF5** A connection reset rejects every in-flight flush: its pending pushes were dropped and
+  their results will never arrive. The changes themselves are not lost (CL5 re-pushes them after
+  reconnect); the caller retries the flush. Closing the client rejects in-flight flushes the same
+  way.
+- **CF6** While a flush is waiting, incoming server events are processed immediately instead of on
+  the throttle, so settlement is frame-independent end to end.
+
 ## 22. `TLSyncRoom` — construction (RC)
 
 - **RC1** The room serializes its schema with a JSON round-trip (so it contains no `undefined` values).

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -665,6 +665,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
         store: S;
     });
     close(): void;
+    flush(): Promise<void>;
     // @internal (undocumented)
     isConnectedToRoom: boolean;
     // @internal (undocumented)

--- a/packages/sync-core/src/lib/TLSyncClient.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.test.ts
@@ -1770,4 +1770,102 @@ describe('TLSyncClient', () => {
 			}).not.toThrow()
 		})
 	})
+
+	describe('21a. flush (CF)', () => {
+		// flush exists for pages that get no frames, so these tests run with the real
+		// frame-throttled paths (not the test shortcut) and requestAnimationFrame dead: nothing
+		// sends or settles unless flush does it without a frame.
+		beforeEach(() => {
+			;(globalThis as any).__FORCE_RAF_IN_TESTS__ = true
+			vi.stubGlobal('requestAnimationFrame', () => 0)
+			vi.stubGlobal('cancelAnimationFrame', () => {})
+		})
+
+		afterEach(() => {
+			client?.close()
+			client = undefined as any
+			delete (globalThis as any).__FORCE_RAF_IN_TESTS__
+			vi.unstubAllGlobals()
+		})
+
+		function commitFor(push: TLPushRequest<TestRecord>) {
+			socket.mockServerMessage({
+				type: 'data',
+				data: [
+					{ type: 'push_result', clientClock: push.clientClock, serverClock: 2, action: 'commit' },
+				],
+			})
+		}
+
+		it('[CF1, CF2, CF6] sends and settles without a single frame', async () => {
+			connectClient()
+
+			store.put([makePage('No Frames Page')])
+			// the throttled path is starved: nothing has been sent
+			expect(getSentPushes()).toHaveLength(0)
+
+			const flushed = client.flush()
+			const pushes = getSentPushes()
+			expect(pushes).toHaveLength(1)
+
+			commitFor(pushes[0])
+			await expect(flushed).resolves.toBeUndefined()
+		})
+
+		it('[CF3] resolves immediately when nothing is unsettled', async () => {
+			connectClient()
+			await expect(client.flush()).resolves.toBeUndefined()
+		})
+
+		it('[CF2] is not starved by edits made after the call', async () => {
+			connectClient()
+
+			store.put([makePage('First', 'a1')])
+			const flushed = client.flush()
+			const firstPush = getSentPushes()[0]
+			expect(firstPush).toBeDefined()
+
+			// a later edit lands while the flush is in flight and is never settled
+			store.put([makePage('Second', 'a2')])
+
+			commitFor(firstPush)
+			await expect(flushed).resolves.toBeUndefined()
+		})
+
+		it('[CF4] rejects when the store is possibly corrupted', async () => {
+			connectClient()
+			store.markAsPossiblyCorrupted()
+			await expect(client.flush()).rejects.toThrow('possibly corrupted')
+		})
+
+		it('[CF4] rejects when disconnected with changes still unsent', async () => {
+			connectClient()
+			socket.mockConnectionStatus('offline')
+
+			store.put([makePage('Offline Page')])
+			await expect(client.flush()).rejects.toThrow('not connected')
+		})
+
+		it('[CF5] a connection reset rejects the in-flight flush instead of hanging or lying', async () => {
+			connectClient()
+
+			store.put([makePage('Doomed Page')])
+			const flushed = client.flush()
+			expect(getSentPushes()).toHaveLength(1)
+
+			socket.mockConnectionStatus('offline')
+			await expect(flushed).rejects.toThrow('connection was reset')
+		})
+
+		it('[CF5] closing the client rejects the in-flight flush', async () => {
+			connectClient()
+
+			store.put([makePage('Closing Page')])
+			const flushed = client.flush()
+			expect(getSentPushes()).toHaveLength(1)
+
+			client.close()
+			await expect(flushed).rejects.toThrow('closed before')
+		})
+	})
 })

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -4,6 +4,7 @@ import {
 	RecordsDiff,
 	Store,
 	UnknownRecord,
+	isRecordsDiffEmpty,
 	reverseRecordsDiff,
 	squashRecordDiffsMutable,
 } from '@tldraw/store'
@@ -381,6 +382,13 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 
 	/** The queue of in-flight push requests that have not yet been acknowledged by the server */
 	private pendingPushRequests: TLPushRequest<R>[] = []
+
+	/** Callers of {@link TLSyncClient.flush} waiting for the server to settle a captured clock. */
+	private readonly flushWaiters = new Set<{
+		targetClock: number
+		resolve(): void
+		reject(error: Error): void
+	}>()
 	private unsentChanges: {
 		nextDiff?: RecordsDiff<R>
 		nextPresence?: R | null
@@ -510,46 +518,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.fpsScheduler = new FpsScheduler(COLLABORATIVE_MODE_FPS)
 
 		// Initialize throttled methods after throttle instance is created
-		this.sendUnsentChanges = this.fpsScheduler.fpsThrottle(() => {
-			this.debug('sending unsent changes', {
-				isConnectedToRoom: this.isConnectedToRoom,
-				unsentChanges: this.unsentChanges,
-			})
-			if (!this.isConnectedToRoom || this.store.isPossiblyCorrupted()) {
-				return
-			}
-			if (!this.unsentChanges.nextDiff && !this.unsentChanges.nextPresence) {
-				return
-			}
-			const diff = this.unsentChanges.nextDiff
-				? (getNetworkDiff(this.unsentChanges.nextDiff) ?? undefined)
-				: undefined
-			const presence = this.unsentChanges.nextPresence
-				? getPresenceOp<R>(this.lastPushedPresenceState, this.unsentChanges.nextPresence)
-				: undefined
-
-			if (!diff && !presence) {
-				return
-			}
-
-			const pushRequest: TLPushRequest<R> = {
-				type: 'push',
-				clientClock: this.clientClock,
-				diff,
-				presence,
-			}
-
-			this.debug('sending push request', pushRequest)
-			this.socket.sendMessage(pushRequest)
-
-			if (this.unsentChanges.nextPresence) {
-				this.lastPushedPresenceState = this.unsentChanges.nextPresence
-			}
-			this.clientClock++
-			this.pendingPushRequests.push(pushRequest)
-			this.unsentChanges.nextDiff = undefined
-			this.unsentChanges.nextPresence = undefined
-		})
+		this.sendUnsentChanges = this.fpsScheduler.fpsThrottle(() => this.sendUnsentChangesNow())
 
 		this.scheduleRebase = this.fpsScheduler.fpsThrottle(this.rebase)
 
@@ -722,6 +691,12 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.firstUnansweredPingAt = null
 		this.pendingPushRequests = []
 		this.incomingDiffBuffer = []
+		// CF5: the pending pushes above were just dropped, so their results will never arrive — a
+		// waiter left in place would either hang forever or, worse, be resolved by the emptied
+		// queue as if the server had settled changes it never received.
+		this.rejectFlushWaiters(
+			new Error('The connection was reset before the server settled the flushed changes')
+		)
 		this.unsentChanges.nextDiff = undefined
 		this.unsentChanges.nextPresence = undefined
 		if (this.socket.connectionStatus === 'online') {
@@ -831,13 +806,13 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			case 'push_result':
 				if (!this.isConnectedToRoom) break
 				this.incomingDiffBuffer.push(event)
-				this.scheduleRebase()
+				this.rebaseSoon()
 				break
 			case 'data':
 				// wait for a connect to succeed before processing more events
 				if (!this.isConnectedToRoom) break
 				this.incomingDiffBuffer.push(...event.data)
-				this.scheduleRebase()
+				this.rebaseSoon()
 				break
 			case 'incompatibility_error':
 				// legacy unrecoverable errors
@@ -853,6 +828,112 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			default:
 				exhaustiveSwitchError(event)
 		}
+	}
+
+	/**
+	 * Send every change the store holds right now — without waiting for a frame — and resolve once
+	 * the server has settled them. Edits made after the call are not waited for: the promise
+	 * covers exactly the state at the moment of the call, so a busy client can never starve a
+	 * flush.
+	 */
+	flush(): Promise<void> {
+		this.debug('flush')
+		// CF4: pushes silently stop for a corrupted store (CP7) — resolving here would claim
+		// "settled" for changes that will never be sent.
+		if (this.store.isPossiblyCorrupted()) {
+			return Promise.reject(
+				new Error('Cannot flush: the store is possibly corrupted and sync is stopped')
+			)
+		}
+		// CF1: deliver the store's batched listener notifications so "right now" includes edits
+		// still in its queue, then send directly — the throttled path only queues on the fps
+		// scheduler, and a page that gets no frames never drains it.
+		this.store._flushHistory()
+		this.sendUnsentChangesNow()
+		// CF4: while disconnected, local changes live only in the speculative diff (CP3) — the send
+		// above was a no-op, they will only leave after a reconnect, and waiting for one here has
+		// no bound the client can promise.
+		if (!this.isConnectedToRoom && !isRecordsDiffEmpty(this.speculativeChanges)) {
+			return Promise.reject(
+				new Error('Cannot flush: not connected to the room; retry after reconnecting')
+			)
+		}
+		const targetClock = this.clientClock - 1
+		if (
+			this.pendingPushRequests.length === 0 ||
+			this.pendingPushRequests[0].clientClock > targetClock
+		) {
+			// CF3
+			return Promise.resolve()
+		}
+		return new Promise<void>((resolve, reject) => {
+			this.flushWaiters.add({ targetClock, resolve, reject })
+		})
+	}
+
+	// CF6: the throttle rides requestAnimationFrame, and the page of a waiting flush may never get
+	// another frame — the push went out only because flush sent it directly, and its result would
+	// otherwise sit buffered until a frame that never comes.
+	private rebaseSoon() {
+		if (this.flushWaiters.size > 0) {
+			this.rebase()
+		} else {
+			this.scheduleRebase()
+		}
+	}
+
+	// Pushes are answered strictly in order and clocks are monotonic, so "settled through clock N"
+	// is a single comparison against the front of the queue.
+	private settleFlushWaiters() {
+		if (this.flushWaiters.size === 0) return
+		const front = this.pendingPushRequests[0]
+		for (const waiter of this.flushWaiters) {
+			if (!front || front.clientClock > waiter.targetClock) {
+				this.flushWaiters.delete(waiter)
+				waiter.resolve()
+			}
+		}
+	}
+
+	private sendUnsentChangesNow() {
+		this.debug('sending unsent changes', {
+			isConnectedToRoom: this.isConnectedToRoom,
+			unsentChanges: this.unsentChanges,
+		})
+		if (!this.isConnectedToRoom || this.store.isPossiblyCorrupted()) {
+			return
+		}
+		if (!this.unsentChanges.nextDiff && !this.unsentChanges.nextPresence) {
+			return
+		}
+		const diff = this.unsentChanges.nextDiff
+			? (getNetworkDiff(this.unsentChanges.nextDiff) ?? undefined)
+			: undefined
+		const presence = this.unsentChanges.nextPresence
+			? getPresenceOp<R>(this.lastPushedPresenceState, this.unsentChanges.nextPresence)
+			: undefined
+
+		if (!diff && !presence) {
+			return
+		}
+
+		const pushRequest: TLPushRequest<R> = {
+			type: 'push',
+			clientClock: this.clientClock,
+			diff,
+			presence,
+		}
+
+		this.debug('sending push request', pushRequest)
+		this.socket.sendMessage(pushRequest)
+
+		if (this.unsentChanges.nextPresence) {
+			this.lastPushedPresenceState = this.unsentChanges.nextPresence
+		}
+		this.clientClock++
+		this.pendingPushRequests.push(pushRequest)
+		this.unsentChanges.nextDiff = undefined
+		this.unsentChanges.nextPresence = undefined
 	}
 
 	/**
@@ -873,9 +954,21 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.disposables.forEach((dispose) => dispose())
 		this.sendUnsentChanges.cancel?.()
 		this.scheduleRebase.cancel?.()
+		// CF5
+		this.rejectFlushWaiters(
+			new Error('The sync client closed before the server settled the flushed changes')
+		)
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
+	}
+
+	private rejectFlushWaiters(error: Error) {
+		if (this.flushWaiters.size === 0) return
+		for (const waiter of this.flushWaiters) {
+			waiter.reject(error)
+		}
+		this.flushWaiters.clear()
 	}
 
 	private lastPushedPresenceState: R | null = null
@@ -1016,6 +1109,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				}
 			})
 			this.lastServerClock = diffs.at(-1)?.serverClock ?? this.lastServerClock
+			this.settleFlushWaiters()
 		} catch (e) {
 			console.error(e)
 			this.store.ensureStoreIsUsable()


### PR DESCRIPTION
`TLSyncClient` sends pushes and processes their results on the frame-scheduled network throttle. A page that gets no frames — a minimized or occluded window in the desktop app, a background tab — neither sends its unsent changes nor processes the results of pushes already in flight. There is currently no way for a caller to get a durability guarantee without a frame: the desktop app's save barrier works around this from outside by reaching into `window.tlsync` and draining the scheduler by hand, and we hit real save timeouts in the field this week from exactly this gap (same family as #9964, where hidden-tab throttling starved the ping loop).

This adds one method: `flush()` sends everything the store holds at the moment of the call, without the throttle, and resolves once the server has settled it.

Design decisions, per the new CF rules in `packages/sync-core/SPEC.md`:

- The promise covers exactly the state at call time (a captured client clock), so a busy client can never starve a flush. Later edits may ride along in the same push but are never waited for.
- It rejects, naming the cause, rather than hanging or resolving falsely: corrupted store (whose pushes stop silently per CP7), disconnected with local changes still unsettled, a connection reset that dropped the in-flight pushes, and `close()`. The reset case matters most — a naive implementation resolves there, because the reset empties the pending queue that settlement checks against.
- While a flush is waiting, incoming server events are processed directly instead of on the throttle (`rebaseSoon()`), because the receive side rides the same rAF scheduler as the send side — without this, a flush at zero fps sends fine and then never hears the answer.
- No timeout in the SDK; callers own their deadline.

The send body is extracted from the throttle closure into `sendUnsentChangesNow()` (pure move) so both the throttled path and `flush()` share it.

Follow-up once this lands: the desktop app can replace its external acknowledgement machinery (generation counters over a wrapped socket, plus the `window.tlsync` scheduler drain) with `await client.flush()`.

### Change type

- [x] `feature`

### Test plan

New `21a. flush (CF)` block in `TLSyncClient.test.ts`, run with the real frame-throttled paths (`__FORCE_RAF_IN_TESTS__`) and `requestAnimationFrame` stubbed dead, so nothing sends or settles unless `flush()` does it without a frame. Covers: send-and-settle with zero frames, immediate resolve when nothing is unsettled, non-starvation by later edits, and all four rejection cases.

- [x] Unit tests

### Release notes

- Added `TLSyncClient.flush()`, which sends all pending local changes immediately — without waiting for an animation frame — and resolves once the server has acknowledged them. Useful for save barriers and other durability checkpoints in windows that are minimized, occluded, or otherwise not receiving frames.