### PR TITLE
fix(commenting): keep canvas comment surfaces below the editor chrome

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -1,8 +1,16 @@
 /* The comments layer renders through `EditorPortal`, so its pieces can pick their own layer rather
-   than the one the component is mounted in. Pins live in the canvas-in-front layer (beneath the UI
-   panels at z-index 300), so the toolbar and style panel draw over them; the open thread's popover
-   goes to the menus layer instead (`.tlui-cmt-canvas-popover`) so it isn't clipped. Click-through
-   except on its own children. */
+   than the one the component is mounted in. Every piece stays beneath the UI panels (z-index 300),
+   so the toolbar and style panel stay visible and clickable while a thread is open: pins in the
+   canvas-in-front layer, and the surfaces that float above them on the shared layer below.
+   Click-through except on its own children. */
+
+.tl-container {
+	/* The layer shared by the comment surfaces that float over the canvas — the hover preview, the
+	   open thread's popover, and the placement composer. Derived from the panels slot rather than a
+	   literal, so these can't drift above the UI panels if that slot moves. */
+	--tlui-cmt-layer-floating: calc(var(--tl-layer-panels) - 10);
+}
+
 .tlui-cmt-canvas-layer {
 	position: absolute;
 	inset: 0;
@@ -189,7 +197,7 @@
    marker — the pin would appear pressed just for being hovered. */
 .tlui-cmt-canvas-preview {
 	position: absolute;
-	z-index: var(--tl-layer-menus);
+	z-index: var(--tlui-cmt-layer-floating);
 	pointer-events: auto;
 }
 
@@ -198,9 +206,9 @@
    Invisible, part of the panel's hover region, and only present while the panel is.
 
    It spans the gap and stops there. Reaching any further would put it over the marker itself, and
-   since it sits in the menus layer — above the pins — it would take the marker's hover and clicks:
-   the pin would go dead exactly where it looks most alive. The marker needs no covering anyway, as
-   it carries the same hover handlers.
+   since it sits above the pins it would take the marker's hover and clicks: the pin would go dead
+   exactly where it looks most alive. The marker needs no covering anyway, as it carries the same
+   hover handlers.
 
    The gap is the panel's own offset (`--tlui-cmt-preview-offset`, set from `POPOVER_OFFSET` so
    there's one source) less however far the marker reaches toward it, per variant below. */
@@ -403,19 +411,19 @@
 	transform: none;
 }
 
-/* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin. */
+/* The open thread's popover — portaled to the floating comment layer, positioned at the pin. */
 .tlui-cmt-canvas-popover {
 	position: absolute;
-	z-index: var(--tl-layer-menus);
+	z-index: var(--tlui-cmt-layer-floating);
 	pointer-events: auto;
 }
 
-/* The placement composer — a distinct floating view (portaled to the menus layer, below the click
-   point): a draft avatar pin beside a pill field that is itself the surface (no wrapping panel).
-   Scoped here so the in-thread reply composer keeps its own squarer look. */
+/* The placement composer — a distinct floating view (portaled to the floating comment layer, below
+   the click point): a draft avatar pin beside a pill field that is itself the surface (no wrapping
+   panel). Scoped here so the in-thread reply composer keeps its own squarer look. */
 .tlui-cmt-canvas-composer {
 	position: absolute;
-	z-index: var(--tl-layer-menus);
+	z-index: var(--tlui-cmt-layer-floating);
 	pointer-events: auto;
 	/* Anchor the draft avatar bottom-left like the pins it becomes: it is a pin wide and sits 4px
 	   into the row, so its bottom-left corner is 4px right of and 4px + a pin below the composer's
@@ -537,10 +545,11 @@
 	margin-bottom: 4px;
 }
 
-/* The comments list panel — a right-side surface shown while the comments sidebar is open. Below
-   the popover layer, so an open thread still draws over it. Its top aligns flush with the style
-   panel (48px from the top, clearing the share panel) and it sizes to its content, scrolling past
-   max-height rather than stretching the full canvas height. */
+/* The comments list panel — a right-side surface shown while the comments sidebar is open. On the
+   panels layer, above the floating comment surfaces, so an open thread near the right edge tucks
+   behind it. Its top aligns flush with the style panel (48px from the top, clearing the share
+   panel) and it sizes to its content, scrolling past max-height rather than stretching the full
+   canvas height. */
 .tlui-cmt-canvas-sidebar {
 	position: absolute;
 	top: 48px;

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -288,9 +288,9 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	}
 
 	// Portalled rather than rendered into this component's slot: pins sit below the collaborator
-	// cursors and popovers above the UI panels, and no single canvas layer spans both. The portal
-	// also fixes where the layer lands among the container's children, keeping it behind the UI's
-	// skip link in the tab order.
+	// cursors and popovers above the in-front content, and no single canvas layer spans both. The
+	// portal also fixes where the layer lands among the container's children, keeping it behind the
+	// UI's skip link in the tab order.
 	return (
 		<EditorPortal>
 			{/* Wheel pass-through lives on each interactive element, not this root: the root spans the

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -387,8 +387,8 @@ export const ThreadPin = memo(function ThreadPin({
 						{pinContent}
 					</CommentPin>
 				</button>
-				{/* The popover portals up to the menus layer (above the UI panels) so it isn't clipped;
-			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
+				{/* The popover portals up to the floating comment layer, clear of the in-front content;
+			    the pin itself stays in the canvas-in-front layer. Both sit beneath the UI panels. */}
 				{open && (
 					<ThreadPopover
 						base={{

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -151,8 +151,9 @@ export const POPOVER_OFFSET = {
 	list: { x: MARKER_SIZE + PREVIEW_GAP, y: CARD_TOP_Y - MARKER_SIZE / 2 },
 } as const
 
-/** The open thread's popover container, portaled above the UI panels. A wheel over it passes
- *  through to the canvas (unless it scrolls its own content), like tldraw's panels. */
+/** The open thread's popover container, portaled to the comment layer beneath the UI panels. A
+ *  wheel over it passes through to the canvas (unless it scrolls its own content), like tldraw's
+ *  panels. */
 export function ThreadPopover({
 	base,
 	children,


### PR DESCRIPTION
This PR fixes a bug where comment UI drew over the toolbar and style panel, hiding them and swallowing their clicks while a thread was open. Closes #10623.

### Before

The comment layer renders through `EditorPortal`, so each piece picks its own layer. Pins sat on the canvas-in-front layer, below the UI panels — but the three surfaces anchored to them (the hover preview, the open thread's popover, and the placement composer) sat on the menus layer at 400, above the UI panels at 300. Opening a thread near the top right or the bottom of the canvas covered the style panel or the toolbar, and `elementFromPoint` over the overlap returned the popover, so the chrome underneath could not be clicked either.

The popover's place on the menus layer was documented as being "so it isn't clipped". That rationale doesn't hold: `.tl-container` sets `overflow: clip`, and the popover is portaled into a `display: contents` host inside it, so it is clipped at the container bounds at any z-index. The layer choice only ever affected occlusion.

### After

The three surfaces share one layer below the UI panels, so the toolbar and style panel stay visible and clickable while commenting — consistent with the pins they belong to.

### Implementation notes

The shared value is derived rather than a literal, following the existing pattern in this file (`calc(var(--tl-layer-collaborators) - 5)` for the pin layer):

```css
--tlui-cmt-layer-floating: calc(var(--tl-layer-panels) - 10);
```

The comments sidebar deliberately stays on the panels layer. Worth flagging: it now draws over an open thread where the two overlap, where the thread previously drew over it. That trade was chosen over moving the sidebar beneath the style panel it shares a corner with.

No collision avoidance was added, so a thread opened near the toolbar is now partly hidden behind it. Left as a deliberate follow-up.

### Change type

- [x] `bugfix`

### Test plan

1. Open the `commenting` example, place a comment near the style panel, switch to the select tool, and open the thread.
2. The style panel draws over the popover, and its buttons stay clickable.

- [x] Unit tests — existing `packages/commenting` suite (377) passes. No new test: the change is CSS layering, not covered by the unit suite.
- [ ] End to end tests

### Release notes

- Fix comment threads, previews and the comment composer drawing over the toolbar and style panel.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +35 / -25  |
