### PR TITLE
fix(ci): run the templates deploy as a publish job with the deploy-production environment

### DIFF
--- a/.github/actions/deploy-templates/action.yml
+++ b/.github/actions/deploy-templates/action.yml
@@ -1,0 +1,63 @@
+name: Deploy templates
+description: >
+  Build the starter-kit demos against the checked-out SDK and deploy the cloudflare-hosted ones to
+  *.templates.tldraw.dev. Shared by deploy-templates.yml (template changes, manual runs) and
+  publish.yml (releases). Expects the repo to be checked out already; runs the setup action itself.
+
+# The cloudflare credentials are secrets on the deploy-production environment, so the job using
+# this action has to select that environment and pass them in. Only a job can select an environment
+# (a reusable-workflow `uses:` job can't), which is why this is a composite action rather than a
+# workflow_call workflow — see #10636.
+inputs:
+  license-key:
+    description: tldraw license key the demos are built with (TEMPLATES_TLDRAW_LICENSE_KEY)
+    required: true
+  cloudflare-account-id:
+    description: Cloudflare account the workers deploy to (CLOUDFLARE_ACCOUNT_ID)
+    required: true
+  cloudflare-api-token:
+    description: Cloudflare API token with workers permissions (CLOUDFLARE_API_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup
+
+    # most templates run `tsc` as part of their build, which resolves the workspace packages
+    # through their project references and so needs the declarations built first
+    - name: Build types
+      shell: bash
+      run: yarn build-types
+
+    - name: Deploy templates
+      shell: bash
+      env:
+        CI: 1
+        PRINT_GITHUB_ANNOTATIONS: 1
+        ALLOW_REFRESH_ASSETS_CHANGES: 1
+        TEMPLATES_TLDRAW_LICENSE_KEY: ${{ inputs.license-key }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare-api-token }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+      run: |
+        # the templates import tldraw/tldraw.css, which is generated and gitignored
+        yarn lazy prebuild
+
+        cd templates
+        all_templates=$(ls -d */ | cut -f1 -d'/')
+        cd ..
+
+        # the demos are independent of each other, so deploy them all before failing: one broken
+        # template shouldn't leave the rest stranded on an old build with no signal about which.
+        # templates with no `deploy` config in their package.json skip themselves.
+        failed=""
+        for template in $all_templates; do
+          echo "::group::Deploying $template"
+          yarn tsx ./internal/scripts/deploy-template.ts $template || failed="$failed $template"
+          echo "::endgroup::"
+        done
+
+        if [ -n "$failed" ]; then
+          echo "::error::Failed to deploy templates:$failed"
+          exit 1
+        fi

--- a/.github/actions/deploy-templates/action.yml
+++ b/.github/actions/deploy-templates/action.yml
@@ -5,9 +5,10 @@ description: >
   publish.yml (releases). Expects the repo to be checked out already; runs the setup action itself.
 
 # The cloudflare credentials are secrets on the deploy-production environment, so the job using
-# this action has to select that environment and pass them in. Only a job can select an environment
-# (a reusable-workflow `uses:` job can't), which is why this is a composite action rather than a
-# workflow_call workflow — see #10636.
+# this action has to select that environment and pass them in. This is a composite action rather
+# than a workflow_call workflow because a called workflow only ever sees the secrets its caller
+# hands it, and an `environment:` on a job inside the callee does not add that environment's
+# secrets to them — see #10636.
 inputs:
   license-key:
     description: tldraw license key the demos are built with (TEMPLATES_TLDRAW_LICENSE_KEY)
@@ -28,6 +29,11 @@ runs:
     # through their project references and so needs the declarations built first
     - name: Build types
       shell: bash
+      env:
+        # build-types pulls in refresh-assets, which rewrites the generated version files. in CI it
+        # exits 1 on any change to a committed asset instead of writing it, which would fail the
+        # deploy on a release ref whose generated files aren't already in sync.
+        ALLOW_REFRESH_ASSETS_CHANGES: 1
       run: yarn build-types
 
     - name: Deploy templates

--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -3,7 +3,9 @@ name: Deploy templates
 # Deploys the cloudflare-hosted starter kit demos at *.templates.tldraw.dev, which are the live
 # embeds on the docs pages. Two things should reach them: a change to a template (so edits go live
 # without waiting for a release), and a release (so the demos pick up the new SDK — an SDK bump
-# never touches templates/, so the path filter alone would never fire for one).
+# never touches templates/, so the path filter alone would never fire for one). This workflow
+# covers the first; publish.yml covers the second with a job of its own, using the same
+# .github/actions/deploy-templates steps.
 #
 # The vercel-hosted demos (chat, shader, workflow) deploy through vercel's own git integration and
 # aren't handled here.
@@ -14,20 +16,6 @@ on:
     paths:
       - 'templates/**'
   workflow_dispatch:
-  workflow_call:
-    # the cloudflare credentials aren't listed here: they're secrets on the deploy-production
-    # environment, which the job below selects. `workflow_call` has no `environment` keyword, so
-    # they can't be passed in by a caller — an environment secret always wins over a passed one.
-    secrets:
-      TEMPLATES_TLDRAW_LICENSE_KEY:
-        required: true
-      DISCORD_DEPLOY_WEBHOOK_URL:
-        required: false
-
-env:
-  CI: 1
-  PRINT_GITHUB_ANNOTATIONS: 1
-  ALLOW_REFRESH_ASSETS_CHANGES: 1
 
 defaults:
   run:
@@ -56,40 +44,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
-
-      # most templates run `tsc` as part of their build, which resolves the workspace packages
-      # through their project references and so needs the declarations built first
-      - name: Build types
-        run: yarn build-types
-
-      - name: Deploy templates
-        env:
-          TEMPLATES_TLDRAW_LICENSE_KEY: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          # the templates import tldraw/tldraw.css, which is generated and gitignored
-          yarn lazy prebuild
-
-          cd templates
-          all_templates=$(ls -d */ | cut -f1 -d'/')
-          cd ..
-
-          # the demos are independent of each other, so deploy them all before failing: one broken
-          # template shouldn't leave the rest stranded on an old build with no signal about which.
-          # templates with no `deploy` config in their package.json skip themselves.
-          failed=""
-          for template in $all_templates; do
-            echo "::group::Deploying $template"
-            yarn tsx ./internal/scripts/deploy-template.ts $template || failed="$failed $template"
-            echo "::endgroup::"
-          done
-
-          if [ -n "$failed" ]; then
-            echo "::error::Failed to deploy templates:$failed"
-            exit 1
-          fi
+      - uses: ./.github/actions/deploy-templates
+        with:
+          license-key: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Notify Discord on failure
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -293,9 +293,35 @@ jobs:
 
   deploy_templates:
     name: Deploys the template demos with the new SDK version
-    uses: tldraw/tldraw/.github/workflows/deploy-templates.yml@main
     if: needs.publish.outputs.mode == 'new' || ((needs.publish.outputs.mode == 'patch' || needs.publish.outputs.mode == 'manual') && needs.publish.outputs.is_latest_version == 'true')
-    secrets:
-      TEMPLATES_TLDRAW_LICENSE_KEY: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}
-      DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
     needs: publish
+    # CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are secrets on this environment rather than on
+    # the repository. Only a job can select an environment — a reusable-workflow (`uses:`) job can't,
+    # which is how the v5.4.0 release ran this with both empty (#10636) — so the deploy runs here as
+    # a job of its own, sharing its steps with deploy-templates.yml through the composite action.
+    environment: deploy-production
+    timeout-minutes: 60
+    runs-on: ubuntu-latest-16-cores-arm-open
+    # same group as deploy-templates.yml: a release deploy and a template-change deploy can otherwise
+    # race each other onto the same custom domains, and the loser silently wins.
+    concurrency:
+      group: deploy-templates
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/deploy-templates
+        with:
+          license-key: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -296,9 +296,11 @@ jobs:
     if: needs.publish.outputs.mode == 'new' || ((needs.publish.outputs.mode == 'patch' || needs.publish.outputs.mode == 'manual') && needs.publish.outputs.is_latest_version == 'true')
     needs: publish
     # CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are secrets on this environment rather than on
-    # the repository. Only a job can select an environment — a reusable-workflow (`uses:`) job can't,
-    # which is how the v5.4.0 release ran this with both empty (#10636) — so the deploy runs here as
-    # a job of its own, sharing its steps with deploy-templates.yml through the composite action.
+    # the repository, and a job has to select the environment to see them. Calling deploy-templates.yml
+    # as a reusable workflow doesn't do it: a called workflow only ever sees the secrets its caller
+    # hands it, so the v5.4.0 release reached the deploy with both empty (#10636) even though the
+    # called job selected deploy-production itself. The deploy runs here as a job of its own instead,
+    # sharing its steps with deploy-templates.yml through the composite action.
     environment: deploy-production
     timeout-minutes: 60
     runs-on: ubuntu-latest-16-cores-arm-open


### PR DESCRIPTION
In order to get the starter-kit demos redeployed on an SDK release, this moves the deploy steps into a composite action, `.github/actions/deploy-templates`, and gives `publish.yml` a job of its own that selects the `deploy-production` environment and uses it. `deploy-templates.yml` keeps its push and manual triggers and uses the same action, so the two paths can't drift.

The reusable-workflow call failed on the v5.4.0 release (#10636). `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` exist only as secrets on the `deploy-production` environment, not the repository. A reusable-workflow (`uses:`) job can't select an environment, and the caller can't pass secrets it can't see, so both were empty in the called job and all four Cloudflare-hosted demos failed. A plain job can select the environment, which is how the push and manual triggers of `deploy-templates.yml` have always worked, and how the demos got redeployed today.

Details:

- The action takes the license key and the two Cloudflare values as inputs; both workflows pass them from `secrets`. It runs the setup action, `yarn build-types`, and the same deploy loop as before.
- The publish job carries the same `concurrency: deploy-templates` group and 60-minute timeout as the standalone workflow, so a release deploy and a template-change deploy still can't race onto the same domains.
- It checks out the ref the publish ran on (`production` for a new release, `vX.Y.x` for a patch), which is what the demos should build against: the templates build against the workspace SDK, not npm.
- `deploy-templates.yml` drops its `workflow_call` trigger and the comment that claimed environment secrets reach a called job.

### Change type

- [x] `bugfix`

### Test plan

Can't be exercised before the next publish. The composite action is the exact set of steps that succeeded on today's manual run (https://github.com/tldraw/tldraw/actions/runs/33624236493), and a template change on `main` will run it through `deploy-templates.yml` before then.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +101 / -53 |
