### PR TITLE
fix(editor): preserve flags, ignored children, and options in Group2d.transform

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2105,7 +2105,7 @@ export class Group2d extends Geometry2d {
     // (undocumented)
     toSimpleSvgPath(): string;
     // (undocumented)
-    transform(transform: Mat): Geometry2d;
+    transform(transform: MatModel, opts?: TransformedGeometry2dOptions): Geometry2d;
     // (undocumented)
     uninterpolateAlongEdge(point: VecLike, filters?: Geometry2dFilters): number;
 }

--- a/packages/editor/src/lib/primitives/geometry/Group2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.test.ts
@@ -340,18 +340,36 @@ describe('Group2d.transform', () => {
 		expect(t.vertices.length).toBe(8)
 	})
 
-	it('carries the label, debug colour and ignore flags forward', () => {
+	it('carries all the flags forward', () => {
 		const g = new Group2d({
 			children: [rectA()],
 			isLabel: true,
+			isEmptyLabel: true,
+			isInternal: true,
+			excludeFromShapeBounds: true,
 			debugColor: 'red',
 			ignore: true,
 		})
 		expect(g.transform(Mat.Identity())).toMatchObject({
 			isLabel: true,
+			isEmptyLabel: true,
+			isInternal: true,
+			excludeFromShapeBounds: true,
 			debugColor: 'red',
 			ignore: true,
 		})
+	})
+
+	it('applies the transform options over the carried flags', () => {
+		const g = new Group2d({ children: [rectA()], isLabel: true, isInternal: true })
+		expect(
+			g.transform(Mat.Identity(), {
+				isLabel: false,
+				isInternal: false,
+				debugColor: 'red',
+				ignore: true,
+			})
+		).toMatchObject({ isLabel: false, isInternal: false, debugColor: 'red', ignore: true })
 	})
 
 	it('scales hit testing with the transform', () => {
@@ -361,12 +379,15 @@ describe('Group2d.transform', () => {
 		expect(t.distanceToPoint(new Vec(300, 50))).toBe(100)
 	})
 
-	// Locks in current behaviour, see #10562.
-	it('drops the ignored children', () => {
+	// #10562: transform used to drop the ignored children.
+	it('keeps the transformed ignored children', () => {
 		const ignored = new Rectangle2d({ x: 500, width: 10, height: 10, isFilled: true, ignore: true })
 		const g = new Group2d({ children: [rectA(), ignored] })
-		expect(g.ignoredChildren.length).toBe(1)
-		expect((g.transform(Mat.Identity()) as Group2d).ignoredChildren).toEqual([])
+		const t = g.transform(Mat.Translate(10, 20)) as Group2d
+		expect(t.children.length).toBe(1)
+		expect(t.ignoredChildren.length).toBe(1)
+		expect(t.ignoredChildren[0].ignore).toBe(true)
+		expect(t.ignoredChildren[0].bounds).toMatchObject({ x: 510, y: 20, w: 10, h: 10 })
 	})
 })
 

--- a/packages/editor/src/lib/primitives/geometry/Group2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Group2d.ts
@@ -1,8 +1,13 @@
 import { assert, invLerp, lerp } from '@tldraw/utils'
 import { Box } from '../Box'
-import { Mat } from '../Mat'
+import { MatModel } from '../Mat'
 import { Vec, VecLike } from '../Vec'
-import { Geometry2d, Geometry2dFilters, Geometry2dOptions } from './Geometry2d'
+import {
+	Geometry2d,
+	Geometry2dFilters,
+	Geometry2dOptions,
+	TransformedGeometry2dOptions,
+} from './Geometry2d'
 
 /** @public */
 export class Group2d extends Geometry2d {
@@ -226,12 +231,18 @@ export class Group2d extends Geometry2d {
 		return childTLength / totalLength
 	}
 
-	override transform(transform: Mat): Geometry2d {
+	override transform(transform: MatModel, opts?: TransformedGeometry2dOptions): Geometry2d {
+		// Each child's own transform preserves its `ignore` flag, so the constructor
+		// re-partitions ignored children back into `ignoredChildren` instead of dropping
+		// them (#10562).
 		return new Group2d({
-			children: this.children.map((c) => c.transform(transform)),
-			isLabel: this.isLabel,
-			debugColor: this.debugColor,
-			ignore: this.ignore,
+			children: [...this.children, ...this.ignoredChildren].map((c) => c.transform(transform)),
+			isLabel: opts?.isLabel ?? this.isLabel,
+			isEmptyLabel: this.isEmptyLabel,
+			isInternal: opts?.isInternal ?? this.isInternal,
+			debugColor: opts?.debugColor ?? this.debugColor,
+			ignore: opts?.ignore ?? this.ignore,
+			excludeFromShapeBounds: this.excludeFromShapeBounds,
 		})
 	}
 


### PR DESCRIPTION
This PR fixes a bug where transforming a `Group2d` dropped its ignored children and reset its `isInternal`, `excludeFromShapeBounds`, and `isEmptyLabel` flags to their defaults. It also makes `Group2d.transform` accept the `opts` argument that every other geometry honors. Fixes #10562.

### Before

`Group2d.transform` rebuilt the group from its transformed non-ignored children only, forwarding just `isLabel`, `debugColor`, and `ignore`. The children the constructor had partitioned into `ignoredChildren` were never passed along, so the transformed group lost them — they don't affect bounds or hit testing, but the debug geometry overlay in `CanvasOverlays.tsx` draws them, so they silently disappeared from it. A transformed internal or bounds-excluded group came back as a regular one. And the override took only the matrix (`transform(transform: Mat)`), so any `opts` a caller passed were silently discarded.

### After

`group.transform(m, opts)` matches the base `Geometry2d.transform` signature and produces a group with the same flags and the same set of (transformed) ignored children, with `opts` applied over the carried flags the same way `TransformedGeometry2d` applies them.

### Implementation notes

Ignored children round-trip through the constructor: they are transformed and passed back in the `children` config, and since each child's own transform preserves its `ignore` flag (group children are never groups themselves — the constructor flattens them — so they all go through `TransformedGeometry2d`, which copies flags off the source geometry), the constructor re-partitions them back into `ignoredChildren`. Mirroring `TransformedGeometry2d`, `opts` can override `isLabel`, `isInternal`, `debugColor`, and `ignore`, while `isEmptyLabel` and `excludeFromShapeBounds` always carry over from the source group.

### API changes

- Changed `Group2d.transform` to match the base `Geometry2d.transform` signature: it now takes a `MatModel` instead of a `Mat` and accepts an optional `TransformedGeometry2dOptions` argument.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the updated and new `Group2d.transform` tests fail on `main` (the transformed group's `ignoredChildren` comes back empty, the flags reset, and `opts` has no effect) and pass with this change

### Release notes

- Fix `Group2d.transform` dropping ignored children, resetting the `isInternal`, `excludeFromShapeBounds`, and `isEmptyLabel` flags, and ignoring the `opts` argument.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +18 / -7   |
| Tests           | +26 / -5   |
| Automated files | +1 / -1    |
