### PR TITLE
fix(editor): reject viewport deep links with no area

### DIFF
--- a/packages/editor/src/lib/utils/deepLinks.test.ts
+++ b/packages/editor/src/lib/utils/deepLinks.test.ts
@@ -81,6 +81,21 @@ describe('parseDeepLinkString', () => {
 		expect(() => parseDeepLinkString('v')).toThrow('Invalid deep link string')
 	})
 
+	it('throws on a viewport link with no area', () => {
+		expect(() => parseDeepLinkString('v0.0.0.0')).toThrow('Invalid deep link string')
+		expect(() => parseDeepLinkString('v100.100.0.200')).toThrow('Invalid deep link string')
+		expect(() => parseDeepLinkString('v100.100.200.0')).toThrow('Invalid deep link string')
+		expect(() => parseDeepLinkString('v100.100.-200.-100')).toThrow('Invalid deep link string')
+	})
+
+	it('accepts a viewport link positioned at the origin', () => {
+		expect(parseDeepLinkString('v0.0.200.100')).toEqual({
+			type: 'viewport',
+			bounds: new Box(0, 0, 200, 100),
+			pageId: undefined,
+		})
+	})
+
 	it('throws on an unknown link type', () => {
 		expect(() => parseDeepLinkString('xabc')).toThrow('Invalid deep link string')
 	})

--- a/packages/editor/src/lib/utils/deepLinks.ts
+++ b/packages/editor/src/lib/utils/deepLinks.ts
@@ -74,9 +74,14 @@ export function parseDeepLinkString(deepLinkString: string): TLDeepLink {
 		case 'v': {
 			const [x, y, w, h, pageId] = deepLinkString.slice(1).split('.')
 			const bounds = new Box(Number(x), Number(y), Number(w), Number(h))
-			// Number('abc') is NaN rather than an error, so without this check a malformed
-			// viewport link would bypass the caller's fallback and park the camera at the origin
-			if (![bounds.x, bounds.y, bounds.w, bounds.h].every(Number.isFinite)) {
+			// Number('abc') is NaN rather than an error, and a box with no area parses cleanly but
+			// can only be zoomed to by clamping to max zoom at its corner. Both bypass the caller's
+			// fallback and park the camera at the origin, so both count as an invalid link here.
+			const isUsableViewport =
+				[bounds.x, bounds.y, bounds.w, bounds.h].every(Number.isFinite) &&
+				bounds.w > 0 &&
+				bounds.h > 0
+			if (!isUsableViewport) {
 				throw Error('Invalid deep link string')
 			}
 			return {

--- a/packages/tldraw/src/test/handleDeepLink.test.tsx
+++ b/packages/tldraw/src/test/handleDeepLink.test.tsx
@@ -88,6 +88,21 @@ describe('type: viewport', () => {
 		expect(editor.getZoomLevel()).toBe(1)
 	})
 
+	it('falls back to fitting the page content when the bounds have no area', () => {
+		editor.createShapes([
+			{ id: createShapeId(), type: 'geo', x: 2000, y: 2000, props: { w: 100, h: 100 } },
+		])
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		editor.navigateToDeepLink({ url: 'http://localhost/?d=v0.0.0.0' })
+		warn.mockRestore()
+
+		expect(editor.getViewportPageBounds()).toMatchObject({
+			x: 2050 - editor.bounds.width / 2,
+			y: 2050 - editor.bounds.height / 2,
+		})
+		expect(editor.getZoomLevel()).toBe(1)
+	})
+
 	it('will not change the viewport if the specific page does not exist', () => {
 		const pageId = PageRecordType.createId('foo')
 


### PR DESCRIPTION
A viewport deep link whose bounds parse to a zero or negative width or height passes the `Number.isFinite` check, so parsing succeeds and the camera is zoomed to an empty box — clamping to max zoom at the box's corner instead of falling back to fitting the page content.

On staging, `?d=v0.0.0.0` lands on a 180×113 page-unit viewport at the origin, zoom 8, with no content on screen and nothing in the console. `?d=v-1471`, `?d=vNaN.0.100.100` and `?d=garbage` all fall back correctly, so this is the gap left by the finite check in #10508.

`parseDeepLinkString` now rejects a non-positive width or height alongside the non-finite case, under one `isUsableViewport` predicate. Throwing is what routes the link into `navigateToDeepLink`'s existing fit-content fallback, so an unusable viewport takes the same path as one that fails to parse.

One consequence worth flagging: an editor whose container is 0×0 (hidden, unmounted) would generate a link this parser now rejects. It falls back to fitting content rather than parking at the origin, which is the better of the two, but it does mean `createDeepLinkString` can emit a string its own parser refuses.

Closes #10625

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open a file with content away from the page origin.
2. Load it with `?d=v0.0.0.0`.
3. The camera fits the page content at 100%, rather than sitting empty at the origin.

- [x] Unit tests
- [ ] End to end tests

`deepLinks.test.ts` covers `v0.0.0.0`, a single zero dimension, negative dimensions, and a viewport legitimately positioned at the origin. `handleDeepLink.test.tsx` gains a behavioural test beside the existing malformed-bounds one, asserting the fit-content fallback; it fails without the change to `deepLinks.ts`.

### Release notes

- Fixed a viewport deep link with a zero-size viewport moving the camera to the page origin instead of falling back to fitting the page content.
