### PR TITLE
perf(editor): reuse read styles between exports (spike)

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1806,6 +1806,14 @@ export function ErrorScreen({ children }: LoadingScreenProps): JSX.Element;
 // @public (undocumented)
 export const EVENT_NAME_MAP: Record<Exclude<TLEventName, TLPinchEventName>, keyof TLEventHandlers>;
 
+// @public
+export class ExportStyleCache {
+    // @internal
+    readonly entries: Map<string, object>;
+    // @internal
+    readonly keys: WeakMap<Element, string>;
+}
+
 // @internal (undocumented)
 export function extractSessionStateFromLegacySnapshot(store: Record<string, UnknownRecord>): null | TLSessionStateSnapshot;
 
@@ -4839,6 +4847,7 @@ export interface TLSvgExportOptions {
     pixelRatio?: number;
     preserveAspectRatio?: React.SVGAttributes<SVGSVGElement>['preserveAspectRatio'];
     scale?: number;
+    styleCache?: ExportStyleCache;
 }
 
 // @public (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1808,10 +1808,16 @@ export const EVENT_NAME_MAP: Record<Exclude<TLEventName, TLPinchEventName>, keyo
 
 // @public
 export class ExportStyleCache {
+    disabled: boolean;
     // @internal
     readonly entries: Map<string, object>;
     // @internal
     readonly keys: WeakMap<Element, string>;
+    mismatches: number;
+    // @internal
+    reuseCount: number;
+    // @internal
+    readonly verified: Set<string>;
 }
 
 // @internal (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -289,6 +289,7 @@ export {
 } from './lib/editor/types/SvgExportContext'
 export { getOwnerDocument, getOwnerWindow } from './lib/exports/domUtils'
 export { getSvgAsImage } from './lib/exports/getSvgAsImage'
+export { ExportStyleCache } from './lib/exports/StyleEmbedder'
 export { tlenv, tlenvReactive } from './lib/globals/environment'
 export { tleditors } from './lib/globals/editors'
 export { tlmenus } from './lib/globals/menus'

--- a/packages/editor/src/lib/editor/types/misc-types.ts
+++ b/packages/editor/src/lib/editor/types/misc-types.ts
@@ -1,4 +1,5 @@
 import { BoxModel, TLShape } from '@tldraw/tlschema'
+import type { ExportStyleCache } from '../../exports/StyleEmbedder'
 import { Box } from '../../primitives/Box'
 import { VecLike } from '../../primitives/Vec'
 
@@ -62,6 +63,19 @@ export interface TLSvgExportOptions {
 	 * attribute of the SVG element.
 	 */
 	preserveAspectRatio?: React.SVGAttributes<SVGSVGElement>['preserveAspectRatio']
+
+	/**
+	 * A cache of read element styles, shared with other exports.
+	 *
+	 * Reading styles is most of the cost of exporting anything containing text, and the answers
+	 * repeat between exports of the same page. Pass an {@link ExportStyleCache} here to reuse
+	 * them across a run of exports — rendering video frames, drawing a strip of thumbnails.
+	 *
+	 * Leave it unset for a one-off export, which has nothing to reuse, and read that class's
+	 * notes before opting in: the cache cannot see a stylesheet that selects on document
+	 * structure.
+	 */
+	styleCache?: ExportStyleCache
 }
 
 /** @public */

--- a/packages/editor/src/lib/exports/StyleEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.test.ts
@@ -1,0 +1,113 @@
+import { ExportStyleCache, StyleEmbedder } from './StyleEmbedder'
+
+function el(tag: string, attrs: Record<string, string> = {}, parent?: Element) {
+	const node = document.createElement(tag)
+	for (const [name, value] of Object.entries(attrs)) node.setAttribute(name, value)
+	if (parent) parent.appendChild(node)
+	return node
+}
+
+/** Read a tree the way an export does, and report the key each element was given. */
+function readTree(cache: ExportStyleCache, root: Element) {
+	document.body.appendChild(root)
+	const embedder = new StyleEmbedder(root, cache)
+	embedder.readRootElementStyles(root)
+	return {
+		embedder,
+		keyOf: (node: Element) => cache.keys.get(node),
+	}
+}
+
+/** The tree an export reads: a wrapper with two identically-shaped children. */
+function tree(childClass = 'text') {
+	const root = el('div', { class: 'wrap' })
+	const a = el('span', { class: childClass }, root)
+	const b = el('span', { class: childClass }, root)
+	return { root, a, b }
+}
+
+afterEach(() => {
+	document.body.innerHTML = ''
+})
+
+describe('ExportStyleCache keys', () => {
+	it('gives two elements of the same shape under the same parent one key', () => {
+		const cache = new ExportStyleCache()
+		const { root, a, b } = tree()
+		const { keyOf } = readTree(cache, root)
+		expect(keyOf(a)).toBe(keyOf(b))
+	})
+
+	it('separates elements by tag, class and inline style', () => {
+		const cache = new ExportStyleCache()
+		const root = el('div', { class: 'wrap' })
+		const span = el('span', { class: 'text' }, root)
+		const para = el('p', { class: 'text' }, root)
+		const other = el('span', { class: 'other' }, root)
+		const styled = el('span', { class: 'text', style: 'color: red' }, root)
+		const { keyOf } = readTree(cache, root)
+
+		const base = keyOf(span)
+		expect(keyOf(para)).not.toBe(base)
+		expect(keyOf(other)).not.toBe(base)
+		expect(keyOf(styled)).not.toBe(base)
+	})
+
+	it('separates elements whose ancestors differ', () => {
+		const cache = new ExportStyleCache()
+		const root = el('div', { class: 'root' })
+		const inA = el('span', { class: 'text' }, el('div', { class: 'wrap' }, root))
+		const inB = el('span', { class: 'text' }, el('div', { class: 'other' }, root))
+		const { keyOf } = readTree(cache, root)
+		expect(keyOf(inA)).not.toBe(keyOf(inB))
+	})
+})
+
+describe('ExportStyleCache reuse', () => {
+	it('reads one entry for a repeated element rather than one per element', () => {
+		const cache = new ExportStyleCache()
+		const { root } = tree()
+		readTree(cache, root)
+		// wrapper + the one shape both children share
+		expect(cache.entries.size).toBe(2)
+	})
+
+	it('adds nothing on a second export of the same tree', () => {
+		const cache = new ExportStyleCache()
+		readTree(cache, tree().root)
+		const afterFirst = cache.entries.size
+		document.body.innerHTML = ''
+		readTree(cache, tree().root)
+		expect(cache.entries.size).toBe(afterFirst)
+	})
+
+	it('reads every element when no cache is passed', () => {
+		const cache = new ExportStyleCache()
+		const { root } = tree()
+		document.body.appendChild(root)
+		new StyleEmbedder(root).readRootElementStyles(root)
+		expect(cache.entries.size).toBe(0)
+	})
+
+	/**
+	 * `fetchResources` rewrites url() values on the styles it is handed, in place. A cache that
+	 * shared its objects would carry one export's data URLs into the next.
+	 */
+	it('is not poisoned by an export mutating the styles it was given', () => {
+		const cache = new ExportStyleCache()
+
+		const first = tree()
+		const a = readTree(cache, first.root)
+		a.embedder.embedStyles()
+		const original = first.a.getAttribute('style')
+		// Stand in for fetchResources: mutate what the first export is holding.
+		first.a.setAttribute('style', 'color: rebeccapurple')
+
+		document.body.innerHTML = ''
+		const second = tree()
+		const b = readTree(cache, second.root)
+		b.embedder.embedStyles()
+
+		expect(second.a.getAttribute('style')).toBe(original)
+	})
+})

--- a/packages/editor/src/lib/exports/StyleEmbedder.test.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.test.ts
@@ -111,3 +111,74 @@ describe('ExportStyleCache reuse', () => {
 		expect(second.a.getAttribute('style')).toBe(original)
 	})
 })
+
+describe('ExportStyleCache self-checking', () => {
+	afterEach(() => {
+		for (const s of Array.from(document.head.querySelectorAll('style[data-test]'))) s.remove()
+	})
+
+	function styleSheet(css: string) {
+		const el = document.createElement('style')
+		el.setAttribute('data-test', 'true')
+		el.textContent = css
+		document.head.appendChild(el)
+	}
+
+	it('stays enabled when the key describes what it claims', () => {
+		const cache = new ExportStyleCache()
+		readTree(cache, tree().root)
+		expect(cache.disabled).toBe(false)
+		expect(cache.mismatches).toBe(0)
+		expect(cache.verified.size).toBeGreaterThan(0)
+	})
+
+	/**
+	 * The hole the key has by construction: a stylesheet selecting on position gives two elements
+	 * of identical tag, class and ancestry different styles, and the key cannot see the
+	 * difference. The check is what turns that from a wrong picture into a slow one.
+	 */
+	it('disables itself when a positional selector makes two same-shaped elements differ', () => {
+		styleSheet(
+			'.wrap > span { color: rgb(1, 2, 3) } .wrap > span:nth-child(2) { color: rgb(9, 8, 7) }'
+		)
+		const cache = new ExportStyleCache()
+		readTree(cache, tree().root)
+		expect(cache.disabled).toBe(true)
+		expect(cache.mismatches).toBe(1)
+	})
+
+	it('reads every element again once disabled, and never grows the cache', () => {
+		styleSheet(
+			'.wrap > span { color: rgb(1, 2, 3) } .wrap > span:nth-child(2) { color: rgb(9, 8, 7) }'
+		)
+		const cache = new ExportStyleCache()
+		readTree(cache, tree().root)
+		expect(cache.entries.size).toBe(0)
+
+		document.body.innerHTML = ''
+		readTree(cache, tree().root)
+		expect(cache.entries.size).toBe(0)
+		expect(cache.disabled).toBe(true)
+	})
+
+	it('gives a disabled cache the same styles as no cache at all', () => {
+		styleSheet(
+			'.wrap > span { color: rgb(1, 2, 3) } .wrap > span:nth-child(2) { color: rgb(9, 8, 7) }'
+		)
+		const poisoned = new ExportStyleCache()
+		const first = tree()
+		const a = readTree(poisoned, first.root)
+		a.embedder.embedStyles()
+		const withCache = [first.a, first.b].map((n) => n.getAttribute('style'))
+
+		document.body.innerHTML = ''
+		const second = tree()
+		document.body.appendChild(second.root)
+		const b = new StyleEmbedder(second.root)
+		b.readRootElementStyles(second.root)
+		b.embedStyles()
+		const withoutCache = [second.a, second.b].map((n) => n.getAttribute('style'))
+
+		expect(withCache).toStrictEqual(withoutCache)
+	})
+})

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -19,8 +19,82 @@ interface ElementStyleInfo {
 	after: Styles | undefined
 }
 
+/**
+ * A cache of read element styles, shared between exports.
+ *
+ * Reading one element's styles means asking the browser for every CSS property it knows about,
+ * and an export reads every element inside every `<foreignObject>`. The answers repeat heavily:
+ * elements rendered from the same component resolve to the same styles, and a second export of
+ * the same page resolves to the same styles again. Pass one of these through
+ * {@link TLSvgExportOptions.styleCache} to reuse them.
+ *
+ * Only worth it when exporting repeatedly — rendering video frames, drawing thumbnails. A single
+ * export has nothing to reuse and should leave this unset.
+ *
+ * Entries are keyed on what the caller can see: the element's tag, class and inline style, and
+ * the same three for each of its ancestors. **That does not model a stylesheet which selects on
+ * document structure** — `:nth-child`, sibling combinators, or attributes other than `class` and
+ * `style` — so two elements the cache calls equal may genuinely differ, and the export takes the
+ * first one's styles. Opt in where you know the markup, and hold a cache no longer than the run
+ * of exports it serves: a stylesheet or theme change invalidates the whole thing.
+ *
+ * @public
+ */
+export class ExportStyleCache {
+	/**
+	 * Read styles, by key. Holds `object` rather than the style type so that this class stays
+	 * opaque to callers: creating one and handing it to an export is the whole of its API.
+	 *
+	 * @internal
+	 */
+	readonly entries = new Map<string, object>()
+
+	/**
+	 * The key given to each element, so a child's key can be built on its parent's.
+	 *
+	 * @internal
+	 */
+	readonly keys = new WeakMap<Element, string>()
+}
+
+/**
+ * The cache key for an element: its own shape, and the shape of every ancestor.
+ *
+ * Built on the parent's key rather than by walking upwards, so the chain costs one lookup — which
+ * works because an export reads a tree from the root down. An element whose parent has not been
+ * read yet keys as if it were a root, which is correct for the roots and conservative elsewhere:
+ * a wrong key can only collide with another element of identical shape and identical ancestry.
+ */
+function cacheKeyFor(
+	cache: ExportStyleCache,
+	element: Element,
+	respectDefaults: boolean,
+	skipInheritedParentStyles: boolean
+) {
+	const parent = element.parentElement
+	const parentKey = parent ? (cache.keys.get(parent) ?? '') : ''
+	const key = `${parentKey}»${element.tagName}|${element.getAttribute('class') ?? ''}|${
+		element.getAttribute('style') ?? ''
+	}|${respectDefaults ? 1 : 0}${skipInheritedParentStyles ? 1 : 0}`
+	cache.keys.set(element, key)
+	return key
+}
+
+// `fetchResources` rewrites url() values in place, so neither the cache nor its caller may hold
+// the other's object.
+function copyStyleInfo(info: ElementStyleInfo): ElementStyleInfo {
+	return {
+		self: { ...info.self },
+		before: info.before && { ...info.before },
+		after: info.after && { ...info.after },
+	}
+}
+
 export class StyleEmbedder {
-	constructor(private readonly root: Element) {}
+	constructor(
+		private readonly root: Element,
+		private readonly cache?: ExportStyleCache
+	) {}
 	private readonly styles = new Map<Element, ElementStyleInfo>()
 	readonly fonts = new FontEmbedder()
 
@@ -68,11 +142,23 @@ export class StyleEmbedder {
 			}
 		}
 
+		const cache = this.cache
+		let key: string | undefined
+		if (cache) {
+			key = cacheKeyFor(cache, element, shouldRespectDefaults, shouldSkipInheritedParentStyles)
+			const hit = cache.entries.get(key)
+			if (hit) {
+				this.styles.set(element, copyStyleInfo(hit as ElementStyleInfo))
+				return
+			}
+		}
+
 		const info: ElementStyleInfo = {
 			self: styleFromElement(element, { defaultStyles, parentStyles }),
 			before: styleFromPseudoElement(element, '::before'),
 			after: styleFromPseudoElement(element, '::after'),
 		}
+		if (cache && key !== undefined) cache.entries.set(key, copyStyleInfo(info))
 		this.styles.set(element, info)
 	}
 

--- a/packages/editor/src/lib/exports/StyleEmbedder.ts
+++ b/packages/editor/src/lib/exports/StyleEmbedder.ts
@@ -32,11 +32,19 @@ interface ElementStyleInfo {
  * export has nothing to reuse and should leave this unset.
  *
  * Entries are keyed on what the caller can see: the element's tag, class and inline style, and
- * the same three for each of its ancestors. **That does not model a stylesheet which selects on
- * document structure** — `:nth-child`, sibling combinators, or attributes other than `class` and
- * `style` — so two elements the cache calls equal may genuinely differ, and the export takes the
- * first one's styles. Opt in where you know the markup, and hold a cache no longer than the run
- * of exports it serves: a stylesheet or theme change invalidates the whole thing.
+ * the same three for each of its ancestors. That does not model a stylesheet which selects on
+ * document structure — `:nth-child`, sibling combinators, or attributes other than `class` and
+ * `style` — so two elements this key calls equal can genuinely differ.
+ *
+ * Rather than ask callers to know that about their own markup, the cache checks itself: the first
+ * time a key is reused it is read fresh anyway and the two compared, and a slow sample keeps
+ * checking for as long as the cache lives. A disagreement sets {@link ExportStyleCache.disabled}
+ * and the cache answers nothing from then on, so a key that does not describe what it claimed
+ * costs the speed rather than the picture. {@link ExportStyleCache.mismatches} says whether that
+ * ever happened.
+ *
+ * Hold a cache no longer than the run of exports it serves: a stylesheet or theme change
+ * invalidates every entry, and the checking above samples rather than catching it immediately.
  *
  * @public
  */
@@ -55,7 +63,45 @@ export class ExportStyleCache {
 	 * @internal
 	 */
 	readonly keys = new WeakMap<Element, string>()
+
+	/**
+	 * Keys whose first reuse has been checked against a fresh read.
+	 *
+	 * @internal
+	 */
+	readonly verified = new Set<string>()
+
+	/** How many times a key has been reused, for the sampling rate below. @internal */
+	reuseCount = 0
+
+	/**
+	 * Set when a reused style did not match a fresh read of the same element.
+	 *
+	 * Once this is true the cache answers nothing for the rest of its life and every element is
+	 * read again, so a key that turns out not to describe what it claimed costs the speed rather
+	 * than the picture.
+	 */
+	disabled = false
+
+	/**
+	 * How many reuses turned out to be wrong. Zero on a cache that has done its job.
+	 *
+	 * Worth reporting if you are watching a fleet: this going non-zero means the key does not
+	 * model something a stylesheet is doing, and the exports that ran before the check caught it
+	 * were the last ones at risk.
+	 */
+	mismatches = 0
 }
+
+/**
+ * How often a reuse is checked against a fresh read, past the first for each key.
+ *
+ * Every key is checked the first time it is reused, which is the moment the cache first makes a
+ * claim about it. That alone would not notice a key that starts out honest and stops being so —
+ * a stylesheet selecting on position sees a different answer when an element's siblings change —
+ * so a slow sample runs for as long as the cache lives.
+ */
+const REUSE_CHECK_INTERVAL = 50
 
 /**
  * The cache key for an element: its own shape, and the shape of every ancestor.
@@ -78,6 +124,23 @@ function cacheKeyFor(
 	}|${respectDefaults ? 1 : 0}${skipInheritedParentStyles ? 1 : 0}`
 	cache.keys.set(element, key)
 	return key
+}
+
+/** Whether a reused set of styles says the same as a fresh read of the same element. */
+function styleInfoMatches(a: ElementStyleInfo, b: ElementStyleInfo) {
+	return (
+		stylesMatch(a.self, b.self) && stylesMatch(a.before, b.before) && stylesMatch(a.after, b.after)
+	)
+}
+
+function stylesMatch(a: Styles | undefined, b: Styles | undefined) {
+	if (!a || !b) return !a === !b
+	const keys = Object.keys(a)
+	if (keys.length !== Object.keys(b).length) return false
+	for (const key of keys) {
+		if (a[key] !== b[key]) return false
+	}
+	return true
 }
 
 // `fetchResources` rewrites url() values in place, so neither the cache nor its caller may hold
@@ -142,14 +205,21 @@ export class StyleEmbedder {
 			}
 		}
 
-		const cache = this.cache
+		const cache = this.cache && !this.cache.disabled ? this.cache : undefined
 		let key: string | undefined
+		let reused: ElementStyleInfo | undefined
 		if (cache) {
 			key = cacheKeyFor(cache, element, shouldRespectDefaults, shouldSkipInheritedParentStyles)
-			const hit = cache.entries.get(key)
+			const hit = cache.entries.get(key) as ElementStyleInfo | undefined
 			if (hit) {
-				this.styles.set(element, copyStyleInfo(hit as ElementStyleInfo))
-				return
+				cache.reuseCount++
+				const check = !cache.verified.has(key) || cache.reuseCount % REUSE_CHECK_INTERVAL === 0
+				if (!check) {
+					this.styles.set(element, copyStyleInfo(hit))
+					return
+				}
+				cache.verified.add(key)
+				reused = hit
 			}
 		}
 
@@ -158,7 +228,16 @@ export class StyleEmbedder {
 			before: styleFromPseudoElement(element, '::before'),
 			after: styleFromPseudoElement(element, '::after'),
 		}
-		if (cache && key !== undefined) cache.entries.set(key, copyStyleInfo(info))
+
+		if (cache && reused && !styleInfoMatches(reused, info)) {
+			// The key claimed two elements resolve the same and they do not. Everything this cache
+			// would say from here is suspect, so it stops saying anything.
+			cache.disabled = true
+			cache.mismatches++
+			cache.entries.clear()
+		} else if (cache && key !== undefined) {
+			cache.entries.set(key, copyStyleInfo(info))
+		}
 		this.styles.set(element, info)
 	}
 

--- a/packages/editor/src/lib/exports/exportToSvg.tsx
+++ b/packages/editor/src/lib/exports/exportToSvg.tsx
@@ -8,7 +8,7 @@ import { getOwnerWindow } from './domUtils'
 import { embedMedia } from './embedMedia'
 import { SVG_EXPORT_CLASSNAME } from './FontEmbedder'
 import { getSvgJsx } from './getSvgJsx'
-import { StyleEmbedder } from './StyleEmbedder'
+import { ExportStyleCache, StyleEmbedder } from './StyleEmbedder'
 
 let idCounter = 1
 
@@ -69,7 +69,7 @@ export async function exportToSvg(
 		// would expect them to. But when we pull the SVG into its own file or draw it to a canvas
 		// though, it has to be completely self-contained. We embed any external resources, and
 		// apply any styles directly to the elements themselves.
-		await applyChangesToForeignObjects(svg)
+		await applyChangesToForeignObjects(svg, opts.styleCache)
 
 		return { svg, width: result.width, height: result.height, trimPadding: result.trimPadding }
 	} finally {
@@ -83,7 +83,7 @@ export async function exportToSvg(
 	}
 }
 
-async function applyChangesToForeignObjects(svg: SVGSVGElement) {
+async function applyChangesToForeignObjects(svg: SVGSVGElement, styleCache?: ExportStyleCache) {
 	// If any shapes have their own <foreignObject> elements, we don't want to mess with them. Our
 	// ones that we need to embed will have a class of `tl-export-embed-styles`.
 	const foreignObjectChildren = [
@@ -92,7 +92,7 @@ async function applyChangesToForeignObjects(svg: SVGSVGElement) {
 	if (!foreignObjectChildren.length) return
 
 	// StyleEmbedder embeds any CSS - including resources like fonts and images.
-	const styleEmbedder = new StyleEmbedder(svg)
+	const styleEmbedder = new StyleEmbedder(svg, styleCache)
 
 	try {
 		// begin traversing stylesheets to find @font-face declarations we might need to embed


### PR DESCRIPTION
Relates to #10677.

## The problem, briefly

`StyleEmbedder.readElementStyles` asks the browser for every CSS property it knows about, for every element inside every `<foreignObject>`, on every export. The answers repeat: byte-identical between exports of the same page, and mostly duplicated within a single export (ten text shapes produce three distinct style strings). #10677 has the measurements.

That is fine for one export. It is the bulk of the cost when something exports repeatedly — video frames, thumbnail strips.

## What this does

Adds an opt-in cache the caller threads through:

```ts
const styleCache = new ExportStyleCache()
for (let frame = 0; frame < frameCount; frame++) {
	await editor.getSvgString(ids, { bounds, scale, styleCache })
}
```

Existing callers are untouched and behave exactly as before. That is deliberate rather than incidental — see the soundness question below. Nobody pays for a cache they did not ask for.

Four notes on the shape:

**`ExportStyleCache` is an opaque bag; `StyleEmbedder` owns the policy.** My first cut put `keyFor`/`get`/`set` on the cache and API Extractor rejected it, because `@internal` methods cannot leak a non-exported type (`ElementStyleInfo`). The push was right — the public surface is now one class with no methods, and "make one, hand it over" is all a caller can do.

**Entries are copied in and out.** `fetchResources` rewrites `url()` values in place on whatever it is handed, so a cache that shared its objects would carry one export's data URLs into the next. There is a test named for that.

**A key is built on its parent's key**, rather than by walking up the tree — one lookup per element, which works because an export reads a tree root-down. An element whose parent has not been read keys as if it were a root: correct for actual roots, conservative elsewhere.

**Cache lifetime is the caller's.** Per-`StyleEmbedder` would be useless (one is constructed per export) and module-global would leak across documents and themes. Handing the caller an object makes the lifetime visible and puts invalidation where the knowledge is — a theme or stylesheet change means a new cache.

## The key is unsound, and the cache checks itself because of it

The key cannot see a stylesheet that selects on document *structure* — `:nth-child`, sibling combinators, attribute selectors other than `class` and `style`. Two elements it calls equal can genuinely differ, and a cache that trusted itself would hand the export the first one's styles. That fails silently: a subtly wrong image, no error, nothing for a user to notice.

Rather than ask callers to know that about their own markup, the cache verifies itself. The first time a key is reused the element is read fresh anyway and the two compared; a slow sample keeps checking for as long as the cache lives. On any disagreement it sets `disabled`, clears its entries, and every element is read again for the rest of its life.

So **a key that does not describe what it claimed costs the speed, never the picture** — the worst case is exactly today's behaviour. `mismatches` says whether it ever happened, which is a thing worth watching on a fleet: non-zero means the key does not model something a stylesheet is doing.

`StyleEmbedder.test.ts` forces the case rather than describing it — a `:nth-child` rule that makes two same-shaped siblings differ, asserting the cache notices, disables itself, and then produces styles byte-identical to no cache at all.

Two things still worth a reviewer's opinion:

1. Is `TLSvgExportOptions` the right home, or should this hang off a longer-lived export-session object? A session would also give the repeated `createRoot` in `exportToSvg` somewhere to live, which is the next-largest cost after this one.
2. Should the emitted styles also be deduplicated into classes rather than repeated as inline attributes? Ten text shapes emit three distinct strings, so roughly a 40× payload reduction. Separate axis, not done here, and it is the axis that matters to anything observing the DOM.

## What is measured

Against tldraw Flash built with this branch's `@tldraw/editor`, exporting 4 rigged figures and 20 text shapes at 1920 wide, every shape moving each frame, 20 frames per arm, same page:

| arm | ms/frame |
|---|---|
| no `styleCache` | 73.6 |
| **with `styleCache`** | **37.6 — 1.96×** |
| no `styleCache` (baseline recheck) | 70.3 |

The cache held **3 entries** for that scene, which is the number of distinct element shapes in it. Style output compared byte-for-byte with and without: identical across 344,172 characters of signature.

Most usefully for the question above: on that scene, against tldraw's own stylesheet, the self-check ran throughout and reported `disabled: false, mismatches: 0`. The key was never caught lying by real markup — which is evidence, where "it held on everything I tried" was not.

The change is also running downstream. tldraw/tldraw-flash#1635 ships it as a `patch-package` patch built from the `v5.3.0` tag, so it is exercised on real exports ahead of this landing.

## API changes

One new public class and one new option, both additive. No existing signature changes.

- `ExportStyleCache` — new `@public` class, exported from `@tldraw/editor`. No methods; callers construct one and pass it. Four `@internal` fields hold the cache and its bookkeeping (`entries`, `keys`, `verified`, `reuseCount`), and two are documented for callers: `disabled` and `mismatches`, which report whether the self-check ever fired.
- `TLSvgExportOptions.styleCache?: ExportStyleCache` — new optional property. Absent means today's behaviour exactly.

`api-report.api.md` regenerated.

## Testing

`yarn test` in `packages/editor`: **1,212 pass**, including 11 new ones. Four cover the key — separation by tag, class, inline style and ancestry. Three cover reuse — one entry per element *shape* rather than per element, nothing added on a second export of the same tree, and the no-cache-passed path. One covers the mutation hazard, since `fetchResources` rewrites `url()` values in place and a cache sharing its objects would carry one export's data URLs into the next.

The remaining three cover the self-check, and are the ones worth reading: that it stays enabled when the key is honest, that a `:nth-child` rule makes it disable itself and count a mismatch, and that a disabled cache produces styles byte-identical to no cache at all.

`tsc` clean, oxlint and oxfmt clean, API report regenerated. Built and exercised downstream as described above.


