### PR TITLE
refactor(dotcom): stop declaring the legacy file owner columns

### DIFF
--- a/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
@@ -179,7 +179,7 @@ function describeChange(row: AdminOutboxRow): string {
 	if (prev.sharedLinkType !== next.sharedLinkType) {
 		changes.push(`link type → ${next.sharedLinkType}`)
 	}
-	if (prev.ownerId !== next.ownerId || prev.owningGroupId !== next.owningGroupId) {
+	if (prev.owningGroupId !== next.owningGroupId) {
 		changes.push('ownership moved')
 	}
 	return changes.length ? changes.join(', ') : 'updated'

--- a/apps/dotcom/sync-worker/src/fileEffects.test.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.test.ts
@@ -6,9 +6,7 @@ function file(partial: Partial<TlaFile>): TlaFile {
 	return {
 		id: 'f1',
 		name: 'file',
-		ownerId: 'u1',
 		ownerName: '',
-		ownerAvatar: '',
 		thumbnail: '',
 		shared: true,
 		sharedLinkType: 'edit',

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
@@ -6,9 +6,7 @@ function file(partial: Partial<TlaFile>): TlaFile {
 	return {
 		id: 'f1',
 		name: 'file',
-		ownerId: 'u1',
 		ownerName: '',
-		ownerAvatar: '',
 		thumbnail: '',
 		shared: true,
 		sharedLinkType: 'edit',

--- a/apps/dotcom/sync-worker/src/undeleteFile.test.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.test.ts
@@ -6,10 +6,8 @@ function makeFile(overrides: Partial<TlaFile> = {}): TlaFile {
 	return {
 		id: 'file-1',
 		name: 'My file',
-		ownerId: 'user-1',
-		owningGroupId: undefined,
+		owningGroupId: 'group-9',
 		ownerName: '',
-		ownerAvatar: '',
 		thumbnail: '',
 		shared: true,
 		sharedLinkType: 'edit',
@@ -122,7 +120,7 @@ describe('undeleteFile', () => {
 	})
 
 	it('restores the group_file link for a group-owned file', async () => {
-		const file = makeFile({ ownerId: undefined, owningGroupId: 'group-9' })
+		const file = makeFile()
 		const { db, inserts } = makeFakeDb(file, { groupRow: { isDeleted: false } })
 		const result = await undeleteFile(db, file.id)
 		expect(result.result).toBe('restored')
@@ -140,7 +138,7 @@ describe('undeleteFile', () => {
 	})
 
 	it('returns group_deleted and writes nothing when the owning group is soft-deleted', async () => {
-		const file = makeFile({ ownerId: undefined, owningGroupId: 'group-9' })
+		const file = makeFile()
 		const { db, updates, inserts } = makeFakeDb(file, {
 			groupRow: { isDeleted: true },
 		})
@@ -150,7 +148,7 @@ describe('undeleteFile', () => {
 	})
 
 	it('returns group_deleted and writes nothing when the owning group row is missing', async () => {
-		const file = makeFile({ ownerId: undefined, owningGroupId: 'group-9' })
+		const file = makeFile()
 		const { db, updates, inserts } = makeFakeDb(file, {
 			groupRow: 'none',
 		})

--- a/apps/dotcom/sync-worker/src/undeleteFile.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.ts
@@ -16,8 +16,8 @@ export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<Unde
 		if (!file) return { result: 'not_found' }
 		if (!file.isDeleted) return { result: 'not_deleted', file }
 
-		// owningGroupId is nullable until #10050's follow-up migration makes it NOT NULL; this
-		// guard goes with it.
+		// owningGroupId stays optional in the client schema until #10592 tightens it, a release
+		// after the NOT NULL migration has replicated everywhere; this guard goes with that.
 		if (file.owningGroupId) {
 			const group = await tx
 				.selectFrom('group')

--- a/apps/dotcom/sync-worker/src/utils/publishSnapshots.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/publishSnapshots.test.ts
@@ -17,9 +17,7 @@ function file(partial: Partial<TlaFile>): TlaFile {
 	return {
 		id: 'f1',
 		name: 'file',
-		ownerId: 'u1',
 		ownerName: '',
-		ownerAvatar: '',
 		thumbnail: '',
 		shared: true,
 		sharedLinkType: 'edit',

--- a/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/hasReadAccessToFile.test.ts
@@ -13,14 +13,13 @@ const destroy = vi.fn(async () => {})
 
 interface FileRow {
 	id: string
-	ownerId: string
 	owningGroupId: string | null
 	shared: boolean
 	isDeleted: boolean
 }
 
 // What the stub was actually asked, so the query itself can be asserted rather than assumed. Without
-// this the stub discards its arguments: change the predicate to `where('ownerId', '=', fileId)` and
+// this the stub discards its arguments: change the predicate to `where('owningGroupId', '=', fileId)` and
 // every case below still passes while the check reads the wrong row entirely.
 let lastQuery: { table?: string; columns?: unknown; where?: unknown[] } = {}
 
@@ -28,7 +27,6 @@ let lastQuery: { table?: string; columns?: unknown; where?: unknown[] } = {}
 function mockFileRow(row: Partial<FileRow> | undefined) {
 	const value: FileRow | undefined = row && {
 		id: 'file-1',
-		ownerId: 'owner',
 		owningGroupId: null,
 		shared: false,
 		isDeleted: false,
@@ -69,7 +67,7 @@ describe('hasReadAccessToFile', () => {
 	// The decision table below is only worth anything if the row it decides on is the right one, and
 	// the stub cannot tell: it returns the same value whatever it is asked. Asserted once, here.
 	it('reads the named file, by id', async () => {
-		mockFileRow({ ownerId: 'user-1' })
+		mockFileRow({})
 		await hasReadAccessToFile(env, 'user-1', 'file-1')
 
 		expect(lastQuery.table).toBe('file')
@@ -81,24 +79,24 @@ describe('hasReadAccessToFile', () => {
 	// Unlike the write check, `sharedLinkType` is irrelevant: a link shared for editing is also one
 	// that can be viewed, and this only ever grants viewing.
 	it('admits anyone for a link-shared file, whatever the link type', async () => {
-		mockFileRow({ ownerId: 'someone-else', shared: true })
+		mockFileRow({ shared: true })
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(granted())
 	})
 
 	it('admits a group member who can access the group’s files', async () => {
-		mockFileRow({ ownerId: 'someone-else', owningGroupId: 'group-1' })
+		mockFileRow({ owningGroupId: 'group-1' })
 		vi.mocked(getRole).mockResolvedValue('member' as any)
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(granted())
 	})
 
 	it('refuses a group member whose role cannot access files', async () => {
-		mockFileRow({ ownerId: 'someone-else', owningGroupId: 'group-1' })
+		mockFileRow({ owningGroupId: 'group-1' })
 		vi.mocked(getRole).mockResolvedValue(null as any)
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(DENIED)
 	})
 
 	it('refuses a stranger’s unshared file', async () => {
-		mockFileRow({ ownerId: 'someone-else' })
+		mockFileRow({})
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual(DENIED)
 	})
 
@@ -119,7 +117,7 @@ describe('hasReadAccessToFile', () => {
 	// Handed back so the resolution that follows can re-apply the gate to it rather than dialling
 	// Postgres again for a strict subset of the same columns.
 	it('hands back the row it read', async () => {
-		mockFileRow({ ownerId: 'user-1', shared: true })
+		mockFileRow({ shared: true })
 		expect(await hasReadAccessToFile(env, 'user-1', 'file-1')).toEqual({
 			ok: true,
 			file: { id: 'file-1', shared: true, isDeleted: false },
@@ -129,7 +127,7 @@ describe('hasReadAccessToFile', () => {
 	// createPostgresConnectionPool news up a pg.Pool per call, so a leaked one accumulates in the
 	// isolate across every MCP resolve.
 	it('closes the pool on both outcomes', async () => {
-		mockFileRow({ ownerId: 'user-1' })
+		mockFileRow({})
 		await hasReadAccessToFile(env, 'user-1', 'file-1')
 		mockFileRow(undefined)
 		await hasReadAccessToFile(env, 'user-1', 'file-1')

--- a/internal/scripts/dotcom/copy-random-files-to-staging.ts
+++ b/internal/scripts/dotcom/copy-random-files-to-staging.ts
@@ -100,9 +100,7 @@ async function copyFilesToStaging(fileIds: string[]) {
 				const testFile: TlaFile = {
 					id: newId,
 					name: 'Test File',
-					ownerId: null,
 					ownerName: 'Test User',
-					ownerAvatar: null,
 					thumbnail: '',
 					shared: false,
 					sharedLinkType: 'link',

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -66,10 +66,8 @@ function makeComment(overrides: Partial<TlaComment> & { id: string; fileId: stri
 function makeFile(overrides: Partial<TlaFile> & { id: string }): TlaFile {
 	return {
 		name: 'Untitled',
-		ownerId: null,
 		owningGroupId: null,
 		ownerName: '',
-		ownerAvatar: '',
 		thumbnail: '',
 		shared: false,
 		sharedLinkType: 'edit',
@@ -130,8 +128,6 @@ function makeFileState(
 		lastEditAt: null,
 		lastSessionState: null,
 		lastVisitAt: null,
-		isFileOwner: false,
-		isPinned: false,
 		...overrides,
 	}
 }
@@ -437,17 +433,6 @@ describe('file mutations', () => {
 		const { tx } = createMockTx(s)
 		const m = createMutators(otherId)
 		await expectForbidden(() => m.file.update(tx, { id: f.id, name: 'Hacked' }))
-	})
-
-	it('cannot change immutable field (ownerId)', async () => {
-		// ownerId is unused by the app but still declared and still guarded, so nothing can write
-		// it while the column exists. The guard and this test both go in the column-drop PR.
-		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
-		s.file.push(f)
-		const { tx } = createMockTx(s)
-		const m = createMutators(userId)
-		await expectForbidden(() => m.file.update(tx, { id: f.id, ownerId: 'evil' }))
 	})
 
 	it('cannot change immutable field (owningGroupId)', async () => {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -340,7 +340,6 @@ export function createMutators(userId: string) {
 			await tx.mutate.file_state.insert({
 				fileId,
 				userId,
-				isPinned: false,
 				lastEditAt: null,
 				lastVisitAt: null,
 				firstVisitAt: null,

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -55,8 +55,6 @@ export const file_state = table('file_state')
 		lastEditAt: number().optional(),
 		lastSessionState: string().optional(),
 		lastVisitAt: number().optional(),
-		isFileOwner: boolean().optional(),
-		isPinned: boolean().optional(),
 	})
 	.primaryKey('userId', 'fileId')
 
@@ -82,10 +80,8 @@ export const file = table('file')
 	.columns({
 		id: string(),
 		name: string(),
-		ownerId: string().optional(),
 		owningGroupId: string().optional(),
 		ownerName: string(),
-		ownerAvatar: string().optional(),
 		thumbnail: string(),
 		shared: boolean(),
 		sharedLinkType: string(),
@@ -416,17 +412,15 @@ export const immutableColumns = {
 	user: new Set<keyof TlaUser>(['email', 'createdAt', 'updatedAt', 'avatar']),
 	file: new Set<keyof TlaFile>([
 		'ownerName',
-		'ownerAvatar',
 		'owningGroupId',
 		'publishedSlug',
-		'ownerId',
 		'thumbnail',
 		'isDeleted',
 		'createSource',
 		'updatedAt',
 		'createdAt',
 	]),
-	file_state: new Set<keyof TlaFileState>(['firstVisitAt', 'isFileOwner']),
+	file_state: new Set<keyof TlaFileState>(['firstVisitAt']),
 } as const
 
 export function isColumnMutable(tableName: keyof typeof immutableColumns, column: string) {


### PR DESCRIPTION
In order to drop the legacy user-owns-file columns (#10050) without locking live clients out while the deploy runs, this PR removes `file.ownerId`, `file.ownerAvatar`, `file_state.isFileOwner` and `file_state.isPinned` from the Zero client schema, the immutable-column sets, and the one mutator that still wrote `isPinned`. The Postgres columns stay; #10591 drops them and must ship a release after this.

The ordering matters because Zero's rule for removing columns is client → API → DB, and our deploy pipeline runs migrations first. Zero's view-syncer rejects a connected client whose schema declares a column the replica no longer has, sending it to the "please reload" modal until the SPA deploy lands, and the sync-worker asserts the same against `pg_catalog` before running any mutator. #10391 removed every read and write but deliberately kept the columns declared, so it does not cover this step. With the declarations gone first, the column drop is invisible to live clients.

Safe on its own: a client schema may be a subset of the replica, and `file_state.isPinned` has a default in Postgres so the mutator no longer needs to write it.

### Change type

- [x] `other`

### Test plan

Verified on the preview deploy (`dotcom-preview-please`), whose database sits at migration 049: all four columns still exist in Postgres while the deployed client and sync-worker no longer declare them, which is the production state after this ships.

1. Load the app and a board. Zero connects and syncs with the narrower client schema; no "please reload" modal, no schema error from zero-cache.
2. Create a board through `createFile`. The file_state insert now relies on the database default for `isPinned`.
3. Pin and unpin the board, unshare and re-share it, rename the home workspace. Each mutation was driven through the shared mutators with its server result awaited, so a rejected push would have surfaced as an error rather than an optimistic local change. All returned success.
4. Open the admin effect outbox page. It renders and queries on the new schema.

Not covered: a second account's first visit to a shared board. The same file_state insert runs in `createFile`, which is covered above.

- [x] Unit tests
- [x] Preview deploy

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +1 / -8    |
| Tests          | +12 / -37  |
| Apps           | +1 / -1    |
| Config/tooling | +0 / -2    |

