### PR TITLE
fix(infra): point the MCP app dashboard at the current tool names

### DIFF
--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -478,6 +478,126 @@ spec:
                 mode: multi
                 sort: desc
           version: 13.2.0-29854286369
+    panel-10:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_end'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_end'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: session_end events from the tldraw MCP server (MCP_ANALYTICS
+          dataset). Requires the MCP_ANALYTICS table in this datasource.
+        id: 10
+        links: []
+        title: MCP sessions ended
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
     panel-8:
       kind: Panel
       spec:
@@ -762,8 +882,17 @@ spec:
               kind: ElementReference
               name: panel-7
             height: 8
-            width: 8
+            width: 6
             x: 0
+            y: 26
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-10
+            height: 8
+            width: 6
+            x: 6
             y: 26
         - kind: GridLayoutItem
           spec:
@@ -771,8 +900,8 @@ spec:
               kind: ElementReference
               name: panel-8
             height: 8
-            width: 8
-            x: 8
+            width: 6
+            x: 12
             y: 26
         - kind: GridLayoutItem
           spec:
@@ -780,8 +909,8 @@ spec:
               kind: ElementReference
               name: panel-9
             height: 8
-            width: 8
-            x: 16
+            width: 6
+            x: 18
             y: 26
   links: []
   liveNow: false

--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -127,160 +127,6 @@ spec:
                 mode: single
                 sort: none
           version: 13.0.0-22478626928
-    panel-2:
-      kind: Panel
-      spec:
-        data:
-          kind: QueryGroup
-          spec:
-            queries:
-              - kind: PanelQuery
-                spec:
-                  hidden: false
-                  query:
-                    datasource:
-                      name: bdgu7tk03irr4e
-                    group: vertamedia-clickhouse-datasource
-                    kind: DataQuery
-                    spec:
-                      dateTimeType: DATETIME
-                      editorMode: builder
-                      extrapolate: true
-                      format: time_series
-                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
-                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
-                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
-                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
-                      intervalFactor: 1
-                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
-                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
-                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'create_shapes'\n    GROUP BY date, tool\n\
-                        \    ORDER BY date ASC\n"
-                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
-                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
-                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
-                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'create_shapes'\n    GROUP BY date, tool\n\
-                        \    ORDER BY date ASC"
-                      round: 0s
-                      skip_comments: true
-                    version: v0
-                  refId: A
-            queryOptions: {}
-            transformations: []
-        description: Sessions are created when you make a request to the MCP worker
-        id: 2
-        links: []
-        title: Tool Call (create_shapes)
-        vizConfig:
-          group: stat
-          kind: VizConfig
-          spec:
-            fieldConfig:
-              defaults:
-                color:
-                  mode: thresholds
-                thresholds:
-                  mode: absolute
-                  steps:
-                    - color: green
-                      value: 0
-              overrides: []
-            options:
-              colorMode: value
-              graphMode: area
-              justifyMode: center
-              orientation: auto
-              percentChangeColorMode: standard
-              reduceOptions:
-                calcs:
-                  - sum
-                fields: ''
-                values: false
-              showPercentChange: false
-              textMode: auto
-              wideLayout: true
-          version: 13.0.0-22478626928
-    panel-3:
-      kind: Panel
-      spec:
-        data:
-          kind: QueryGroup
-          spec:
-            queries:
-              - kind: PanelQuery
-                spec:
-                  hidden: false
-                  query:
-                    datasource:
-                      name: bdgu7tk03irr4e
-                    group: vertamedia-clickhouse-datasource
-                    kind: DataQuery
-                    spec:
-                      dateTimeType: DATETIME
-                      editorMode: builder
-                      extrapolate: true
-                      format: time_series
-                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
-                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
-                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
-                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
-                      intervalFactor: 1
-                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
-                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
-                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'update_shapes'\n    GROUP BY date, tool\n\
-                        \    ORDER BY date ASC\n"
-                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
-                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
-                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
-                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'update_shapes'\n    GROUP BY date, tool\n\
-                        \    ORDER BY date ASC"
-                      round: 0s
-                      skip_comments: true
-                    version: v0
-                  refId: A
-            queryOptions: {}
-            transformations: []
-        description: Sessions are created when you make a request to the MCP worker
-        id: 3
-        links: []
-        title: Tool Call (update_shapes)
-        vizConfig:
-          group: stat
-          kind: VizConfig
-          spec:
-            fieldConfig:
-              defaults:
-                color:
-                  mode: thresholds
-                thresholds:
-                  mode: absolute
-                  steps:
-                    - color: yellow
-                      value: 0
-              overrides: []
-            options:
-              colorMode: value
-              graphMode: area
-              justifyMode: center
-              orientation: auto
-              percentChangeColorMode: standard
-              reduceOptions:
-                calcs:
-                  - sum
-                fields: ''
-                values: false
-              showPercentChange: false
-              textMode: auto
-              wideLayout: true
-          version: 13.0.0-22478626928
     panel-4:
       kind: Panel
       spec:
@@ -302,22 +148,23 @@ spec:
                       extrapolate: true
                       format: time_series
                       formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
-                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
-                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
-                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                        \ '$interval' SECOND) as date, blob2 as tool, count() as total\n\
+                        \    FROM 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'exec'\n    GROUP BY date, tool\n    ORDER\
+                        \ BY date ASC\n"
                       intervalFactor: 1
                       query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
                         \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
                         \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
                         \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'read_me'\n    GROUP BY date, tool\n    ORDER\
+                        \    and blob2 = 'exec'\n    GROUP BY date, tool\n    ORDER\
                         \ BY date ASC\n"
                       rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
                         \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
                         \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
                         \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'read_me'\n    GROUP BY date, tool\n    ORDER\
+                        \    and blob2 = 'exec'\n    GROUP BY date, tool\n    ORDER\
                         \ BY date ASC"
                       round: 0s
                       skip_comments: true
@@ -325,10 +172,10 @@ spec:
                   refId: A
             queryOptions: {}
             transformations: []
-        description: Sessions are created when you make a request to the MCP worker
+        description: tool_called events for the exec tool.
         id: 4
         links: []
-        title: Tool Call (read_me)
+        title: Tool call (exec)
         vizConfig:
           group: stat
           kind: VizConfig
@@ -358,7 +205,7 @@ spec:
               textMode: auto
               wideLayout: true
           version: 13.0.0-22478626928
-    panel-5:
+    panel-2:
       kind: Panel
       spec:
         data:
@@ -379,22 +226,23 @@ spec:
                       extrapolate: true
                       format: time_series
                       formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
-                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
-                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
-                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
-                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                        \ '$interval' SECOND) as date, blob2 as tool, count() as total\n\
+                        \    FROM 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'search'\n    GROUP BY date, tool\n    ORDER\
+                        \ BY date ASC\n"
                       intervalFactor: 1
                       query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
                         \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
                         \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
                         \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'delete_shapes'\n    GROUP BY date, tool\n\
+                        \    and blob2 = 'search'\n    GROUP BY date, tool\n\
                         \    ORDER BY date ASC\n"
                       rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
                         \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
                         \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
                         \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
-                        \    and blob2 = 'delete_shapes'\n    GROUP BY date, tool\n\
+                        \    and blob2 = 'search'\n    GROUP BY date, tool\n\
                         \    ORDER BY date ASC"
                       round: 0s
                       skip_comments: true
@@ -402,10 +250,10 @@ spec:
                   refId: A
             queryOptions: {}
             transformations: []
-        description: Tool calls
-        id: 5
+        description: tool_called events for the search tool.
+        id: 2
         links: []
-        title: Tool Call (delete_shapes)
+        title: Tool call (search)
         vizConfig:
           group: stat
           kind: VizConfig
@@ -417,7 +265,7 @@ spec:
                 thresholds:
                   mode: absolute
                   steps:
-                    - color: red
+                    - color: green
                       value: 0
               overrides: []
             options:
@@ -896,7 +744,7 @@ spec:
               kind: ElementReference
               name: panel-4
             height: 13
-            width: 6
+            width: 12
             x: 0
             y: 13
         - kind: GridLayoutItem
@@ -905,26 +753,8 @@ spec:
               kind: ElementReference
               name: panel-2
             height: 13
-            width: 6
-            x: 6
-            y: 13
-        - kind: GridLayoutItem
-          spec:
-            element:
-              kind: ElementReference
-              name: panel-3
-            height: 13
-            width: 6
+            width: 12
             x: 12
-            y: 13
-        - kind: GridLayoutItem
-          spec:
-            element:
-              kind: ElementReference
-              name: panel-5
-            height: 13
-            width: 6
-            x: 18
             y: 13
         - kind: GridLayoutItem
           spec:


### PR DESCRIPTION
This PR fixes a bug where four panels on the `MCP app sessions` Grafana dashboard always read "No data". It also adds a sessions-ended panel next to sessions started.

### Before

The dashboard's four per-tool stat panels filtered `blob2` on `create_shapes`, `update_shapes`, `read_me` and `delete_shapes`. #8512 ("code mode") deleted those tools and replaced them with `search` and `exec`, so nothing has written those blob values since. Their `formattedQuery` fields were stale in a second way too: they still held the old `session_start` builder query, so opening a panel in the editor showed SQL that had nothing to do with what it ran.

### After

Two panels, `Tool call (exec)` and `Tool call (search)`, matching the tools `writeToolAnalytics` actually emits from `apps/mcp-app/src/tools/`. The two surplus panels are gone and the row is two columns wide instead of four.

The bottom row gains `MCP sessions ended`, reading the `session_end` event the worker writes when a session DO is torn down. Paired with `MCP sessions started` it shows whether sessions are being reaped as expected. Note the ended series lags the started one by the idle TTL, so the two won't line up on a short time range.

### Implementation notes

The app-only tools (`_exec_callback`, `_get_canvas_state`, `read_checkpoint`, `save_checkpoint`) write no analytics, so there's nothing to give them panels for. `MCP tool calls by tool`, `MCP canvas resource reads` and the session panels were already querying live event names and are untouched.

This only affects the `MCP app sessions` dashboard (`apps/mcp-app`, `MCP_ANALYTICS` dataset). The separate `MCP server (shared boards)` dashboard reads the sync worker's `MEASURE` dataset and its event names are current.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Not unit-testable. Verified by hand: the queries match the blob values written by `writeToolAnalytics` (`['tool_called', toolName, code]`) and `MCP_ANALYTICS.writeDataPoint` in `apps/mcp-app/src/worker.ts`. CI dry-runs the `gcx` push; the panels can be confirmed on the dashboard after deploy.

### Code changes

| Section        | LOC change   |
| -------------- | ------------ |
| Config/tooling | +139 / -180  |
