### PR TITLE
fix(editor): stop getSvgPathData from mutating stored geometry points

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
@@ -225,4 +225,13 @@ describe('Arc2d.getSvgPathData', () => {
 		})
 		expect(arc.getSvgPathData()).toBe('M10, 0 A10 10 0 0 1 7.07, 7.07')
 	})
+
+	it('does not mutate the stored points', () => {
+		const start = new Vec(10, 0)
+		const end = new Vec(10 / Math.SQRT2, 10 / Math.SQRT2)
+		const arc = new Arc2d({ center: new Vec(0, 0), start, end, sweepFlag: 1, largeArcFlag: 0 })
+		arc.getSvgPathData()
+		expect(start).toMatchObject({ x: 10, y: 0 })
+		expect(end).toMatchObject({ x: 10 / Math.SQRT2, y: 10 / Math.SQRT2 })
+	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Arc2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.ts
@@ -105,7 +105,7 @@ export class Arc2d extends Geometry2d {
 			_largeArcFlag: largeArcFlag,
 			_sweepFlag: sweepFlag,
 		} = this
-		return `${first ? `M${start.toFixed()}` : ``} A${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${end.toFixed()}`
+		return `${first ? `M${start}` : ``} A${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${end}`
 	}
 
 	override getLength() {

--- a/packages/editor/src/lib/primitives/geometry/CubicBezier2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicBezier2d.test.ts
@@ -172,4 +172,17 @@ describe('CubicBezier2d.getSvgPathData', () => {
 		})
 		expect(b.getSvgPathData()).toBe('M 0.12, 0  C1.01, 2 3, 5 10, 10')
 	})
+
+	it('does not mutate the stored points', () => {
+		const start = new Vec(0.123, 0)
+		const cp1 = new Vec(1.006, 2)
+		const cp2 = new Vec(3, 4.999)
+		const end = new Vec(10, 10.005)
+		const b = new CubicBezier2d({ start, cp1, cp2, end })
+		b.getSvgPathData()
+		expect(start).toMatchObject({ x: 0.123, y: 0 })
+		expect(cp1).toMatchObject({ x: 1.006, y: 2 })
+		expect(cp2).toMatchObject({ x: 3, y: 4.999 })
+		expect(end).toMatchObject({ x: 10, y: 10.005 })
+	})
 })

--- a/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/CubicBezier2d.ts
@@ -81,7 +81,7 @@ export class CubicBezier2d extends Polyline2d {
 
 	getSvgPathData(first = true) {
 		const { _a: a, _b: b, _c: c, _d: d } = this
-		return `${first ? `M ${a.toFixed()} ` : ``} C${b.toFixed()} ${c.toFixed()} ${d.toFixed()}`
+		return `${first ? `M ${a} ` : ``} C${b} ${c} ${d}`
 	}
 
 	static GetAtT(segment: CubicBezier2d, t: number) {

--- a/packages/editor/src/lib/primitives/geometry/Edge2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Edge2d.test.ts
@@ -1,5 +1,23 @@
-describe('Edge2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { Edge2d } from './Edge2d'
+
+describe('Edge2d.getSvgPathData', () => {
+	it('emits a move and a line command, rounded to two decimals', () => {
+		const edge = new Edge2d({ start: new Vec(0.123456, 0), end: new Vec(10, 10.987654) })
+		expect(edge.getSvgPathData()).toBe('M0.12, 0 L10, 10.99')
+	})
+
+	it('omits the move command when not first', () => {
+		const edge = new Edge2d({ start: new Vec(0.123456, 0), end: new Vec(10, 10.987654) })
+		expect(edge.getSvgPathData(false)).toBe(' L10, 10.99')
+	})
+
+	it('does not mutate the stored points', () => {
+		const start = new Vec(0.123456, 0)
+		const end = new Vec(10, 10.987654)
+		const edge = new Edge2d({ start, end })
+		edge.getSvgPathData()
+		expect(start).toMatchObject({ x: 0.123456, y: 0 })
+		expect(end).toMatchObject({ x: 10, y: 10.987654 })
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Edge2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Edge2d.ts
@@ -68,6 +68,6 @@ export class Edge2d extends Geometry2d {
 
 	getSvgPathData(first = true) {
 		const { _start: start, _end: end } = this
-		return `${first ? `M${start.toFixed()}` : ``} L${end.toFixed()}`
+		return `${first ? `M${start}` : ``} L${end}`
 	}
 }

--- a/packages/editor/src/lib/primitives/geometry/Point2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Point2d.test.ts
@@ -1,5 +1,16 @@
-describe('Point2d', () => {
-	it('should be tested', () => {
-		expect(true).toBe(true)
+import { Vec } from '../Vec'
+import { Point2d } from './Point2d'
+
+describe('Point2d.getSvgPathData', () => {
+	it('emits a move command rounded to two decimals', () => {
+		const point = new Point2d({ margin: 0, point: new Vec(0.123456, 7.891234) })
+		expect(point.getSvgPathData()).toBe('M0.12, 7.89')
+	})
+
+	it('does not mutate the stored point', () => {
+		const vec = new Vec(0.123456, 7.891234)
+		const point = new Point2d({ margin: 0, point: vec })
+		point.getSvgPathData()
+		expect(vec).toMatchObject({ x: 0.123456, y: 7.891234 })
 	})
 })

--- a/packages/editor/src/lib/primitives/geometry/Point2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Point2d.ts
@@ -28,6 +28,6 @@ export class Point2d extends Geometry2d {
 
 	getSvgPathData() {
 		const { _point: point } = this
-		return `M${point.toFixed()}`
+		return `M${point}`
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where generating a geometry's SVG path string permanently rounded its stored points to two decimals, corrupting later hit tests, nearest-point and length calculations on the cached geometry instance. Fixes #10561.

### Before

`Edge2d`, `Arc2d`, `CubicBezier2d` and `Point2d` called `Vec.prototype.toFixed()` on their own stored points inside `getSvgPathData`. That method rounds the vector in place and returns `this`, so the first `getSvgPathData` call rounded the geometry's points to two decimals. Geometries are cached per shape, so every subsequent calculation on that instance used the rounded points.

### After

`getSvgPathData` interpolates the points directly and the stored points keep full precision. The emitted path strings are byte-identical: template-literal interpolation calls `Vec.toString()`, which is `Vec.ToString(Vec.ToFixed(this))` — the same two-decimal rounding, applied to a copy by the non-mutating static `Vec.ToFixed`.

### Implementation notes

`Vec.prototype.toFixed()` itself still mutates. It is public API and `Box.toFixed()` shares the behavior, so the issue leaves that question out of scope.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new "does not mutate the stored points" tests for all four geometries fail on `main` and pass with this change; the path-output assertions are unchanged and still pass.

### Release notes

- Fix geometry hit tests losing precision after a shape's SVG path data was generated

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -4    |
| Tests     | +57 / -6   |
