### PR TITLE
fix(editor): keep the current theme when setting an unregistered theme id

### DIFF
--- a/packages/editor/src/lib/editor/managers/ThemeManager/ThemeManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/ThemeManager/ThemeManager.test.ts
@@ -1,0 +1,53 @@
+import { TLTheme } from '@tldraw/tlschema'
+import { MockInstance, vi } from 'vitest'
+import { TestEditor } from '../../../test/TestEditor'
+import { DEFAULT_THEME } from './defaultThemes'
+
+// Optional so that other tests' theme objects still satisfy TLThemes.
+declare module '@tldraw/tlschema' {
+	interface TLThemes {
+		ocean?: TLTheme
+		sunset?: TLTheme
+	}
+}
+
+const oceanTheme: TLTheme = { ...DEFAULT_THEME, id: 'ocean' }
+
+let editor: TestEditor
+let warn: MockInstance
+
+beforeEach(() => {
+	editor = new TestEditor({ themes: { ocean: oceanTheme } })
+	warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+	warn.mockRestore()
+	editor.dispose()
+})
+
+describe('setCurrentTheme', () => {
+	it('switches to a registered theme', () => {
+		editor.setCurrentTheme('ocean')
+
+		expect(editor.getCurrentThemeId()).toBe('ocean')
+		expect(editor.getCurrentTheme()).toBe(oceanTheme)
+		expect(warn).not.toHaveBeenCalled()
+	})
+
+	it('warns and keeps the current theme when the id is not registered', () => {
+		editor.setCurrentTheme('sunset')
+
+		expect(warn).toHaveBeenCalledWith("Theme 'sunset' not found. Available themes: default, ocean")
+		expect(editor.getCurrentThemeId()).toBe('default')
+		expect(editor.getCurrentTheme()).toBe(DEFAULT_THEME)
+	})
+
+	it('keeps the previous theme rather than falling back to default', () => {
+		editor.setCurrentTheme('ocean')
+		editor.setCurrentTheme('sunset')
+
+		expect(editor.getCurrentThemeId()).toBe('ocean')
+		expect(editor.getCurrentTheme()).toBe(oceanTheme)
+	})
+})

--- a/packages/editor/src/lib/editor/managers/ThemeManager/ThemeManager.ts
+++ b/packages/editor/src/lib/editor/managers/ThemeManager/ThemeManager.ts
@@ -69,14 +69,20 @@ export class ThemeManager {
 		return this._themes.get()[this.getCurrentThemeId()]!
 	}
 
-	/** Set the current theme by id. The theme must have been previously registered. */
+	/**
+	 * Set the current theme by id. The theme must have been previously registered; an
+	 * unregistered id is ignored and the current theme is kept.
+	 */
 	setCurrentTheme(id: TLThemeId): void {
-		if (process.env.NODE_ENV !== 'production') {
-			if (!(id in this._themes.get())) {
+		// Storing an unregistered id would make getCurrentTheme() return
+		// undefined despite its TLTheme return type.
+		if (!(id in this._themes.get())) {
+			if (process.env.NODE_ENV !== 'production') {
 				console.warn(
 					`Theme '${id}' not found. Available themes: ${Object.keys(this._themes.get()).join(', ')}`
 				)
 			}
+			return
 		}
 
 		this._currentThemeId.set(id)


### PR DESCRIPTION
This PR fixes a bug where `editor.getCurrentTheme()` returned `undefined` after `editor.setCurrentTheme()` was called with an unregistered theme id, breaking anything that reads theme colors afterwards. Fixes #10557.

### Before

`ThemeManager.setCurrentTheme` warned in development when the id was not registered, but stored it anyway. `getCurrentTheme()` looks the current id up with a non-null assertion, so it returned `undefined` at runtime despite its `TLTheme` return type — and in production builds it did so silently, since the warning is development-only.

### After

A `setCurrentTheme` call with an unregistered id is rejected: the current theme is kept and `getCurrentTheme()` continues to return a registered theme. The development-only warning fires as before; the guard itself runs in all builds, so production can no longer store a bad id either.

### Implementation notes

The issue offered two acceptable behaviors: reject the call, or fall back to the default theme. Rejecting matches the manager's existing handling of invalid input — `updateThemes` refuses an update that removes the `default` theme and keeps the previous themes. The `'default'` fallback in `updateThemes` covers a different situation: a valid update that removes the current theme out from under the manager, where keeping it is impossible. For an invalid `setCurrentTheme` call the current theme is still valid, so rejecting loses no state and matches what the existing warning already tells the developer. The warning stays gated to development like the file's other warnings.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new tests in `ThemeManager.test.ts` fail on `main` (the unregistered id is stored and `getCurrentTheme()` returns `undefined`) and pass with this change

### Release notes

- Fix `getCurrentTheme()` returning `undefined` after `setCurrentTheme()` was called with an unregistered theme id.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -3    |
| Tests     | +53 / -0   |
