### PR TITLE
docs(skills): record before and after videos for interaction PRs

### DIFF
--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -141,6 +141,56 @@ This PR fixes a bug where <symptom a user or developer would hit>.
 
 tldraw/tldraw#10117, #10118, and #10119 are worked examples of bug fixes in this shape.
 
+### Before and after recordings
+
+When a bug fix or improvement changes how a canvas interaction behaves — a drag, resize, rotate, crop, handle, or tool gesture that a reviewer would otherwise have to run locally to see — put a short recording in each of the Before and After sections. Prose describes the mechanism; the recordings show the symptom and its absence, and reviewers trust them more than a description of a jump or a jitter. Skip this for changes that are not visible on the canvas (data, API, docs, tooling).
+
+`scripts/record-interaction.mjs` records a scripted interaction against the running examples app as a 16:9 MP4. It hides the tldraw chrome, injects a visible cursor (headless recordings have none), runs a scenario module, trims the setup frames, and transcodes with ffmpeg. `scripts/example-scenario.mjs` is a starting point; copy it to a scratch location and change the body to the interaction the PR affects. Do not commit scenarios.
+
+Run from the repo root with `yarn dev` serving the examples app:
+
+```bash
+# After: the current branch
+node skills/write-pr/scripts/record-interaction.mjs <scenario.mjs> <scratch>/after.mp4
+
+# Before: main's versions of the files this branch modifies, hot-reloaded by vite
+git diff --name-only --diff-filter=M origin/main...HEAD | xargs git checkout origin/main --
+sleep 10
+node skills/write-pr/scripts/record-interaction.mjs <scenario.mjs> <scratch>/before.mp4
+git diff --name-only --diff-filter=M origin/main...HEAD | xargs git checkout HEAD --
+git status --porcelain   # must be empty before continuing
+```
+
+Restrict the checkout to modified files: checking out a whole directory from `main` also stages files that only exist there, and files added on this branch have no `main` version to restore. Only use this approach when the working tree is clean.
+
+Rules for the recordings themselves:
+
+- **Same scenario for both.** The two videos must differ only in the code under test, so the reviewer compares like with like. Record After first, confirm the scenario shows the behavior, then record Before.
+- **Make the symptom unmissable.** Pick inputs that exaggerate the bug — a large rotation, a long drag, a non-square shape. A 15 degree turn that shifts a shape by a few pixels reads as nothing at video scale.
+- **Check the frames before attaching.** Pull a contact sheet (`ffmpeg -i before.mp4 -vf "select='not(mod(n\,15))',scale=320:-1,tile=6x3" -frames:v 1 sheet.png`) and look at it. A Before recording that looks identical to After usually means the checkout did not take effect, not that the bug is subtle.
+- **No burned-in labels.** The `### Before` and `### After` headings already say which is which.
+- **Keep them short.** A few seconds of setup, the interaction, a beat at the end. Under ten seconds each.
+
+Attach with `gh pr create` or `gh pr edit` (gh 2.99 or later, run inside the repo, absolute paths). Reference each file in the body as the only content of its paragraph, directly under the heading it illustrates, and gh rewrites the reference to the uploaded asset:
+
+```bash
+gh pr edit <number> --body-file body.md --attach /abs/path/before.mp4 --attach /abs/path/after.mp4
+```
+
+```md
+### Before
+
+<mechanism>
+
+![Before](/abs/path/before.mp4)
+
+### After
+
+<behavior now>
+
+![After](/abs/path/after.mp4)
+```
+
 ### Change type
 
 - Tick exactly one type with `[x]`

--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -147,7 +147,7 @@ When a bug fix or improvement changes how a canvas interaction behaves — a dra
 
 `scripts/record-interaction.mjs` records a scripted interaction against the running examples app as a 16:9 MP4. It hides the tldraw chrome, injects a visible cursor (headless recordings have none), runs a scenario module, trims the setup frames, and transcodes with ffmpeg. `scripts/example-scenario.mjs` is a starting point; copy it to a scratch location and change the body to the interaction the PR affects. Do not commit scenarios.
 
-Run from the repo root with `yarn dev` serving the examples app:
+It needs ffmpeg on the path and a Playwright Chromium build. Install scripts are disabled in this repo, so the browser is not downloaded by `yarn install`; run `yarn playwright install chromium` once. Then, from the repo root with `yarn dev` serving the examples app:
 
 ```bash
 # After: the current branch

--- a/skills/write-pr/scripts/example-scenario.mjs
+++ b/skills/write-pr/scripts/example-scenario.mjs
@@ -1,0 +1,42 @@
+// Example scenario for record-interaction.mjs: drag a shape, rotate it with the
+// keyboard shortcut mid-drag, then keep dragging. Copy this file and change the
+// body to match the interaction your PR affects.
+//
+// `page` is the Playwright page. `helpers` gives you:
+//   editor(fn, arg)   run `fn(editor, arg)` inside the page against the live editor
+//   drag(from, to)    move the mouse in small steps so the motion is visible
+//   pause(ms)         wait
+
+export default async function scenario(page, { editor, drag, pause }) {
+	await editor((editor) => {
+		editor.user.updateUserPreferences({ animationSpeed: 0, colorScheme: 'light' })
+		editor.createShape({
+			type: 'geo',
+			x: 300,
+			y: 240,
+			props: { w: 320, h: 160, geo: 'rectangle', color: 'blue', fill: 'solid' },
+		})
+		editor.selectNone()
+	})
+	await pause(500)
+
+	const start = { x: 460, y: 320 }
+	await page.mouse.move(start.x, start.y)
+	await pause(300)
+	await page.mouse.down()
+	await drag(start, { x: 620, y: 320 })
+	await pause(400)
+
+	// The external change: six rotate-clockwise presses for a full quarter turn
+	for (let i = 0; i < 6; i++) {
+		await page.keyboard.press('Shift+Period')
+		await pause(120)
+	}
+	await pause(800)
+
+	await drag({ x: 620, y: 320 }, { x: 640, y: 460 })
+	await pause(400)
+	await drag({ x: 640, y: 460 }, { x: 820, y: 420 })
+	await pause(500)
+	await page.mouse.up()
+}

--- a/skills/write-pr/scripts/record-interaction.mjs
+++ b/skills/write-pr/scripts/record-interaction.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Record a scripted canvas interaction as a 16:9 MP4 for a PR's Before/After
+// sections. Drives the examples app with Playwright, injects a visible cursor
+// (headless recordings have none), hides the tldraw chrome so the canvas fills
+// the frame, runs a scenario module, then trims the setup frames and transcodes
+// with ffmpeg.
+//
+// Usage (from the repo root, with `yarn dev` serving localhost:5420):
+//   node skills/write-pr/scripts/record-interaction.mjs <scenario.mjs> <out.mp4> [--url URL] [--keep-ui]
+//
+// The scenario module default-exports `async (page, helpers) => {}`. See
+// example-scenario.mjs next to this file for the available helpers.
+
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { chromium } from 'playwright'
+
+const args = process.argv.slice(2)
+const positional = args.filter((a) => !a.startsWith('--'))
+const flag = (name) => {
+	const i = args.indexOf(name)
+	return i === -1 ? undefined : args[i + 1]
+}
+const [scenarioPath, outPath] = positional
+if (!scenarioPath || !outPath) {
+	console.error('usage: record-interaction.mjs <scenario.mjs> <out.mp4> [--url URL] [--keep-ui]')
+	process.exit(1)
+}
+const url = flag('--url') ?? 'http://localhost:5420/develop'
+const keepUi = args.includes('--keep-ui')
+
+const WIDTH = 1280
+const HEIGHT = 720
+
+const scenario = (await import(pathToFileURL(path.resolve(scenarioPath)).href)).default
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'record-interaction-'))
+
+const browser = await chromium.launch()
+const context = await browser.newContext({
+	viewport: { width: WIDTH, height: HEIGHT },
+	deviceScaleFactor: 1,
+	recordVideo: { dir: tmpDir, size: { width: WIDTH, height: HEIGHT } },
+})
+const recordingStartedAt = Date.now()
+const page = await context.newPage()
+await page.goto(url)
+await page.waitForSelector('.tl-canvas')
+// Let the first render, fonts, and any HMR reload settle before we start.
+await page.waitForTimeout(1500)
+
+await page.evaluate((keepUi) => {
+	if (!keepUi) {
+		const style = document.createElement('style')
+		style.textContent = '.tlui-layout, .tlui-debug-panel { display: none !important }'
+		document.head.appendChild(style)
+	}
+	const cursor = document.createElement('div')
+	cursor.innerHTML =
+		'<svg width="28" height="28" viewBox="0 0 24 24"><path d="M5 3l14 8.5-6.5 1.5-3.5 6z" fill="#000" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>'
+	Object.assign(cursor.style, {
+		position: 'fixed',
+		left: '-100px',
+		top: '-100px',
+		zIndex: 99999,
+		pointerEvents: 'none',
+	})
+	document.body.appendChild(cursor)
+	window.addEventListener(
+		'pointermove',
+		(e) => {
+			cursor.style.left = e.clientX - 4 + 'px'
+			cursor.style.top = e.clientY - 3 + 'px'
+		},
+		true
+	)
+}, keepUi)
+
+const helpers = {
+	/** Run `fn(editor)` inside the page. The examples app exposes `window.editor`. */
+	editor: (fn, arg) => page.evaluate(([src, arg]) => new Function('editor', 'arg', `return (${src})(editor, arg)`)(window.editor, arg), [fn.toString(), arg]),
+	/** Move the mouse from one point to another in small steps so the recording shows motion. */
+	drag: async (from, to, { steps = 40, dwellMs = 12 } = {}) => {
+		for (let i = 1; i <= steps; i++) {
+			const t = i / steps
+			await page.mouse.move(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
+			await page.waitForTimeout(dwellMs)
+		}
+	},
+	pause: (ms) => page.waitForTimeout(ms),
+}
+
+// Everything before this point is setup and gets trimmed from the output.
+const scenarioStartedAt = Date.now()
+await scenario(page, helpers)
+await page.waitForTimeout(1000)
+
+const video = page.video()
+await context.close()
+const rawPath = await video.path()
+await browser.close()
+
+const trimSeconds = ((scenarioStartedAt - recordingStartedAt) / 1000).toFixed(2)
+fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true })
+const ffmpeg = spawnSync(
+	'ffmpeg',
+	[
+		'-v', 'error', '-y',
+		'-ss', trimSeconds,
+		'-i', rawPath,
+		'-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '22', '-preset', 'slow',
+		'-movflags', '+faststart', '-an',
+		path.resolve(outPath),
+	],
+	{ stdio: 'inherit' }
+)
+fs.rmSync(tmpDir, { recursive: true, force: true })
+if (ffmpeg.status !== 0) {
+	console.error('ffmpeg failed; is it installed? (brew install ffmpeg)')
+	process.exit(ffmpeg.status ?? 1)
+}
+console.log(`wrote ${path.resolve(outPath)}`)

--- a/skills/write-pr/scripts/record-interaction.mjs
+++ b/skills/write-pr/scripts/record-interaction.mjs
@@ -37,70 +37,86 @@ const HEIGHT = 720
 
 const scenario = (await import(pathToFileURL(path.resolve(scenarioPath)).href)).default
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'record-interaction-'))
+process.on('exit', () => fs.rmSync(tmpDir, { recursive: true, force: true }))
 
-const browser = await chromium.launch()
-const context = await browser.newContext({
-	viewport: { width: WIDTH, height: HEIGHT },
-	deviceScaleFactor: 1,
-	recordVideo: { dir: tmpDir, size: { width: WIDTH, height: HEIGHT } },
-})
-const recordingStartedAt = Date.now()
-const page = await context.newPage()
-await page.goto(url)
-await page.waitForSelector('.tl-canvas')
-// Let the first render, fonts, and any HMR reload settle before we start.
-await page.waitForTimeout(1500)
-
-await page.evaluate((keepUi) => {
-	if (!keepUi) {
-		const style = document.createElement('style')
-		style.textContent = '.tlui-layout, .tlui-debug-panel { display: none !important }'
-		document.head.appendChild(style)
-	}
-	const cursor = document.createElement('div')
-	cursor.innerHTML =
-		'<svg width="28" height="28" viewBox="0 0 24 24"><path d="M5 3l14 8.5-6.5 1.5-3.5 6z" fill="#000" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>'
-	Object.assign(cursor.style, {
-		position: 'fixed',
-		left: '-100px',
-		top: '-100px',
-		zIndex: 99999,
-		pointerEvents: 'none',
-	})
-	document.body.appendChild(cursor)
-	window.addEventListener(
-		'pointermove',
-		(e) => {
-			cursor.style.left = e.clientX - 4 + 'px'
-			cursor.style.top = e.clientY - 3 + 'px'
-		},
-		true
+let browser
+try {
+	browser = await chromium.launch()
+} catch (e) {
+	console.error(
+		'Could not launch Chromium. Install scripts are disabled in this repo, so run `yarn playwright install chromium` once first.'
 	)
-}, keepUi)
-
-const helpers = {
-	/** Run `fn(editor)` inside the page. The examples app exposes `window.editor`. */
-	editor: (fn, arg) => page.evaluate(([src, arg]) => new Function('editor', 'arg', `return (${src})(editor, arg)`)(window.editor, arg), [fn.toString(), arg]),
-	/** Move the mouse from one point to another in small steps so the recording shows motion. */
-	drag: async (from, to, { steps = 40, dwellMs = 12 } = {}) => {
-		for (let i = 1; i <= steps; i++) {
-			const t = i / steps
-			await page.mouse.move(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
-			await page.waitForTimeout(dwellMs)
-		}
-	},
-	pause: (ms) => page.waitForTimeout(ms),
+	throw e
 }
 
-// Everything before this point is setup and gets trimmed from the output.
-const scenarioStartedAt = Date.now()
-await scenario(page, helpers)
-await page.waitForTimeout(1000)
+let rawPath
+let recordingStartedAt
+let scenarioStartedAt
+try {
+	const context = await browser.newContext({
+		viewport: { width: WIDTH, height: HEIGHT },
+		deviceScaleFactor: 1,
+		recordVideo: { dir: tmpDir, size: { width: WIDTH, height: HEIGHT } },
+	})
+	recordingStartedAt = Date.now()
+	const page = await context.newPage()
+	await page.goto(url)
+	await page.waitForSelector('.tl-canvas')
+	// Let the first render, fonts, and any HMR reload settle before we start.
+	await page.waitForTimeout(1500)
 
-const video = page.video()
-await context.close()
-const rawPath = await video.path()
-await browser.close()
+	await page.evaluate((keepUi) => {
+		if (!keepUi) {
+			const style = document.createElement('style')
+			style.textContent = '.tlui-layout, .tlui-debug-panel { display: none !important }'
+			document.head.appendChild(style)
+		}
+		const cursor = document.createElement('div')
+		cursor.innerHTML =
+			'<svg width="28" height="28" viewBox="0 0 24 24"><path d="M5 3l14 8.5-6.5 1.5-3.5 6z" fill="#000" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>'
+		Object.assign(cursor.style, {
+			position: 'fixed',
+			left: '-100px',
+			top: '-100px',
+			zIndex: 99999,
+			pointerEvents: 'none',
+		})
+		document.body.appendChild(cursor)
+		window.addEventListener(
+			'pointermove',
+			(e) => {
+				cursor.style.left = e.clientX - 4 + 'px'
+				cursor.style.top = e.clientY - 3 + 'px'
+			},
+			true
+		)
+	}, keepUi)
+
+	const helpers = {
+		/** Run `fn(editor)` inside the page. The examples app exposes `window.editor`. */
+		editor: (fn, arg) => page.evaluate(([src, arg]) => new Function('editor', 'arg', `return (${src})(editor, arg)`)(window.editor, arg), [fn.toString(), arg]),
+		/** Move the mouse from one point to another in small steps so the recording shows motion. */
+		drag: async (from, to, { steps = 40, dwellMs = 12 } = {}) => {
+			for (let i = 1; i <= steps; i++) {
+				const t = i / steps
+				await page.mouse.move(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
+				await page.waitForTimeout(dwellMs)
+			}
+		},
+		pause: (ms) => page.waitForTimeout(ms),
+	}
+
+	// Everything before this point is setup and gets trimmed from the output.
+	scenarioStartedAt = Date.now()
+	await scenario(page, helpers)
+	await page.waitForTimeout(1000)
+
+	rawPath = await page.video().path()
+} finally {
+	// Closing the context is what flushes the recording to disk, so it has to run
+	// even when the scenario throws; otherwise a failed attempt leaks a browser.
+	await browser.close()
+}
 
 const trimSeconds = ((scenarioStartedAt - recordingStartedAt) / 1000).toFixed(2)
 fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true })
@@ -116,7 +132,6 @@ const ffmpeg = spawnSync(
 	],
 	{ stdio: 'inherit' }
 )
-fs.rmSync(tmpDir, { recursive: true, force: true })
 if (ffmpeg.status !== 0) {
 	console.error('ffmpeg failed; is it installed? (brew install ffmpeg)')
 	process.exit(ffmpeg.status ?? 1)


### PR DESCRIPTION
In order to give reviewers of interaction fixes something to look at instead of reproducing a drag or rotate locally, this PR teaches the `write-pr` skill to record short Before and After videos and attach them to the PR. It comes out of #9215, where two recordings of the drag-then-rotate bug made the symptom obvious in a way the prose could not.

The skill gains a section under the bug fix and improvement template that says when recordings are warranted (visible canvas interactions only), how to capture the Before state by checking out main's versions of the modified files under a running dev server, and how to attach both files with `gh pr edit --attach` so gh rewrites the body references to the uploaded assets. It also carries the lessons from the first run: use the same scenario for both, exaggerate the input so the symptom is unmissable, check a contact sheet before attaching, and leave the labels out because the headings already carry them.

Two scripts back this up. `record-interaction.mjs` drives the examples app with Playwright at 1280x720, hides the tldraw chrome, injects a visible cursor since headless recordings have none, runs a scenario module, trims the setup frames, and transcodes to MP4 with ffmpeg. `example-scenario.mjs` is the drag-then-rotate scenario from #9215 as a template to copy and edit. Scenarios are meant to live in a scratch directory, not the repo.

The recorder resolves `playwright` from the repo's node modules, so it has to run from inside the repo. Attaching needs gh 2.99 or later.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev`, then from the repo root: `node skills/write-pr/scripts/record-interaction.mjs skills/write-pr/scripts/example-scenario.mjs /tmp/after.mp4`.
2. Check the output is a 1280x720 MP4 of a rectangle being dragged, rotated a quarter turn, and dragged again, with a cursor visible and no tldraw UI.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +216 / -0  |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4Xyb2oXm7TA9WKxPArmxw
