### PR TITLE
fix(internal): handle a manually merged dotcom hotfix PR

### DIFF
--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -89,6 +89,12 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		)
 		nicelog(`Waiting for PR #${createdPr.data.number} to be ready for merge...`)
 
+		async function noteManualMerge(mergedByLogin: string | undefined) {
+			const by = mergedByLogin ? `@${mergedByLogin}` : 'someone'
+			nicelog(`Hotfix PR #${createdPr.data.number} was merged manually by ${by}`)
+			await discord.message(`✅ Hotfix PR #${createdPr.data.number} was merged manually by ${by}`)
+		}
+
 		// Maximum wait time: 15 minutes total (action timeout is 20 mins, we need buffer for Discord notification)
 		const maxWaitTimeMs = 15 * 60 * 1000
 		const startTime = Date.now()
@@ -107,21 +113,39 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 			}
 			const prStatus = await getPrDetailsByNumber(octokit, createdPr.data.number)
 
+			// github stops reporting mergeability once a PR is merged or closed by hand, so without
+			// this we'd spin until the timeout and report a false failure for a hotfix that landed.
+			if (prStatus.merged) {
+				await noteManualMerge(prStatus.merged_by?.login)
+				break
+			}
+			if (prStatus.state === 'closed') {
+				throw new Error(`Hotfix PR #${createdPr.data.number} was closed without being merged`)
+			}
+
 			nicelog(`PR #${createdPr.data.number} mergeable_state: ${prStatus.mergeable_state}`)
 
 			if (prStatus.mergeable_state === 'clean') {
 				nicelog(`PR #${createdPr.data.number} is ready for merge`)
-				await octokit.rest.pulls.merge({
-					owner: 'tldraw',
-					repo: 'tldraw',
-					pull_number: createdPr.data.number,
-					merge_method: 'squash',
-					commit_title: `[HOTFIX] ${pr.title}`,
-					commit_message: `This is an automated hotfix for dotcom deployment.
+				try {
+					await octokit.rest.pulls.merge({
+						owner: 'tldraw',
+						repo: 'tldraw',
+						pull_number: createdPr.data.number,
+						merge_method: 'squash',
+						commit_title: `[HOTFIX] ${pr.title}`,
+						commit_message: `This is an automated hotfix for dotcom deployment.
 
 Original PR: #${pr.number}
 Original Author: @${pr.user?.login}`,
-				})
+					})
+				} catch (error) {
+					// the merge api rejects an already-merged PR, so re-check before reporting a failure
+					const latest = await getPrDetailsByNumber(octokit, createdPr.data.number)
+					if (!latest.merged) throw error
+					await noteManualMerge(latest.merged_by?.login)
+					break
+				}
 
 				nicelog(`Successfully merged hotfix PR #${createdPr.data.number}`)
 				break


### PR DESCRIPTION
This PR fixes a bug where the dotcom hotfix action reports a failure in Discord for a hotfix that actually shipped, whenever someone merges the generated hotfix PR by hand.

### Before

The wait loop decides everything from `mergeable_state`, which GitHub reports as `unknown` once a PR is merged — so a hand-merged hotfix polls until the 15-minute timeout, then throws. Same for a closed PR, and for a merge landing between the poll and our own `pulls.merge` call.

### After

Each poll checks `merged` and `state` first: a hand merge posts `✅ Hotfix PR #N was merged manually by @user` and ends green, a close fails fast, and a lost merge race takes the merged path.

### Implementation notes

Doesn't fix what prompts the manual merges: a *pending* non-required check makes `mergeable_state` `unstable`, which the loop treats as fatal (#10587 — required checks green at 08:03:24, `Cursor Bugbot` ran to 08:09:49). Cursor has no per-PR or per-branch way to skip it.

### Change type

- [x] `bugfix`

### Test plan

No tests — both paths are GitHub API races. Verified with `yarn typecheck` against the run logs for #10587.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +32 / -8   |
