### PR TITLE
fix(editor): reject circle crossings outside the arc in Arc2d.hitTestLineSegment

### DIFF
--- a/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.test.ts
@@ -193,10 +193,17 @@ describe('Arc2d.hitTestLineSegment', () => {
 		expect(quarter().hitTestLineSegment(new Vec(1, 1), new Vec(2, 2))).toBe(false)
 	})
 
-	// Locks in current behaviour, see #10555.
-	it('hits crossings just beyond the end points (known quirk)', () => {
-		// (5, -8.66) is at -60°, off the quarter arc, but getPointInArcT clamps it to the start
-		expect(quarter().hitTestLineSegment(new Vec(5, -20), new Vec(5, 0))).toBe(true)
+	it('misses crossings just beyond the end points', () => {
+		// (5, -8.66) is at -60°, off the quarter arc (#10554)
+		expect(quarter().hitTestLineSegment(new Vec(5, -20), new Vec(5, 0))).toBe(false)
+	})
+
+	it('hits crossings exactly at the end points', () => {
+		// through the shared start point (10, 0) of both arcs
+		expect(quarter().hitTestLineSegment(new Vec(5, -5), new Vec(15, 5))).toBe(true)
+		expect(threeQuarter().hitTestLineSegment(new Vec(5, -5), new Vec(15, 5))).toBe(true)
+		// through the end point (0, 10)
+		expect(quarter().hitTestLineSegment(new Vec(-5, 5), new Vec(5, 15))).toBe(true)
 	})
 
 	it('checks both directions of the long arc', () => {

--- a/packages/editor/src/lib/primitives/geometry/Arc2d.ts
+++ b/packages/editor/src/lib/primitives/geometry/Arc2d.ts
@@ -1,5 +1,14 @@
 import { intersectLineSegmentCircle } from '../intersect'
-import { getArcMeasure, getPointInArcT, getPointOnCircle } from '../utils'
+import {
+	approximately,
+	approximatelyLte,
+	clockwiseAngleDist,
+	counterClockwiseAngleDist,
+	getArcMeasure,
+	getPointInArcT,
+	getPointOnCircle,
+	PI2,
+} from '../utils'
 import { Vec, VecLike } from '../Vec'
 import { getVerticesCountForArcLength } from './geometry-constants'
 import { Geometry2d, Geometry2dOptions } from './Geometry2d'
@@ -70,19 +79,21 @@ export class Arc2d extends Geometry2d {
 	}
 
 	hitTestLineSegment(A: VecLike, B: VecLike): boolean {
-		const {
-			_center,
-			_radius: radius,
-			_measure: measure,
-			_angleStart: angleStart,
-			_angleEnd: angleEnd,
-		} = this
+		const { _center, _radius: radius, _measure: measure, _angleStart: angleStart } = this
 		const intersection = intersectLineSegmentCircle(A, B, _center, radius)
 		if (intersection === null) return false
 
+		// Don't use getPointInArcT here: it clamps angles outside the arc's range to the nearest
+		// end point, which would turn crossings on the complementary part of the circle into
+		// hits (#10554). Measure the swept angle from the start instead.
 		return intersection.some((p) => {
-			const result = getPointInArcT(measure, angleStart, angleEnd, _center.angle(p))
-			return result >= 0 && result <= 1
+			const sweptAngle =
+				measure > 0
+					? clockwiseAngleDist(angleStart, _center.angle(p))
+					: counterClockwiseAngleDist(angleStart, _center.angle(p))
+			// counterClockwiseAngleDist reports a crossing at the start point itself as a full
+			// turn rather than zero, so accept ~PI2 as well
+			return approximatelyLte(sweptAngle, Math.abs(measure)) || approximately(sweptAngle, PI2)
 		})
 	}
 

--- a/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
+++ b/packages/editor/src/lib/primitives/geometry/Stadium2d.test.ts
@@ -170,11 +170,10 @@ describe('Stadium2d.hitTestLineSegment', () => {
 		expect(wideFilled().hitTestLineSegment(new Vec(45, 2), new Vec(55, 2))).toBe(false)
 	})
 
-	// Locks in current behaviour, see #10555.
-	it('hits an interior segment that crosses the far side of an arc circle (known quirk)', () => {
-		// (50, 25) is on the left arc's circle but opposite the arc itself; Arc2d clamps points on
-		// the complementary arc to the nearest end point, so the crossing counts as a hit
-		expect(wideFilled().hitTestLineSegment(new Vec(30, 25), new Vec(70, 25))).toBe(true)
+	it('misses an interior segment that crosses the far side of an arc circle', () => {
+		// (50, 25) is on both arc circles but opposite the arcs themselves, inside the outline (#10554)
+		expect(wideFilled().hitTestLineSegment(new Vec(30, 25), new Vec(70, 25))).toBe(false)
+		expect(wide().hitTestLineSegment(new Vec(30, 25), new Vec(70, 25))).toBe(false)
 	})
 })
 


### PR DESCRIPTION
This PR fixes a bug where `Arc2d.hitTestLineSegment` reported hits for segments that cross the arc's circle on the complementary part of the circle, so a segment passing through the inside of a stadium without touching its outline still counted as a hit. Fixes #10554.

### Before

`hitTestLineSegment` intersected the segment with the arc's full circle, then converted each intersection's angle to a 0–1 parameter along the arc with `getPointInArcT`. That conversion clamps angles that fall outside the arc's angular range to exactly 0 or 1, and the subsequent range check accepted them, so crossings on the complementary part of the circle near either end point counted as hits. On a 100×50 `Stadium2d`, a segment through the interior point (50, 25) — on both arc circles but off both arcs — reported a hit.

### After

Each intersection is accepted only when the angle swept from the arc's start to the intersection, measured in the arc's sweep direction, falls within the arc's measure. A small angular tolerance keeps crossings exactly at an end point hitting (`counterClockwiseAngleDist` reports the start point itself as a full turn rather than zero).

`getPointInArcT` itself is unchanged: `Arc2d.nearestPoint` relies on its clamping to project points beyond the arc onto the nearest end point, which is correct there, and the helper is public API.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the two flipped tests ("misses crossings just beyond the end points" in `Arc2d.test.ts` and "misses an interior segment that crosses the far side of an arc circle" in `Stadium2d.test.ts`) fail on `main` and pass with this change; the stadium test is the repro from the issue. A new test covers crossings exactly at the arc's end points.

### Release notes

- Fix `Arc2d.hitTestLineSegment` reporting hits for segments that cross the arc's circle outside the arc's angular range

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +21 / -10  |
| Tests     | +15 / -9   |
