### PR TITLE
fix(internal): strip skip-ci markers in the dotcom hotfix flow

### DIFF
--- a/.github/workflows/trigger-dotcom-hotfix.yml
+++ b/.github/workflows/trigger-dotcom-hotfix.yml
@@ -1,11 +1,19 @@
 name: Trigger dotcom hotfix
 
+# pull_request_target rather than push/pull_request, for the same reason as
+# trigger-sdk-hotfix.yml: release-notes PRs squash-merge with `[skip ci]` in the title, which
+# suppresses the push-to-main run entirely, and the `labeled` event fires before the merge so the
+# `merged == true` gate rejects it. Neither path ever reached the script. GitHub's skip-ci markers
+# do not apply to pull_request_target. `closed` replaces the old push trigger (which ran on every
+# merge to main just to check labels), and `labeled` allows re-triggering by re-adding the label to
+# an already-merged PR. Secrets exposure is safe here: the job only runs for merged PRs carrying a
+# maintainer-applied hotfix label, checkout uses the trusted base branch, and the only PR-derived
+# code the script builds is the PR's already-merged commit from main.
 on:
-  push:
+  pull_request_target:
+    types: [closed, labeled]
     branches:
       - main
-  pull_request:
-    types: [labeled]
 
 defaults:
   run:
@@ -23,10 +31,11 @@ jobs:
     concurrency: dotcom-hotfix
     environment: npm deploy
     if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       github.event.label.name == 'dotcom-hotfix-please')
+      github.event.pull_request.merged == true &&
+      ((github.event.action == 'closed' &&
+        contains(github.event.pull_request.labels.*.name, 'dotcom-hotfix-please')) ||
+       (github.event.action == 'labeled' &&
+        github.event.label.name == 'dotcom-hotfix-please'))
 
     steps:
       - name: Generate a token

--- a/internal/scripts/lib/skip-ci.ts
+++ b/internal/scripts/lib/skip-ci.ts
@@ -1,0 +1,16 @@
+// GitHub skips push-triggered workflows when any of these markers appear anywhere in a commit
+// message (title or body). See
+// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+const SKIP_CI_MARKER = /\s*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
+
+/**
+ * Remove GitHub's skip-ci markers from a commit message or PR title.
+ *
+ * Release-notes PRs carry `[skip ci]` in their title on purpose, so their squash-merge onto `main`
+ * doesn't run the push workflows. The hotfix scripts cherry-pick that same commit onto a branch
+ * whose push *must* trigger a workflow (the release branch's publish, or the hotfixes branch's
+ * production build), so the marker has to go before the push.
+ */
+export function stripSkipCiMarkers(message: string): string {
+	return message.replace(SKIP_CI_MARKER, '').trim()
+}

--- a/internal/scripts/lib/skip-ci.ts
+++ b/internal/scripts/lib/skip-ci.ts
@@ -1,7 +1,10 @@
-// GitHub skips push-triggered workflows when any of these markers appear anywhere in a commit
-// message (title or body). See
+// GitHub skips both push- and pull_request-triggered workflows when one of these markers appears
+// in a commit message, in the positions documented at
 // https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-const SKIP_CI_MARKER = /\s*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
+// `[^\S\r\n]` rather than `\s`: eating the newlines around a marker on its own body line would
+// close the blank line separating subject from body, and `git commit --amend -m` would then fold
+// the whole first paragraph into the subject.
+const SKIP_CI_MARKER = /[^\S\r\n]*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
 
 /**
  * Remove GitHub's skip-ci markers from a commit message or PR title.

--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -4,6 +4,7 @@ import { exec } from './lib/exec'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
 import { getPrDetailsAndCommitSha, getPrDetailsByNumber, labelPresent } from './lib/pr-info'
+import { stripSkipCiMarkers } from './lib/skip-ci'
 
 function getEnv() {
 	return makeEnv(['DISCORD_DEPLOY_WEBHOOK_URL', 'GITHUB_TOKEN'])
@@ -43,6 +44,15 @@ async function main() {
 		await exec('git', ['reset', '--hard', 'origin/hotfixes'])
 		await exec('git', ['checkout', '-b', hotfixBranchName])
 		await exec('git', ['cherry-pick', commitSha])
+
+		// release-notes PRs squash-merge with `[skip ci]` in the title. github honours that marker on
+		// the cherry-picked commit too, so the hotfix branch's required checks would never start and
+		// the PR below would sit in `blocked` until the timeout. strip it before pushing.
+		const message = (await exec('git', ['log', '-1', '--format=%B'])).trim()
+		const cleanedMessage = stripSkipCiMarkers(message)
+		if (cleanedMessage !== message) {
+			await exec('git', ['commit', '--amend', '-m', cleanedMessage])
+		}
 	})
 
 	await discord.step('Pushing hotfix branch to remote', async () => {
@@ -50,7 +60,11 @@ async function main() {
 	})
 
 	await discord.step('Creating hotfix PR and waiting for checks to pass', async () => {
-		const prTitle = `[HOTFIX] ${pr.title}`
+		// the squash-merge onto `hotfixes` is what triggers the production build, and github reads
+		// skip-ci markers from the whole commit message. keep them out of the title (used as the
+		// commit subject) and the body (used as the commit body when someone merges by hand).
+		const originalTitle = stripSkipCiMarkers(pr.title)
+		const prTitle = `[HOTFIX] ${originalTitle}`
 
 		// Extract API changes section from original PR if present
 		const apiChangesHeader = '### API changes'
@@ -67,7 +81,7 @@ async function main() {
 		const prBody = `This is an automated hotfix PR for dotcom deployment.
 
 **Original PR:** [#${pr.number}](https://github.com/tldraw/tldraw/pull/${pr.number})
-**Original Title:** ${pr.title}
+**Original Title:** ${originalTitle}
 **Original Author:** @${pr.user?.login}
 
 This PR cherry-picks the changes from the original PR to the hotfixes branch for immediate dotcom deployment.${apiChangesSection}
@@ -102,6 +116,8 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		// Wait for 5 minutes initially, then check every 15 seconds (our checks take at least 5 mins)
 		await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000))
 
+		let checkedForMissingChecks = false
+
 		while (true) {
 			// Check if we've exceeded the timeout
 			const elapsedTime = Date.now() - startTime
@@ -133,7 +149,7 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 						repo: 'tldraw',
 						pull_number: createdPr.data.number,
 						merge_method: 'squash',
-						commit_title: `[HOTFIX] ${pr.title}`,
+						commit_title: prTitle,
 						commit_message: `This is an automated hotfix for dotcom deployment.
 
 Original PR: #${pr.number}
@@ -156,6 +172,23 @@ Original Author: @${pr.user?.login}`,
 				nicelog(`PR #${createdPr.data.number} has conflicts and cannot be merged`)
 				throw new Error(`Hotfix PR #${createdPr.data.number} has conflicts`)
 			} else {
+				// `blocked` with no check runs at all means nothing is going to change: the push didn't
+				// start any workflows (a skip-ci marker that survived, or a required check that isn't
+				// wired up). fail now with a pointer instead of spinning until the timeout.
+				if (prStatus.mergeable_state === 'blocked' && !checkedForMissingChecks) {
+					checkedForMissingChecks = true
+					const checks = await octokit.rest.checks.listForRef({
+						owner: 'tldraw',
+						repo: 'tldraw',
+						ref: prStatus.head.sha,
+						per_page: 1,
+					})
+					if (checks.data.total_count === 0) {
+						throw new Error(
+							`Hotfix PR #${createdPr.data.number} is blocked and no check runs have started on ${hotfixBranchName}. The required checks will never report, so it can't be merged automatically. Look at the commit message on that branch for a skip-ci marker: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
+						)
+					}
+				}
 				nicelog(
 					`PR #${createdPr.data.number} merge status: ${prStatus.mergeable_state}, waiting...`
 				)

--- a/internal/scripts/trigger-sdk-hotfix.ts
+++ b/internal/scripts/trigger-sdk-hotfix.ts
@@ -7,6 +7,7 @@ import { exec } from './lib/exec'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
 import { getPrDetailsAndCommitSha, labelPresent, PullRequest } from './lib/pr-info'
+import { stripSkipCiMarkers } from './lib/skip-ci'
 import { getAllWorkspacePackages } from './lib/workspace'
 
 function getEnv() {
@@ -93,9 +94,7 @@ async function main() {
 			// merge commits (e.g. release-notes updates) carry `[skip ci]`, which would
 			// suppress it. strip skip-ci markers from the cherry-picked commit message.
 			const message = (await exec('git', ['log', '-1', '--format=%B'])).trim()
-			const cleanedMessage = message
-				.replace(/ *\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi, '')
-				.trim()
+			const cleanedMessage = stripSkipCiMarkers(message)
 			if (cleanedMessage !== message) {
 				await exec('git', ['commit', '--amend', '-m', cleanedMessage])
 			}


### PR DESCRIPTION
In order to make `dotcom-hotfix-please` work on release-notes PRs, this strips GitHub's skip-ci markers everywhere the dotcom hotfix flow writes a commit message. Those PRs carry the marker in their title on purpose (so the squash onto `main` skips the push workflows), and the bot cherry-picked that commit verbatim onto `hotfixes`.

Two things went wrong on the v5.4.0 release because of it (#10629):

- No workflow ran on the hotfix branch, so the four checks required by the `hotfixes` ruleset never reported. The hotfix PR (#10626) sat in `blocked` until the script's 15-minute timeout.
- A hand-merged squash kept the marker in its title, so the push to `hotfixes` never triggered the production build. Last cycle's #9881 merged that way and its commit never reached `production`.

`trigger-sdk-hotfix.ts` already handled this for release branches. This moves its regex into `internal/scripts/lib/skip-ci.ts`, uses it from both scripts, and in the dotcom script applies it to the cherry-picked commit message, the `[HOTFIX]` PR title, the "Original Title" line in the PR body (which becomes the squash body on a manual merge), and the `commit_title` passed to the merge API.

It also fails fast instead of spinning: when the PR is `blocked` and the branch head has zero check runs, nothing is going to change, so the script now throws with a pointer at the branch rather than reporting a timeout ten minutes later.

### Change type

- [x] `bugfix`

### Test plan

Can't be exercised outside CI. The next release-notes PR labelled `dotcom-hotfix-please` during freeze week is the test: its hotfix PR should get checks, auto-merge, and produce a `Deploy from hotfix` commit on `production`.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +58 / -6   |
