### PR TITLE
fix(tldraw): only start a toolbar drag-out once the pointer leaves the toolbar

### DIFF
--- a/apps/docs/content/sdk-features/options.mdx
+++ b/apps/docs/content/sdk-features/options.mdx
@@ -85,7 +85,7 @@ Control when pointer movement becomes a drag operation:
 | `uiDragDistanceSquared`       | 16      | Distance² for UI element drag (4px)      |
 | `uiCoarseDragDistanceSquared` | 625     | Distance² for touch UI drag (25px)       |
 
-Values are squared to avoid computing square roots during drag detection. The larger touch thresholds prevent accidental drags on mobile devices. The UI thresholds apply to dragging a tool out of the toolbar: the drag only starts once the pointer has left the toolbar, so the threshold only affects presses that begin near its edge.
+Values are squared to avoid computing square roots during drag detection. The larger touch thresholds prevent accidental drags on mobile devices. The UI thresholds govern dragging a tool out of the toolbar. A drag starts once the pointer has left the toolbar, so they matter only for presses that begin near its edge.
 
 ### Handle and hit testing
 

--- a/apps/docs/content/sdk-features/options.mdx
+++ b/apps/docs/content/sdk-features/options.mdx
@@ -85,7 +85,7 @@ Control when pointer movement becomes a drag operation:
 | `uiDragDistanceSquared`       | 16      | Distance² for UI element drag (4px)      |
 | `uiCoarseDragDistanceSquared` | 625     | Distance² for touch UI drag (25px)       |
 
-Values are squared to avoid computing square roots during drag detection. The larger touch thresholds prevent accidental drags on mobile devices.
+Values are squared to avoid computing square roots during drag detection. The larger touch thresholds prevent accidental drags on mobile devices. The UI thresholds apply to dragging a tool out of the toolbar: the drag only starts once the pointer has left the toolbar, so the threshold only affects presses that begin near its edge.
 
 ### Handle and hit testing
 

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -295,19 +295,17 @@ export function TldrawUiMenuItem<
 }
 
 /**
- * A drag out of the toolbar starts once the pointer has left the toolbar and travelled past the
- * drag distance threshold. Distance alone isn't enough: tapping a button with a stylus, finger or
- * trackpad almost always includes a few pixels of movement, which spawned unwanted shapes (#6906,
- * #7666). Leaving the toolbar is the intent signal; the threshold only guards presses that land
- * right at the toolbar's edge.
+ * Distance alone can't separate a drag from a tap: stylus, finger and trackpad taps move a few
+ * pixels, which used to spawn shapes (#6906, #7666). Leaving the toolbar is the intent signal;
+ * the distance threshold only guards presses that land right at its edge.
  */
 function isDragOutOfToolbar(
 	editor: Editor,
 	e: React.PointerEvent<HTMLButtonElement>,
 	screenSpaceStart: VecModel,
-	bounds: Element
+	toolbarRect: DOMRect
 ) {
-	const { left, top, right, bottom } = bounds.getBoundingClientRect()
+	const { left, top, right, bottom } = toolbarRect
 	const { clientX: x, clientY: y } = e
 	if (x >= left && x <= right && y >= top && y <= bottom) return false
 
@@ -334,7 +332,7 @@ function useDraggableEvents(
 			| {
 					name: 'pointing'
 					screenSpaceStart: VecModel
-					dragOutBounds: Element
+					toolbarRect: DOMRect
 			  }
 			| {
 					name: 'dragging'
@@ -348,9 +346,11 @@ function useDraggableEvents(
 			state = {
 				name: 'pointing',
 				screenSpaceStart: { x: e.clientX, y: e.clientY },
-				// The toolbar this button sits in: the main toolbar or the overflow popover. A button
-				// rendered outside any toolbar uses its own bounds.
-				dragOutBounds: e.currentTarget.closest('.tlui-toolbar') ?? e.currentTarget,
+				// The overflow popover is its own .tlui-toolbar; a button outside any toolbar falls
+				// back to its own rect.
+				toolbarRect: (
+					e.currentTarget.closest('.tlui-toolbar') ?? e.currentTarget
+				).getBoundingClientRect(),
 			}
 
 			e.currentTarget.setPointerCapture(e.pointerId)
@@ -360,7 +360,7 @@ function useDraggableEvents(
 			if ((e as any).isSpecialRedispatchedEvent) return
 
 			if (state.name === 'pointing') {
-				if (isDragOutOfToolbar(editor, e, state.screenSpaceStart, state.dragOutBounds)) {
+				if (isDragOutOfToolbar(editor, e, state.screenSpaceStart, state.toolbarRect)) {
 					const screenSpaceStart = state.screenSpaceStart
 					state = {
 						name: 'dragging',
@@ -389,6 +389,16 @@ function useDraggableEvents(
 							name: 'pointer_move',
 							...getPointerInfo(editor, e),
 							point: screenSpaceStart,
+						})
+
+						// The shape was created at the press point, under the toolbar, and this event is
+						// already marked as handled so the canvas won't forward it. Move the shape to the
+						// pointer now, or it sits there until the next pointer move.
+						editor.dispatch({
+							type: 'pointer',
+							target: 'canvas',
+							name: 'pointer_move',
+							...getPointerInfo(editor, e),
 						})
 
 						hideAllTooltips()

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuItem.tsx
@@ -1,4 +1,5 @@
 import {
+	Editor,
 	exhaustiveSwitchError,
 	getPointerInfo,
 	preventDefault,
@@ -293,6 +294,33 @@ export function TldrawUiMenuItem<
 	}
 }
 
+/**
+ * A drag out of the toolbar starts once the pointer has left the toolbar and travelled past the
+ * drag distance threshold. Distance alone isn't enough: tapping a button with a stylus, finger or
+ * trackpad almost always includes a few pixels of movement, which spawned unwanted shapes (#6906,
+ * #7666). Leaving the toolbar is the intent signal; the threshold only guards presses that land
+ * right at the toolbar's edge.
+ */
+function isDragOutOfToolbar(
+	editor: Editor,
+	e: React.PointerEvent<HTMLButtonElement>,
+	screenSpaceStart: VecModel,
+	bounds: Element
+) {
+	const { left, top, right, bottom } = bounds.getBoundingClientRect()
+	const { clientX: x, clientY: y } = e
+	if (x >= left && x <= right && y >= top && y <= bottom) return false
+
+	// Read the pointer type off the event rather than `isCoarsePointer`: the instance state flag
+	// is synced a frame after the first pointer down, so a pen tap right after mouse use would be
+	// judged with the mouse threshold.
+	const minDistanceSq =
+		e.pointerType === 'mouse'
+			? editor.options.uiDragDistanceSquared
+			: editor.options.uiCoarseDragDistanceSquared
+	return Vec.Dist2(screenSpaceStart, { x, y }) > minDistanceSq
+}
+
 function useDraggableEvents(
 	onDragStart: TLUiToolItem['onDragStart'],
 	onSelect: TLUiToolItem['onSelect']
@@ -306,6 +334,7 @@ function useDraggableEvents(
 			| {
 					name: 'pointing'
 					screenSpaceStart: VecModel
+					dragOutBounds: Element
 			  }
 			| {
 					name: 'dragging'
@@ -319,6 +348,9 @@ function useDraggableEvents(
 			state = {
 				name: 'pointing',
 				screenSpaceStart: { x: e.clientX, y: e.clientY },
+				// The toolbar this button sits in: the main toolbar or the overflow popover. A button
+				// rendered outside any toolbar uses its own bounds.
+				dragOutBounds: e.currentTarget.closest('.tlui-toolbar') ?? e.currentTarget,
 			}
 
 			e.currentTarget.setPointerCapture(e.pointerId)
@@ -328,13 +360,7 @@ function useDraggableEvents(
 			if ((e as any).isSpecialRedispatchedEvent) return
 
 			if (state.name === 'pointing') {
-				const distanceSq = Vec.Dist2(state.screenSpaceStart, { x: e.clientX, y: e.clientY })
-				if (
-					distanceSq >
-					(editor.getInstanceState().isCoarsePointer
-						? editor.options.uiCoarseDragDistanceSquared
-						: editor.options.uiDragDistanceSquared)
-				) {
+				if (isDragOutOfToolbar(editor, e, state.screenSpaceStart, state.dragOutBounds)) {
 					const screenSpaceStart = state.screenSpaceStart
 					state = {
 						name: 'dragging',

--- a/packages/tldraw/src/test/dragFromToolbar-dom.test.tsx
+++ b/packages/tldraw/src/test/dragFromToolbar-dom.test.tsx
@@ -1,0 +1,152 @@
+import { act } from '@testing-library/react'
+import { Editor } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+// These tests drive the toolbar button's real pointer handlers (useDraggableEvents) rather than
+// calling onDragStart directly, so the drag-out threshold is exercised the way a device exercises
+// it. jsdom is missing PointerEvent, pointer capture and layout, so those are polyfilled here.
+
+if (typeof (globalThis as any).PointerEvent === 'undefined') {
+	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
+		pointerId: number
+		pointerType: string
+		pressure: number
+		isPrimary: boolean
+		constructor(type: string, params: any = {}) {
+			super(type, params)
+			this.pointerId = params.pointerId ?? 0
+			this.pointerType = params.pointerType ?? ''
+			this.pressure = params.pressure ?? 0
+			this.isPrimary = params.isPrimary ?? false
+		}
+	}
+}
+if (!Element.prototype.setPointerCapture) {
+	Element.prototype.setPointerCapture = () => {}
+	Element.prototype.releasePointerCapture = () => {}
+	Element.prototype.hasPointerCapture = () => false
+}
+
+// A 400×48 toolbar pill along the bottom of the window.
+const toolbarRect = { left: 100, top: 900, right: 500, bottom: 948 }
+
+type PointerType = 'mouse' | 'pen' | 'touch'
+
+function pointerEvent(type: string, x: number, y: number, pointerType: PointerType) {
+	return new (globalThis as any).PointerEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		clientX: x,
+		clientY: y,
+		button: 0,
+		pointerId: 1,
+		pointerType,
+		isPrimary: true,
+	})
+}
+
+let editor: Editor
+let button: HTMLElement
+
+beforeEach(async () => {
+	;({ editor } = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	}))
+	button = document.querySelector('[data-testid="tools.arrow"]') as HTMLElement
+	const toolbar = button.closest('.tlui-toolbar') as HTMLElement
+	toolbar.getBoundingClientRect = () =>
+		({
+			...toolbarRect,
+			x: toolbarRect.left,
+			y: toolbarRect.top,
+			width: toolbarRect.right - toolbarRect.left,
+			height: toolbarRect.bottom - toolbarRect.top,
+			toJSON() {},
+		}) as DOMRect
+})
+
+async function press(x: number, y: number, pointerType: PointerType) {
+	await act(async () => {
+		button.dispatchEvent(pointerEvent('pointerdown', x, y, pointerType))
+	})
+}
+
+// The button holds pointer capture, so moves keep arriving on it after the pointer leaves it.
+async function move(x: number, y: number, pointerType: PointerType) {
+	await act(async () => {
+		button.dispatchEvent(pointerEvent('pointermove', x, y, pointerType))
+	})
+}
+
+async function release(x: number, y: number, pointerType: PointerType) {
+	await act(async () => {
+		button.dispatchEvent(pointerEvent('pointerup', x, y, pointerType))
+		button.dispatchEvent(
+			new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y })
+		)
+	})
+}
+
+function shapeTypes() {
+	return editor.getCurrentPageShapes().map((s) => s.type)
+}
+
+describe('dragging a tool out of the toolbar', () => {
+	it('does not start a drag while the pointer stays inside the toolbar, however far it moves', async () => {
+		await press(300, 924, 'mouse')
+		await move(306, 924, 'mouse') // past the 4px mouse threshold
+		await move(300, 947, 'mouse') // down to the bottom edge
+		expect(shapeTypes()).toEqual([])
+
+		await release(300, 947, 'mouse')
+		expect(shapeTypes()).toEqual([])
+		expect(editor.getCurrentToolId()).toBe('arrow') // the press was a click
+	})
+
+	it('treats a pen tap that slides along the toolbar as a click', async () => {
+		await press(300, 924, 'pen')
+		await move(340, 926, 'pen') // 40px along the toolbar, past the 25px coarse threshold
+		await release(340, 926, 'pen')
+
+		expect(shapeTypes()).toEqual([])
+		expect(editor.getCurrentToolId()).toBe('arrow')
+	})
+
+	it('starts a drag once the pointer leaves the toolbar', async () => {
+		await press(300, 924, 'mouse')
+		await move(300, 880, 'mouse')
+
+		expect(shapeTypes()).toEqual(['arrow'])
+		expect(editor.isIn('select.translating')).toBe(true)
+	})
+
+	it('guards a pen press at the toolbar edge with the coarse threshold', async () => {
+		await press(300, 902, 'pen') // 2px inside the top edge
+		await move(300, 895, 'pen') // 5px outside, 7px travelled
+		expect(shapeTypes()).toEqual([])
+
+		await move(300, 870, 'pen') // 32px travelled
+		expect(shapeTypes()).toEqual(['arrow'])
+	})
+
+	it('guards a mouse press at the toolbar edge with the mouse threshold', async () => {
+		await press(300, 902, 'mouse')
+		await move(300, 899, 'mouse') // 1px outside, 3px travelled
+		expect(shapeTypes()).toEqual([])
+
+		await move(300, 895, 'mouse') // 7px travelled
+		expect(shapeTypes()).toEqual(['arrow'])
+	})
+
+	it('reads the pointer type from the event, not the editor coarse pointer state', async () => {
+		// The instance state flag syncs a frame after the first pointer down, so it still says
+		// "mouse" during the first pen tap after mouse use.
+		await act(async () => {
+			editor.updateInstanceState({ isCoarsePointer: false })
+		})
+		await press(300, 902, 'pen')
+		await move(300, 890, 'pen') // 12px travelled: past the mouse threshold, not the pen one
+		expect(shapeTypes()).toEqual([])
+	})
+})

--- a/packages/tldraw/src/test/dragFromToolbar-dom.test.tsx
+++ b/packages/tldraw/src/test/dragFromToolbar-dom.test.tsx
@@ -5,28 +5,7 @@ import { renderTldrawComponentWithEditor } from './testutils/renderTldrawCompone
 
 // These tests drive the toolbar button's real pointer handlers (useDraggableEvents) rather than
 // calling onDragStart directly, so the drag-out threshold is exercised the way a device exercises
-// it. jsdom is missing PointerEvent, pointer capture and layout, so those are polyfilled here.
-
-if (typeof (globalThis as any).PointerEvent === 'undefined') {
-	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
-		pointerId: number
-		pointerType: string
-		pressure: number
-		isPrimary: boolean
-		constructor(type: string, params: any = {}) {
-			super(type, params)
-			this.pointerId = params.pointerId ?? 0
-			this.pointerType = params.pointerType ?? ''
-			this.pressure = params.pressure ?? 0
-			this.isPrimary = params.isPrimary ?? false
-		}
-	}
-}
-if (!Element.prototype.setPointerCapture) {
-	Element.prototype.setPointerCapture = () => {}
-	Element.prototype.releasePointerCapture = () => {}
-	Element.prototype.hasPointerCapture = () => false
-}
+// it. jsdom has no layout, so the toolbar's rect is stubbed.
 
 // A 400×48 toolbar pill along the bottom of the window.
 const toolbarRect = { left: 100, top: 900, right: 500, bottom: 948 }
@@ -34,7 +13,7 @@ const toolbarRect = { left: 100, top: 900, right: 500, bottom: 948 }
 type PointerType = 'mouse' | 'pen' | 'touch'
 
 function pointerEvent(type: string, x: number, y: number, pointerType: PointerType) {
-	return new (globalThis as any).PointerEvent(type, {
+	return new PointerEvent(type, {
 		bubbles: true,
 		cancelable: true,
 		clientX: x,
@@ -79,12 +58,20 @@ async function move(x: number, y: number, pointerType: PointerType) {
 	})
 }
 
+// jsdom doesn't synthesize a click from pointerup, so dispatch it by hand.
 async function release(x: number, y: number, pointerType: PointerType) {
 	await act(async () => {
 		button.dispatchEvent(pointerEvent('pointerup', x, y, pointerType))
 		button.dispatchEvent(
 			new MouseEvent('click', { bubbles: true, cancelable: true, clientX: x, clientY: y })
 		)
+	})
+}
+
+// The editor queues pointer moves until the next tick.
+async function tick() {
+	await act(async () => {
+		editor.emit('tick', 16)
 	})
 }
 
@@ -96,10 +83,10 @@ describe('dragging a tool out of the toolbar', () => {
 	it('does not start a drag while the pointer stays inside the toolbar, however far it moves', async () => {
 		await press(300, 924, 'mouse')
 		await move(306, 924, 'mouse') // past the 4px mouse threshold
-		await move(300, 947, 'mouse') // down to the bottom edge
+		await move(480, 948, 'mouse') // 180px, past the 25px coarse threshold, right on the bottom edge
 		expect(shapeTypes()).toEqual([])
 
-		await release(300, 947, 'mouse')
+		await release(480, 948, 'mouse')
 		expect(shapeTypes()).toEqual([])
 		expect(editor.getCurrentToolId()).toBe('arrow') // the press was a click
 	})
@@ -116,9 +103,19 @@ describe('dragging a tool out of the toolbar', () => {
 	it('starts a drag once the pointer leaves the toolbar', async () => {
 		await press(300, 924, 'mouse')
 		await move(300, 880, 'mouse')
-
 		expect(shapeTypes()).toEqual(['arrow'])
-		expect(editor.isIn('select.translating')).toBe(true)
+		expect(editor.getPath()).toBe('select.translating')
+
+		// The shape is created at the press point and moved under the pointer right away.
+		await tick()
+		const { x, y } = editor.getShapePageBounds(editor.getCurrentPageShapes()[0])!.center
+		const pointer = editor.screenToPage({ x: 300, y: 880 })
+		expect({ x, y }).toEqual({ x: pointer.x, y: pointer.y })
+
+		// The click that follows a drag doesn't select the tool.
+		await release(300, 880, 'mouse')
+		expect(editor.getPath()).toBe('select.idle')
+		expect(shapeTypes()).toEqual(['arrow'])
 	})
 
 	it('guards a pen press at the toolbar edge with the coarse threshold', async () => {
@@ -140,12 +137,13 @@ describe('dragging a tool out of the toolbar', () => {
 	})
 
 	it('reads the pointer type from the event, not the editor coarse pointer state', async () => {
-		// The instance state flag syncs a frame after the first pointer down, so it still says
-		// "mouse" during the first pen tap after mouse use.
+		await press(300, 902, 'pen')
+		// In the browser the coarse pointer flag reaches the instance state a frame after the
+		// pointer down, so it still says "mouse" during the first pen tap after mouse use. The sync
+		// is synchronous in tests, so force the stale value by hand.
 		await act(async () => {
 			editor.updateInstanceState({ isCoarsePointer: false })
 		})
-		await press(300, 902, 'pen')
 		await move(300, 890, 'pen') // 12px travelled: past the mouse threshold, not the pen one
 		expect(shapeTypes()).toEqual([])
 	})


### PR DESCRIPTION
This PR fixes a bug where tapping a tool in the toolbar with a stylus, finger or trackpad could create a shape instead of selecting the tool. Closes #6906, closes #7666.

### Before

`useDraggableEvents` started a drag-out as soon as the pointer moved past a radial distance from the press point: 4px when the editor's `isCoarsePointer` instance state was false, 25px otherwise. A tap almost always includes a few pixels of movement, and the 4px case hit pen users far more often than intended: the instance state flag is synced from the environment one animation frame after the first pointer down (`useCoarsePointer` runs through `useReactor`), so the first pen tap after any mouse use was judged with the mouse threshold, and any pointer the browser reports as a mouse (trackpads, some stylus drivers) always was. Movement along the toolbar counted the same as movement away from it, so sliding from one tool to the next started a drag too.


https://github.com/user-attachments/assets/af4440f3-167c-4751-8882-81e78e39ee8a

### After

A drag-out starts only once the pointer has left the bounding rect of the toolbar the button belongs to (`closest('.tlui-toolbar')`: the main toolbar pill or the overflow popover, falling back to the button's own rect outside any toolbar) and has moved past the existing distance threshold. From the centre of a 48px tool button that is ~24px of outward travel before anything happens, sliding along the toolbar never starts a drag, and the threshold only guards presses that land right at the toolbar's edge. The threshold is picked from the event's `pointerType` (`'mouse'` → `uiDragDistanceSquared`, anything else → `uiCoarseDragDistanceSquared`) instead of the instance state flag, so it is right on the first tap. Intentional drag-out is unchanged: dragging a tool onto the canvas still creates the shape and enters `select.translating`. Because the drag now starts further from the press point, the shape is moved under the pointer as soon as it is created, rather than sitting at the press point under the toolbar until the next pointer move. The options docs note that the UI thresholds apply once outside the toolbar.


https://github.com/user-attachments/assets/8cb6a09a-3331-4bc7-81b0-fdae49832dfa

### Implementation notes

Disabling drag-out for pens (#9263, #7668) was ruled out in the #9263 review because it removes SDK functionality for pen users, and raising the radial threshold alone would stay direction-blind and keyed off the frame-late flag. Reading `pointerType` per event also keeps the toolbar's floor independent of how #10398 / #10454 settle pen classification globally.

Not changed: the defaults of `uiDragDistanceSquared` (4px) and `uiCoarseDragDistanceSquared` (25px). With the exit check doing the work, the 4px value only matters for mouse presses within 4px of the toolbar edge; raising it is a cheap follow-up if edge slips still show up.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open http://localhost:5420/develop.
2. Press a tool button and wiggle the pointer a few pixels, or slide across to the neighbouring tool, then release: the tool is selected and no shape is created. Repeat with a stylus or trackpad if you have one.
3. Drag a tool up onto the canvas: the shape appears under the pointer as it leaves the toolbar and drops where you release. Repeat from the "more tools" popover.

- [x] Unit tests — `dragFromToolbar-dom.test.tsx` drives the button's real pointer handlers in jsdom; the inside-the-toolbar, slide-along-the-toolbar, shape-follows-the-pointer and pointer-type cases fail on `main`
- [x] End to end tests — the existing `test-toolbar.spec.ts` drag-out tests pass unchanged

### Release notes

- Fix accidental shape creation when tapping a toolbar tool with a stylus, finger or trackpad: dragging a tool out of the toolbar now requires the pointer to actually leave the toolbar

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +43 / -7   |
| Tests         | +150 / -0  |
| Documentation | +1 / -1    |


