### PR TITLE
test(tldraw): drop dead PointerEvent polyfill from pinch-dom test

### DIFF
--- a/packages/tldraw/src/test/pinch-dom.test.tsx
+++ b/packages/tldraw/src/test/pinch-dom.test.tsx
@@ -5,30 +5,7 @@ import { renderTldrawComponentWithEditor } from './testutils/renderTldrawCompone
 
 // These tests drive the real DOM event handlers (useCanvasEvents for pointer
 // events, useGestureEvents for touch pinch) rather than dispatching synthetic
-// editor events, so they exercise the same path a touch device takes. jsdom is
-// missing a few browser APIs those handlers rely on, so we polyfill them here.
-
-if (typeof (globalThis as any).PointerEvent === 'undefined') {
-	// jsdom has no PointerEvent; the canvas handlers do `e instanceof PointerEvent`.
-	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
-		pointerId: number
-		pointerType: string
-		pressure: number
-		isPrimary: boolean
-		constructor(type: string, params: any = {}) {
-			super(type, params)
-			this.pointerId = params.pointerId ?? 0
-			this.pointerType = params.pointerType ?? ''
-			this.pressure = params.pressure ?? 0
-			this.isPrimary = params.isPrimary ?? false
-		}
-	}
-}
-if (!Element.prototype.setPointerCapture) {
-	Element.prototype.setPointerCapture = () => {}
-	Element.prototype.releasePointerCapture = () => {}
-	Element.prototype.hasPointerCapture = () => false
-}
+// editor events, so they exercise the same path a touch device takes.
 
 const ids = {
 	a: createShapeId('a'),


### PR DESCRIPTION
In order to stop this test from claiming jsdom lacks APIs it has, and to keep the next DOM-driven test from copying the workaround, this PR drops two polyfill blocks from `pinch-dom.test.tsx` whose guards never fire:

- `globalThis.PointerEvent` is already defined. The repo's jsdom (29.x) ships the constructor, and it propagates `pointerId`, `pointerType`, `isPrimary`, and the client coordinates the `pointerDownEvent` helper passes.
- `Element.prototype.setPointerCapture` is already defined. `internal/config/vitest/setup.ts` stubs `setPointerCapture`, `releasePointerCapture`, and `hasPointerCapture` for every test file through the shared `setupFiles` entry in the package's vitest config.

The polyfill landed with the test in #9006 against jsdom 25. The next day #9019 bumped jsdom to v29 and added the shared pointer capture stub, so both blocks have been dead since. The header comment loses the sentence that said jsdom is missing these APIs. Nothing else in the file changes, and the DOM-driven toolbar test in #10651 already builds `PointerEvent`s the same way without a polyfill.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests: `yarn test run src/test/pinch-dom.test.tsx` in `packages/tldraw` passes (3 tests)

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +1 / -24   |
