### PR TITLE
fix(draw): merge split strokes into one closed shape when they close

### DIFF
--- a/apps/docs/content/sdk-features/default-shapes.mdx
+++ b/apps/docs/content/sdk-features/default-shapes.mdx
@@ -239,9 +239,9 @@ Properties:
 
 Configuration options:
 
-| Option              | Type     | Default | Description                                                               |
-| ------------------- | -------- | ------- | ------------------------------------------------------------------------- |
-| `maxPointsPerShape` | `number` | `600`   | Maximum points before starting a new shape. Same behavior as draw shapes. |
+| Option              | Type     | Default | Description                                                                                                                             |
+| ------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxPointsPerShape` | `number` | `600`   | Maximum points before starting a new shape. Splits like draw shapes, but highlights never close, so their pieces are never merged back. |
 
 The highlight's `underlayOpacity` (default `0.82`) and `overlayOpacity` (default `0.35`) are display values that can be overridden via `getCustomDisplayValues`:
 

--- a/apps/docs/content/sdk-features/draw-shape.mdx
+++ b/apps/docs/content/sdk-features/draw-shape.mdx
@@ -73,6 +73,8 @@ The shape closes when:
 
 When a shape closes, the shape sets `isClosed` to true and fills according to its fill style. Highlight shapes don't support closing.
 
+A long stroke that the tool has split across several shapes (see `maxPointsPerShape` below) is judged as a whole when it completes. If it closed, the pieces are merged back into one shape so the fill covers the whole loop.
+
 ## Line snapping
 
 When drawing straight lines with Shift held, you can snap to previous segments in the current stroke. This helps create precise geometric constructions:
@@ -133,7 +135,7 @@ const ConfiguredDrawUtil = DrawShapeUtil.configure({
 })
 ```
 
-When a stroke exceeds the maximum point count, the draw tool completes the current shape and creates a new one at the current position. This prevents performance issues with very long strokes.
+When a stroke exceeds the maximum point count, the draw tool completes the current shape and creates a new one at the current position. This prevents performance issues with very long strokes. If a split stroke ends near where it began, the pieces are merged back into one closed shape when the pointer lifts, so a long loop can still be filled.
 
 ## Creating draw shapes programmatically
 

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -1,5 +1,6 @@
-import { TLDrawShape } from '@tldraw/editor'
+import { TLDrawShape, Vec, last } from '@tldraw/editor'
 import { TestEditor } from '../../../test/TestEditor'
+import { getPointsFromDrawSegments } from './getPath'
 import { Drawing } from './toolStates/Drawing'
 
 let editor: TestEditor
@@ -185,5 +186,108 @@ describe('Close threshold with zoom', () => {
 		const shape = shapes[shapes.length - 1]
 		// Highlight shapes don't have isClosed
 		expect((shape as any).props.isClosed).toBeUndefined()
+	})
+})
+
+describe('Strokes split past maxPointsPerShape', () => {
+	const center = { x: 300, y: 300 }
+	const radius = 200
+	// Enough to split the stroke into three shapes at the default cap of 600
+	const samples = 1500
+
+	function samplePoint(i: number) {
+		const angle = (i / samples) * Math.PI * 2
+		return new Vec(center.x + Math.cos(angle) * radius, center.y + Math.sin(angle) * radius)
+	}
+
+	// Draws around a circle so the stroke ends where it began
+	function drawLoop(tool: 'draw' | 'highlight' = 'draw') {
+		editor.setCurrentTool(tool)
+		const start = samplePoint(0)
+		editor.pointerDown(start.x, start.y)
+		for (let i = 1; i <= samples; i++) {
+			const point = samplePoint(i)
+			editor.pointerMove(point.x, point.y)
+		}
+		editor.pointerUp()
+		return editor.getCurrentPageShapes() as TLDrawShape[]
+	}
+
+	// Draws one page unit per point along y=300, so the stroke splits at x=600
+	function drawLine(length: number) {
+		editor.setCurrentTool('draw')
+		editor.pointerDown(0, 300)
+		for (let x = 1; x <= length; x++) {
+			editor.pointerMove(x, 300)
+		}
+	}
+
+	it('Keeps an open stroke split into several shapes', () => {
+		drawLine(samples)
+		editor.pointerUp()
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(3)
+		for (const shape of shapes) {
+			expect(shape.props).toMatchObject({ isClosed: false, isComplete: true })
+		}
+	})
+
+	it('Merges a split stroke back into one closed shape when it ends where it began', () => {
+		const shapes = drawLoop()
+		expect(shapes).toHaveLength(1)
+		const [shape] = shapes
+		expect(shape.props).toMatchObject({ isClosed: true, isComplete: true })
+
+		// The merged path visits every sampled point in order at its page position.
+		// Pieces meet at a shared point, so the path may repeat itself there.
+		const transform = editor.getShapePageTransform(shape)
+		const pagePoints = getPointsFromDrawSegments(shape.props.segments).map((point) =>
+			transform.applyToPoint(point)
+		)
+		expect(pagePoints.length).toBeGreaterThanOrEqual(samples + 1)
+		let j = 0
+		for (let i = 0; i <= samples; i++) {
+			const expected = samplePoint(i)
+			while (j < pagePoints.length - 1 && Vec.Dist(pagePoints[j], expected) > 0.5) j++
+			expect(Vec.Dist(pagePoints[j], expected), `sample ${i}`).toBeLessThan(0.5)
+		}
+	})
+
+	it('Undoes and redoes the merged stroke as one step', () => {
+		drawLoop()
+		editor.undo()
+		expect(editor.getCurrentPageShapes()).toHaveLength(0)
+		editor.redo()
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(shapes[0].props.isClosed).toBe(true)
+	})
+
+	it('Does not close a later piece that only returns to where the stroke split', () => {
+		drawLine(700)
+		editor.pointerMove(700, 200)
+		editor.pointerMove(600, 200)
+		editor.pointerMove(600, 300)
+		editor.pointerUp()
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(2)
+		for (const shape of shapes) {
+			expect(shape.props.isClosed).toBe(false)
+		}
+	})
+
+	it('Never merges highlight strokes', () => {
+		expect(drawLoop('highlight')).toHaveLength(3)
+	})
+
+	it('Extends the merged shape on a following shift-click', () => {
+		drawLoop()
+		editor.keyDown('Shift')
+		editor.pointerDown(600, 600)
+		editor.pointerUp()
+		editor.keyUp('Shift')
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(last(shapes[0].props.segments)?.type).toBe('straight')
 	})
 })

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -276,6 +276,42 @@ describe('Strokes split past maxPointsPerShape', () => {
 		}
 	})
 
+	it('Judges a shift-click extension of a split stroke from where the stroke began', () => {
+		drawLine(700)
+		editor.pointerMove(700, 200)
+		editor.pointerUp()
+		// Extend the last piece back onto the split point
+		editor.keyDown('Shift')
+		editor.pointerDown(600, 301)
+		editor.pointerUp()
+		editor.keyUp('Shift')
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(2)
+		for (const shape of shapes) {
+			expect(shape.props.isClosed).toBe(false)
+		}
+	})
+
+	it('Merges a split stroke that shift-click extensions close', () => {
+		drawLine(700)
+		editor.pointerUp()
+		editor.keyDown('Shift')
+		editor.pointerDown(700, 500)
+		editor.pointerUp()
+		editor.pointerDown(0, 300)
+		editor.pointerUp()
+		editor.keyUp('Shift')
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(shapes[0].props.isClosed).toBe(true)
+		expect(shapes[0].props.segments.map((segment) => segment.type)).toEqual([
+			'free',
+			'free',
+			'straight',
+			'straight',
+		])
+	})
+
 	it('Never merges highlight strokes', () => {
 		expect(drawLoop('highlight')).toHaveLength(3)
 	})

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -7,6 +7,7 @@ import {
 	TLHighlightShape,
 	TLKeyboardEventInfo,
 	TLPointerEventInfo,
+	TLShapeId,
 	TLShapePartial,
 	DIM_2D,
 	Vec,
@@ -63,6 +64,12 @@ export class Drawing extends StateNode {
 	currentSegmentPoints: Vec[] = []
 
 	markId = null as null | string
+
+	// The shapes this stroke has been split across (past maxPointsPerShape), in
+	// drawing order, and the length of the pieces before the current one. A piece
+	// on its own can't tell whether the stroke as a whole has closed.
+	strokePieceIds: TLShapeId[] = []
+	strokeLengthBeforeCurrentPiece = 0
 
 	override onEnter(info: TLPointerEventInfo) {
 		this.markId = null
@@ -159,13 +166,38 @@ export class Drawing extends StateNode {
 	) {
 		if (!this.canClose()) return false
 
+		// A piece after a split can't see where the stroke started. Judged on its
+		// own it would close on the split point and fill only itself, so the whole
+		// stroke is judged instead when it completes.
+		if (this.strokePieceIds.length > 1) return false
+
+		const firstPoint = b64Vecs.decodeFirstPoint(segments[0].path, segments[0].dim)
+		const lastSegment = segments[segments.length - 1]
+		const lastPoint = b64Vecs.decodeLastPoint(lastSegment.path, lastSegment.dim)
+		if (firstPoint === null || lastPoint === null) return false
+
+		return this.getIsStrokeClosed(
+			firstPoint,
+			lastPoint,
+			this.currentLineLength,
+			size,
+			scale,
+			strokeWidth
+		)
+	}
+
+	private getIsStrokeClosed(
+		startPoint: VecModel,
+		endPoint: VecModel,
+		lineLength: number,
+		size: TLDefaultSizeStyle,
+		scale: number,
+		strokeWidth?: number
+	) {
 		if (strokeWidth === undefined) {
 			const theme = this.editor.getCurrentTheme()
 			strokeWidth = theme.strokeWidth * STROKE_SIZES[size]
 		}
-		const firstPoint = b64Vecs.decodeFirstPoint(segments[0].path, segments[0].dim)
-		const lastSegment = segments[segments.length - 1]
-		const lastPoint = b64Vecs.decodeLastPoint(lastSegment.path, lastSegment.dim)
 
 		const isDynamicResizingEnabled = this.editor.user.getIsDynamicResizeMode()
 
@@ -177,13 +209,7 @@ export class Drawing extends StateNode {
 				// 100 is low-zoom boost, 0.18 is the zoom knee, 3 controls falloff steepness
 				100 / (1 + Math.pow(this.zoomOnEnter / 0.18, 3))
 
-		return (
-			firstPoint !== null &&
-			lastPoint !== null &&
-			firstPoint !== lastPoint &&
-			this.currentLineLength > strokeWidth * 4 * scale &&
-			Vec.DistMin(firstPoint, lastPoint, threshold)
-		)
+		return lineLength > strokeWidth * 4 * scale && Vec.DistMin(startPoint, endPoint, threshold)
 	}
 
 	/**
@@ -239,6 +265,8 @@ export class Drawing extends StateNode {
 				// Connect dots
 
 				this.didJustShiftClickToExtendPreviousShapeLine = true
+				this.strokePieceIds = [shape.id]
+				this.strokeLengthBeforeCurrentPiece = 0
 
 				const prevSegment = last(shape.props.segments)
 				if (!prevSegment) throw Error('Expected a previous segment!')
@@ -317,6 +345,8 @@ export class Drawing extends StateNode {
 		}
 		this.currentLineLength = 0
 		this.initialShape = this.editor.getShape<DrawableShape>(id)
+		this.strokePieceIds = [id]
+		this.strokeLengthBeforeCurrentPiece = 0
 	}
 
 	private updateDrawingShape() {
@@ -687,7 +717,9 @@ export class Drawing extends StateNode {
 
 				this.editor.updateShapes([shapePartial])
 
-				// Set a maximum length for the lines array; after 200 points, complete the line.
+				// Past maxPointsPerShape, continue the stroke in a new shape: every move
+				// re-encodes and re-renders the whole shape, so an uncapped stroke slows
+				// down as it grows. complete() merges the pieces again if the stroke closes.
 				if (cachedPoints.length > this.util.options.maxPointsPerShape) {
 					this.editor.updateShapes([{ id, type: this.shapeType, props: { isComplete: true } }])
 
@@ -725,6 +757,8 @@ export class Drawing extends StateNode {
 					this.initialShape = structuredClone(shape)
 					this.mergeNextPoint = false
 					this.lastRecordedPoint = currentPagePoint.clone()
+					this.strokePieceIds.push(newShapeId)
+					this.strokeLengthBeforeCurrentPiece += this.currentLineLength
 					this.currentLineLength = 0
 				}
 
@@ -772,11 +806,91 @@ export class Drawing extends StateNode {
 	complete() {
 		const { initialShape } = this
 		if (!initialShape) return
-		this.editor.updateShapes([
-			{ id: initialShape.id, type: initialShape.type, props: { isComplete: true } },
-		])
+		if (!this.mergeStrokePiecesIfClosed()) {
+			this.editor.updateShapes([
+				{ id: initialShape.id, type: initialShape.type, props: { isComplete: true } },
+			])
+		}
 
 		this.parent.transition('idle')
+	}
+
+	/**
+	 * A stroke split past `maxPointsPerShape` is judged for closing as a whole once it
+	 * completes. If it closed, its pieces are merged back into the first one so the fill has
+	 * a single polygon to paint. Merging only now, rather than as soon as the stroke closes,
+	 * keeps the cost of each pointer move bounded by the cap.
+	 *
+	 * Returns whether the pieces were merged.
+	 */
+	private mergeStrokePiecesIfClosed(): boolean {
+		if (!this.canClose() || this.strokePieceIds.length < 2) return false
+
+		const pieces: TLDrawShape[] = []
+		for (const id of this.strokePieceIds) {
+			const piece = this.editor.getShape<TLDrawShape>(id)
+			if (!piece) return false
+			pieces.push(piece)
+		}
+
+		const first = pieces[0]
+		const lastPiece = pieces[pieces.length - 1]
+		const firstSegment = first.props.segments[0]
+		const lastSegment = last(lastPiece.props.segments)
+		if (!firstSegment || !lastSegment) return false
+		const startPoint = b64Vecs.decodeFirstPoint(firstSegment.path, firstSegment.dim)
+		const endPoint = b64Vecs.decodeLastPoint(lastSegment.path, lastSegment.dim)
+		if (!startPoint || !endPoint) return false
+
+		// Segment points are stored before scaleX/scaleY, so moving a point between
+		// pieces goes through page space with the scale applied and removed again.
+		const toPagePoint = (piece: TLDrawShape, point: VecModel) =>
+			this.editor.getShapePageTransform(piece).applyToPoint({
+				x: point.x * piece.props.scaleX,
+				y: point.y * piece.props.scaleY,
+				z: point.z,
+			})
+		const toPiecePoint = (piece: TLDrawShape, pagePoint: VecModel): VecModel => {
+			const point = this.editor.getPointInShapeSpace(piece, pagePoint)
+			return {
+				x: toFixed(point.x / piece.props.scaleX),
+				y: toFixed(point.y / piece.props.scaleY),
+				z: pagePoint.z,
+			}
+		}
+
+		const lineLength = this.strokeLengthBeforeCurrentPiece + this.currentLineLength
+		const isClosed = this.getIsStrokeClosed(
+			toPiecePoint(lastPiece, toPagePoint(first, startPoint)),
+			endPoint,
+			lineLength,
+			lastPiece.props.size,
+			lastPiece.props.scale
+		)
+		if (!isClosed) return false
+
+		const segments = [...first.props.segments]
+		for (let i = 1; i < pieces.length; i++) {
+			const piece = pieces[i]
+			for (const segment of piece.props.segments) {
+				const points = b64Vecs
+					.decodePoints(segment.path, segment.dim)
+					.map((point) => toPiecePoint(first, toPagePoint(piece, point)))
+				segments.push({ ...segment, path: b64Vecs.encodePoints(points, segment.dim) })
+			}
+		}
+
+		this.editor.updateShapes<TLDrawShape>([
+			{ id: first.id, type: first.type, props: { segments, isClosed: true } },
+		])
+		this.editor.deleteShapes(this.strokePieceIds.slice(1))
+
+		// A following shift-click should extend the merged shape, not a deleted piece
+		this.initialShape = this.editor.getShape<TLDrawShape>(first.id)
+		this.strokePieceIds = [first.id]
+		this.strokeLengthBeforeCurrentPiece = 0
+		this.currentLineLength = lineLength
+		return true
 	}
 
 	cancel() {

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -265,8 +265,18 @@ export class Drawing extends StateNode {
 				// Connect dots
 
 				this.didJustShiftClickToExtendPreviousShapeLine = true
-				this.strokePieceIds = [shape.id]
-				this.strokeLengthBeforeCurrentPiece = 0
+
+				// Extending the last piece of a split stroke continues that stroke, so
+				// closing is still judged from where the stroke began rather than from
+				// the split point. Undo may have removed the other pieces since.
+				const isExtendingSplitStroke =
+					this.strokePieceIds.length > 1 &&
+					last(this.strokePieceIds) === shape.id &&
+					this.strokePieceIds.every((id) => this.editor.getShape(id))
+				if (!isExtendingSplitStroke) {
+					this.strokePieceIds = [shape.id]
+					this.strokeLengthBeforeCurrentPiece = 0
+				}
 
 				const prevSegment = last(shape.props.segments)
 				if (!prevSegment) throw Error('Expected a previous segment!')
@@ -829,7 +839,9 @@ export class Drawing extends StateNode {
 		const pieces: TLDrawShape[] = []
 		for (const id of this.strokePieceIds) {
 			const piece = this.editor.getShape<TLDrawShape>(id)
-			if (!piece) return false
+			// A collaborator may have deleted or locked a piece mid-stroke; updateShapes
+			// and deleteShapes would skip a locked one and leave the stroke torn
+			if (!piece || this.editor.isShapeOrAncestorLocked(piece)) return false
 			pieces.push(piece)
 		}
 


### PR DESCRIPTION
This PR fixes a bug where a long freehand loop never closes or fills: past `maxPointsPerShape` the draw tool continues the stroke in a new shape, and closure was judged per shape, so a loop spanning several pieces could not be filled. Relates to #7072, which reports the same split as a selection problem. A live fill preview for split strokes is tracked in #10658.

### Before

`Drawing` continues a free segment in a new draw shape once it passes `maxPointsPerShape` (600 points, a few seconds of mouse input). `getIsClosed` compared the first and last points of the *current shape*, so after a split the "start" was the split point rather than where the stroke began. A loop that returned to its real start never registered as closed, and fills only paint closed shapes. A later piece could also close spuriously by passing back over the invisible split point, filling just that piece.

### After

The drawing state tracks the pieces of the current stroke and their accumulated length. While drawing, a piece after a split is never marked closed. On pointer up, closure is judged for the whole stroke: the start of the first piece against the end of the last, with the total length and the same zoom-aware threshold. If it closed, the later pieces' segments are converted into the first shape's space and appended to it, `isClosed` is set, and the other pieces are deleted, all inside the stroke's history mark so one undo removes the whole stroke. Open strokes still split exactly as before, and highlight strokes never close so they never merge. `draw-shape.mdx` and `default-shapes.mdx` describe the behavior.

### Implementation notes

- Merging on pointer up rather than as soon as the loop closes keeps every pointer move bounded by the cap, which is what the cap is for: each move re-encodes the current segment and re-renders the whole shape. The trade-off is that a split stroke gets its fill on release instead of as a live preview while still drawing. Merging live the moment the loop first closes would restore the preview at the price of O(total points) per move for the rest of the gesture. #10658 lays out three ways to get the preview back, with measurements and a recommendation.
- Measured in the examples app at zoom 1 with a 1500-point loop (three pieces): the merge on pointer up takes about 2 ms; computing the merged shape's geometry takes 0.6 ms against 0.1 ms for a 600-point piece, and geometry only recomputes on prop changes, not on translate; a hit test inside the loop takes 0.05 ms; the record is about 8.5 KB.
- Other costs of a merged shape: a later style change resends the whole path (about 5.5 KB per 1000 points with the 2D encoding) instead of one piece, and the pieces can no longer be culled or erased individually. A piece that only loops back to its split point no longer closes; a test pins that down.
- Appended segments keep their own Float32 anchors, so a merged shape carries no more delta-encoding drift than its pieces did.
- Points move between pieces through page space with `scaleX`/`scaleY` applied and removed, so a stroke that shift-extends a resized shape and then splits still merges correctly.
- A shift-click that extends the last piece of a split stroke keeps the piece list, so its closure is also judged from the stroke's start, and the extension merges the stroke if it closes it. The merge is skipped if a collaborator locked a piece mid-stroke, since `updateShapes` and `deleteShapes` would silently skip it and leave the stroke torn.
- Long *open* strokes still split (#7072). The same bookkeeping could merge those too by dropping the closure condition, at the same one-time cost; left out to keep this to the fill bug.

### Change type

- [x] `bugfix`

### Test plan

1. With the draw tool and a fill style selected, draw a large loop slowly enough to pass 600 points (a couple of seconds with a mouse), ending back where it started.
2. Confirm the loop fills as one shape on release, and that one undo removes it.
3. Draw a long open scribble and confirm it still splits as before.

- [x] Unit tests — six of the eight new tests fail on `main` (merge, undo/redo, split-point closing, both shift-extend cases, and shift-click extending the merged shape) and pass with this change; the other two pin down that open strokes still split and highlights never merge

### Release notes

- Fix long freehand loops never closing or filling once the draw tool has split the stroke into several shapes.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +140 / -14 |
| Tests         | +141 / -1  |
| Documentation | +6 / -4    |
