### PR TITLE
feat(create-tldraw): scaffold into the current directory with .

### DIFF
--- a/packages/create-tldraw/README.md
+++ b/packages/create-tldraw/README.md
@@ -8,13 +8,14 @@ A CLI tool for quickly scaffolding a new tldraw project. Inspired by `npm create
 $ npm create tldraw -- --help
 Usage: create-tldraw [OPTION]... [DIRECTORY]
 
-Create a new tldraw project.
+Create a new tldraw project from a starter kit.
 With no arguments, you'll be guided through an interactive setup.
+Pass . as the directory to create the project in the current directory.
 
 Options:
    -h, --help           Display this help message.
    -t, --template NAME  Use a specific template.
-   -o, --overwrite      Overwrite the target directory if it exists.
+   --no-telemetry       Disable anonymous usage tracking.
 
 Available starter kits:
  • basic                A minimal tldraw template with Vite, React, and TypeScript.
@@ -24,6 +25,14 @@ Available starter kits:
  • multiplayer          Real-time multiplayer for tldraw, built with Cloudflare Durable Objects.
  • workflow             Visual node-based builder for workflows.
 ```
+
+To scaffold into the current directory instead of a new folder, pass `.` as the directory:
+
+```
+$ npm create tldraw@latest .
+```
+
+If the directory already has files in it, you'll be asked whether to keep them, remove them (`.git` is always kept), or cancel.
 
 ## Development
 

--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -1,14 +1,16 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import process from 'node:process'
 import { Readable } from 'node:stream'
 import { parse as parseArgs } from '@bomb.sh/args'
-import { outro, spinner, text } from '@clack/prompts'
+import { outro, select, spinner, text } from '@clack/prompts'
 import picocolors from 'picocolors'
 import * as tar from 'tar'
 import { groupSelect, GroupSelectOption } from './group-select'
 import { Template, TEMPLATES } from './templates'
 import {
+	cancel,
+	emptyDir,
 	formatTargetDir,
 	getInstallCommand,
 	getPackageManager,
@@ -43,8 +45,9 @@ async function main() {
 	const template = await templatePicker(args.template, args['no-telemetry'])
 	const name = await namePicker(maybeTargetDir)
 
-	const requestedDir = maybeTargetDir ?? resolve(process.cwd(), name)
-	const targetDir = findAvailableDir(requestedDir)
+	const targetDir = maybeTargetDir
+		? await prepareRequestedDir(maybeTargetDir)
+		: findAvailableDir(resolve(process.cwd(), name))
 	mkdirSync(targetDir, { recursive: true })
 
 	await downloadTemplate(template, targetDir)
@@ -62,12 +65,6 @@ async function main() {
 
 	outro(doneMessage.join('\n'))
 }
-
-main().catch((err) => {
-	if (DEBUG) console.error(err)
-	outro(`it's bad`)
-	process.exit(1)
-})
 
 async function templatePicker(argOption?: string, noTelemetry?: boolean) {
 	let template: Template
@@ -141,6 +138,45 @@ async function namePicker(argOption?: string) {
 
 	if (!name.trim()) return defaultName
 	return pathToName(name)
+}
+
+// A directory the user named explicitly (e.g. `.`) must not be swapped for a suffixed sibling, so ask
+// what to do with its existing contents instead.
+async function prepareRequestedDir(targetDir: string): Promise<string> {
+	if (isDirEmpty(targetDir)) {
+		return targetDir
+	}
+
+	const displayName = relative(process.cwd(), targetDir) || '.'
+	if (!lstatSync(targetDir).isDirectory()) {
+		outro(`${displayName} exists and is not a directory.`)
+		process.exit(1)
+	}
+
+	const action = await handleCancel(
+		select({
+			message: picocolors.bold(
+				`${displayName === '.' ? 'The current directory' : displayName} is not empty. How would you like to proceed?`
+			),
+			options: [
+				{
+					value: 'ignore',
+					label: 'Ignore existing files and continue',
+					hint: 'template files overwrite any that conflict',
+				},
+				{
+					value: 'empty',
+					label: 'Remove existing files and continue',
+					hint: 'keeps .git',
+				},
+				{ value: 'cancel', label: 'Cancel' },
+			],
+		})
+	)
+
+	if (action === 'cancel') cancel()
+	if (action === 'empty') emptyDir(targetDir)
+	return targetDir
 }
 
 function findAvailableDir(targetDir: string): string {
@@ -249,6 +285,7 @@ function getHelp() {
 		'',
 		'Create a new tldraw project from a starter kit.',
 		"With no arguments, you'll be guided through an interactive setup.",
+		'Pass . as the directory to create the project in the current directory.',
 		'',
 		picocolors.bold('Options:'),
 		...formatRows(
@@ -261,3 +298,10 @@ function getHelp() {
 		'',
 	].join('\n')
 }
+
+// Runs last so every module-level const above is initialised before main() touches it synchronously.
+main().catch((err) => {
+	if (DEBUG) console.error(err)
+	outro(`it's bad`)
+	process.exit(1)
+})

--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -43,13 +43,17 @@ async function main() {
 	const maybeTargetDir = args._[0] ? formatTargetDir(resolve(String(args._[0]))) : undefined
 
 	// Settle the directory before anything else so a cancel here doesn't waste a template pick.
-	if (maybeTargetDir) await prepareRequestedDir(maybeTargetDir)
+	const dirAction = maybeTargetDir ? await prepareRequestedDir(maybeTargetDir) : undefined
 
 	const template = await templatePicker(args.template, args['no-telemetry'])
 	const name = await namePicker(maybeTargetDir)
 
 	const targetDir = maybeTargetDir ?? findAvailableDir(resolve(process.cwd(), name))
 	mkdirSync(targetDir, { recursive: true })
+
+	// Only destroy existing files once every prompt has passed; a cancel or bad -t after the
+	// "remove" choice must leave the directory untouched.
+	if (dirAction === 'empty') emptyDir(targetDir)
 
 	await downloadTemplate(template, targetDir)
 	await renameTemplate(name, targetDir)
@@ -141,10 +145,13 @@ async function namePicker(argOption?: string) {
 	return pathToName(name)
 }
 
+type RequestedDirAction = 'ignore' | 'empty'
+
 // A directory the user named explicitly (e.g. `.`) must not be swapped for a suffixed sibling, so ask
-// what to do with its existing contents instead.
-async function prepareRequestedDir(targetDir: string) {
-	if (isDirEmpty(targetDir)) return
+// what to do with its existing contents instead. Returns the choice rather than acting on it so the
+// caller can defer any deletion until the rest of the setup has succeeded.
+async function prepareRequestedDir(targetDir: string): Promise<RequestedDirAction | undefined> {
+	if (isDirEmpty(targetDir)) return undefined
 
 	// Show the full path for anything outside the cwd so "remove existing files" on `..` isn't a surprise.
 	const relativeName = relative(process.cwd(), targetDir)
@@ -155,7 +162,7 @@ async function prepareRequestedDir(targetDir: string) {
 	}
 
 	const action = await handleCancel(
-		select({
+		select<RequestedDirAction | 'cancel'>({
 			message: picocolors.bold(
 				`${displayName === '.' ? 'The current directory' : displayName} is not empty. How would you like to proceed?`
 			),
@@ -176,7 +183,7 @@ async function prepareRequestedDir(targetDir: string) {
 	)
 
 	if (action === 'cancel') cancel()
-	if (action === 'empty') emptyDir(targetDir)
+	return action
 }
 
 function findAvailableDir(targetDir: string): string {

--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -1,4 +1,4 @@
-import { lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import process from 'node:process'
 import { Readable } from 'node:stream'
@@ -42,12 +42,13 @@ async function main() {
 
 	const maybeTargetDir = args._[0] ? formatTargetDir(resolve(String(args._[0]))) : undefined
 
+	// Settle the directory before anything else so a cancel here doesn't waste a template pick.
+	if (maybeTargetDir) await prepareRequestedDir(maybeTargetDir)
+
 	const template = await templatePicker(args.template, args['no-telemetry'])
 	const name = await namePicker(maybeTargetDir)
 
-	const targetDir = maybeTargetDir
-		? await prepareRequestedDir(maybeTargetDir)
-		: findAvailableDir(resolve(process.cwd(), name))
+	const targetDir = maybeTargetDir ?? findAvailableDir(resolve(process.cwd(), name))
 	mkdirSync(targetDir, { recursive: true })
 
 	await downloadTemplate(template, targetDir)
@@ -142,13 +143,13 @@ async function namePicker(argOption?: string) {
 
 // A directory the user named explicitly (e.g. `.`) must not be swapped for a suffixed sibling, so ask
 // what to do with its existing contents instead.
-async function prepareRequestedDir(targetDir: string): Promise<string> {
-	if (isDirEmpty(targetDir)) {
-		return targetDir
-	}
+async function prepareRequestedDir(targetDir: string) {
+	if (isDirEmpty(targetDir)) return
 
-	const displayName = relative(process.cwd(), targetDir) || '.'
-	if (!lstatSync(targetDir).isDirectory()) {
+	// Show the full path for anything outside the cwd so "remove existing files" on `..` isn't a surprise.
+	const relativeName = relative(process.cwd(), targetDir)
+	const displayName = !relativeName ? '.' : relativeName.startsWith('..') ? targetDir : relativeName
+	if (!statSync(targetDir).isDirectory()) {
 		outro(`${displayName} exists and is not a directory.`)
 		process.exit(1)
 	}
@@ -176,7 +177,6 @@ async function prepareRequestedDir(targetDir: string): Promise<string> {
 
 	if (action === 'cancel') cancel()
 	if (action === 'empty') emptyDir(targetDir)
-	return targetDir
 }
 
 function findAvailableDir(targetDir: string): string {
@@ -299,7 +299,8 @@ function getHelp() {
 	].join('\n')
 }
 
-// Runs last so every module-level const above is initialised before main() touches it synchronously.
+// Runs last: with -t, templatePicker reaches TELEMETRY_URLS synchronously, so calling main() above
+// that declaration throws a temporal dead zone ReferenceError.
 main().catch((err) => {
 	if (DEBUG) console.error(err)
 	outro(`it's bad`)

--- a/packages/create-tldraw/src/utils.test.ts
+++ b/packages/create-tldraw/src/utils.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isDirEmpty } from './utils'
+import { emptyDir, isDirEmpty } from './utils'
 
 describe('isDirEmpty', () => {
 	let tempDir: string
@@ -27,5 +27,31 @@ describe('isDirEmpty', () => {
 		mkdirSync(join(dirPath, '.git'))
 
 		expect(isDirEmpty(dirPath)).toBe(true)
+	})
+})
+
+describe('emptyDir', () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'create-tldraw-'))
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it('removes everything except .git', () => {
+		mkdirSync(join(tempDir, '.git'))
+		writeFileSync(join(tempDir, '.git', 'HEAD'), 'ref: refs/heads/main')
+		mkdirSync(join(tempDir, 'src'))
+		writeFileSync(join(tempDir, 'src', 'index.ts'), 'x')
+		writeFileSync(join(tempDir, 'README.md'), 'x')
+
+		emptyDir(tempDir)
+
+		expect(readdirSync(tempDir)).toEqual(['.git'])
+		expect(existsSync(join(tempDir, '.git', 'HEAD'))).toBe(true)
+		expect(isDirEmpty(tempDir)).toBe(true)
 	})
 })

--- a/packages/create-tldraw/src/utils.test.ts
+++ b/packages/create-tldraw/src/utils.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { emptyDir, isDirEmpty } from './utils'
@@ -19,6 +27,14 @@ describe('isDirEmpty', () => {
 		writeFileSync(filePath, 'x')
 
 		expect(isDirEmpty(filePath)).toBe(false)
+	})
+
+	it('follows a symlink to an empty directory', () => {
+		const dirPath = join(tempDir, 'real')
+		mkdirSync(dirPath)
+		symlinkSync(dirPath, join(tempDir, 'link'))
+
+		expect(isDirEmpty(join(tempDir, 'link'))).toBe(true)
 	})
 
 	it('treats a directory containing only .git as empty', () => {

--- a/packages/create-tldraw/src/utils.ts
+++ b/packages/create-tldraw/src/utils.ts
@@ -1,5 +1,5 @@
-import { existsSync, lstatSync, readdirSync } from 'node:fs'
-import { basename, resolve } from 'node:path'
+import { existsSync, lstatSync, readdirSync, rmSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
 import { isCancel, outro } from '@clack/prompts'
 
 export function nicelog(...args: unknown[]) {
@@ -19,6 +19,14 @@ export function isDirEmpty(path: string) {
 
 	const files = readdirSync(path)
 	return files.length === 0 || (files.length === 1 && files[0] === '.git')
+}
+
+// Keeps .git so scaffolding into a freshly initialised repo doesn't destroy its history.
+export function emptyDir(path: string) {
+	for (const file of readdirSync(path)) {
+		if (file === '.git') continue
+		rmSync(join(path, file), { recursive: true, force: true })
+	}
 }
 
 export function pathToName(path: string) {
@@ -41,7 +49,7 @@ function toValidPackageName(projectName: string) {
 		.replace(/[^a-z\d\-~]+/g, '-')
 }
 
-function cancel(): never {
+export function cancel(): never {
 	outro('Setup cancelled.\n   Try again or visit https://tldraw.dev/docs to learn more.')
 	process.exit(1)
 }

--- a/packages/create-tldraw/src/utils.ts
+++ b/packages/create-tldraw/src/utils.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync, rmSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { isCancel, outro } from '@clack/prompts'
 
@@ -13,7 +13,7 @@ export function isDirEmpty(path: string) {
 	}
 
 	// Existing files block the target path, so only directories should be inspected with readdirSync.
-	if (!lstatSync(path).isDirectory()) {
+	if (!statSync(path).isDirectory()) {
 		return false
 	}
 


### PR DESCRIPTION
This PR improves `create-tldraw` so that `npm create tldraw@latest .` scaffolds a project into the current directory. It also fixes a bug where passing `-t <template>` crashed the CLI before it did anything.

### Before

`.` resolved to the current directory, but `findAvailableDir` treated every target the same way: if the directory had anything in it besides `.git`, the CLI silently scaffolded into a sibling folder named `<cwd>-1`. Running it inside a freshly initialised repo with a `README.md` or `.gitignore` therefore never produced a project where you asked for one.

Separately, `-t basic` (or any template flag) threw `TELEMETRY_URLS is not iterable`. The top-level `main()` call sat above that `const`, and the `-t` path reaches it synchronously before the module finishes evaluating. The interactive path only worked because the template picker's `await` let the rest of the module run first.

### After

A directory the user names explicitly is never swapped for a suffixed sibling. If it is empty (or holds only `.git`) the project goes straight in. If it has other files, the CLI prompts, matching `create-vite`:

- Ignore existing files and continue (template files overwrite any that conflict)
- Remove existing files and continue (keeps `.git`)
- Cancel

A target that exists but is a file exits with a clear message, and a symlink to a directory is followed. The directory question is asked before the template picker so cancelling doesn't waste a step or fire telemetry. For a target outside the cwd, such as `..`, the prompt shows the absolute path so the remove option is not a surprise. The suffix behaviour is unchanged for the no-argument flow, where the CLI picks the directory from the app name.

The `main()` invocation now runs at the end of the module, so the `-t` flag works again. The `--help` output and README mention `.`, and the README no longer documents a `--overwrite` flag that was removed in #10082.

### Change type

- [x] `improvement`

### Test plan

Built the CLI and ran it in scratch directories through a pseudo-terminal:

1. Empty git-inited directory, `create-tldraw -t basic .`: scaffolds in place, package name taken from the folder, no `cd` step in the done message, no sibling folder.
2. Directory with `README.md` and `junk.txt`: prompt appears. Ignore keeps `junk.txt` and overwrites the README. Remove wipes everything except `.git`. Cancel leaves the folder untouched.
3. `create-tldraw -t basic afile` where `afile` is a regular file: exits with "afile exists and is not a directory."
4. `create-tldraw -t basic` on `main` reproduces the crash. It passes with this change.

- [x] Unit tests

### Release notes

- Add support for `npm create tldraw .` to scaffold into the current directory, with a prompt when the directory is not empty
- Fix `create-tldraw -t <template>` crashing on startup

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +67 / -14  |
| Tests         | +44 / -2   |
| Documentation | +11 / -2   |
