### PR TITLE
fix(editor): select the last shape when navigating prev with no selection

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -2304,8 +2304,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shapeIds = readingOrderShapes.map((shape) => shape.id)
 
 			const currentIndex = currentShapeId ? shapeIds.indexOf(currentShapeId) : -1
+			// With no current index, stepping from -1 makes 'prev' land one shape
+			// before the last; seed it from 0 so it wraps to the last shape. See #10559.
+			const startIndex = currentIndex === -1 && direction === 'prev' ? 0 : currentIndex
 			const adjacentIndex =
-				(currentIndex + (direction === 'next' ? 1 : -1) + shapeIds.length) % shapeIds.length
+				(startIndex + (direction === 'next' ? 1 : -1) + shapeIds.length) % shapeIds.length
 			adjacentShapeId = shapeIds[adjacentIndex]
 		} else {
 			if (!currentShapeId) return

--- a/packages/tldraw/src/test/navigation.test.ts
+++ b/packages/tldraw/src/test/navigation.test.ts
@@ -996,6 +996,39 @@ describe('Shape navigation', () => {
 			expect(editor.getSelectedShapeIds().length).toBeGreaterThan(0)
 		})
 
+		it('selects the first shape in reading order on next with no selection', () => {
+			// Create shapes left to right
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0 },
+				{ id: ids.box3, type: 'geo', x: 200, y: 0 },
+			])
+
+			// Start with no selection
+			editor.selectNone()
+
+			// Navigating forward should select the first shape
+			editor.selectAdjacentShape('next')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		})
+
+		// See #10559
+		it('selects the last shape in reading order on prev with no selection', () => {
+			// Create shapes left to right
+			editor.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 100, y: 0 },
+				{ id: ids.box3, type: 'geo', x: 200, y: 0 },
+			])
+
+			// Start with no selection
+			editor.selectNone()
+
+			// Navigating backward should wrap to the last shape, not the second-to-last
+			editor.selectAdjacentShape('prev')
+			expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+		})
+
 		it('navigates in row-wise reading order with complex layouts', () => {
 			// Create shapes in a grid-like pattern
 			editor.createShapes([


### PR DESCRIPTION
This PR fixes a bug where `editor.selectAdjacentShape('prev')` with nothing selected selected the second-to-last shape in reading order instead of the last one. Fixes #10559 and fixes #10560.

### Before

`Editor.selectAdjacentShape` seeds the current index with `-1` when nothing is selected (`shapeIds.indexOf` also returns `-1` when the current shape isn't in the reading-order list). For `'prev'` the step then computes `(-1 - 1 + n) % n === n - 2`, so the wrap landed one shape early: with three shapes and no selection, `'prev'` selected the middle shape. `'next'` was unaffected, since `(-1 + 1 + n) % n === 0` correctly lands on the first shape. The same math backs keyboard shape navigation, so the empty-selection case was reachable from the UI as well as the API.

### After

With no current index, `'prev'` steps from `0` instead, so it wraps to `n - 1` — the last shape in reading order, symmetric with `'next'` selecting the first. Navigation with an existing selection is unchanged, as is the indexOf-miss case, which now behaves like no selection.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests in `packages/tldraw/src/test/navigation.test.ts` cover `'next'` and `'prev'` with no selection; the `'prev'` test fails on `main` and passes with this change

### Release notes

- Fix keyboard shape navigation selecting the wrong shape when navigating backward with no selection

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |
| Tests     | +33 / -0   |
