### PR TITLE
docs(agents): use -t instead of --grep for vitest name filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Testing:
 
 - `yarn test` in a workspace - run tests in watch mode
 - `yarn test run` in a workspace - run tests once
-- `yarn test run --grep "pattern"` in a workspace - run matching tests
+- `yarn test run -t "pattern"` in a workspace - run tests whose names match
 - `yarn vitest` - run all tests across the repo; slow, avoid unless necessary
 - `yarn e2e` - run examples e2e tests
 - `yarn e2e-dotcom` - run tldraw.com e2e tests
@@ -83,7 +83,7 @@ Code quality:
 
 ## Validation workflow
 
-- For narrow package changes, run the relevant workspace test first, for example `cd packages/tldraw && yarn test run --grep "SelectTool"`.
+- For narrow package changes, run the relevant workspace test first, for example `cd packages/tldraw && yarn test run -t "SelectTool"`.
 - For changes that affect shared types, migrations, editor behavior, or cross-package contracts, run `yarn typecheck` from the repo root.
 - For public API changes, run `yarn api-check` and include intentional API report updates.
 - For asset changes, run `yarn refresh-assets` or `yarn typecheck` so generated assets stay current.

--- a/skills/write-unit-tests/SKILL.md
+++ b/skills/write-unit-tests/SKILL.md
@@ -26,7 +26,7 @@ Each package has its own `TestEditor`, and they are not interchangeable: `packag
 
 ```bash
 cd packages/tldraw && yarn test run
-cd packages/tldraw && yarn test run --grep "SelectTool"
+cd packages/tldraw && yarn test run -t "SelectTool"
 cd packages/tldraw && yarn test          # watch mode
 ```
 


### PR DESCRIPTION
In order to stop agents from following documented advice into a crash, this PR fixes the test-filtering command in AGENTS.md and the write-unit-tests skill. Both documented `yarn test run --grep "pattern"`, but `--grep` is not a vitest flag: workspace `test` scripts run vitest directly, and vitest 4 exits with `CACError: Unknown option --grep`. The working equivalent is `-t` (`--testNamePattern`), which also composes with a positional file filter, verified in `packages/editor` and `packages/tldraw`.

The `--grep` advice in the write-e2e-tests skill is untouched: `yarn e2e` runs Playwright, where `--grep` is a real flag.

### Change type

- [x] `other`

### Test plan

1. `cd packages/tldraw && yarn test run -t "SelectTool"` — the documented example runs the matching tests (26 passed, 2956 skipped)
2. `cd packages/editor && yarn test run --grep "Vec"` — the old advice crashes with `CACError: Unknown option --grep`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +3 / -3    |