### PR TITLE
fix(editor): tolerate a group child whose record has gone

### DIFF
--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -39,14 +39,29 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 			return new Rectangle2d({ width: 1, height: 1, isFilled: false })
 		}
 
-		return new Group2d({
-			children: children.map((childId) => {
-				const shape = this.editor.getShape(childId)!
-				return this.editor
-					.getShapeGeometry(childId)
-					.transform(this.editor.getShapeLocalTransform(shape)!, { isLabel: false })
-			}),
-		})
+		// A child id can outlive its record. The children index and the geometry cache are separate
+		// derivations, so inside a transaction that removes a child the index can still name it while
+		// `getShapeGeometry` already answers nothing — its `!` hides that it returns `undefined` for a
+		// record the store no longer holds. Asserting instead of checking threw a `TypeError` out of a
+		// reactive recompute, where no caller could catch it.
+		const geometries: Geometry2d[] = []
+		for (const childId of children) {
+			const child = this.editor.getShape(childId)
+			if (!child) continue
+			const geometry = this.editor.getShapeGeometry(childId)
+			if (!geometry) continue
+			const transform = this.editor.getShapeLocalTransform(child)
+			if (!transform) continue
+			geometries.push(geometry.transform(transform, { isLabel: false }))
+		}
+
+		// Every child resolved to nothing, so there is no meaningful extent to report. Matches the
+		// no-children case above rather than building an empty `Group2d`, whose bounds are `NaN`.
+		if (geometries.length === 0) {
+			return new Rectangle2d({ width: 1, height: 1, isFilled: false })
+		}
+
+		return new Group2d({ children: geometries })
 	}
 
 	component(shape: TLGroupShape) {

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -13,10 +13,14 @@ import {
 	assert,
 	compact,
 	createShapeId,
+	Geometry2d,
+	Group2d,
+	TLGeometryOpts,
 	mockUniqueId,
 	sortByIndex,
 	toRichText,
 } from '@tldraw/editor'
+import { vi } from 'vitest'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
 import { TestEditor } from './TestEditor'
 
@@ -31,6 +35,8 @@ const ids = {
 	boxE: createShapeId('boxE'),
 	boxF: createShapeId('boxF'),
 	boxX: createShapeId('boxX'),
+	boxY: createShapeId('boxY'),
+	boxZ: createShapeId('boxZ'),
 	lineA: createShapeId('lineA'),
 	groupA: createShapeId('groupA'),
 }
@@ -1156,6 +1162,64 @@ describe("when a group's children are deleted", () => {
 		expect(editor.getShape(groupBId)).toBeUndefined()
 		expect(editor.getShape(groupCId)).toBeUndefined()
 		expect(editor.getShape(groupAId)).not.toBeUndefined()
+	})
+
+	it('reports the extent of the children that still resolve', () => {
+		editor.createShapes([box(ids.boxX, 80, 0), box(ids.boxY, 100, 0), box(ids.boxZ, 120, 0)])
+		editor.select(ids.boxX, ids.boxY, ids.boxZ)
+		editor.groupShapes(editor.getSelectedShapeIds())
+		const groupId = onlySelectedId()
+		editor.selectNone()
+
+		const intact = editor.getShapeGeometry(groupId).bounds.width
+
+		// A child id that outlives its record: the children index still names it while the geometry
+		// cache answers nothing. `getShapeGeometry`'s signature hides this — it asserts non-undefined
+		// over a cache lookup that misses for a record the store no longer holds.
+		const realGetShapeGeometry = editor.getShapeGeometry.bind(editor)
+		const spy = vi
+			.spyOn(editor, 'getShapeGeometry')
+			.mockImplementation((shape: TLShape | TLShapeId, opts?: TLGeometryOpts) => {
+				const id = typeof shape === 'string' ? shape : shape.id
+				if (id === ids.boxZ) return undefined as unknown as Geometry2d
+				return realGetShapeGeometry(shape, opts)
+			})
+
+		try {
+			const geometry = editor
+				.getShapeUtil<TLGroupShape>('group')
+				.getGeometry(editor.getShape<TLGroupShape>(groupId)!)
+			// The two surviving boxes still bound the group; the missing one is skipped rather than
+			// taking the whole recompute down with it.
+			expect(geometry.bounds.width).toBeLessThan(intact)
+			expect(geometry).toBeInstanceOf(Group2d)
+		} finally {
+			spy.mockRestore()
+		}
+	})
+
+	it('falls back to a unit box when no child resolves', () => {
+		editor.createShapes([box(ids.boxX, 80, 0), box(ids.boxY, 100, 0)])
+		editor.select(ids.boxX, ids.boxY)
+		editor.groupShapes(editor.getSelectedShapeIds())
+		const groupId = onlySelectedId()
+		editor.selectNone()
+
+		const spy = vi
+			.spyOn(editor, 'getShapeGeometry')
+			.mockImplementation(() => undefined as unknown as Geometry2d)
+
+		try {
+			const geometry = editor
+				.getShapeUtil<TLGroupShape>('group')
+				.getGeometry(editor.getShape<TLGroupShape>(groupId)!)
+			// The same answer as a group with no children at all, rather than an empty `Group2d`
+			// whose bounds come back NaN and poison every measurement downstream.
+			expect(geometry.bounds.width).toBe(1)
+			expect(geometry.bounds.height).toBe(1)
+		} finally {
+			spy.mockRestore()
+		}
 	})
 
 	it('preserves the collapsed group z-index when reparenting the last child', () => {


### PR DESCRIPTION
Closes #10660.

`GroupShapeUtil.getGeometry` mapped every id from `getSortedChildIdsForParent` straight into `getShapeGeometry(childId).transform(...)`, behind three non-null assertions. Two of them are not true.

A child id can outlive its record. The children index and the geometry cache are separate derivations, so inside a transaction that removes a child the index can still name it while the cache already answers nothing — `getShapeGeometry` ends in `.get(id)!`, which asserts non-undefined over a lookup that misses for a record the store no longer holds. Reading `.transform` off that throws:

```
TypeError: Cannot read properties of undefined (reading 'transform')
```

It throws from inside a reactive recompute during `Transaction.commit`, so no caller is on the stack to catch it. In a host app it reached the route's error boundary and replaced the editor — for a shape the user was not touching.

Children that no longer resolve are skipped. A group where none resolve falls back to the same unit box as a group with no children, rather than an empty `Group2d`, whose bounds come back `NaN` and would quietly poison every measurement downstream.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Two unit tests in `packages/tldraw/src/test/groups.test.tsx`, under the existing "when a group's children are deleted" block.

I could not reproduce the real timing window in node, and would rather say so than imply otherwise: the children index invalidates inside the same transaction that removes the child, so a test that deletes a child never observes the intermediate state. Three attempts at it all passed against the unfixed code.

The tests therefore pin the invariant rather than the race — they force a child's geometry to be missing and assert the group survives. Reverting the fix makes both fail with the exact error from the report:

```
× reports the extent of the children that still resolve
× falls back to a unit box when no child resolves
TypeError: Cannot read properties of undefined (reading 'transform')
```

1. A three-child group with one child's geometry missing still reports a `Group2d`, bounded by the two that remain.
2. A group with no resolvable children returns a 1x1 box, matching the no-children branch above it.

- [x] Unit tests
- [ ] End to end tests

`@tldraw/editor` (1,201) and `tldraw` (2,916) suites pass, plus `yarn typecheck` and `yarn api-check`.

### Release notes

- Fixed a crash when a group's child was removed during a transaction, which could replace the editor with an error screen.
