### PR TITLE
docs(releases): fix the frame selection shortcut and the v5.1.0 copy-styles claim

### DIFF
--- a/apps/docs/content/getting-started/releases.mdx
+++ b/apps/docs/content/getting-started/releases.mdx
@@ -35,7 +35,7 @@ We ship an experimental `tldraw-migrate` agent skill that helps a coding agent u
 
 - [v5.3](/releases/v5.3.0) - Commenting with anchored threads on the canvas, new collaboration packages, geo shape flipping, crop snapping, and faster viewport culling
 - [v5.2](/releases/v5.2.0) - Faster freehand ink, a frame selection action, SDK-wide performance improvements, and breaking changes to the collaborator user-id types and Node support
-- [v5.1](/releases/v5.1.0) - Page menu redesign, copy-styles shortcut, selectable locked shapes, public translation APIs, and performance improvements
+- [v5.1](/releases/v5.1.0) - Page menu redesign, selectable locked shapes, public translation APIs, and performance improvements
 - [v5.0](/releases/v5.0.0) - Custom themes, overlays, performance, extensiblity, and attribution
 
 ## v4.x

--- a/apps/docs/content/releases/v5.1.0.mdx
+++ b/apps/docs/content/releases/v5.1.0.mdx
@@ -1,6 +1,6 @@
 ---
 title: v5.1.0
-description: Page menu redesign, a copy-styles shortcut, a selectLockedShapes option, public translation APIs, and more
+description: Page menu redesign, a selectLockedShapes option, public translation APIs, and more
 author: tldraw
 date: 06/03/2026
 order: 0
@@ -11,14 +11,13 @@ keywords:
   - v5.1
   - v5.1.0
   - page-menu
-  - copy-styles
   - locked-shapes
   - translations
 ---
 
 [View on GitHub](https://github.com/tldraw/tldraw/releases/tag/v5.1.0)
 
-This release redesigns the page menu around inline interaction, adds a keyboard shortcut to copy styles from a hovered shape, and adds a `selectLockedShapes` option for inspecting locked shapes, along with new public translation APIs, canvas performance improvements, and various rendering and UI bug fixes.
+This release redesigns the page menu around inline interaction and adds a `selectLockedShapes` option for inspecting locked shapes, along with new public translation APIs, canvas performance improvements, and various rendering and UI bug fixes.
 
 ## What's new
 

--- a/apps/docs/content/releases/v5.2.0.mdx
+++ b/apps/docs/content/releases/v5.2.0.mdx
@@ -12,6 +12,7 @@ keywords:
   - v5.2.0
   - freehand-ink
   - frame-selection
+  - copy-styles
   - performance
   - breaking-changes
 ---
@@ -28,7 +29,7 @@ We rewrote the freehand ink algorithm. Draw and highlighter strokes now compute 
 
 ### Frame selection ([#8151](https://github.com/tldraw/tldraw/pull/8151))
 
-A new "Frame selection" action wraps the selected shapes in a frame with `cmd+shift+f`. When a frame is selected, the same shortcut removes it.
+A new "Frame selection" action wraps the selected shapes in a frame with `cmd+alt+g`. When a frame is selected, the same shortcut removes it.
 
 ## API changes
 


### PR DESCRIPTION
In order to stop the release notes pointing readers at keyboard shortcuts that never shipped, this PR corrects two claims in the docs content. Relates to #8962 and #10422.

The v5.2.0 "Frame selection" section said the action was bound to `cmd+shift+f`. That was the old **Remove frame** binding, which #8151 deleted in the same change that added the action. The binding that shipped in 5.2.0 is `cmd+alt+g`; #10481 later added the `ctrl+alt+g` twin, which next.mdx already covers.

The v5.1.0 description, keywords, and intro, plus the v5.1 line on the releases index page, advertised a shortcut that copies styles from a hovered shape. #8917 added it on `q` on 2026-05-22, but the double binding reported in #8962 got it reverted by hotfix before the v5.1.0 tag was cut on 2026-06-03, so v5.1.0 has no such shortcut and the article body never listed one. The shortcut that exists today is `shift+q` from #9028, which shipped in v5.2.0 and is already listed there, so the `copy-styles` keyword moves to the v5.2.0 frontmatter instead of disappearing.

Both facts were checked against the `kbd` table in `actions.tsx` at the v5.1.0 and v5.2.0 tags.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev-docs` and open the v5.1.0 and v5.2.0 release pages and the releases index.
2. Check that the frame selection section names `cmd+alt+g`, and that neither the v5.1.0 page nor the index mentions a copy-styles shortcut.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +5 / -5    |
