### PR TITLE
fix(editor): keep an open menu registered when its owner re-renders

### DIFF
--- a/packages/editor/src/lib/hooks/useGlobalMenuIsOpen.ts
+++ b/packages/editor/src/lib/hooks/useGlobalMenuIsOpen.ts
@@ -1,6 +1,7 @@
 import { useValue } from '@tldraw/state-react'
 import { useCallback, useEffect, useRef } from 'react'
 import { tlmenus } from '../globals/menus'
+import { useEvent } from './useEvent'
 
 /** @public */
 export function useGlobalMenuIsOpen(
@@ -27,6 +28,12 @@ export function useGlobalMenuIsOpen(
 
 	const isOpen = useValue('is menu open', () => tlmenus.getOpenMenus().includes(id), [id])
 
+	// Hosts usually pass an inline handler (`<Tldraw onUiEvent={(name, data) => ...} />`), which the
+	// events context hands straight on, so this arrives with a new identity on every render. The
+	// effect below tears the menu out of the registry when it re-runs and cannot put it back, so an
+	// unstable identity here closes open menus whenever the host re-renders for any reason.
+	const handleEvent = useEvent((eventName: string) => onEvent?.(eventName))
+
 	useEffect(() => {
 		// When the effect runs, if the menu is open then
 		// add it to the open menus list.
@@ -37,7 +44,7 @@ export function useGlobalMenuIsOpen(
 		// hook but it's necessary to handle the case where the
 		// this effect runs twice or re-runs.
 		if (rIsOpen.current) {
-			onEvent?.('open-menu')
+			handleEvent('open-menu')
 			tlmenus.addOpenMenu(id)
 		}
 
@@ -49,7 +56,7 @@ export function useGlobalMenuIsOpen(
 				// Close menu and all submenus when the parent is closed
 				tlmenus.getOpenMenus().forEach((menuId) => {
 					if (menuId.startsWith(id)) {
-						onEvent?.('close-menu')
+						handleEvent('close-menu')
 						tlmenus.deleteOpenMenu(menuId)
 					}
 				})
@@ -57,7 +64,7 @@ export function useGlobalMenuIsOpen(
 				rIsOpen.current = false
 			}
 		}
-	}, [id, onEvent])
+	}, [id, handleEvent])
 
 	return [isOpen, onOpenChange] as const
 }

--- a/packages/editor/src/lib/test/useGlobalMenuIsOpen.test.tsx
+++ b/packages/editor/src/lib/test/useGlobalMenuIsOpen.test.tsx
@@ -1,0 +1,64 @@
+import { act, render } from '@testing-library/react'
+import { useCallback } from 'react'
+import { tlmenus } from '../globals/menus'
+import { useGlobalMenuIsOpen } from '../hooks/useGlobalMenuIsOpen'
+
+const MENU_ID = 'test-menu'
+
+let setOpen: (isOpen: boolean) => void
+
+// `onEvent` identity changes with `nonce`, the way a host passing an inline `onUiEvent` to
+// <Tldraw> hands `useMenuIsOpen` a fresh callback on every render.
+function Menu({ nonce }: { nonce: number }) {
+	const onEvent = useCallback(() => nonce, [nonce])
+	const [isOpen, onOpenChange] = useGlobalMenuIsOpen(MENU_ID, undefined, onEvent)
+	setOpen = onOpenChange
+	return <div data-testid="state">{isOpen ? 'open' : 'closed'}</div>
+}
+
+describe('useGlobalMenuIsOpen', () => {
+	beforeEach(() => {
+		tlmenus.clearOpenMenus()
+	})
+
+	it('keeps an open menu open when the host re-renders', () => {
+		const { rerender } = render(<Menu nonce={0} />)
+
+		act(() => setOpen(true))
+		expect(tlmenus.isMenuOpen(MENU_ID)).toBe(true)
+
+		rerender(<Menu nonce={1} />)
+		expect(tlmenus.isMenuOpen(MENU_ID)).toBe(true)
+	})
+
+	it('stays closed after the menu is closed through tlmenus directly', () => {
+		const { rerender } = render(<Menu nonce={0} />)
+
+		act(() => setOpen(true))
+		// How ReactionPicker dismisses its palette: drop the registry entry rather than routing
+		// through the hook's own onOpenChange. A re-render must not bring it back.
+		act(() => tlmenus.deleteOpenMenu(MENU_ID))
+		expect(tlmenus.hasAnyOpenMenus()).toBe(false)
+
+		rerender(<Menu nonce={1} />)
+		expect(tlmenus.hasAnyOpenMenus()).toBe(false)
+	})
+
+	it('drops the entry when a menu unmounts while open', () => {
+		const { unmount } = render(<Menu nonce={0} />)
+
+		act(() => setOpen(true))
+		expect(tlmenus.hasAnyOpenMenus()).toBe(true)
+
+		unmount()
+		expect(tlmenus.hasAnyOpenMenus()).toBe(false)
+	})
+
+	it('closes through onOpenChange', () => {
+		render(<Menu nonce={0} />)
+
+		act(() => setOpen(true))
+		act(() => setOpen(false))
+		expect(tlmenus.hasAnyOpenMenus()).toBe(false)
+	})
+})


### PR DESCRIPTION
An open menu was dropped from the `tlmenus` registry whenever the component owning it re-rendered for an unrelated reason. The radix `open` prop is derived from that registry, so the menu closed on its own.

`useGlobalMenuIsOpen`'s effect deletes the menu on cleanup and cannot add it back: the cleanup clears `rIsOpen`, and the effect body reads that same ref to decide whether to re-register. React runs cleanup on every re-run, not just unmount, so a re-run deletes and never restores — the opposite of what the effect's own comment says it is for.

It re-ran on every host render because `onEvent` arrives with a fresh identity: `TldrawUiEventsProvider` passes the host's handler straight through as the context value, and hosts normally pass an inline arrow (`<Tldraw onUiEvent={(name, data) => …} />`, as the docs show). Holding it through `useEvent` keeps the identity stable, so the effect only runs when the menu itself changes.

### Why not just drop the ref reset

Deleting `rIsOpen.current = false` from the cleanup is the smaller-looking fix and it is wrong. Without it, a re-run re-registers a menu that was closed *out of band* through `tlmenus.deleteOpenMenu` — which is how `ReactionPicker` dismisses its palette — so a dismissed menu would pop back open. Fixing the trigger avoids both failures. The test covers both directions.

### How to test

Preview: https://pr-10644-preview-deploy.tldraw.com/

`yarn test run useGlobalMenuIsOpen` in `packages/editor` is the direct check — the added test fails on `main` and passes here.

By hand, in an app that passes an inline `onUiEvent` and re-renders while a menu is open: open any menu and trigger an unrelated host re-render. The menu should stay open; on `main` it closes itself.

### Notes

Behaviour change worth a second opinion: a menu that previously closed on a host re-render now stays open. That dismissal was accidental rather than designed, and I found nothing relying on it, but I have not audited every consumer.

Not related to #9020, despite touching the same `useGlobalMenuIsOpen` / `tlmenus` round-trip: driving sibling submenu switches in the `end-to-end` example fails 32/96 both with and without this change, same distribution across timings.

Closes #10643

