### PR TITLE
fix(editor): keep non-resizing shapes in place when resizing a group

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8325,29 +8325,28 @@ export class Editor extends EventEmitter<TLEventMap> {
 			scaleAxisRotation
 		)
 
-		const initialPageCenterInParentSpace = this.getPointInParentSpace(
-			initialShape.id,
-			initialPageCenter
-		)
-		const newPageCenterInParentSpace = this.getPointInParentSpace(initialShape.id, newPageCenter)
-
-		const delta = Vec.Sub(newPageCenterInParentSpace, initialPageCenterInParentSpace)
+		// Position the shape absolutely in its parent's current space: a parent-space delta added
+		// to the shape's initial x/y would double-count any move the parent itself makes during
+		// the same gesture — a repositioned group carries its children with it (#10617).
+		const initialPageOrigin = Mat.applyToPoint(pageTransform, new Vec())
+		const newPageOrigin = Vec.Add(newPageCenter, Vec.Sub(initialPageOrigin, initialPageCenter))
+		const newLocalOrigin = this.getPointInParentSpace(initialShape.id, newPageOrigin)
 
 		if (workingShape) {
 			// the util's onResize ran but returned no change; keep the working update (which may
 			// include changes from onResizeStart / onResizeEnd) and reposition the shape
 			return {
 				...workingShape,
-				x: initialShape.x + delta.x,
-				y: initialShape.y + delta.y,
+				x: newLocalOrigin.x,
+				y: newLocalOrigin.y,
 			}
 		}
 
 		return {
 			id,
 			type: initialShape.type as any,
-			x: initialShape.x + delta.x,
-			y: initialShape.y + delta.y,
+			x: newLocalOrigin.x,
+			y: newLocalOrigin.y,
 		}
 	}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8241,10 +8241,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		let workingShape: TLShape | null = null
 
+		const initialPagePoint = Mat.applyToPoint(pageTransform, new Vec())
+
 		if (util.onResize && util.canResize(initialShape)) {
 			// get the model changes from the shape util
 			const newPagePoint = this._scalePagePoint(
-				Mat.applyToPoint(pageTransform, new Vec(0, 0)),
+				initialPagePoint,
 				scaleOrigin,
 				scale,
 				scaleAxisRotation
@@ -8264,11 +8266,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 			myScale.x = areWidthAndHeightAlignedWithCorrectAxis ? scale.x : scale.y
 			myScale.y = areWidthAndHeightAlignedWithCorrectAxis ? scale.y : scale.x
 
-			// adjust initial model for situations where the parent has moved during the resize
-			// e.g. groups
-			const initialPagePoint = Mat.applyToPoint(pageTransform, new Vec())
-
-			// need to adjust the shape's x and y points in case the parent has moved since start of resizing
+			// need to adjust the shape's x and y points in case the parent has moved since start of
+			// resizing, e.g. groups
 			const { x, y } = this.getPointInParentSpace(initialShape.id, initialPagePoint)
 
 			workingShape = initialShape
@@ -8325,28 +8324,32 @@ export class Editor extends EventEmitter<TLEventMap> {
 			scaleAxisRotation
 		)
 
-		// Position the shape absolutely in its parent's current space: a parent-space delta added
-		// to the shape's initial x/y would double-count any move the parent itself makes during
-		// the same gesture — a repositioned group carries its children with it (#10617).
-		const initialPageOrigin = Mat.applyToPoint(pageTransform, new Vec())
-		const newPageOrigin = Vec.Add(newPageCenter, Vec.Sub(initialPageOrigin, initialPageCenter))
-		const newLocalOrigin = this.getPointInParentSpace(initialShape.id, newPageOrigin)
+		// A parent-space delta added to the shape's initial x/y would double-count the parent's own
+		// move during the same gesture — a repositioned group carries its children with it (#10617).
+		const repositionedPagePoint = Vec.Add(
+			newPageCenter,
+			Vec.Sub(initialPagePoint, initialPageCenter)
+		)
+		const repositionedLocalPoint = this.getPointInParentSpace(
+			initialShape.id,
+			repositionedPagePoint
+		)
 
 		if (workingShape) {
 			// the util's onResize ran but returned no change; keep the working update (which may
 			// include changes from onResizeStart / onResizeEnd) and reposition the shape
 			return {
 				...workingShape,
-				x: newLocalOrigin.x,
-				y: newLocalOrigin.y,
+				x: repositionedLocalPoint.x,
+				y: repositionedLocalPoint.y,
 			}
 		}
 
 		return {
 			id,
 			type: initialShape.type as any,
-			x: newLocalOrigin.x,
-			y: newLocalOrigin.y,
+			x: repositionedLocalPoint.x,
+			y: repositionedLocalPoint.y,
 		}
 	}
 

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3631,6 +3631,103 @@ describe('shapes that have do not resize', () => {
 	})
 })
 
+describe('resizing a group with shapes that do not resize', () => {
+	const rectId = createShapeId('rect')
+	const bookmarkId = createShapeId('bookmark')
+	const groupId = createShapeId('groupA')
+
+	function setupConcentricGroup() {
+		editor.createShapes([
+			box(rectId, 0, 0, 200, 320),
+			// a bookmark without an asset is 320 tall
+			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
+		])
+		editor.groupShapes([rectId, bookmarkId], { groupId })
+		editor.select(groupId)
+	}
+
+	it('keeps a non-resizable shape centred when resizing from the bottom right', () => {
+		setupConcentricGroup()
+		editor.resizeSelection({ scaleX: 2, scaleY: 2.1 }, 'bottom_right')
+
+		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 400, h: 672 })
+		// same result as resizing the two shapes as an ungrouped selection
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 176, w: 200, h: 320 })
+	})
+
+	it('keeps a non-resizable shape centred when resizing from the top left', () => {
+		setupConcentricGroup()
+		editor.resizeSelection({ scaleX: 2, scaleY: 2.1 }, 'top_left')
+
+		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: -200, y: -352, w: 400, h: 672 })
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({
+			x: -100,
+			y: -176,
+			w: 200,
+			h: 320,
+		})
+	})
+
+	it('scales the relative position of an off-centre non-resizable shape', () => {
+		editor.createShapes([
+			box(rectId, 0, 0, 800, 640),
+			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
+		])
+		editor.groupShapes([rectId, bookmarkId], { groupId })
+		editor.select(groupId)
+		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
+
+		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 1600, h: 1280 })
+		// the bookmark's centre scales from (100, 160) to (200, 320)
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 160, w: 200, h: 320 })
+	})
+
+	it('scales the relative position of a note', () => {
+		const noteId = createShapeId('noteA')
+		editor.createShapes([box(rectId, 0, 0, 400, 400), { id: noteId, type: 'note', x: 0, y: 0 }])
+		editor.groupShapes([rectId, noteId], { groupId })
+		editor.select(groupId)
+		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
+
+		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 800, h: 800 })
+		// the note's centre scales from (100, 100) to (200, 200)
+		expect(editor.getShapePageBounds(noteId)).toMatchObject({ x: 100, y: 100, w: 200, h: 200 })
+	})
+
+	it('keeps a non-resizable shape centred in nested groups', () => {
+		const outerRectId = createShapeId('outerRect')
+		const outerGroupId = createShapeId('groupB')
+		editor.createShapes([
+			box(rectId, 0, 0, 200, 320),
+			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
+		])
+		editor.groupShapes([rectId, bookmarkId], { groupId })
+		editor.createShapes([box(outerRectId, 0, 0, 200, 320)])
+		editor.groupShapes([groupId, outerRectId], { groupId: outerGroupId })
+		editor.select(outerGroupId)
+		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
+
+		expect(editor.getShapePageBounds(outerRectId)).toMatchObject({ x: 0, y: 0, w: 400, h: 640 })
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 160, w: 200, h: 320 })
+	})
+
+	it('keeps a non-resizable shape in place when flipping a selection that contains its group', () => {
+		const otherRectId = createShapeId('otherRect')
+		editor.createShapes([
+			box(rectId, 0, 0, 200, 320),
+			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
+			box(otherRectId, 400, 0, 200, 320),
+		])
+		editor.groupShapes([rectId, bookmarkId], { groupId })
+		editor.select(groupId, otherRectId)
+		editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+
+		expect(editor.getShapePageBounds(otherRectId)).toMatchObject({ x: 0, y: 0, w: 200, h: 320 })
+		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 400, y: 0, w: 200, h: 320 })
+		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 400, y: 0, w: 200, h: 320 })
+	})
+})
+
 // describe('clicking the drag handle imprecisely', () => {
 //   it('does not prevent grid snapping', () => {
 //     // 0   10

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -3632,34 +3632,35 @@ describe('shapes that have do not resize', () => {
 })
 
 describe('resizing a group with shapes that do not resize', () => {
-	const rectId = createShapeId('rect')
+	const boxId = createShapeId('box')
 	const bookmarkId = createShapeId('bookmark')
 	const groupId = createShapeId('groupA')
 
-	function setupConcentricGroup() {
+	function setupGroup(w = 200, h = 320) {
 		editor.createShapes([
-			box(rectId, 0, 0, 200, 320),
+			box(boxId, 0, 0, w, h),
 			// a bookmark without an asset is 320 tall
 			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
 		])
-		editor.groupShapes([rectId, bookmarkId], { groupId })
-		editor.select(groupId)
+		editor.groupShapes([boxId, bookmarkId], { groupId })
 	}
 
-	it('keeps a non-resizable shape centred when resizing from the bottom right', () => {
-		setupConcentricGroup()
+	it('keeps a non-resizable shape centered when resizing from the bottom right', () => {
+		setupGroup()
+		editor.select(groupId)
 		editor.resizeSelection({ scaleX: 2, scaleY: 2.1 }, 'bottom_right')
 
-		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 400, h: 672 })
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: 0, y: 0, w: 400, h: 672 })
 		// same result as resizing the two shapes as an ungrouped selection
 		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 176, w: 200, h: 320 })
 	})
 
-	it('keeps a non-resizable shape centred when resizing from the top left', () => {
-		setupConcentricGroup()
+	it('keeps a non-resizable shape centered when resizing from the top left', () => {
+		setupGroup()
+		editor.select(groupId)
 		editor.resizeSelection({ scaleX: 2, scaleY: 2.1 }, 'top_left')
 
-		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: -200, y: -352, w: 400, h: 672 })
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: -200, y: -352, w: 400, h: 672 })
 		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({
 			x: -100,
 			y: -176,
@@ -3668,62 +3669,51 @@ describe('resizing a group with shapes that do not resize', () => {
 		})
 	})
 
-	it('scales the relative position of an off-centre non-resizable shape', () => {
-		editor.createShapes([
-			box(rectId, 0, 0, 800, 640),
-			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
-		])
-		editor.groupShapes([rectId, bookmarkId], { groupId })
+	it('scales the relative position of an off-center non-resizable shape', () => {
+		setupGroup(800, 640)
 		editor.select(groupId)
 		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
 
-		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 1600, h: 1280 })
-		// the bookmark's centre scales from (100, 160) to (200, 320)
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: 0, y: 0, w: 1600, h: 1280 })
+		// the bookmark keeps its size while its center scales from (100, 160) to (200, 320)
 		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 160, w: 200, h: 320 })
 	})
 
 	it('scales the relative position of a note', () => {
+		// unlike a bookmark, a note can resize but its onResize returns nothing in the default
+		// 'none' resize mode, so it is repositioned through a different branch
 		const noteId = createShapeId('noteA')
-		editor.createShapes([box(rectId, 0, 0, 400, 400), { id: noteId, type: 'note', x: 0, y: 0 }])
-		editor.groupShapes([rectId, noteId], { groupId })
+		editor.createShapes([box(boxId, 0, 0, 400, 400), { id: noteId, type: 'note', x: 0, y: 0 }])
+		editor.groupShapes([boxId, noteId], { groupId })
 		editor.select(groupId)
 		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
 
-		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 0, y: 0, w: 800, h: 800 })
-		// the note's centre scales from (100, 100) to (200, 200)
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: 0, y: 0, w: 800, h: 800 })
 		expect(editor.getShapePageBounds(noteId)).toMatchObject({ x: 100, y: 100, w: 200, h: 200 })
 	})
 
-	it('keeps a non-resizable shape centred in nested groups', () => {
-		const outerRectId = createShapeId('outerRect')
+	it('keeps a non-resizable shape centered in nested groups', () => {
+		const outerBoxId = createShapeId('outerBox')
 		const outerGroupId = createShapeId('groupB')
-		editor.createShapes([
-			box(rectId, 0, 0, 200, 320),
-			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
-		])
-		editor.groupShapes([rectId, bookmarkId], { groupId })
-		editor.createShapes([box(outerRectId, 0, 0, 200, 320)])
-		editor.groupShapes([groupId, outerRectId], { groupId: outerGroupId })
+		setupGroup()
+		editor.createShapes([box(outerBoxId, 0, 0, 200, 320)])
+		editor.groupShapes([groupId, outerBoxId], { groupId: outerGroupId })
 		editor.select(outerGroupId)
 		editor.resizeSelection({ scaleX: 2, scaleY: 2 }, 'bottom_right')
 
-		expect(editor.getShapePageBounds(outerRectId)).toMatchObject({ x: 0, y: 0, w: 400, h: 640 })
+		expect(editor.getShapePageBounds(outerBoxId)).toMatchObject({ x: 0, y: 0, w: 400, h: 640 })
 		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 100, y: 160, w: 200, h: 320 })
 	})
 
-	it('keeps a non-resizable shape in place when flipping a selection that contains its group', () => {
-		const otherRectId = createShapeId('otherRect')
-		editor.createShapes([
-			box(rectId, 0, 0, 200, 320),
-			{ id: bookmarkId, type: 'bookmark', x: 0, y: 0, props: { w: 200 } },
-			box(otherRectId, 400, 0, 200, 320),
-		])
-		editor.groupShapes([rectId, bookmarkId], { groupId })
-		editor.select(groupId, otherRectId)
+	it('moves a non-resizable shape with its group when flipping a selection that contains the group', () => {
+		const otherBoxId = createShapeId('otherBox')
+		setupGroup()
+		editor.createShapes([box(otherBoxId, 400, 0, 200, 320)])
+		editor.select(groupId, otherBoxId)
 		editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 
-		expect(editor.getShapePageBounds(otherRectId)).toMatchObject({ x: 0, y: 0, w: 200, h: 320 })
-		expect(editor.getShapePageBounds(rectId)).toMatchObject({ x: 400, y: 0, w: 200, h: 320 })
+		expect(editor.getShapePageBounds(otherBoxId)).toMatchObject({ x: 0, y: 0, w: 200, h: 320 })
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: 400, y: 0, w: 200, h: 320 })
 		expect(editor.getShapePageBounds(bookmarkId)).toMatchObject({ x: 400, y: 0, w: 200, h: 320 })
 	})
 })


### PR DESCRIPTION
This PR fixes a bug where a bookmark (or any shape that keeps its size during a resize) drifts toward the dragged handle when its group is resized from a selection handle. Closes #10617.

### Before

The reposition fall-through in `Editor.getResizeShapePartial` — used for shapes whose util can't resize (bookmarks, fixed-size embeds) and for shapes whose `onResize` returns nothing (notes in the default `'none'` resize mode) — moved the shape by a parent-space delta added to its initial x/y. The delta is a difference of two points mapped through the parent's current transform, so the parent's own translation cancels out of it. But a group parent translates during the same gesture (`GroupShapeUtil` has no `onResize`, so the group itself is repositioned by its scaled centre, and its children ride along), which meant the group's move was applied to those children twice. For a bookmark centred in its group the error is exactly the group's translation, so the bookmark's corner tracks the dragged handle; nested groups add one more group delta per ancestor, and flipping a selection that contains a group hits the same path.

The bookmark case regressed in #10491, which started snapshotting non-resizable shapes during a selection resize; the note case is long-standing.

### After

The fall-through positions the shape absolutely in its parent's current space, the same way the resize branch already does for resizable children: the shape keeps its page-space centre-to-origin offset, and the new origin is converted with `getPointInParentSpace`. Non-resizing children of resized groups now land where the equivalent ungrouped selection resize puts them — from any handle, in nested groups, and when flipping.

### Change type

- [x] `bugfix`

### Test plan

1. Paste a URL to create a bookmark, draw a rectangle around it, and group them.
2. Select the group and drag a corner handle away.
3. The bookmark keeps its size and stays centred over the scaled rectangle.

- [x] Unit tests — the six new tests fail on `main` and pass with this change

### Release notes

- Fix bookmarks, notes and other non-resizing shapes being mispositioned when their group is resized or flipped.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +17 / -15  |
| Tests     | +87 / -0   |
