### PR TITLE
fix(ui): pass wheel events through open menus so the canvas still pans

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -3,6 +3,7 @@ import { type PointerEvent, useCallback, useEffect, useRef, useState } from 'rea
 import { flushSync } from 'react-dom'
 import { useCanvasEvents } from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
+import { usePassThroughWheelEvents } from '../hooks/usePassThroughWheelEvents'
 import { Vec } from '../primitives/Vec'
 import { releasePointerCapture, setPointerCapture } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
@@ -24,6 +25,11 @@ export function MenuClickCapture() {
 	const showElement = isMenuOpen || isPointing
 
 	const canvasEvents = useCanvasEvents()
+
+	// The overlay covers the canvas, so the canvas's own wheel listener never sees a wheel over it.
+	// Without this, panning and zooming die for as long as any menu is open.
+	const rCaptureElement = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(rCaptureElement)
 
 	const rPointerState = useRef({
 		isDown: false,
@@ -192,6 +198,7 @@ export function MenuClickCapture() {
 	return (
 		showElement && (
 			<div
+				ref={rCaptureElement}
 				className="tlui-menu-click-capture"
 				data-testid="menu-click-capture.content"
 				{...canvasEvents}

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenu.tsx
@@ -9,6 +9,7 @@ import { ContextMenu as _ContextMenu } from 'radix-ui'
 import { ReactNode, memo, useCallback, useContext, useEffect, useRef } from 'react'
 import { ContextMenuPagePointContext } from '../../context/actions'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { DefaultContextMenuContent } from './DefaultContextMenuContent'
@@ -138,6 +139,7 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 	// override. If there's no menu content, then the user has set it to null,
 	// so skip rendering the menu.
 	const content = children ?? <DefaultContextMenuContent />
+	const setContextMenuContent = useMenuWheelPassThrough()
 
 	return (
 		<_ContextMenu.Root dir={dir} onOpenChange={handleOpenChange} modal={false}>
@@ -154,6 +156,7 @@ export const DefaultContextMenu = memo(function DefaultContextMenu({
 			{isOpen && (
 				<_ContextMenu.Portal container={container}>
 					<_ContextMenu.Content
+						ref={setContextMenuContent}
 						className="tlui-menu tlui-scrollable"
 						data-testid="context-menu"
 						aria-label={msg('context-menu.title')}

--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenu.tsx
@@ -2,6 +2,7 @@ import { useContainer } from '@tldraw/editor'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
 import { ReactNode, memo } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
@@ -16,6 +17,7 @@ export interface TLUiMainMenuProps {
 /** @public @react */
 export const DefaultMainMenu = memo(function DefaultMainMenu({ children }: TLUiMainMenuProps) {
 	const container = useContainer()
+	const setMenuContent = useMenuWheelPassThrough()
 	const [isOpen, onOpenChange] = useMenuIsOpen('main menu')
 	const msg = useTranslation()
 	const dir = useDirection()
@@ -34,6 +36,7 @@ export const DefaultMainMenu = memo(function DefaultMainMenu({ children }: TLUiM
 			</_DropdownMenu.Trigger>
 			<_DropdownMenu.Portal container={container}>
 				<_DropdownMenu.Content
+					ref={setMenuContent}
 					className="tlui-menu"
 					side="bottom"
 					align="start"

--- a/packages/tldraw/src/lib/ui/components/SharePanel/DefaultPeopleMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/DefaultPeopleMenu.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react'
 import { useTldrawUiComponents } from '../../context/components'
 import { useCollaborationStatus } from '../../hooks/useCollaborationStatus'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { OfflineIndicator } from '../OfflineIndicator/OfflineIndicator'
 import { DefaultPeopleMenuContent } from './DefaultPeopleMenuContent'
@@ -19,6 +20,7 @@ export function DefaultPeopleMenu({ children }: DefaultPeopleMenuProps) {
 	const dir = useDirection()
 
 	const container = useContainer()
+	const setMenuContent = useMenuWheelPassThrough()
 	const editor = useEditor()
 
 	const userIds = usePeerIds()
@@ -52,6 +54,7 @@ export function DefaultPeopleMenu({ children }: DefaultPeopleMenuProps) {
 			</_Popover.Trigger>
 			<_Popover.Portal container={container}>
 				<_Popover.Content
+					ref={setMenuContent}
 					dir={dir}
 					className="tlui-menu"
 					side="bottom"

--- a/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceColorPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/UserPresenceColorPicker.tsx
@@ -2,6 +2,7 @@ import { USER_COLORS, getOwnerWindow, track, useContainer, useEditor } from '@tl
 import { Popover as _Popover } from 'radix-ui'
 import React, { useCallback, useRef, useState } from 'react'
 import { useUiEvents } from '../../context/events'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
@@ -11,6 +12,7 @@ import { TldrawUiGrid } from '../primitives/layout'
 export const UserPresenceColorPicker = track(function UserPresenceColorPicker() {
 	const editor = useEditor()
 	const container = useContainer()
+	const setMenuContent = useMenuWheelPassThrough()
 	const msg = useTranslation()
 	const dir = useDirection()
 	const trackEvent = useUiEvents()
@@ -97,6 +99,7 @@ export const UserPresenceColorPicker = track(function UserPresenceColorPicker() 
 			</_Popover.Trigger>
 			<_Popover.Portal container={container}>
 				<_Popover.Content
+					ref={setMenuContent}
 					dir={dir}
 					className="tlui-menu tlui-people-menu__user__color-picker"
 					align="start"

--- a/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ZoomMenu/DefaultZoomMenu.tsx
@@ -4,6 +4,7 @@ import { ReactNode, memo, useCallback } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
 import { TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
@@ -17,6 +18,7 @@ export interface TLUiZoomMenuProps {
 /** @public @react */
 export const DefaultZoomMenu = memo(function DefaultZoomMenu({ children }: TLUiZoomMenuProps) {
 	const container = useContainer()
+	const setMenuContent = useMenuWheelPassThrough()
 	const [isOpen, onOpenChange] = useMenuIsOpen('zoom menu')
 	const dir = useDirection()
 
@@ -30,6 +32,7 @@ export const DefaultZoomMenu = memo(function DefaultZoomMenu({ children }: TLUiZ
 			<ZoomTriggerButton />
 			<_DropdownMenu.Portal container={container}>
 				<_DropdownMenu.Content
+					ref={setMenuContent}
 					className="tlui-menu"
 					side="top"
 					align="start"

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -1,7 +1,7 @@
-import { preventDefault, useContainer } from '@tldraw/editor'
+import { preventDefault, useContainer, usePassThroughWheelEvents } from '@tldraw/editor'
 import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
-import { ReactNode } from 'react'
+import { ReactNode, useRef, useState } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from './Button/TldrawUiButton'
@@ -84,9 +84,22 @@ export function TldrawUiDropdownMenuContent({
 }: TLUiDropdownMenuContentProps) {
 	const container = useContainer()
 
+	// The menu portals into the container, so it sits outside the canvas and outside any
+	// pass-through root. Without this, a wheel over an open menu never reaches the canvas.
+	// A menu long enough to scroll still scrolls: the hook defers to real scroll containers.
+	//
+	// Opening the menu doesn't re-render this component — radix mounts the content from context
+	// after the root's state changes, and `children` keeps its identity so React bails out here.
+	// A plain ref would still read null, so the node reports itself through state instead.
+	const [content, setContent] = useState<HTMLDivElement | null>(null)
+	const rContent = useRef<HTMLDivElement | null>(null)
+	rContent.current = content
+	usePassThroughWheelEvents(rContent)
+
 	return (
 		<_DropdownMenu.Portal container={container}>
 			<_DropdownMenu.Content
+				ref={setContent}
 				className={classNames('tlui-menu', className)}
 				side={side}
 				sideOffset={sideOffset}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -1,8 +1,9 @@
-import { preventDefault, useContainer, usePassThroughWheelEvents } from '@tldraw/editor'
+import { preventDefault, useContainer } from '@tldraw/editor'
 import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
-import { ReactNode, useRef, useState } from 'react'
+import { ReactNode } from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from './Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from './Button/TldrawUiButtonIcon'
@@ -84,17 +85,7 @@ export function TldrawUiDropdownMenuContent({
 }: TLUiDropdownMenuContentProps) {
 	const container = useContainer()
 
-	// The menu portals into the container, so it sits outside the canvas and outside any
-	// pass-through root. Without this, a wheel over an open menu never reaches the canvas.
-	// A menu long enough to scroll still scrolls: the hook defers to real scroll containers.
-	//
-	// Opening the menu doesn't re-render this component — radix mounts the content from context
-	// after the root's state changes, and `children` keeps its identity so React bails out here.
-	// A plain ref would still read null, so the node reports itself through state instead.
-	const [content, setContent] = useState<HTMLDivElement | null>(null)
-	const rContent = useRef<HTMLDivElement | null>(null)
-	rContent.current = content
-	usePassThroughWheelEvents(rContent)
+	const setContent = useMenuWheelPassThrough()
 
 	return (
 		<_DropdownMenu.Portal container={container}>
@@ -180,9 +171,11 @@ export function TldrawUiDropdownMenuSubContent({
 	children,
 }: TLUiDropdownMenuSubContentProps) {
 	const container = useContainer()
+	const setContent = useMenuWheelPassThrough()
 	return (
 		<_DropdownMenu.Portal container={container}>
 			<_DropdownMenu.SubContent
+				ref={setContent}
 				data-testid={id}
 				className="tlui-menu tlui-menu__submenu__content"
 				alignOffset={alignOffset}

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { Popover as _Popover } from 'radix-ui'
 import React from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection } from '../../hooks/useTranslation/useTranslation'
 
 /** @public */
@@ -70,6 +71,14 @@ export function TldrawUiPopoverContent({
 	const container = useContainer()
 	const dir = useDirection()
 	const ref = React.useRef<HTMLDivElement>(null)
+	const passThroughRef = useMenuWheelPassThrough()
+	const setContent = React.useCallback(
+		(node: HTMLDivElement | null) => {
+			ref.current = node
+			passThroughRef(node)
+		},
+		[passThroughRef]
+	)
 
 	const handleOpenAutoFocus = React.useCallback(() => {
 		if (!autoFocusFirstButton) return
@@ -91,7 +100,7 @@ export function TldrawUiPopoverContent({
 				alignOffset={alignOffset}
 				collisionPadding={collisionPadding}
 				dir={dir}
-				ref={ref}
+				ref={setContent}
 				onOpenAutoFocus={handleOpenAutoFocus}
 				onEscapeKeyDown={(e) => disableEscapeKeyDown && e.preventDefault()}
 			>

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSelect.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { Select as _Select } from 'radix-ui'
 import * as React from 'react'
 import { useMenuIsOpen } from '../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../hooks/useMenuWheelPassThrough'
 import { useDirection } from '../../hooks/useTranslation/useTranslation'
 import { TLUiIconType } from '../../icon-types'
 import { TldrawUiIcon } from './TldrawUiIcon'
@@ -155,10 +156,12 @@ export function TldrawUiSelectContent({
 	className,
 }: TLUiSelectContentProps) {
 	const container = useContainer()
+	const setContent = useMenuWheelPassThrough()
 
 	return (
 		<_Select.Portal container={container}>
 			<_Select.Content
+				ref={setContent}
 				className={classNames('tlui-menu tlui-select__content', className)}
 				position="popper"
 				side={side}

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
@@ -2,6 +2,7 @@ import { useContainer } from '@tldraw/editor'
 import { ContextMenu as _ContextMenu } from 'radix-ui'
 import { ReactNode } from 'react'
 import { useMenuIsOpen } from '../../../hooks/useMenuIsOpen'
+import { useMenuWheelPassThrough } from '../../../hooks/useMenuWheelPassThrough'
 import { TLUiTranslationKey } from '../../../hooks/useTranslation/TLUiTranslationKey'
 import { useDirection, useTranslation } from '../../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../Button/TldrawUiButton'
@@ -33,6 +34,7 @@ export function TldrawUiMenuSubmenu<Translation extends string = string>({
 }: TLUiMenuSubmenuProps<Translation>) {
 	const { type: menuType, sourceId } = useTldrawUiMenuContext()
 	const container = useContainer()
+	const setSubmenuContent = useMenuWheelPassThrough()
 	const msg = useTranslation()
 	const dir = useDirection()
 	const labelToUse = label
@@ -75,6 +77,7 @@ export function TldrawUiMenuSubmenu<Translation extends string = string>({
 					<_ContextMenu.ContextMenuPortal container={container}>
 						<_ContextMenu.ContextMenuSubContent
 							data-testid={`${sourceId}-sub.${id}-content`}
+							ref={setSubmenuContent}
 							className="tlui-menu tlui-menu__submenu__content"
 							alignOffset={-1}
 							sideOffset={-4}

--- a/packages/tldraw/src/lib/ui/hooks/useMenuWheelPassThrough.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useMenuWheelPassThrough.ts
@@ -1,0 +1,24 @@
+import { usePassThroughWheelEvents } from '@tldraw/editor'
+import { useRef, useState } from 'react'
+
+/**
+ * Wheel pass-through for a radix content element, returned as a ref callback to spread onto it.
+ *
+ * Menus, popovers and context menus portal into the container, so they sit outside the canvas and
+ * outside every pass-through root: without this a wheel over one reaches nothing, and a pan stops
+ * the moment the pointer crosses it.
+ *
+ * A plain ref object is not enough. Opening one of these does not re-render the component that owns
+ * the content — radix mounts it from context, and `children` keeps its identity so React bails out
+ * — so `usePassThroughWheelEvents` would re-check its ref and still read null. Routing the node
+ * through state re-renders the owner at the moment the node appears.
+ *
+ * Content long enough to scroll still scrolls: the hook defers to real scroll containers.
+ */
+export function useMenuWheelPassThrough() {
+	const [content, setContent] = useState<HTMLDivElement | null>(null)
+	const rContent = useRef<HTMLDivElement | null>(null)
+	rContent.current = content
+	usePassThroughWheelEvents(rContent)
+	return setContent
+}


### PR DESCRIPTION
Wheel and trackpad panning stopped wherever a menu, popover or context menu sat over the canvas: you could pan everywhere right up until the pointer crossed one, and then it died.

The canvas wheel listener is attached to `.tl-canvas` (`useGestureEvents(rCanvas)`), so anything drawn over the canvas has to redispatch wheels explicitly. Every tldraw panel does this with `usePassThroughWheelEvents` — the toolbar, style panel, minimap, the commenting canvas overlays, the mention picker. The portaled menu surfaces did not, and neither did the `MenuClickCapture` overlay.

Same class as #9723 and #9698.

### What changed

- **The portaled content surfaces** — dropdown, popover, select, submenu, context menu — plus the four menus that render radix content directly instead of going through those primitives: main menu, zoom menu, people menu, presence colour picker.
- **`MenuClickCapture`**, the full-screen overlay mounted whenever a menu is registered as open. It already forwarded pointer drags to the canvas so drag-panning survived an open menu (#6918, #8501); wheel was the case never covered.

The ref handling is shared as `useMenuWheelPassThrough` rather than repeated nine times. A plain ref object does not work here: these elements mount from radix context without re-rendering the component that owns them, so `usePassThroughWheelEvents` re-checks its ref and still reads `null`. Routing the node through state re-renders the owner at the moment the node appears.

Dialogs are deliberately excluded — a dialog is modal, so a wheel over it should not drive the canvas underneath.

### How to test

Preview: https://pr-10634-preview-deploy.tldraw.com/

Open any example, then with each of these open, two-finger scroll (or wheel) **over it** and **away from it** — the canvas should pan in both cases, and does neither on `main`:

- the main menu, the zoom menu, the actions menu, a right-click context menu
- the comment reaction picker: place a comment, send it, click the pin, then **Add reaction**

Two behaviours to confirm are preserved:

- **A menu long enough to scroll must still scroll, not pan.** Shrink the window so the main menu overflows; the menu should scroll and the camera should stay put.
- Picking an emoji still adds the reaction and dismisses the grid; shift-pick still keeps it open.

Measured on the `commenting` example, camera read off the `.tl-html-layer` transform:

| wheel over | before | after |
| --- | --- | --- |
| main menu | no pan | pans |
| zoom menu | no pan | pans |
| actions menu (a popover) | no pan | pans |
| context menu | no pan | pans |
| comment reaction picker | no pan | pans |
| the click-capture overlay | no pan | pans |
| main menu, overflowing | scrolls | scrolls, camera still |

The popover case was reproduced on the deployed preview against production as an unfixed control: with the actions menu open, a wheel over the popover moved the camera 0 while a wheel away from it moved it −400.

Closes #10624
