### PR TITLE
fix(tldraw): drop the creation of an abandoned empty text shape from history

### DIFF
--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -65,6 +65,12 @@ export function registerDefaultSideEffects(editor: Editor) {
 							// then create the shape with a flag that will let it know to
 							// go back to the text tool once the edit is complete.
 							const shape = editor.getEditingShape()
+							// When editing begins as part of creating the shape, the tool leaves a
+							// mark named after it. Carrying that mark into the editing state lets it
+							// drop the whole creation if the shape doesn't survive the edit.
+							const creatingMarkId = shape
+								? (editor.getMarkIdMatching(`creating_text:${shape.id}`) ?? undefined)
+								: undefined
 							if (
 								shape &&
 								shape.type === 'text' &&
@@ -75,11 +81,13 @@ export function registerDefaultSideEffects(editor: Editor) {
 									target: 'shape',
 									shape: shape,
 									isCreatingTextWhileToolLocked: true,
+									creatingMarkId,
 								})
 							} else {
 								editor.setCurrentTool('select.editing_shape', {
 									target: 'shape',
 									shape: shape,
+									creatingMarkId,
 								})
 							}
 						}

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -65,18 +65,19 @@ export function registerDefaultSideEffects(editor: Editor) {
 							// then create the shape with a flag that will let it know to
 							// go back to the text tool once the edit is complete.
 							const shape = editor.getEditingShape()
-							// When editing begins as part of creating the shape, the tool leaves a
-							// mark named after it. Carrying that mark into the editing state lets it
-							// drop the whole creation if the shape doesn't survive the edit.
-							const creatingMarkId = shape
+							const isCreatingShape =
+								!!shape &&
+								shape.type === 'text' &&
+								editor.isInAny('text.pointing', 'select.resizing')
+							// The creating tool leaves a mark named after the shape. Carrying it into
+							// the editing state lets that state drop the whole creation if the shape
+							// doesn't survive the edit. Only look while the shape is being created:
+							// the mark stays on the undo stack afterwards, so editing an old text
+							// shape would otherwise find it and bail over everything done since.
+							const creatingMarkId = isCreatingShape
 								? (editor.getMarkIdMatching(`creating_text:${shape.id}`) ?? undefined)
 								: undefined
-							if (
-								shape &&
-								shape.type === 'text' &&
-								editor.isInAny('text.pointing', 'select.resizing') &&
-								editor.getInstanceState().isToolLocked
-							) {
+							if (isCreatingShape && editor.getInstanceState().isToolLocked) {
 								editor.setCurrentTool('select.editing_shape', {
 									target: 'shape',
 									shape: shape,

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -1,4 +1,4 @@
-import { DefaultTextAlignStyle, toRichText } from '@tldraw/editor'
+import { createShapeId, DefaultTextAlignStyle, toRichText } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from '../../../test/TestEditor'
 import { TextShapeTool } from './TextShapeTool'
@@ -72,6 +72,70 @@ describe(TextShapeTool, () => {
 		expect(editor.getCurrentPageShapes().length).toBe(0)
 		editor.redo()
 		expect(editor.getCurrentPageShapes().length).toBe(0)
+	})
+
+	it('Costs no undo step when an empty text shape is abandoned', () => {
+		const boxId = createShapeId()
+		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		editor.select(boxId)
+		editor.markHistoryStoppingPoint()
+		editor.updateShape({ id: boxId, type: 'geo', x: 500 })
+		expect(editor.getShape(boxId)!.x).toBe(500)
+
+		editor.setCurrentTool('text')
+		editor.pointerDown(200, 200)
+		editor.pointerUp()
+		editor.expectToBeIn('select.editing_shape')
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		// Dropping the creation also restores the selection it replaced
+		expect(editor.getSelectedShapeIds()).toEqual([boxId])
+
+		// The abandoned creation left nothing behind, so the first undo reaches the move
+		editor.undo()
+		expect(editor.getShape(boxId)!.x).toBe(0)
+	})
+
+	it('Costs no undo step when an empty text shape dragged out to a fixed width is abandoned', () => {
+		const boxId = createShapeId()
+		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		editor.markHistoryStoppingPoint()
+		editor.updateShape({ id: boxId, type: 'geo', x: 500 })
+
+		editor.setCurrentTool('text')
+		editor.pointerDown(200, 200)
+		vi.advanceTimersByTime(200)
+		editor.pointerMove(400, 200)
+		editor.pointerUp()
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+
+		editor.undo()
+		expect(editor.getShape(boxId)!.x).toBe(0)
+	})
+
+	it('Still costs one undo step when the text shape survives', () => {
+		const boxId = createShapeId()
+		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		editor.markHistoryStoppingPoint()
+		editor.updateShape({ id: boxId, type: 'geo', x: 500 })
+
+		editor.setCurrentTool('text')
+		editor.pointerDown(200, 200)
+		editor.pointerUp()
+		editor.updateShapes([
+			{
+				...editor.getCurrentPageShapes().find((s) => s.type === 'text')!,
+				type: 'text',
+				props: { richText: toRichText('Hello') },
+			},
+		])
+		editor.cancel()
+		expect(editor.getCurrentPageShapes().length).toBe(2)
+
+		editor.undo()
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		expect(editor.getShape(boxId)!.x).toBe(500)
 	})
 })
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeTool.test.ts
@@ -114,6 +114,29 @@ describe(TextShapeTool, () => {
 		expect(editor.getShape(boxId)!.x).toBe(0)
 	})
 
+	it('Does not discard later work when an existing text shape is emptied', () => {
+		// The mark from a shape's creation stays on the undo stack after the shape survives, so
+		// editing that shape later must not treat it as the creation of the shape being edited
+		editor.setCurrentTool('text')
+		editor.pointerDown(200, 200)
+		editor.pointerUp()
+		const textId = editor.getCurrentPageShapes().find((s) => s.type === 'text')!.id
+		editor.updateShapes([{ id: textId, type: 'text', props: { richText: toRichText('Hello') } }])
+		editor.cancel()
+		expect(editor.getShape(textId)).toBeDefined()
+
+		const boxId = createShapeId()
+		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+		editor.select(textId)
+		editor.setEditingShape(textId)
+		editor.updateShapes([{ id: textId, type: 'text', props: { richText: toRichText('') } }])
+		editor.cancel()
+
+		expect(editor.getShape(textId)).toBeUndefined()
+		expect(editor.getShape(boxId)).toBeDefined()
+	})
+
 	it('Still costs one undo step when the text shape survives', () => {
 		const boxId = createShapeId()
 		editor.createShape({ id: boxId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -116,8 +116,8 @@ export class Pointing extends StateNode {
 	}
 
 	private complete() {
-		this.editor.markHistoryStoppingPoint('creating text shape')
 		const id = createShapeId()
+		this.editor.markHistoryStoppingPoint(`creating_text:${id}`)
 		const originPagePoint = this.editor.inputs.getOriginPagePoint()
 		const shape = this.createTextShape(id, originPagePoint, true, 20)
 		if (!shape) return

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -17,6 +17,11 @@ import {
 
 interface EditingShapeInfo {
 	isCreatingTextWhileToolLocked?: boolean
+	/**
+	 * The mark from the creation of the shape we're about to edit, when editing began as part of
+	 * creating it. Lets us drop the whole creation if the shape doesn't survive the edit.
+	 */
+	creatingMarkId?: string
 }
 
 export class EditingShape extends StateNode {
@@ -50,8 +55,18 @@ export class EditingShape extends StateNode {
 	}
 
 	override onExit() {
-		const hadEditingShape = !!this.editor.getEditingShapeId()
+		const editingShapeId = this.editor.getEditingShapeId()
+		const hadEditingShape = !!editingShapeId
 		this.editor.setEditingShape(null)
+
+		// A shape util can delete its own shape when the edit ends with nothing in it, as the text
+		// shape does. That leaves the mark from the shape's creation with only the selection change
+		// after it, so undo stops there and appears to do nothing. Bail to the mark instead, which
+		// drops the abandoned creation from history entirely.
+		const { creatingMarkId } = this.info
+		if (creatingMarkId && editingShapeId && !this.editor.getShape(editingShapeId)) {
+			this.editor.bailToMark(creatingMarkId)
+		}
 
 		cancelUpdateHoveredShapeId(this.editor)
 


### PR DESCRIPTION
Press <kbd>T</kbd>, click on empty canvas, and leave without typing. The shape is deleted, but the mark from its creation stays on the undo stack with the selection change after it — so the next <kbd>Cmd</kbd>+<kbd>Z</kbd> stops there and reverts nothing visible, and it takes a second press to reach whatever you did before.

#10369 fixed the half of this that redo could see: the `onEditEnd` deletion is now recorded, so redo no longer resurrects the shape. The extra press is what's left. The shape's add and remove cancel in `squashRecordDiffsMutable`, but the selection change doesn't, so `HistoryManager._undo`'s "pop intermediate marks when nothing has happened since the last mark" path never fires.

By contrast, a selection change next to a document change costs no extra press today: move a shape leaving it selected, click empty canvas to deselect, and one undo both restores the selection and reverts the move.

**The change**

The text tool's click path now names its mark `creating_text:{shapeId}`, which the drag-to-create path already did. `defaultSideEffects` — which is what actually enters `select.editing_shape`, and already infers `isCreatingTextWhileToolLocked` there — looks that mark up and carries it into the state. `EditingShape.onExit` bails to it when the shape it was editing no longer exists after `setEditingShape(null)`, so an abandoned creation leaves no trace instead of a stop with only a selection change behind it.

Recovering the mark by name follows `Translating`, which reads `creatingMarkId` off its transition info and falls back to `getMarkIdMatching('creating:{shapeId}')`. Passing it as transition info from the tool isn't available here: the side effect enters the editing state on `setEditingShape`, before the tool's own `setCurrentTool` call, which is then a no-op.

**Guarding the mark lookup**

A creation mark stays on the undo stack once its shape survives. Looking it up on every entry into the editing state meant emptying that shape at any later point bailed over everything done since it was created — unrecoverably, since `bail` doesn't push to the redo stack. Caught by Bugbot on the first commit; the lookup now happens only while the shape is being created, which is the condition the surrounding branch already evaluates for the tool-lock flag. `Translating` guards its equivalent fallback the same way with `isCreating`.

**Worth a reviewer's explicit agreement:** bailing restores the selection you had before reaching for the text tool, where today you're left with nothing selected. `Pointing.cancel()` already behaves this way on the drag path, and "an abandoned creation leaves no trace" argues for it, but it is a visible change. Pinned by an assertion in the first test rather than left implicit.

Closes #10632

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Move a shape somewhere obvious.
2. Press <kbd>T</kbd>, click empty canvas, leave without typing (Escape or click away).
3. Press <kbd>Cmd</kbd>+<kbd>Z</kbd> once — the move reverts.
4. Repeat, but type something before leaving: the text shape survives and one undo removes it, leaving the move applied.
5. Type in a text shape, do some other work, then come back and delete all of its text: the shape goes, everything else stays.

- [x] Unit tests
- [ ] End to end tests

Four tests in `TextShapeTool.test.ts`: the click path, the drag-to-fixed-width path, a shape emptied long after it was created, and a guard that a surviving text shape still costs exactly one undo step. Each of the first three fails without its half of the change. Full `tldraw` package suite passes (2918 tests).

### Release notes

- Fixed leaving an empty text shape costing an undo press that reverted nothing.
