### PR TITLE
perf(dotcom): lighter thumbnail render page and live capture for MCP

### DIFF
--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -7,6 +7,7 @@ import {
 	ROOM_PREFIX,
 	SNAPSHOT_PREFIX,
 	SOCIAL_PREVIEW_BYPASS_PARAM,
+	THUMBNAIL_RENDER_PATH,
 } from '@tldraw/dotcom-shared'
 import { T } from '@tldraw/validate'
 import { config } from 'dotenv'
@@ -161,6 +162,14 @@ async function build() {
 
 	writeFileSync('.vercel/output/static/index.html', newIndex)
 
+	// The thumbnail render entry waits on these same faces during its settle phase, so it preloads
+	// them too — otherwise their fetch starts only after the SDK has booted and the editor mounted.
+	const thumbnailHtml = readFileSync('.vercel/output/static/thumbnail-render.html', 'utf8')
+	writeFileSync(
+		'.vercel/output/static/thumbnail-render.html',
+		thumbnailHtml.replace('<!-- $PRELOADED_FONTS -->', () => fontPreloads)
+	)
+
 	const multiplayerServerUrl = getMultiplayerServerURL() ?? 'http://localhost:8787'
 
 	// Includes the .js.map files: they're content-hashed like the chunks they describe, so they're
@@ -231,6 +240,17 @@ async function build() {
 						check: true,
 						src: '/',
 						dest: '/index.html',
+						headers: commonSecurityHeaders,
+					},
+					// The thumbnail render page is its own Vite entry, not an SPA route, so a Browser
+					// Run capture boots the SDK without the app shell. Rewritten here rather than
+					// served at its build filename so the URL the sync-worker renders
+					// (MCP_SCREENSHOT_RENDER_ORIGIN + THUMBNAIL_RENDER_PATH) never moves. Must come
+					// before the SPA fallback below, which would otherwise answer with index.html.
+					{
+						check: true,
+						src: `^${THUMBNAIL_RENDER_PATH}$`,
+						dest: '/thumbnail-render.html',
 						headers: commonSecurityHeaders,
 					},
 					// serve static files

--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -242,11 +242,9 @@ async function build() {
 						dest: '/index.html',
 						headers: commonSecurityHeaders,
 					},
-					// The thumbnail render page is its own Vite entry, not an SPA route, so a Browser
-					// Run capture boots the SDK without the app shell. Rewritten here rather than
-					// served at its build filename so the URL the sync-worker renders
-					// (MCP_SCREENSHOT_RENDER_ORIGIN + THUMBNAIL_RENDER_PATH) never moves. Must come
-					// before the SPA fallback below, which would otherwise answer with index.html.
+					// The render page's own entry (see pages/thumbnail-render.tsx), rewritten so the URL
+					// the sync-worker renders never moves. Must come before the SPA fallback below,
+					// which would otherwise answer with index.html.
 					{
 						check: true,
 						src: `^${THUMBNAIL_RENDER_PATH}$`,

--- a/apps/dotcom/client/scripts/vite-thumbnail-screenshot-plugin.ts
+++ b/apps/dotcom/client/scripts/vite-thumbnail-screenshot-plugin.ts
@@ -1,5 +1,5 @@
 import type { Browser } from '@playwright/test'
-import type { Plugin } from 'vite'
+import type { Connect, Plugin } from 'vite'
 
 // Stands in for Cloudflare Browser Rendering while developing. The sync worker's screenshot surfaces
 // (the MCP tool, the OG queue) need a browser to visit the render page, and local dev has no way to
@@ -21,6 +21,31 @@ export const LOCAL_SCREENSHOT_PATH = '/__screenshot'
 // The only page this will ever open. Deliberately asserted here rather than taken from the request:
 // an allowlist the caller supplies is not an allowlist. Mirrors THUMBNAIL_RENDER_PATH.
 const RENDER_PATH = '/__thumbnail-render'
+
+// Serves the render page from its own entry in dev, mirroring the edge rewrite the deployed client
+// gets from scripts/build.ts. Registered before Vite's own middlewares, so the SPA HTML fallback
+// never sees the path — which also means a broken rewrite fails loudly here instead of silently
+// serving the app shell.
+export function thumbnailRenderEntryPlugin(): Plugin {
+	const rewrite = (url: string | undefined) =>
+		url === RENDER_PATH || url?.startsWith(`${RENDER_PATH}?`)
+			? `/thumbnail-render.html${url.slice(RENDER_PATH.length)}`
+			: null
+	const middleware: Connect.NextHandleFunction = (req, _res, next) => {
+		const rewritten = rewrite(req.url)
+		if (rewritten) req.url = rewritten
+		next()
+	}
+	return {
+		name: 'thumbnail-render-entry',
+		configureServer(server) {
+			server.middlewares.use(middleware)
+		},
+		configurePreviewServer(server) {
+			server.middlewares.use(middleware)
+		},
+	}
+}
 
 export function thumbnailScreenshotPlugin(): Plugin {
 	// Chromium takes about a second to start, so it is launched once for the dev server's lifetime

--- a/apps/dotcom/client/scripts/vite-thumbnail-screenshot-plugin.ts
+++ b/apps/dotcom/client/scripts/vite-thumbnail-screenshot-plugin.ts
@@ -22,10 +22,9 @@ export const LOCAL_SCREENSHOT_PATH = '/__screenshot'
 // an allowlist the caller supplies is not an allowlist. Mirrors THUMBNAIL_RENDER_PATH.
 const RENDER_PATH = '/__thumbnail-render'
 
-// Serves the render page from its own entry in dev, mirroring the edge rewrite the deployed client
-// gets from scripts/build.ts. Registered before Vite's own middlewares, so the SPA HTML fallback
-// never sees the path — which also means a broken rewrite fails loudly here instead of silently
-// serving the app shell.
+// The dev counterpart of the edge rewrite in scripts/build.ts. Registered before Vite's own
+// middlewares, so the SPA HTML fallback never sees the path — a broken rewrite fails loudly here
+// instead of silently serving the app shell.
 export function thumbnailRenderEntryPlugin(): Plugin {
 	const rewrite = (url: string | undefined) =>
 		url === RENDER_PATH || url?.startsWith(`${RENDER_PATH}?`)

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -11,10 +11,6 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/__debug-tail/?$",
   },
   {
-    "reactRouterPattern": "/__thumbnail-render",
-    "vercelRouterPattern": "^/__thumbnail-render/?$",
-  },
-  {
     "reactRouterPattern": "/admin",
     "vercelRouterPattern": "^/admin/?$",
   },

--- a/apps/dotcom/client/src/pages/dev-browser-run-thumbnail.tsx
+++ b/apps/dotcom/client/src/pages/dev-browser-run-thumbnail.tsx
@@ -92,7 +92,7 @@ function ThumbnailPreview({
 		}
 	}, [dataUrl])
 
-	return <ThumbnailImage dataUrl={dataUrl} width={width} height={height} />
+	return <ThumbnailImage src={dataUrl} width={width} height={height} />
 }
 
 function getFixtureName(value: string | null): FixtureName {

--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -5,6 +5,7 @@ import {
 	THUMBNAIL_SETTLE_TIMEOUT_MS,
 	ThumbnailRenderParams,
 	ThumbnailShapeMeasurement,
+	ThumbnailRenderTimingsRequestBody,
 	ThumbnailSnapshotResponseBody,
 	getLicenseKey,
 } from '@tldraw/dotcom-shared'
@@ -12,7 +13,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
 	Box,
 	Editor,
-	FileHelpers,
 	Image,
 	SerializedSchema,
 	TLPageId,
@@ -26,13 +26,60 @@ import {
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { assetUrls } from '../utils/assetUrls'
-import { defineLoader } from '../utils/defineLoader'
 import { embedShapeUtils } from '../utils/embedShapeUtil'
+
+// The thumbnail render page: a real editor, loaded with one board's records, that exports itself
+// and displays the export for Browser Run to screenshot. Served as its own Vite entry
+// (thumbnail-render.html + thumbnail-render-main.tsx) rather than as an SPA route, so a capture
+// boots the SDK and nothing else — no router, no Clerk, no service worker. /__thumbnail-render is
+// rewritten to that entry at the edge (scripts/build.ts) and in dev
+// (vite-thumbnail-screenshot-plugin.ts), so the URL the sync-worker renders never moves.
 
 const THUMBNAIL_SNAPSHOT_ENDPOINT = '/api/app/thumbnail-render/snapshot'
 const THUMBNAIL_RESULT_ENDPOINT = '/api/app/thumbnail-render/result'
 
-type LoaderData =
+// Phase stamps for the timing beacon, module-scoped because the page renders exactly once. Each is
+// performance.now() at the moment the phase completed; the beacon ships them after the export so
+// the deltas — boot, acquire, mount, settle, export — can be read per render from telemetry
+// (`render_page_timings`). Worker-side timing can only see the session total; this is what ranks
+// the page's own phases against each other.
+const pageTimings: {
+	/** Authorises the beacon. Never set on the dev fixture page, which therefore sends none. */
+	token?: string
+	bootAt?: number
+	dataAt?: number
+	mountAt?: number
+	settledAt?: number
+} = {}
+
+// Fire-and-forget: nothing waits on this, and `keepalive` lets the request outlive the page —
+// which it must, because the screenshot (and the session's teardown) follows the ready marker
+// almost immediately.
+function sendTimingsBeacon(exportedAt: number) {
+	const { token, bootAt, dataAt, mountAt, settledAt } = pageTimings
+	if (
+		!token ||
+		bootAt === undefined ||
+		dataAt === undefined ||
+		mountAt === undefined ||
+		settledAt === undefined
+	) {
+		return
+	}
+	const body: ThumbnailRenderTimingsRequestBody = {
+		token,
+		timings: { bootAt, dataAt, mountAt, settledAt, exportedAt },
+	}
+	// A plain same-origin fetch: forcing it into no-cors mode turned out to stop delivery entirely.
+	fetch(THUMBNAIL_RESULT_ENDPOINT, {
+		method: 'POST',
+		keepalive: true,
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	}).catch(() => {})
+}
+
+export type ThumbnailRenderData =
 	| {
 			ok: true
 			token: string
@@ -45,8 +92,12 @@ type LoaderData =
 			message: string
 	  }
 
-const { loader, useData } = defineLoader(async (args): Promise<LoaderData> => {
-	const token = new URL(args.request.url).searchParams.get('token')
+/** Fetches the render job the URL's token names: the records to draw and how to draw them. */
+export async function acquireThumbnailRenderData(url: URL): Promise<ThumbnailRenderData> {
+	pageTimings.bootAt = performance.now()
+	const token = url.searchParams.get('token')
+	pageTimings.token = token ?? undefined
+
 	if (!token) {
 		return { ok: false, message: 'Missing render token' }
 	}
@@ -63,6 +114,7 @@ const { loader, useData } = defineLoader(async (args): Promise<LoaderData> => {
 		return { ok: false, message: data.message }
 	}
 
+	pageTimings.dataAt = performance.now()
 	return {
 		ok: true,
 		token,
@@ -70,12 +122,9 @@ const { loader, useData } = defineLoader(async (args): Promise<LoaderData> => {
 		schema: data.schema,
 		renderParams: data.renderParams,
 	}
-})
+}
 
-export { loader }
-
-export function Component() {
-	const data = useData()
+export function ThumbnailRenderView({ data }: { data: ThumbnailRenderData }) {
 	if (!data.ok) return <ThumbnailRenderError message={data.message} />
 	return (
 		<ThumbnailRenderPage
@@ -113,13 +162,16 @@ function ThumbnailRenderPage({
 	)
 
 	// Once the export is ready it's shown as a full-viewport <img>, so the worker's Browser Rendering
-	// screenshot captures the exact editor.toImage output rather than the live editor canvas.
-	const [dataUrl, setDataUrl] = useState<string | null>(null)
+	// screenshot captures the exact editor.toImage output rather than the live editor canvas. An
+	// object URL, not a data URL: blobToDataUrl base64-encodes the whole PNG on the main thread,
+	// which on a heavy board is megabytes of string work standing between the export and the ready
+	// marker. Never revoked — the page exists for exactly one render.
+	const [imageUrl, setImageUrl] = useState<string | null>(null)
 	const handleImage = useCallback(async (blob: Blob) => {
-		setDataUrl(await FileHelpers.blobToDataUrl(blob))
+		setImageUrl(URL.createObjectURL(blob))
 	}, [])
 
-	if (dataUrl) return <ThumbnailImage dataUrl={dataUrl} width={width} height={height} />
+	if (imageUrl) return <ThumbnailImage src={imageUrl} width={width} height={height} />
 
 	return (
 		<div
@@ -135,15 +187,21 @@ function ThumbnailRenderPage({
 				licenseKey={getLicenseKey()}
 				assetUrls={assetUrls}
 				shapeUtils={embedShapeUtils}
+				components={{ ErrorFallback: ThumbnailRenderCrash }}
 				snapshot={snapshot}
 				onMount={(editor) => {
+					pageTimings.mountAt = performance.now()
 					editor.user.updateUserPreferences({ colorScheme: theme })
-					editor.updateInstanceState({ isReadonly: true })
 					// Render the specific page the token asked for; without one, keep the page the
 					// snapshot opens to (used by OG images).
 					if (renderParams.pageId && editor.getPage(renderParams.pageId as TLPageId)) {
 						editor.setCurrentPage(renderParams.pageId as TLPageId)
 					}
+					// Before readonly, which the editor's own write guards honour.
+					if (renderParams.capture === 'live' && renderParams.shapeIds?.length) {
+						pruneToRequestedShapes(editor, getRequestedShapeIds(editor, renderParams.shapeIds))
+					}
+					editor.updateInstanceState({ isReadonly: true })
 					// `content` is what every surface asks for today; an explicit viewport is still honoured
 					// (see ThumbnailRenderParams) so the worker can start sending one without waiting on a
 					// separate client deploy to teach this page how to handle it. A shape set overrides
@@ -169,6 +227,7 @@ function ThumbnailRenderPage({
 						height={height}
 						camera={renderParams.camera}
 						shapeIds={renderParams.shapeIds}
+						capture={renderParams.capture}
 						onImage={handleImage}
 					/>
 				)}
@@ -183,18 +242,18 @@ function ThumbnailRenderPage({
 // page is quiescent when the screenshot is taken. Also used by the dev fixture page
 // (dev-browser-run-thumbnail.tsx), so its ready/error markers stay identical to production's.
 export function ThumbnailImage({
-	dataUrl,
+	src,
 	width,
 	height,
 }: {
-	dataUrl: string
+	src: string
 	width: number
 	height: number
 }) {
 	return (
 		<img
 			ref={signalThumbnailReadyIfComplete}
-			src={dataUrl}
+			src={src}
 			alt=""
 			style={{ display: 'block', width, height }}
 			onLoad={signalThumbnailReady}
@@ -210,7 +269,7 @@ function signalThumbnailReady() {
 
 // Marks the terminal failure state on both <html> and <body>: the worker's screenshot wait resolves
 // on either marker, and success marks both, so failure does too.
-function setThumbnailError(message: string) {
+export function setThumbnailError(message: string) {
 	document.body.dataset.thumbnailError = message
 	document.documentElement.dataset.thumbnailError = message
 }
@@ -220,6 +279,17 @@ function setThumbnailError(message: string) {
 // signal readiness directly; otherwise onLoad handles it once decoding finishes.
 function signalThumbnailReadyIfComplete(img: HTMLImageElement | null) {
 	if (img?.complete && img.naturalWidth > 0) signalThumbnailReady()
+}
+
+// Stands in for the SDK's crash screen inside <Tldraw>. Without it a throw during the editor's own
+// render — a snapshot at a schema this bundle cannot migrate, across a client deploy — shows the
+// SDK's fallback with neither marker set, and the capture burns the whole Browser Run timeout
+// instead of failing in milliseconds.
+function ThumbnailRenderCrash({ error }: { error: unknown }) {
+	useEffect(() => {
+		setThumbnailError(error instanceof Error ? error.message : String(error))
+	}, [error])
+	return null
 }
 
 function ThumbnailRenderError({ message }: { message: string }) {
@@ -299,6 +369,22 @@ function getRequestedShapeIds(editor: Editor, shapeIds: string[]): TLShapeId[] {
 	return shapeIds.filter((id): id is TLShapeId => Boolean(editor.getShape(id as TLShapeId)))
 }
 
+// Brings the live canvas to the picture the export draws: only the requested shapes and their
+// descendants. The store holds the whole board, and a live capture would rasterize everything in
+// the fitted viewport — a frame's fill, label and clipping across the cluster, every neighbour at
+// the edge. Reparenting the roots to the page keeps their page position while freeing them from
+// any frame; deleting the rest is the unbind that moves each arrow's stored terminal to where its
+// neighbour actually sat, which is why the neighbours are deleted rather than never loaded.
+function pruneToRequestedShapes(editor: Editor, requestedIds: TLShapeId[]) {
+	const keep = editor.getShapeAndDescendantIds(requestedIds)
+	const roots = requestedIds.filter((id) => {
+		const parentId = editor.getShape(id)?.parentId
+		return parentId !== undefined && !keep.has(parentId as TLShapeId)
+	})
+	editor.reparentShapes(roots, editor.getCurrentPageId())
+	editor.deleteShapes([...editor.getCurrentPageShapeIds()].filter((id) => !keep.has(id)))
+}
+
 // Like fitContentCamera, but framed on a subset of the page. Uses the same inset so a shapes
 // screenshot and a page screenshot of the same board have matching margins. Run again before export
 // for the same reason content fits are: autosized text re-measures once web fonts load.
@@ -337,6 +423,7 @@ export function ThumbnailExportSignal({
 	camera,
 	shapeIds,
 	settleTimeoutMs = THUMBNAIL_SETTLE_TIMEOUT_MS,
+	capture,
 	onImage,
 }: {
 	theme: 'light' | 'dark'
@@ -345,6 +432,8 @@ export function ThumbnailExportSignal({
 	camera?: 'content'
 	shapeIds?: string[]
 	settleTimeoutMs?: number
+	/** `live`: signal ready after settle and fit, without exporting — see ThumbnailRenderParams. */
+	capture?: 'live'
 	onImage(blob: Blob): void | Promise<void>
 }) {
 	const editor = useEditor()
@@ -356,13 +445,15 @@ export function ThumbnailExportSignal({
 		;(async () => {
 			await Promise.race([
 				(async () => {
-					await waitForFonts()
-					await preloadImageAssets(editor, settleDeadline)
+					// Fonts and asset warming are independent, so they overlap; the editor's own <img>
+					// elements are watched last because they appear as the warmed assets resolve.
+					await Promise.all([waitForFonts(), preloadImageAssets(editor, settleDeadline)])
 					await waitForEditorImages(editor, settleDeadline)
 				})(),
 				sleep(settleTimeoutMs),
 			])
 			if (cancelled) return
+			pageTimings.settledAt = performance.now()
 			// Re-fit content now that fonts and assets have settled: autosized text re-measures after
 			// the web font loads, so the fit computed in onMount (before fonts) is stale and would clip.
 			if (shapeIds?.length) {
@@ -370,12 +461,31 @@ export function ThumbnailExportSignal({
 			} else if (camera === 'content') {
 				fitContentCamera(editor, width, height)
 			}
+			// Live capture: the settled, fitted canvas is the picture — the screenshotting browser
+			// rasterizes it, so the export (and the paint of its result) has nothing left to do.
+			// The beacon's exportedAt stamp doubles as ready here; the deltas still read correctly.
+			if (capture === 'live') {
+				// The re-fit above is a store write the canvas catches up with on a later commit, and
+				// shapes culled at the pre-fit camera have no DOM yet. Two animation frames guarantee a
+				// commit and a paint at the fitted camera land before the marker; without them the
+				// screenshot can race the paint and capture a mis-framed or incomplete canvas.
+				await nextAnimationFrame()
+				await nextAnimationFrame()
+				if (cancelled) return
+				sendTimingsBeacon(performance.now())
+				signalThumbnailReady()
+				return
+			}
 			const blob = await exportThumbnailImage(editor, theme, width, height, shapeIds)
 			if (cancelled) return
+			// Before onImage rather than after: the ready marker follows the image paint, and the
+			// screenshot (then the session's teardown) follows the marker — keepalive covers the
+			// race, but not starting one is better.
+			sendTimingsBeacon(performance.now())
 			await onImage(blob)
 		})().catch((error) => {
 			if (cancelled) return
-			// FileHelpers.blobToDataUrl rejects with the FileReader's ProgressEvent rather than an
+			// Some browser APIs reject with an Event (e.g. FileReader's ProgressEvent) rather than an
 			// Error; don't let that stringify to "[object ProgressEvent]" in the error marker.
 			if (error instanceof Event) {
 				setThumbnailError('Could not read thumbnail blob')
@@ -387,7 +497,7 @@ export function ThumbnailExportSignal({
 		return () => {
 			cancelled = true
 		}
-	}, [editor, theme, width, height, camera, shapeIds, settleTimeoutMs, onImage])
+	}, [editor, theme, width, height, camera, shapeIds, settleTimeoutMs, capture, onImage])
 
 	return null
 }
@@ -517,6 +627,10 @@ function makeBlankThumbnail(width: number, height: number, background: string): 
 	})
 }
 
+function nextAnimationFrame() {
+	return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+}
+
 async function waitForFonts() {
 	if (!('fonts' in document)) return
 	try {
@@ -560,9 +674,13 @@ function preloadImage(url: string, deadline: number) {
 // mount. Wait until the set of images inside the editor is fully loaded and stable across a few
 // consecutive checks.
 async function waitForEditorImages(editor: Editor, deadline: number) {
+	// Every <img> the canvas creates is backed by an asset record, so a board with none has nothing
+	// to wait for — and the stability poll below would otherwise idle for several hundred ms.
+	if (editor.getAssets().length === 0) return
 	let stableChecks = 0
-	let lastCount = -1
-	while (Date.now() < deadline && stableChecks < 3) {
+	// Seeded from a real count, so the first check can already count toward stability.
+	let lastCount = editor.getContainer().querySelectorAll('img').length
+	while (Date.now() < deadline) {
 		const images = Array.from(editor.getContainer().querySelectorAll('img'))
 		if (images.every((img) => img.complete) && images.length === lastCount) {
 			stableChecks++
@@ -570,6 +688,8 @@ async function waitForEditorImages(editor: Editor, deadline: number) {
 			stableChecks = 0
 		}
 		lastCount = images.length
+		// Settled: don't pay one more poll interval just to notice.
+		if (stableChecks >= 3) return
 		await sleep(100)
 	}
 }

--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -377,12 +377,23 @@ function getRequestedShapeIds(editor: Editor, shapeIds: string[]): TLShapeId[] {
 // neighbour actually sat, which is why the neighbours are deleted rather than never loaded.
 function pruneToRequestedShapes(editor: Editor, requestedIds: TLShapeId[]) {
 	const keep = editor.getShapeAndDescendantIds(requestedIds)
-	const roots = requestedIds.filter((id) => {
-		const parentId = editor.getShape(id)?.parentId
-		return parentId !== undefined && !keep.has(parentId as TLShapeId)
-	})
-	editor.reparentShapes(roots, editor.getCurrentPageId())
-	editor.deleteShapes([...editor.getCurrentPageShapeIds()].filter((id) => !keep.has(id)))
+	const requested = new Set(requestedIds)
+	// Roots in page rendering order, reparented one at a time: each lands above the page's current
+	// children, so two roots from different parents keep the stacking the export would draw. A
+	// single reparentShapes call orders by the roots' own indices, which are only comparable
+	// between siblings.
+	const roots = editor
+		.getCurrentPageShapesSorted()
+		.filter((shape) => requested.has(shape.id) && !keep.has(shape.parentId as TLShapeId))
+	// Locked shapes are otherwise skipped by deleteShapes, and a locked background is exactly the
+	// kind of neighbour that must not end up in the picture.
+	editor.run(
+		() => {
+			for (const root of roots) editor.reparentShapes([root.id], editor.getCurrentPageId())
+			editor.deleteShapes([...editor.getCurrentPageShapeIds()].filter((id) => !keep.has(id)))
+		},
+		{ ignoreShapeLock: true }
+	)
 }
 
 // Like fitContentCamera, but framed on a subset of the page. Uses the same inset so a shapes
@@ -478,9 +489,7 @@ export function ThumbnailExportSignal({
 			}
 			const blob = await exportThumbnailImage(editor, theme, width, height, shapeIds)
 			if (cancelled) return
-			// Before onImage rather than after: the ready marker follows the image paint, and the
-			// screenshot (then the session's teardown) follows the marker — keepalive covers the
-			// race, but not starting one is better.
+			// Before onImage: the ready marker (and the session's teardown) follows the image paint.
 			sendTimingsBeacon(performance.now())
 			await onImage(blob)
 		})().catch((error) => {

--- a/apps/dotcom/client/src/routes.test.tsx
+++ b/apps/dotcom/client/src/routes.test.tsx
@@ -130,8 +130,12 @@ test('dev reset route exists only in development routing', () => {
 	)
 })
 
-test('the thumbnail render route is included in production routing', () => {
-	expect(spaRoutes.map((route) => route.reactRouterPattern)).toContain('/__thumbnail-render')
+test('the thumbnail render page is not an SPA route', () => {
+	// It is served from its own Vite entry (thumbnail-render.html) via an edge rewrite, so a Browser
+	// Run capture never boots the app shell. Keeping it out of the SPA routes is load-bearing the
+	// other way too: an SPA fallback for this path would mask a broken rewrite by quietly serving
+	// the old page, and every capture would silently pay the shell again.
+	expect(spaRoutes.map((route) => route.reactRouterPattern)).not.toContain('/__thumbnail-render')
 })
 
 test('all React routes match', () => {

--- a/apps/dotcom/client/src/routes.test.tsx
+++ b/apps/dotcom/client/src/routes.test.tsx
@@ -131,10 +131,8 @@ test('dev reset route exists only in development routing', () => {
 })
 
 test('the thumbnail render page is not an SPA route', () => {
-	// It is served from its own Vite entry (thumbnail-render.html) via an edge rewrite, so a Browser
-	// Run capture never boots the app shell. Keeping it out of the SPA routes is load-bearing the
-	// other way too: an SPA fallback for this path would mask a broken rewrite by quietly serving
-	// the old page, and every capture would silently pay the shell again.
+	// An SPA fallback for this path would mask a broken edge rewrite by quietly serving the app
+	// shell, and every capture would silently pay for it again.
 	expect(spaRoutes.map((route) => route.reactRouterPattern)).not.toContain('/__thumbnail-render')
 })
 

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -1,5 +1,4 @@
 import { captureException } from '@sentry/react'
-import { THUMBNAIL_RENDER_PATH } from '@tldraw/dotcom-shared'
 import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
 import { Suspense, lazy, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
@@ -142,8 +141,6 @@ export function createAppRouter({
 				</Route>
 			</Route>
 			<Route path="/__debug-tail" lazy={() => import('./tla/pages/worker-debug-tail')} />
-			{/* Renders a board for Browser Run thumbnail capture from a signed render token */}
-			<Route path={THUMBNAIL_RENDER_PATH} lazy={() => import('./pages/thumbnail-render')} />
 			<Route path="*" lazy={() => import('./pages/not-found')} />
 		</Route>
 	)

--- a/apps/dotcom/client/src/thumbnail-render-main.tsx
+++ b/apps/dotcom/client/src/thumbnail-render-main.tsx
@@ -10,12 +10,10 @@ import {
 	setThumbnailError,
 } from './pages/thumbnail-render'
 
-// The dedicated entry for the thumbnail render page (see thumbnail-render.html). Everything the SPA
-// boots before its router — Sentry, Clerk and its CDN fetch, Helmet, the service worker — is
-// deliberately absent: a capture pays for this entry's load on every render, and none of that can
-// appear in the pixels. What must match the app exactly (the SDK build, tldraw.css, assetUrls,
-// embed shape utils, the license key) is imported by the page module itself.
-
+// Everything the SPA boots before its router — Sentry, Clerk and its CDN fetch, Helmet, the
+// service worker — is deliberately absent: a capture pays for this entry's load on every render,
+// and none of it can appear in the pixels.
+//
 // Every failure this page can have must end in a terminal marker: a page with neither
 // data-thumbnail-ready nor data-thumbnail-error burns the whole Browser Run timeout instead of
 // failing the capture in milliseconds. The SPA route this replaced sat under the router's error

--- a/apps/dotcom/client/src/thumbnail-render-main.tsx
+++ b/apps/dotcom/client/src/thumbnail-render-main.tsx
@@ -14,10 +14,12 @@ import {
 // service worker — is deliberately absent: a capture pays for this entry's load on every render,
 // and none of it can appear in the pixels.
 //
-// Every failure this page can have must end in a terminal marker: a page with neither
-// data-thumbnail-ready nor data-thumbnail-error burns the whole Browser Run timeout instead of
-// failing the capture in milliseconds. The SPA route this replaced sat under the router's error
-// boundary; this boundary and the window handlers below are what stand in for it.
+// A render failure must end in a terminal marker: a page with neither data-thumbnail-ready nor
+// data-thumbnail-error burns the whole Browser Run timeout instead of failing the capture in
+// milliseconds. The SPA route this replaced sat under the router's error boundary; this boundary
+// (and the ErrorFallback override inside <Tldraw>) stands in for it. Deliberately no window-level
+// error or unhandledrejection handler: those fire on benign noise — a ResizeObserver loop as the
+// editor mounts and the camera fits — and would fail a capture that was about to succeed.
 class ThumbnailRenderBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
 	state = { failed: false }
 	static getDerivedStateFromError() {
@@ -30,12 +32,6 @@ class ThumbnailRenderBoundary extends Component<{ children: ReactNode }, { faile
 		return this.state.failed ? null : this.props.children
 	}
 }
-
-window.addEventListener('error', (event) => setThumbnailError(event.message || 'Uncaught error'))
-window.addEventListener('unhandledrejection', (event) => {
-	const reason = event.reason
-	setThumbnailError(reason instanceof Error ? reason.message : String(reason))
-})
 
 const root = createRoot(document.getElementById('root')!)
 

--- a/apps/dotcom/client/src/thumbnail-render-main.tsx
+++ b/apps/dotcom/client/src/thumbnail-render-main.tsx
@@ -1,0 +1,61 @@
+import { Component, ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
+// The full app stylesheet, not a subset: the render page's job is to look exactly like the app,
+// and hand-picking "the rules that reach the canvas" is how a fidelity bug ships. CSS is inert
+// without the DOM that matches it, so the unused majority costs bytes, not correctness.
+import '../styles/globals.css'
+import {
+	ThumbnailRenderView,
+	acquireThumbnailRenderData,
+	setThumbnailError,
+} from './pages/thumbnail-render'
+
+// The dedicated entry for the thumbnail render page (see thumbnail-render.html). Everything the SPA
+// boots before its router — Sentry, Clerk and its CDN fetch, Helmet, the service worker — is
+// deliberately absent: a capture pays for this entry's load on every render, and none of that can
+// appear in the pixels. What must match the app exactly (the SDK build, tldraw.css, assetUrls,
+// embed shape utils, the license key) is imported by the page module itself.
+
+// Every failure this page can have must end in a terminal marker: a page with neither
+// data-thumbnail-ready nor data-thumbnail-error burns the whole Browser Run timeout instead of
+// failing the capture in milliseconds. The SPA route this replaced sat under the router's error
+// boundary; this boundary and the window handlers below are what stand in for it.
+class ThumbnailRenderBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+	state = { failed: false }
+	static getDerivedStateFromError() {
+		return { failed: true }
+	}
+	componentDidCatch(error: unknown) {
+		setThumbnailError(error instanceof Error ? error.message : String(error))
+	}
+	render() {
+		return this.state.failed ? null : this.props.children
+	}
+}
+
+window.addEventListener('error', (event) => setThumbnailError(event.message || 'Uncaught error'))
+window.addEventListener('unhandledrejection', (event) => {
+	const reason = event.reason
+	setThumbnailError(reason instanceof Error ? reason.message : String(reason))
+})
+
+const root = createRoot(document.getElementById('root')!)
+
+async function boot() {
+	const data = await acquireThumbnailRenderData(new URL(window.location.href))
+	root.render(
+		<ThumbnailRenderBoundary>
+			<ThumbnailRenderView data={data} />
+		</ThumbnailRenderBoundary>
+	)
+}
+
+// A rejected acquisition — a 200 whose body fails to parse, an unforeseen throw — reaches the error
+// marker through the same view as any other failure.
+boot().catch((error) => {
+	root.render(
+		<ThumbnailRenderView
+			data={{ ok: false, message: error instanceof Error ? error.message : String(error) }}
+		/>
+	)
+})

--- a/apps/dotcom/client/thumbnail-render.html
+++ b/apps/dotcom/client/thumbnail-render.html
@@ -13,6 +13,12 @@
 				height: 100%;
 				overflow: hidden;
 			}
+			/* The app's license shows the "made with tldraw" mark on the canvas. editor.toImage never
+			   drew it, and a live capture rasterizes the DOM, so without this every live screenshot
+			   carries the mark the export path never had. */
+			.tl-watermark_SEE-LICENSE {
+				display: none;
+			}
 		</style>
 		<!-- Filled by scripts/build.ts with the same font preloads as index.html. -->
 		<!-- $PRELOADED_FONTS -->

--- a/apps/dotcom/client/thumbnail-render.html
+++ b/apps/dotcom/client/thumbnail-render.html
@@ -15,9 +15,10 @@
 			}
 			/* The app's license shows the "made with tldraw" mark on the canvas. editor.toImage never
 			   drew it, and a live capture rasterizes the DOM, so without this every live screenshot
-			   carries the mark the export path never had. */
+			   carries the mark the export path never had. !important because the SDK injects its own
+			   rule for this class (display: flex) after this sheet. */
 			.tl-watermark_SEE-LICENSE {
-				display: none;
+				display: none !important;
 			}
 		</style>
 		<!-- Filled by scripts/build.ts with the same font preloads as index.html. -->

--- a/apps/dotcom/client/thumbnail-render.html
+++ b/apps/dotcom/client/thumbnail-render.html
@@ -14,9 +14,7 @@
 				overflow: hidden;
 			}
 		</style>
-		<!-- Filled by scripts/build.ts with preloads for the canvas fonts (same set as index.html).
-		     The page's settle phase waits on these faces, and without a preload their fetch starts
-		     only after the SDK boots and the editor mounts — serially after the whole JS load. -->
+		<!-- Filled by scripts/build.ts with the same font preloads as index.html. -->
 		<!-- $PRELOADED_FONTS -->
 		<title>tldraw thumbnail render</title>
 	</head>

--- a/apps/dotcom/client/thumbnail-render.html
+++ b/apps/dotcom/client/thumbnail-render.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<!-- Mirrors the #root sizing from index.html so the editor lays out identically here. -->
+		<style>
+			#root {
+				position: relative;
+				inset: 0;
+				width: 100%;
+				height: 100%;
+				overflow: hidden;
+			}
+		</style>
+		<!-- Filled by scripts/build.ts with preloads for the canvas fonts (same set as index.html).
+		     The page's settle phase waits on these faces, and without a preload their fetch starts
+		     only after the SDK boots and the editor mounts — serially after the whole JS load. -->
+		<!-- $PRELOADED_FONTS -->
+		<title>tldraw thumbnail render</title>
+	</head>
+
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./src/thumbnail-render-main.tsx"></script>
+	</body>
+</html>

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -100,9 +100,7 @@ export default defineConfig((env) => ({
 		rollupOptions: {
 			input: {
 				index: fileURLToPath(new URL('./index.html', import.meta.url)),
-				// The thumbnail render page's own entry, so a Browser Run capture boots the SDK
-				// without the app shell. /__thumbnail-render is rewritten to it at the edge
-				// (scripts/build.ts) and in dev (thumbnailRenderEntryPlugin).
+				// See pages/thumbnail-render.tsx.
 				'thumbnail-render': fileURLToPath(new URL('./thumbnail-render.html', import.meta.url)),
 			},
 		},

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -5,7 +5,10 @@ import react from '@vitejs/plugin-react'
 import { config } from 'dotenv'
 import { defineConfig, Plugin } from 'vite'
 import { getMultiplayerServerURL } from './scripts/multiplayer-server-url'
-import { thumbnailScreenshotPlugin } from './scripts/vite-thumbnail-screenshot-plugin'
+import {
+	thumbnailRenderEntryPlugin,
+	thumbnailScreenshotPlugin,
+} from './scripts/vite-thumbnail-screenshot-plugin'
 import { zodLocalePlugin } from './scripts/vite-zod-locale-plugin.js'
 
 export { getMultiplayerServerURL }
@@ -64,6 +67,12 @@ function urlOrLocalFallback(mode: string, url: string | undefined, localFallback
 // https://vitejs.dev/config/
 export default defineConfig((env) => ({
 	plugins: [
+		// Ahead of spaFallbackPlugin, and the order is load-bearing: middleware registers in plugin
+		// order, so this rewrites the extensionless /__thumbnail-render to its .html entry before the
+		// preview server's SPA fallback can rewrite it to /index.html — which would leave every
+		// preview-server capture (including the e2e webServer) hanging on a page that never marks
+		// itself ready.
+		thumbnailRenderEntryPlugin(),
 		spaFallbackPlugin(),
 		thumbnailScreenshotPlugin(),
 		zodLocalePlugin(fileURLToPath(new URL('./scripts/zod-locales-shim.js', import.meta.url))),
@@ -87,6 +96,16 @@ export default defineConfig((env) => ({
 
 		// our svg icons break if we use data urls, so disable inline assets for now
 		assetsInlineLimit: 0,
+
+		rollupOptions: {
+			input: {
+				index: fileURLToPath(new URL('./index.html', import.meta.url)),
+				// The thumbnail render page's own entry, so a Browser Run capture boots the SDK
+				// without the app shell. /__thumbnail-render is rewritten to it at the edge
+				// (scripts/build.ts) and in dev (thumbnailRenderEntryPlugin).
+				'thumbnail-render': fileURLToPath(new URL('./thumbnail-render.html', import.meta.url)),
+			},
+		},
 	},
 	// add backwards-compatible support for NEXT_PUBLIC_ env vars
 	define: {

--- a/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.ts
@@ -5,6 +5,7 @@ import { Environment } from '../../types'
 import {
 	isMintedRenderToken,
 	renderJobAccess,
+	renderParamsForJob,
 	verifyThumbnailRenderToken,
 } from '../../utils/renderTokens'
 import { getPublishedRoomSnapshot } from './getPublishedFile'
@@ -91,18 +92,7 @@ export async function getThumbnailSnapshot(
 		error: false,
 		records: snapshot.documents.map((d) => d.state) as TLRecord[],
 		schema: snapshot.schema,
-		renderParams: {
-			...(job.camera ? { camera: job.camera } : null),
-			...(job.pageId ? { pageId: job.pageId } : null),
-			...(job.shapeIds ? { shapeIds: job.shapeIds } : null),
-			...(job.mode ? { mode: job.mode } : null),
-			x: job.x,
-			y: job.y,
-			z: job.z,
-			width: job.width,
-			height: job.height,
-			theme: job.theme,
-		},
+		renderParams: renderParamsForJob(job),
 	})
 }
 

--- a/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.test.ts
@@ -1,0 +1,146 @@
+import { IRequest } from 'itty-router'
+import { describe, expect, it } from 'vitest'
+import { Environment } from '../../types'
+import {
+	ThumbnailRenderJob,
+	mintThumbnailRenderToken,
+	recordMintedRenderToken,
+} from '../../utils/renderTokens'
+import { putThumbnailRenderResult } from './putThumbnailRenderResult'
+import { makeFakeThumbnailsBucket, makeScreenshotTestEnv } from './screenshotTestHelpers'
+
+function makeRequest(body: unknown): IRequest {
+	return { json: async () => body } as unknown as IRequest
+}
+
+const JOB: ThumbnailRenderJob = {
+	v: 1,
+	kind: 'published',
+	slug: 'board',
+	version: 1,
+	access: 'public',
+	surface: 'mcp',
+	camera: 'content',
+	x: 0,
+	y: 0,
+	z: 1,
+	width: 1200,
+	height: 630,
+	theme: 'light',
+	exp: Date.now() + 60_000,
+}
+
+const TIMINGS = {
+	bootAt: 100,
+	dataAt: 150,
+	mountAt: 900,
+	settledAt: 1400,
+	exportedAt: 2100,
+}
+
+describe('the timing beacon', () => {
+	it('writes one datapoint per beacon, carrying the surface', async () => {
+		const env = makeScreenshotTestEnv() as unknown as Environment
+		const token = await mintThumbnailRenderToken(env, JOB)
+
+		const response = await putThumbnailRenderResult(makeRequest({ token, timings: TIMINGS }), env)
+
+		expect(response.status).toBe(200)
+		const calls = (env.MEASURE as any).writeDataPoint.mock.calls
+		expect(calls).toHaveLength(1)
+		const point = calls[0][0]
+		// writeDataPoint prefixes [eventName, workerName]; the beacon's own blobs follow.
+		expect(point.blobs[0]).toBe('render_page_timings')
+		expect(point.blobs.slice(2)).toEqual(['surface:mcp'])
+		expect(point.doubles).toEqual([100, 150, 900, 1400, 2100])
+	})
+
+	it('refuses a beacon whose token was not signed by us', async () => {
+		const env = makeScreenshotTestEnv() as unknown as Environment
+		const other = makeScreenshotTestEnv({
+			MCP_SCREENSHOT_TOKEN_SECRET: 'someone-elses-secret',
+		}) as unknown as Environment
+		const forged = await mintThumbnailRenderToken(other, JOB)
+
+		const response = await putThumbnailRenderResult(
+			makeRequest({ token: forged, timings: TIMINGS }),
+			env
+		)
+
+		expect(response.status).toBe(403)
+		expect((env.MEASURE as any).writeDataPoint).not.toHaveBeenCalled()
+	})
+
+	// The same bar as the snapshot route: an MCP render token's record is deleted when its capture
+	// ends, so a token copied out of a render URL cannot keep writing rows for the rest of its TTL.
+	it('refuses a signed token that was never minted, and accepts one that was', async () => {
+		// The record lives in THUMBNAILS; without the bucket bound the check trusts the signature.
+		const env = makeScreenshotTestEnv({
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		}) as unknown as Environment
+		const job: ThumbnailRenderJob = { ...JOB, access: 'render' }
+		const unrecorded = await mintThumbnailRenderToken(env, job)
+
+		const refused = await putThumbnailRenderResult(
+			makeRequest({ token: unrecorded, timings: TIMINGS }),
+			env
+		)
+		expect(refused.status).toBe(403)
+
+		const recordedJob = { ...job, exp: job.exp + 1 }
+		const recorded = await mintThumbnailRenderToken(env, recordedJob)
+		await recordMintedRenderToken(env, recordedJob, recorded)
+		const accepted = await putThumbnailRenderResult(
+			makeRequest({ token: recorded, timings: TIMINGS }),
+			env
+		)
+		expect(accepted.status).toBe(200)
+	})
+
+	it('refuses non-finite stamps rather than polluting the dataset', async () => {
+		const env = makeScreenshotTestEnv() as unknown as Environment
+		const token = await mintThumbnailRenderToken(env, JOB)
+
+		const response = await putThumbnailRenderResult(
+			makeRequest({ token, timings: { ...TIMINGS, settledAt: 'NaN' } }),
+			env
+		)
+
+		expect(response.status).toBe(400)
+		expect((env.MEASURE as any).writeDataPoint).not.toHaveBeenCalled()
+	})
+
+	// Valid JSON that is not an object: the endpoint is unauthenticated, so scanners send exactly
+	// this, and `'timings' in null` would escape as a worker 500 where a 400 is the answer.
+	it.each([null, 42, 'a string'])(
+		'refuses the non-object JSON body %j with a 400',
+		async (body) => {
+			const env = makeScreenshotTestEnv() as unknown as Environment
+			const response = await putThumbnailRenderResult(makeRequest(body), env)
+			expect(response.status).toBe(400)
+		}
+	)
+
+	it('refuses timings: null rather than destructuring it', async () => {
+		const env = makeScreenshotTestEnv() as unknown as Environment
+		const token = await mintThumbnailRenderToken(env, JOB)
+
+		const response = await putThumbnailRenderResult(makeRequest({ token, timings: null }), env)
+
+		expect(response.status).toBe(400)
+		expect((env.MEASURE as any).writeDataPoint).not.toHaveBeenCalled()
+	})
+
+	it('leaves the measure-result branch alone', async () => {
+		const env = makeScreenshotTestEnv() as unknown as Environment
+		const token = await mintThumbnailRenderToken(env, { ...JOB, mode: 'measure' })
+
+		const response = await putThumbnailRenderResult(
+			makeRequest({ token, bounds: { 'shape:a': { x: 0, y: 0, w: 10, h: 10 } } }),
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({ error: false, stored: 1 })
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.test.ts
@@ -71,8 +71,6 @@ describe('the timing beacon', () => {
 		expect((env.MEASURE as any).writeDataPoint).not.toHaveBeenCalled()
 	})
 
-	// The same bar as the snapshot route: an MCP render token's record is deleted when its capture
-	// ends, so a token copied out of a render URL cannot keep writing rows for the rest of its TTL.
 	it('refuses a signed token that was never minted, and accepts one that was', async () => {
 		// The record lives in THUMBNAILS; without the bucket bound the check trusts the signature.
 		const env = makeScreenshotTestEnv({
@@ -110,8 +108,6 @@ describe('the timing beacon', () => {
 		expect((env.MEASURE as any).writeDataPoint).not.toHaveBeenCalled()
 	})
 
-	// Valid JSON that is not an object: the endpoint is unauthenticated, so scanners send exactly
-	// this, and `'timings' in null` would escape as a worker 500 where a 400 is the answer.
 	it.each([null, 42, 'a string'])(
 		'refuses the non-object JSON body %j with a 400',
 		async (body) => {

--- a/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
@@ -47,9 +47,7 @@ export async function putThumbnailRenderResult(
 				{ status: 400 }
 			)
 		}
-		// Minted, not merely signed, the same bar the snapshot route sets: a render token is deleted
-		// from the record once its capture ends, so this closes the window in which a token seen in a
-		// render URL could be replayed to write rows for the rest of its TTL.
+		// Minted, not merely signed — the same gate as the snapshot route (see isMintedRenderToken).
 		const job = await verifyThumbnailRenderToken(env, body.token)
 		if (!job || !(await isMintedRenderToken(env, job, body.token))) {
 			return Response.json({ error: true, message: 'Invalid render token' }, { status: 403 })

--- a/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
@@ -1,7 +1,11 @@
-import { ThumbnailRenderResultRequestBody } from '@tldraw/dotcom-shared'
+import {
+	ThumbnailRenderResultRequestBody,
+	ThumbnailRenderTimingsRequestBody,
+} from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
 import { Environment } from '../../types'
-import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
+import { writeDataPoint } from '../../utils/analytics'
+import { isMintedRenderToken, verifyThumbnailRenderToken } from '../../utils/renderTokens'
 import { ShapeMeasurement } from './boardTools'
 import { putRenderResult } from './thumbnailRender'
 
@@ -17,11 +21,52 @@ export async function putThumbnailRenderResult(
 	request: IRequest,
 	env: Environment
 ): Promise<Response> {
-	let body: ThumbnailRenderResultRequestBody
+	let body: ThumbnailRenderResultRequestBody | ThumbnailRenderTimingsRequestBody
 	try {
-		body = (await request.json()) as ThumbnailRenderResultRequestBody
+		body = (await request.json()) as
+			| ThumbnailRenderResultRequestBody
+			| ThumbnailRenderTimingsRequestBody
 	} catch {
 		return Response.json({ error: true, message: 'Invalid JSON body' }, { status: 400 })
+	}
+
+	// `null`, numbers and strings are valid JSON too; refused as the caller's mistake here, where
+	// the `in` and property checks below would throw on them and escape as a worker 500.
+	if (!body || typeof body !== 'object') {
+		return Response.json({ error: true, message: 'Invalid JSON body' }, { status: 400 })
+	}
+
+	// The render page's phase-timing beacon, sharing this route because it shares the route's
+	// auth story: a signed token proves the POST comes from a render we asked for. Telemetry only —
+	// nothing downstream waits on it, so it is accepted for any valid token, screenshot or measure.
+	if ('timings' in body) {
+		// `typeof null` is 'object', and these timings get destructured below.
+		if (!body.token || !body.timings || typeof body.timings !== 'object') {
+			return Response.json(
+				{ error: true, message: 'token and timings are required' },
+				{ status: 400 }
+			)
+		}
+		// Minted, not merely signed, the same bar the snapshot route sets: a render token is deleted
+		// from the record once its capture ends, so this closes the window in which a token seen in a
+		// render URL could be replayed to write rows for the rest of its TTL.
+		const job = await verifyThumbnailRenderToken(env, body.token)
+		if (!job || !(await isMintedRenderToken(env, job, body.token))) {
+			return Response.json({ error: true, message: 'Invalid render token' }, { status: 403 })
+		}
+		const { bootAt, dataAt, mountAt, settledAt, exportedAt } = body.timings
+		const stamps = [bootAt, dataAt, mountAt, settledAt, exportedAt]
+		if (!stamps.every(Number.isFinite)) {
+			return Response.json({ error: true, message: 'timings must be finite' }, { status: 400 })
+		}
+		// One datapoint per completed export: where the in-browser time went. browser_run_session
+		// prices the whole session; this decomposes it into boot / acquire / mount / settle / export,
+		// which is what ranks the render page's optimisations against each other.
+		writeDataPoint(undefined, env.MEASURE, env, 'render_page_timings', {
+			blobs: [`surface:${job.surface ?? 'og'}`],
+			doubles: stamps,
+		})
+		return Response.json({ error: false })
 	}
 
 	if (!body?.token || !body.bounds || typeof body.bounds !== 'object') {

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
@@ -1100,6 +1100,12 @@ async function renderShapeSetScreenshot(
 			width: DEFAULT_THUMBNAIL_WIDTH,
 			height: DEFAULT_THUMBNAIL_HEIGHT,
 			telemetry: { source: 'mcp' },
+			// Preview trial (see THUMBNAIL_RENDER_LIVE_CAPTURE in types.ts): let the screenshot
+			// rasterize the live canvas instead of running editor.toImage in the page. Agent-facing
+			// only — the OG surface keeps the export path's pixel-exact sizing.
+			...(envFlagWord(env.THUMBNAIL_RENDER_LIVE_CAPTURE) === 'true'
+				? { capture: 'live' as const }
+				: null),
 		})
 
 		// The render is already paid for and the PNG in hand is what the caller asked for, so a failed

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
@@ -228,6 +228,7 @@ export async function captureThumbnailScreenshot(
 		width,
 		height,
 		telemetry,
+		capture,
 	}: {
 		/** Which pipeline is asking. Signed into the job; namespaces the minted-token record. */
 		surface: ThumbnailRenderSurface
@@ -250,6 +251,12 @@ export async function captureThumbnailScreenshot(
 		 * definition a screenshot render.
 		 */
 		telemetry: { source: BrowserRunSessionContext['source']; reason?: OgImageRenderReason }
+		/**
+		 * `live` skips the in-page export and lets the screenshot rasterize the live canvas, after the
+		 * page has pruned it to the requested shapes. Signed into the job so the render page reads it
+		 * with the rest of its parameters. See ThumbnailRenderParams.
+		 */
+		capture?: 'live'
 	}
 ): Promise<{ base64: string; durationMs: number }> {
 	const job: ThumbnailRenderJob = {
@@ -264,6 +271,7 @@ export async function captureThumbnailScreenshot(
 		camera: 'content',
 		...(pageId ? { pageId } : null),
 		...(shapeIds?.length ? { shapeIds } : null),
+		...(capture ? { capture } : null),
 		// Ignored while `camera` is 'content', which is what every surface mints; carried because the
 		// job type keeps the explicit-viewport path available (see ThumbnailRenderJob).
 		x: 0,
@@ -279,7 +287,7 @@ export async function captureThumbnailScreenshot(
 		return await runRenderSession(env, buildThumbnailRenderUrl(getRenderOrigin(env), token), {
 			width,
 			height,
-			session: { source: telemetry.source, mode: 'screenshot', reason: telemetry.reason },
+			session: { source: telemetry.source, mode: 'screenshot', reason: telemetry.reason, capture },
 		})
 	} finally {
 		// The MCP surface keys its records by token, so nothing later overwrites this one and it has to
@@ -297,6 +305,8 @@ export interface BrowserRunSessionContext {
 	mode: 'measure' | 'screenshot'
 	/** The queue trigger, on sessions the queue runs. Request-path sessions have none. */
 	reason?: OgImageRenderReason
+	/** `live` when the render was asked to rasterize the live canvas; absent means the page exports. */
+	capture?: 'live'
 }
 
 // The Browser Run spend ledger: one datapoint per browser session actually created, written here at
@@ -313,12 +323,19 @@ function writeBrowserRunSessionTelemetry(
 		durationMs,
 		width,
 		height,
+		browserMsUsed,
 	}: {
 		/** `ok`, or the bounded browser failure code for a session that died. */
 		outcome: string
 		durationMs: number
 		width: number
 		height: number
+		/**
+		 * Browser wall clock billed (`X-Browser-Ms-Used`), 0 for sessions that died before a response
+		 * or ran on the local dev service. `durationMs - browserMsUsed` isolates queueing and
+		 * transfer, which is where most of this pipeline's variance lives.
+		 */
+		browserMsUsed: number
 	}
 ) {
 	writeDataPoint(undefined, env.MEASURE, env, 'browser_run_session', {
@@ -327,8 +344,11 @@ function writeBrowserRunSessionTelemetry(
 			`mode:${session.mode}`,
 			`outcome:${outcome}`,
 			`reason:${session.reason ?? 'none'}`,
+			// Appended: existing blob positions must not shift. `none` on measures, which draw
+			// nothing; a screenshot render exports unless it asked for live.
+			`capture:${session.mode === 'measure' ? 'none' : (session.capture ?? 'export')}`,
 		],
-		doubles: [width, height, durationMs],
+		doubles: [width, height, durationMs, browserMsUsed],
 	})
 }
 
@@ -383,6 +403,7 @@ async function runRenderSession(
 				durationMs: error.durationMs,
 				width,
 				height,
+				browserMsUsed: 0,
 			})
 		}
 		throw error
@@ -396,6 +417,7 @@ async function runRenderSession(
 			durationMs: timed.durationMs,
 			width,
 			height,
+			browserMsUsed: timed.browserMsUsed,
 		})
 		throw new Error('Render produced an empty screenshot')
 	}
@@ -405,6 +427,7 @@ async function runRenderSession(
 		durationMs: timed.durationMs,
 		width,
 		height,
+		browserMsUsed: timed.browserMsUsed,
 	})
 	return { base64: arrayBufferToBase64(buffer), durationMs: timed.durationMs }
 }
@@ -420,6 +443,17 @@ type ThumbnailScreenshotRequestBody = ReturnType<typeof getThumbnailScreenshotRe
 interface TimedCapture {
 	buffer: ArrayBuffer
 	durationMs: number
+	/**
+	 * Browser wall clock billed for the session (Browser Run's `X-Browser-Ms-Used`), or 0 where the
+	 * transport has none (the local dev service). `durationMs - browserMsUsed` is everything that
+	 * happened outside the browser — RPC, Browser Run queueing, response transfer.
+	 */
+	browserMsUsed: number
+}
+
+// Both transports read the billing header through this, so the ledger column means one thing.
+function browserMsUsedOf(response: Response) {
+	return Number(response.headers.get('X-Browser-Ms-Used')) || 0
 }
 
 async function callBrowserRun(
@@ -457,7 +491,7 @@ async function callBrowserRun(
 			timeoutMs: THUMBNAIL_RENDER_TIMEOUT_MS,
 		})
 	})
-	return { buffer, durationMs: Date.now() - startedAt }
+	return { buffer, durationMs: Date.now() - startedAt, browserMsUsed: browserMsUsedOf(response) }
 }
 
 // The request cannot cap its own total: `gotoOptions.timeout` and `waitForSelector.timeout` are
@@ -567,7 +601,7 @@ async function callLocalScreenshotService(
 		)
 	}
 	const buffer = await response.arrayBuffer()
-	return { buffer, durationMs: Date.now() - startedAt }
+	return { buffer, durationMs: Date.now() - startedAt, browserMsUsed: browserMsUsedOf(response) }
 }
 
 // Writes one rendered PNG to a thumbnail cache, stamping the content version (so a stale version

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
@@ -330,11 +330,7 @@ function writeBrowserRunSessionTelemetry(
 		durationMs: number
 		width: number
 		height: number
-		/**
-		 * Browser wall clock billed (`X-Browser-Ms-Used`), 0 for sessions that died before a response
-		 * or ran on the local dev service. `durationMs - browserMsUsed` isolates queueing and
-		 * transfer, which is where most of this pipeline's variance lives.
-		 */
+		/** See TimedCapture.browserMsUsed; 0 for sessions that died before a response. */
 		browserMsUsed: number
 	}
 ) {

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -130,6 +130,11 @@ export interface Environment {
 	// Origin serving the client thumbnail render page (THUMBNAIL_RENDER_PATH). Set per
 	// environment in wrangler.toml.
 	MCP_SCREENSHOT_RENDER_ORIGIN: string | undefined
+	// 'true' opts MCP screenshots into live-canvas capture: the page prunes the canvas to the
+	// requested shapes, settles and fits, and the screenshotting browser rasterizes it instead of
+	// the page exporting itself. Skips the export phase, the expensive part on heavy boards, at the
+	// cost of the export path's pixel-exact sizing. Off everywhere it is unset.
+	THUMBNAIL_RENDER_LIVE_CAPTURE: string | undefined
 	// HMAC secret for short-lived thumbnail render job tokens.
 	MCP_SCREENSHOT_TOKEN_SECRET: string | undefined
 	// The MCP server's public URL, and the resource identifier it advertises in RFC 9728 protected

--- a/apps/dotcom/sync-worker/src/utils/renderTokens.ts
+++ b/apps/dotcom/sync-worker/src/utils/renderTokens.ts
@@ -1,3 +1,4 @@
+import { ThumbnailRenderParams } from '@tldraw/dotcom-shared'
 import {
 	Environment,
 	ThumbnailBoardAccess,
@@ -73,6 +74,8 @@ export interface ThumbnailRenderJob {
 	 * `measure` skips the export and POSTs the page's shape geometry back instead — the only way a
 	 * Worker can obtain bounds, since sizing a shape needs an editor and font metrics.
 	 */
+	/** `live`: the page prunes to `shapeIds`, settles, and lets the screenshot rasterize the canvas. */
+	capture?: 'live'
 	mode?: 'screenshot' | 'measure'
 	/** The viewport the render page sets directly when `camera` is omitted. */
 	x: number
@@ -168,6 +171,23 @@ export async function verifyThumbnailRenderToken(
  */
 export function renderJobAccess(job: Pick<ThumbnailRenderJob, 'access'>): ThumbnailBoardAccess {
 	return job.access ?? 'public'
+}
+
+/** The render parameters a job implies: what the snapshot route answers and the render page draws from. */
+export function renderParamsForJob(job: ThumbnailRenderJob): ThumbnailRenderParams {
+	return {
+		...(job.camera ? { camera: job.camera } : null),
+		...(job.pageId ? { pageId: job.pageId } : null),
+		...(job.shapeIds ? { shapeIds: job.shapeIds } : null),
+		...(job.capture ? { capture: job.capture } : null),
+		...(job.mode ? { mode: job.mode } : null),
+		x: job.x,
+		y: job.y,
+		z: job.z,
+		width: job.width,
+		height: job.height,
+		theme: job.theme,
+	}
 }
 
 /**

--- a/apps/dotcom/sync-worker/src/utils/renderTokens.ts
+++ b/apps/dotcom/sync-worker/src/utils/renderTokens.ts
@@ -70,12 +70,12 @@ export interface ThumbnailRenderJob {
 	 * fits the camera to their common bounds and draws only them. Omitted means the whole page.
 	 */
 	shapeIds?: string[]
+	/** `live`: the page prunes to `shapeIds`, settles, and lets the screenshot rasterize the canvas. */
+	capture?: 'live'
 	/**
 	 * `measure` skips the export and POSTs the page's shape geometry back instead — the only way a
 	 * Worker can obtain bounds, since sizing a shape needs an editor and font metrics.
 	 */
-	/** `live`: the page prunes to `shapeIds`, settles, and lets the screenshot rasterize the canvas. */
-	capture?: 'live'
 	mode?: 'screenshot' | 'measure'
 	/** The viewport the render page sets directly when `camera` is omitted. */
 	x: number

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
@@ -847,6 +847,232 @@ spec:
                 mode: multi
                 sort: desc
           version: 13.2.0-29854286369
+    panel-17:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as total_p50, quantileWeighted(0.5, double4, _sample_interval) as browser_p50, quantileWeighted(0.95, double3, _sample_interval) as total_p95, quantileWeighted(0.95, double4, _sample_interval) as browser_p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'browser_run_session'
+                        AND blob3 = 'source:mcp'
+                        AND blob4 = 'mode:screenshot'
+                        AND blob5 = 'outcome:ok'
+                        AND double4 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as total_p50, quantileWeighted(0.5, double4, _sample_interval) as browser_p50, quantileWeighted(0.95, double3, _sample_interval) as total_p95, quantileWeighted(0.95, double4, _sample_interval) as browser_p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'browser_run_session'
+                        AND blob3 = 'source:mcp'
+                        AND blob4 = 'mode:screenshot'
+                        AND blob5 = 'outcome:ok'
+                        AND double4 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Total session wall clock (double3) against the browser wall clock Browser Run bills for it (double4, from the X-Browser-Ms-Used header), for successful cluster screenshots. The gap between the lines is everything outside the browser — RPC, Browser Run queueing, response transfer — which is where the pipeline variance lives. Sessions with no billed time recorded (failures, the local dev service, rows from before the field existed) are excluded by double4 > 0.'
+        id: 17
+        links: []
+        title: In-browser vs total session time
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-18:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double1, _sample_interval) as boot, quantileWeighted(0.5, double2 - double1, _sample_interval) as acquire, quantileWeighted(0.5, double3 - double2, _sample_interval) as mount, quantileWeighted(0.5, double4 - double3, _sample_interval) as settle, quantileWeighted(0.5, double5 - double4, _sample_interval) as export
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'render_page_timings'
+                        AND blob3 = 'surface:mcp'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double1, _sample_interval) as boot, quantileWeighted(0.5, double2 - double1, _sample_interval) as acquire, quantileWeighted(0.5, double3 - double2, _sample_interval) as mount, quantileWeighted(0.5, double4 - double3, _sample_interval) as settle, quantileWeighted(0.5, double5 - double4, _sample_interval) as export
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'render_page_timings'
+                        AND blob3 = 'surface:mcp'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Where the in-page time goes, from the render page timing beacon (render_page_timings): p50 per phase for this server (surface:mcp). Phases are deltas between performance.now() stamps: script boot, snapshot fetch, editor mount, the settle wait for fonts and assets, and the export. The og surface beacons onto the same event.'
+        id: 18
+        links: []
+        title: Render page phase timings
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
     panel-2:
       kind: Panel
       spec:
@@ -1786,6 +2012,24 @@ spec:
             width: 12
             x: 12
             y: 36
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-17
+            height: 8
+            width: 12
+            x: 0
+            y: 44
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-18
+            height: 8
+            width: 12
+            x: 12
+            y: 44
   links: []
   liveNow: false
   preload: false

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -3616,6 +3616,124 @@ spec:
                 mode: multi
                 sort: desc
           version: 13.2.0-29854286369
+    panel-49:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as total_p50, quantileWeighted(0.5, double4, _sample_interval) as browser_p50, quantileWeighted(0.95, double3, _sample_interval) as total_p95, quantileWeighted(0.95, double4, _sample_interval) as browser_p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'browser_run_session'
+                        AND blob4 = 'mode:screenshot'
+                        AND blob5 = 'outcome:ok'
+                        AND double4 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as total_p50, quantileWeighted(0.5, double4, _sample_interval) as browser_p50, quantileWeighted(0.95, double3, _sample_interval) as total_p95, quantileWeighted(0.95, double4, _sample_interval) as browser_p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'browser_run_session'
+                        AND blob4 = 'mode:screenshot'
+                        AND blob5 = 'outcome:ok'
+                        AND double4 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Total session wall clock (double3) against the browser wall clock Browser Run bills for it (double4, from the X-Browser-Ms-Used header), for successful screenshot renders on every surface — OG image thumbnails and MCP cluster screenshots alike. The gap between the lines is everything outside the browser — RPC, Browser Run queueing, response transfer — which is where the pipeline variance lives. Sessions with no billed time recorded (failures, the local dev service, rows from before the field existed) are excluded by double4 > 0.'
+        id: 49
+        links: []
+        title: In-browser vs total render time
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
   layout:
     kind: GridLayout
     spec:
@@ -3908,6 +4026,15 @@ spec:
             width: 12
             x: 0
             y: 98
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-49
+            height: 8
+            width: 12
+            x: 0
+            y: 106
   links: []
   liveNow: false
   preload: false

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -606,6 +606,9 @@ async function deployTlsyncWorker({ dryRun }: { dryRun: boolean }) {
 			...(previewId
 				? {
 						MCP_SCREENSHOT_RENDER_ORIGIN: `https://${previewId}-preview-deploy.tldraw.com`,
+						// Previews trial live-canvas capture (see THUMBNAIL_RENDER_LIVE_CAPTURE in types.ts);
+						// staging and production stay on the export until it is judged.
+						THUMBNAIL_RENDER_LIVE_CAPTURE: 'true',
 						// Previews advertise and verify against their own public URL like every other
 						// deployed environment — the Host-derived fallback in getMcpResourceUrl is for
 						// local dev and tests only. Injected here because previews have no wrangler.toml

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -174,12 +174,12 @@ export interface ThumbnailShapeMeasurement {
 	text?: string
 }
 
-/** Body of POST /app/thumbnail-render/result — `shapeId -> measurement`, as the editor measured it. */
 /**
  * The render page's phase timings, POSTed to the result route as a fire-and-forget beacon once the
- * export completes. All values are `performance.now()` stamps (ms since navigation start), so the
+ * page is ready. All values are `performance.now()` stamps (ms since navigation start), so the
  * deltas between them are the phase costs a worker-side clock cannot see: script boot, snapshot
- * fetch, editor mount, the settle wait, and the export itself.
+ * fetch, editor mount, the settle wait, and the export itself (on a `live` capture there is no
+ * export, and `exportedAt` is the ready stamp).
  */
 export interface ThumbnailRenderTimingsRequestBody {
 	token: string
@@ -192,6 +192,7 @@ export interface ThumbnailRenderTimingsRequestBody {
 	}
 }
 
+/** Body of POST /app/thumbnail-render/result — `shapeId -> measurement`, as the editor measured it. */
 export interface ThumbnailRenderResultRequestBody {
 	token: string
 	bounds: Record<string, ThumbnailShapeMeasurement>

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -142,6 +142,14 @@ export interface ThumbnailRenderParams {
 	 * drawn, so neighbouring shapes never leak into the frame. When omitted the whole page renders.
 	 */
 	shapeIds?: string[]
+	/**
+	 * `live` means: prune the page to `shapeIds`, settle and fit as normal, then signal ready
+	 * without running `editor.toImage` — the screenshotting browser rasterizes the live canvas
+	 * instead of the page rasterizing itself. Skips the export phase (the expensive part on heavy
+	 * boards) at the cost of the export path's pixel-exact sizing, so only agent-facing surfaces
+	 * opt in. Absent means export as always.
+	 */
+	capture?: 'live'
 	/** `measure` means: skip the export, POST the page's measured geometry back, then signal ready. */
 	mode?: 'screenshot' | 'measure'
 	x: number
@@ -167,6 +175,23 @@ export interface ThumbnailShapeMeasurement {
 }
 
 /** Body of POST /app/thumbnail-render/result — `shapeId -> measurement`, as the editor measured it. */
+/**
+ * The render page's phase timings, POSTed to the result route as a fire-and-forget beacon once the
+ * export completes. All values are `performance.now()` stamps (ms since navigation start), so the
+ * deltas between them are the phase costs a worker-side clock cannot see: script boot, snapshot
+ * fetch, editor mount, the settle wait, and the export itself.
+ */
+export interface ThumbnailRenderTimingsRequestBody {
+	token: string
+	timings: {
+		bootAt: number
+		dataAt: number
+		mountAt: number
+		settledAt: number
+		exportedAt: number
+	}
+}
+
 export interface ThumbnailRenderResultRequestBody {
 	token: string
 	bounds: Record<string, ThumbnailShapeMeasurement>


### PR DESCRIPTION
This PR improves the thumbnail render flow behind MCP cluster screenshots and OG images so that a Browser Run capture spends its time on the board and not on the app shell, and so that MCP screenshots can skip the in-page export. It also adds the measurement needed to judge both. Lifted from the push-screenshot spike (#10471), which stays open for the transport work; nothing here depends on it.

### Before

Every capture navigated to `/__thumbnail-render` as an SPA route, so the page booted Sentry, Clerk and its CDN handshake, the router tree and a service worker before the lazy render route loaded. None of that reaches the pixels. Fonts were fetched only after the editor mounted, asset warming ran after the font wait, and the exported PNG was shown through a base64 data URL built on the main thread. On heavy boards `editor.toImage` dominated the session. The spend ledger recorded the session total only, so queueing and transfer could not be told apart from in-browser time, and nothing showed where the in-page seconds went.

### After

The render page is its own Vite entry (`thumbnail-render.html`) that mounts the page and nothing else. `/__thumbnail-render` is rewritten to it at the edge and in dev, so the URL the sync-worker renders does not move. The entry carries an error boundary, window backstops and an `ErrorFallback` override, so any failure reaches the error marker instead of burning the timeout.

MCP cluster screenshots can ask for `capture: 'live'`, gated by `THUMBNAIL_RENDER_LIVE_CAPTURE` and set on previews only. The page prunes the canvas to the requested shapes, settles, fits, waits two frames and signals ready; the screenshotting browser rasterizes the live canvas and the export never runs. The prune reparents the requested roots to the page in rendering order and deletes everything else under `ignoreShapeLock`, which is also the unbind that moves arrow terminals to where their neighbours sat. OG images keep the export path and its pixel-exact sizing.

The smaller cuts: fonts preload from the entry HTML, fonts and asset warming overlap, asset-free boards skip the image settle poll, the poll seeds from a real count, and the PNG is shown through an object URL.

Measurement: `browser_run_session` gains the billed browser wall clock (`X-Browser-Ms-Used`) as a fourth double and an appended `capture` blob, and the page beacons its phase stamps (boot, fetch, mount, settle, export) to the token-gated result route as `render_page_timings`. Panels for both are added to the MCP server board and the dotcom events board.

### Implementation notes

On the preview for #10471, live capture cut the in-browser p50 for cluster screenshots from about 3.2 s to 1.4 s against the same fleet (n=10 and 20). The dedicated entry's share is bundled with other changes there, so this PR's panels are how it gets measured on its own.

Live capture is a fidelity trade: the frame is the fitted viewport at the browser's raster, not the export's exact bitmap. That is why it is agent-facing only and behind a preview flag.

Verified on the pr-10659 preview: the render entry is served at `/__thumbnail-render` with the font preloads and no app shell, MCP cluster screenshots land as `capture:live` on the session ledger with billed browser milliseconds, the OG queue's renders land as `capture:export`, and the phase beacon arrives from both surfaces. A cluster holding just an arrow whose target had moved is drawn to the target's real position, and a frame cluster draws only its own shapes.

One thing the preview surfaced: the app's license key carries the watermark flag, so the live canvas shows the "made with tldraw" mark that the export never drew. The render page hides that element. That is a call for the reviewer as much as a fix: the page renders tldraw's own boards for tldraw's own thumbnails, and the export path has always produced them without the mark.

### Change type

- [x] `improvement`

### Test plan

1. Add the `dotcom-preview-please` label, then take a cluster screenshot through MCP on the preview.
2. Check the MCP server board: `capture:live` sessions on the in-browser vs total panel, and phase timings arriving.
3. Compare a cluster inside a frame, and one with an arrow to a shape outside the cluster, against the same request on production.

- [x] Unit tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Apps            | +415 / -51 |
| Tests           | +146 / -6 |
| Config/tooling  | +374 / -0 |
| Core code       | +26 / -0 |

