### PR TITLE
feat(mcp-app): teardown without the isolate abort, plus ops diagnostics

### DIFF
--- a/apps/mcp-app/README.md
+++ b/apps/mcp-app/README.md
@@ -171,4 +171,19 @@ Steps:
 
 To rehearse locally: `yarn dev` in another shell with `--var MCP_PRUNE_ADMIN_TOKEN:dev-token` added to the `wrangler dev` line (or run `npx wrangler dev --var MCP_PRUNE_ADMIN_TOKEN:dev-token --var MCP_IS_DEV:true`), then `MCP_WORKER_ORIGIN=http://localhost:8787 MCP_PRUNE_ADMIN_TOKEN=dev-token yarn prune:run --dry-run` against a hand-written `prune-ids.txt` (get ids from `GET /admin/do-id?session=<mcp-session-id>`, dev-only). `prune-integration.test.ts` does this end to end.
 
+### Ops endpoints
+
+All take the same `MCP_PRUNE_ADMIN_TOKEN` bearer and 404 when it is unset.
+
+| Route                 | Purpose                                                                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /admin/prune`   | `{ ids, maxIdleMs, dryRun, force }` — condemn idle objects; the prune script's backend                                                                          |
+| `POST /admin/inspect` | `{ ids }` — what an object actually holds: `bytes`, `tables`, `appTables`, `wiped`, `destroyPending`, `alarm`                                                   |
+| `POST /admin/wipe`    | `{ ids, mode }` — tear down now by strategy: `sdk` (SDK destroy, isolate abort), `quiet` (abort defused, normal shutdown), `raw` (deleteAlarm + deleteAll only) |
+| `GET /admin/config`   | the constants and overrides actually deployed                                                                                                                   |
+
+`inspect` is the way to confirm a teardown landed. Any RPC wakes the object and the agents SDK's constructor recreates its own schema, so `bytes` never returns to zero and the SDK tables are always present — **`appTables` is the signal**: `checkpoints`/`meta` exist only if the session's own data survived. An intact object reports ~152 KB with three app tables; a wiped one reports ~120 KB with none.
+
+`wipe` exists so the teardown strategies can be compared in production without a deploy each: Cloudflare reclaims an object only when "it shuts down [and] its storage is empty", and an isolate abort is not a shutdown.
+
 Expect the `destroyed` error fingerprint in Workers observability to spike during a prune (one event per wiped DO — the SDK's teardown abort) and `session_start` to stay flat; if `session_start` during the run exceeds roughly 1% of condemns, stop the run: condemned DOs are being resurrected.

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -453,9 +453,15 @@ export class TldrawMCP extends McpAgent<Env> {
 	 * Tears down immediately by the named strategy, so the teardown paths can be
 	 * compared against each other in production without a deploy per variant.
 	 *
-	 * - `sdk`: the SDK's own destroy(), abort included — what shipped originally.
+	 * - `sdk`: condemned via the destroy marker, exactly as the prune pass did, so the
+	 *   SDK's own destroy() — isolate abort included — runs from the alarm.
 	 * - `quiet`: destroy() with the abort defused, so the object shuts down normally.
 	 * - `raw`: deleteAlarm + deleteAll only, touching none of the SDK's teardown.
+	 *
+	 * `sdk` cannot destroy inline: the SDK's abort fires on a `setTimeout(0)` that
+	 * races this method's own response, so the caller would record an error for a wipe
+	 * that succeeded — the failure mode that made a production pass report 18,580
+	 * errors against 161 successes.
 	 */
 	async wipeNow(mode: WipeMode): Promise<{ id: string; mode: WipeMode; before: number }> {
 		const id = this.ctx.id.toString()
@@ -466,7 +472,8 @@ export class TldrawMCP extends McpAgent<Env> {
 		} else if (mode === 'quiet') {
 			await this.destroy()
 		} else {
-			await super.destroy()
+			await this.ctx.storage.put('cf_agents_destroy_pending', true)
+			await this.ctx.storage.setAlarm(Date.now() + DESTROY_ALARM_DELAY_MS)
 		}
 		return { id, mode, before }
 	}

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -31,6 +31,23 @@ import { resolveMcpAppHostNameFromServerInfo } from './shared/utils'
 
 // --- Types ---
 
+/** Tables this app creates. Their absence is what proves a teardown wiped the session. */
+const APP_TABLES = ['checkpoints', 'meta', 'canvas_checkpoints']
+
+type WipeMode = 'sdk' | 'quiet' | 'raw'
+
+interface InspectResult {
+	id: string
+	bytes: number
+	tables: string[]
+	appTables: string[]
+	wiped: boolean
+	destroyPending: boolean
+	alarm: number | null
+	lastActivity: number | null
+	checkpointCount: number
+}
+
 export { CanvasStore }
 
 interface Env {
@@ -369,6 +386,92 @@ export class TldrawMCP extends McpAgent<Env> {
 	}
 
 	/**
+	 * Teardown without the SDK's trailing `ctx.abort("destroyed")`.
+	 *
+	 * Cloudflare reclaims an object only when "it shuts down [and] its storage is
+	 * empty". An abort is not a shutdown, so aborting straight after deleteAll()
+	 * appears to leave the object emptied but still enumerated — and still billed.
+	 * Skipping the abort means taking over its other job: severing connections, or a
+	 * client-held stream keeps the wiped instance alive.
+	 */
+	override async destroy() {
+		this.selfDestroyed = true
+		const abort = this.ctx.abort.bind(this.ctx)
+		this.ctx.abort = (reason?: string) => {
+			if (reason !== 'destroyed') abort(reason)
+		}
+		for (const conn of this.getConnections()) {
+			// close() throws synchronously on an already-closing socket; a throw here
+			// would wedge teardown before the storage wipe.
+			try {
+				conn.close(1000, 'Session closed')
+			} catch {
+				// already closing
+			}
+		}
+		await super.destroy()
+	}
+
+	/** True once this instance has torn itself down; it must not serve requests after. */
+	private selfDestroyed = false
+
+	override async fetch(request: Request) {
+		if (this.selfDestroyed) return new Response('Session destroyed', { status: 404 })
+		return super.fetch(request)
+	}
+
+	/**
+	 * Reports what a Durable Object actually holds, for confirming a teardown landed.
+	 *
+	 * Any RPC wakes the object and the Agent constructor recreates its own schema, so
+	 * SDK tables are always present here and `bytes` never returns to zero. The signal
+	 * that distinguishes wiped from intact is `appTables`: `checkpoints`/`meta` exist
+	 * only if this session's own data survived.
+	 */
+	async inspect(): Promise<InspectResult> {
+		const sql = this.ctx.storage.sql
+		const tables = sql
+			.exec(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+			.toArray()
+			.map((r) => String(r.name))
+		const appTables = tables.filter((t) => APP_TABLES.includes(t))
+		const stats = this.readPruneStats()
+		return {
+			id: this.ctx.id.toString(),
+			bytes: sql.databaseSize,
+			tables,
+			appTables,
+			wiped: appTables.length === 0,
+			destroyPending: (await this.ctx.storage.get('cf_agents_destroy_pending')) === true,
+			alarm: await this.ctx.storage.getAlarm(),
+			lastActivity: stats.lastActivity,
+			checkpointCount: stats.checkpointCount,
+		}
+	}
+
+	/**
+	 * Tears down immediately by the named strategy, so the teardown paths can be
+	 * compared against each other in production without a deploy per variant.
+	 *
+	 * - `sdk`: the SDK's own destroy(), abort included — what shipped originally.
+	 * - `quiet`: destroy() with the abort defused, so the object shuts down normally.
+	 * - `raw`: deleteAlarm + deleteAll only, touching none of the SDK's teardown.
+	 */
+	async wipeNow(mode: WipeMode): Promise<{ id: string; mode: WipeMode; before: number }> {
+		const id = this.ctx.id.toString()
+		const before = this.ctx.storage.sql.databaseSize
+		if (mode === 'raw') {
+			await this.ctx.storage.deleteAlarm()
+			await this.ctx.storage.deleteAll()
+		} else if (mode === 'quiet') {
+			await this.destroy()
+		} else {
+			await super.destroy()
+		}
+		return { id, mode, before }
+	}
+
+	/**
 	 * Condemns this DO if it has been idle for `maxIdleMs`. Never calls destroy()
 	 * inline: it writes the SDK's own durable destroy marker and arms an immediate
 	 * alarm, and Agent.alarm() runs destroy() in a fresh invocation before any
@@ -561,6 +664,62 @@ export default {
 					`[admin/prune] ids=${ids.length} total=${Date.now() - startedAt}ms retries=${retries} errors=${results.filter((r: any) => r.error).length} p50=${at(0.5)}ms p95=${at(0.95)}ms max=${sorted[sorted.length - 1]}ms`
 				)
 				return Response.json(results)
+			}
+
+			// Ops diagnostics. Both take { ids: [...] } and fan out like /admin/prune, so a
+			// teardown can be inspected and re-run in production without a deploy per
+			// question. Same token, same 100-id cap.
+			if (url.pathname === '/admin/inspect' || url.pathname === '/admin/wipe') {
+				if (!env.MCP_PRUNE_ADMIN_TOKEN) return new Response('Not found', { status: 404 })
+				if (request.method !== 'POST') return new Response('Method not allowed', { status: 405 })
+				const denied = requireAdminToken(request, env)
+				if (denied) return denied
+				let body: { ids?: unknown; mode?: unknown }
+				try {
+					body = await request.json()
+				} catch {
+					return new Response('Bad request: invalid JSON', { status: 400 })
+				}
+				const ids = Array.isArray(body?.ids) ? body.ids : null
+				if (!ids || ids.length > ADMIN_PRUNE_MAX_IDS) {
+					return new Response(`Bad request: ids[] (max ${ADMIN_PRUNE_MAX_IDS}) required`, {
+						status: 400,
+					})
+				}
+				const wiping = url.pathname === '/admin/wipe'
+				const mode = body?.mode ?? 'quiet'
+				if (wiping && mode !== 'sdk' && mode !== 'quiet' && mode !== 'raw') {
+					return new Response('Bad request: mode must be sdk, quiet or raw', { status: 400 })
+				}
+				const results = await Promise.all(
+					ids.map(async (id) => {
+						try {
+							const stub = env.MCP_OBJECT.get(env.MCP_OBJECT.idFromString(String(id)))
+							return wiping ? await stub.wipeNow(mode as WipeMode) : await stub.inspect()
+						} catch (err) {
+							const name = err instanceof Error ? err.constructor.name : typeof err
+							const message = err instanceof Error ? err.message : String(err)
+							return { id: String(id), error: `${name}: ${message}` }
+						}
+					})
+				)
+				return Response.json(results)
+			}
+
+			// What is actually deployed, so a diagnosis is never based on a stale guess
+			// about which build is live.
+			if (url.pathname === '/admin/config') {
+				if (!env.MCP_PRUNE_ADMIN_TOKEN) return new Response('Not found', { status: 404 })
+				const denied = requireAdminToken(request, env)
+				if (denied) return denied
+				return Response.json({
+					idleTtlMs: idleTtlMs(env),
+					destroyAlarmDelayMs: DESTROY_ALARM_DELAY_MS,
+					maxCheckpoints: MAX_CHECKPOINTS,
+					adminPruneMaxIds: ADMIN_PRUNE_MAX_IDS,
+					destroyOverride: true,
+					isDev: env.MCP_IS_DEV === 'true',
+				})
 			}
 
 			// Dev helper for prune-integration.test.ts: map a session id to its DO id.


### PR DESCRIPTION
In order to work out why 1.2M pruned Durable Objects have had their data deleted but are still enumerated and still billed, this PR removes the isolate abort from teardown and adds the endpoints needed to answer the remaining questions without a deploy each time.

**The suspicion.** Cloudflare's docs say an object "fully ceases to exist if, when it shuts down, its storage is empty". The agents SDK's `destroy()` empties storage and then ends with `setTimeout(() => ctx.abort("destroyed"), 0)`. An abort is not a shutdown. Worse, after one the next touch of that object spawns a fresh isolate whose Agent constructor recreates ~120 KB of SDK schema — so it is not empty either. That matches what production shows: `hasStoredData` still true three days after teardown, total storage flat across a weekend whether pruning ran or not, while the data itself is verifiably gone (re-reads report ~124 KB with no app tables, against ~152 KB intact, and a local repro leaves a 4 KB file with zero tables).

`destroy()` is now overridden to defuse that abort and let the object shut down normally. Skipping the abort means taking over its other job — severing connections, since a client-held stream would otherwise keep the wiped instance alive. This override was written in #10025, closed as cosmetic log noise, and never shipped despite a comment saying it would be folded into the pruning branch. It looks load-bearing for reclamation rather than cosmetic.

**Diagnostics, so the next question doesn't need a deploy.** `POST /admin/inspect` reports what an object actually holds. The subtlety it encodes: any RPC wakes the object and the SDK constructor recreates its own tables, so `bytes` never returns to zero and SDK tables are always present — `appTables` is the signal, because `checkpoints`/`meta` exist only if the session's own data survived. `POST /admin/wipe` tears down by named strategy — `sdk` (as shipped, abort included), `quiet` (abort defused), `raw` (`deleteAlarm` + `deleteAll` only) — so the paths can be compared against each other in production on real objects. `GET /admin/config` reports the constants actually deployed, so a diagnosis is never based on a stale guess about which build is live.

All three share the existing admin token, the 100-id cap, and the same fan-out shape as `/admin/prune`.

**What this does not settle.** Miniflare does not implement reclamation, so the local runs cannot tell us whether the abort is what blocks it. The intended experiment is a production A/B: re-tear-down a few hundred already-condemned ids with `mode=quiet`, leave a matched control group alone, and compare which set drops out of the object listing over the following day.

### Change type

- [x] `improvement`

### Test plan

Against a real worker under `wrangler dev`, three sessions each with a saved checkpoint, torn down one per mode:

1. `inspect` before: all three report 155,648 bytes with `appTables` `["canvas_checkpoints","checkpoints","meta"]` and `wiped: false`.
2. After `wipe`: all three report `wiped: true` with no app tables. `sdk` reports 122,880 bytes (aborted isolate, so the inspect spawned a fresh one and the constructor rebuilt the schema); `quiet` and `raw` report 4,096.
3. `GET /admin/config` reports the deployed constants.
4. `yarn run -T vitest run` — 19 tests pass, including the two `wrangler dev` suites.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +150 / -1  |
| Documentation | +13 / -0 |
