### PR TITLE
chore: scope the release notes commit to the paths it owns

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -25,6 +25,14 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
+    # The skill maintains the release notes pages and nothing else. Both the change
+    # check and the commit below are scoped to these, so a file the agent leaves
+    # anywhere else in the tree cannot ride along into the release notes commit.
+    env:
+      RELEASE_NOTES_PATHS: >-
+        apps/docs/content/releases
+        apps/docs/content/getting-started/releases.mdx
+
     steps:
       - name: Generate GH token
         id: generate_token
@@ -85,7 +93,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if [ -z "$(git status --porcelain)" ]; then
+          if [ -z "$(git status --porcelain -- $RELEASE_NOTES_PATHS)" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -94,7 +102,7 @@ jobs:
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
         run: |
-          git add -A
+          git add -- $RELEASE_NOTES_PATHS
           git commit -m "Update release notes"
           git push -u origin "${{ steps.branch.outputs.branch_name }}"
 


### PR DESCRIPTION
In order to stop unrelated files entering the repo through the release notes job, this scopes its staging to the pages the skill actually maintains. Closes #10638.

The job runs an agent in the repo root and then staged everything with `git add -A`, so any file the agent left in the working tree was committed alongside the release notes — that is how an empty file named `0` was added, removed in #10030, and added straight back the same day in #10066. The change-detection step had the same blind spot: it asked whether anything changed, never what. Both are now scoped to one shared list, so they cannot drift apart.

`add-framer-rewrites.yml` and `i18n-download-strings.yml` already scope their staging this way; this job was the outlier.

Not included, pending the open question on #10638: the job stays silent when the agent leaves unexpected files, rather than warning. Scoping makes that debris invisible instead of committed, which is better but not the same as visible.

### Change type

- [x] `other`

### Test plan

Verified locally under `bash` against the two owned paths, with a stray untracked file in the repo root:

1. Unscoped `git status --porcelain` reports both the release notes edit and `?? stray-debris-test` — the old behaviour.
2. Scoped `git status --porcelain -- $RELEASE_NOTES_PATHS` reports only the release notes edit.
3. Scoped `git add -- $RELEASE_NOTES_PATHS` stages only the release notes edit.

- [ ] Unit tests
- [ ] End to end tests
