### PR TITLE
perf(dotcom): warm only the images the thumbnail capture will draw

### DIFF
--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -24,6 +24,8 @@ import {
 	sleep,
 	useEditor,
 	TLAssetId,
+	TLBookmarkShape,
+	getResolvedBookmarkAssetId,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { assetUrls } from '../utils/assetUrls'
@@ -541,8 +543,14 @@ async function preloadImageAssets(editor: Editor, deadline: number, requestedSha
 		: [...editor.getCurrentPageShapeIds()].filter((id) => !culled.has(id))
 	const urls = new Set<string>()
 	for (const id of editor.getShapeAndDescendantIds(roots)) {
-		const props = editor.getShape(id)?.props as { assetId?: TLAssetId | null } | undefined
-		const asset = props?.assetId ? editor.getAsset(props.assetId) : undefined
+		const shape = editor.getShape(id)
+		if (!shape) continue
+		// A bookmark can show a preview through an asset it derives from its url rather than one it
+		// names, so it resolves the way its shape util does.
+		const assetId = editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark')
+			? getResolvedBookmarkAssetId(editor, shape)
+			: (shape.props as { assetId?: TLAssetId | null }).assetId
+		const asset = assetId ? editor.getAsset(assetId) : undefined
 		if (!asset) continue
 		if (asset.type === 'image' && asset.props.src) urls.add(asset.props.src)
 		if (asset.type === 'bookmark' && asset.props.image) urls.add(asset.props.image)

--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -25,7 +25,8 @@ import {
 	useEditor,
 	TLAssetId,
 	TLBookmarkShape,
-	getResolvedBookmarkAssetId,
+	AssetRecordType,
+	getHashForString,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { assetUrls } from '../utils/assetUrls'
@@ -545,11 +546,14 @@ async function preloadImageAssets(editor: Editor, deadline: number, requestedSha
 	for (const id of editor.getShapeAndDescendantIds(roots)) {
 		const shape = editor.getShape(id)
 		if (!shape) continue
-		// A bookmark can show a preview through an asset it derives from its url rather than one it
-		// names, so it resolves the way its shape util does.
-		const assetId = editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark')
-			? getResolvedBookmarkAssetId(editor, shape)
-			: (shape.props as { assetId?: TLAssetId | null }).assetId
+		// A bookmark with no assetId still shows the preview of the asset its url hashes to, which is
+		// how its shape util resolves one (getResolvedBookmarkAssetId in the SDK, not exported).
+		const named = (shape.props as { assetId?: TLAssetId | null }).assetId
+		const assetId =
+			named ??
+			(editor.isShapeOfType<TLBookmarkShape>(shape, 'bookmark') && shape.props.url
+				? AssetRecordType.createId(getHashForString(shape.props.url))
+				: null)
 		const asset = assetId ? editor.getAsset(assetId) : undefined
 		if (!asset) continue
 		if (asset.type === 'image' && asset.props.src) urls.add(asset.props.src)

--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -23,6 +23,7 @@ import {
 	fetch,
 	sleep,
 	useEditor,
+	TLAssetId,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { assetUrls } from '../utils/assetUrls'
@@ -357,7 +358,7 @@ export function ThumbnailExportSignal({
 			await Promise.race([
 				(async () => {
 					await waitForFonts()
-					await preloadImageAssets(editor, settleDeadline)
+					await preloadImageAssets(editor, settleDeadline, shapeIds)
 					await waitForEditorImages(editor, settleDeadline)
 				})(),
 				sleep(settleTimeoutMs),
@@ -526,18 +527,25 @@ async function waitForFonts() {
 	}
 }
 
-// Warm every image asset in the snapshot so the browser has the bytes before the shapes request
-// them. Failures resolve rather than reject: a broken asset should not block the capture.
-async function preloadImageAssets(editor: Editor, deadline: number) {
+// Warm the images the capture will draw, so the browser has the bytes before the shapes request
+// them. Only those: the store holds every asset on every page of the board, and the settle budget
+// is fixed, so a board with thousands of images elsewhere spent it fetching pictures the export
+// never shows and then timed out — production timeouts track the board's asset count, not the
+// page's. The drawn set is the export's own (see exportThumbnailImage): the requested shapes and
+// their descendants, or the page's shapes that survive culling at the camera fitted on mount.
+// Failures resolve rather than reject: a broken asset should not block the capture.
+async function preloadImageAssets(editor: Editor, deadline: number, requestedShapeIds?: string[]) {
+	const culled = editor.getCulledShapes()
+	const roots = requestedShapeIds?.length
+		? getRequestedShapeIds(editor, requestedShapeIds)
+		: [...editor.getCurrentPageShapeIds()].filter((id) => !culled.has(id))
 	const urls = new Set<string>()
-	for (const record of editor.store.allRecords()) {
-		if (record.typeName !== 'asset') continue
-		if (record.type === 'image' && record.props.src) {
-			urls.add(record.props.src)
-		}
-		if (record.type === 'bookmark' && record.props.image) {
-			urls.add(record.props.image)
-		}
+	for (const id of editor.getShapeAndDescendantIds(roots)) {
+		const props = editor.getShape(id)?.props as { assetId?: TLAssetId | null } | undefined
+		const asset = props?.assetId ? editor.getAsset(props.assetId) : undefined
+		if (!asset) continue
+		if (asset.type === 'image' && asset.props.src) urls.add(asset.props.src)
+		if (asset.type === 'bookmark' && asset.props.image) urls.add(asset.props.image)
 	}
 	await Promise.all([...urls].map((url) => preloadImage(url, deadline)))
 }


### PR DESCRIPTION
This PR improves the thumbnail render page so that a board's images elsewhere no longer cost the capture its settle budget, which is where production render timeouts are coming from.

### Before

Before exporting, the page warmed every image and bookmark asset in the store, on every page of the board, inside the fixed 10 s settle budget. A board with thousands of images somewhere spent that budget fetching pictures the export never draws, then ran into the 45 s render deadline. The session ledger's new columns (#10663) make the correlation plain: in two days of production rows, 16 of 17 timeouts were pages that had reached the worker, the timed-out boards carried a median of 241 image or video assets against 4 for the ones that rendered, and one board with about 5,750 assets timed out on every attempt, three attempts per edit.

### After

The warm-up covers the export's own draw set and nothing else: the requested shapes and their descendants for a shapes screenshot, or the page's shapes that survive culling at the camera fitted on mount. A bookmark that shows a preview through the asset its url hashes to, rather than one it names, is included the way its shape util resolves it. The urls are the same ones the shapes load, since this page uses the default asset store.

### Change type

- [x] `improvement`

### Test plan

1. On a preview, screenshot a page on a board that has several hundred images on another page: it should settle in the ordinary few seconds instead of timing out.
2. Watch `browser_run_session` after deploy: timeouts with a high `double7` (asset count) should fall away, and the ok p50 of `double4` (billed browser ms) at high asset counts should drop.

- [ ] Unit tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +32 / -12  |
