### PR TITLE
chore(dotcom): scale production view-syncers 7 -> 9

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -301,7 +301,7 @@ const zeroVmSizes = {
 		rm: { cpus: 2, memory: '4gb', cpuKind: 'performance' },
 		vs: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		volumeSize: '8gb',
-		vsMinMachines: 7,
+		vsMinMachines: 9,
 		killTimeout: '5m',
 	},
 	preview: { single: { cpus: 2, memory: '2gb' } },


### PR DESCRIPTION
Production view-syncer CPU is peaking at 70-80% daily (~16:00 UTC), and today's ramp is ahead of yesterday's. With 7 machines a single machine loss or rolling deploy at peak pushes the rest toward saturation, and the per-machine number is a 4-core average so individual sync workers are likely pegged earlier than that.

Bumps `vsMinMachines` 7 -> 9. Horizontal rather than bigger VMs: the cookie replay cache pins clients per machine, so more machines means smaller blast radius per restart, and +2 perf-4x machines is roughly a quarter of the cost of going to perf-8x across the board.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`