### PR TITLE
fix(ci): stop a preview label on a merged PR from redeploying staging

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -13,10 +13,10 @@ permissions: write-all
 env:
   CI: 1
   PRINT_GITHUB_ANNOTATIONS: 1
-  # Keyed on the event, not the ref: a pull_request event on an already-merged PR
-  # carries the base branch as github.ref, which turned a late dotcom-preview-please
-  # label into a staging deploy built from the merge commit (#10651).
-  TLDRAW_ENV: ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || 'staging' }}
+  # Keyed on the event, not github.ref: on a merged PR, github.ref is the base branch, so a
+  # late dotcom-preview-please label once redeployed staging from #10651's stale merge commit.
+  # Any other trigger leaves this empty and the deploy script refuses to run.
+  TLDRAW_ENV: ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || '' }}
 
 defaults:
   run:
@@ -24,12 +24,12 @@ defaults:
 
 jobs:
   deploy:
-    name: Deploy dotcom to ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || 'staging' }}
+    name: Deploy dotcom to ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || '' }}
     timeout-minutes: 15
     runs-on: ubuntu-latest-16-cores-arm-open
     environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/production') && 'deploy-production' || 'deploy-staging' }}
-    concurrency: dotcom-${{ github.ref == 'refs/heads/production' && 'deploy-production' || github.ref }}
-    # Labels can still be edited on a closed PR, which has no merge ref left to build.
+    concurrency: dotcom-${{ (github.event_name == 'pull_request' && format('pr-{0}', github.event.number)) || (github.ref == 'refs/heads/production' && 'deploy-production') || github.ref }}
+    # Closed PRs still take labels, and a closed PR's github.ref is its base branch.
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores-arm-open
     environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/production') && 'deploy-production' || 'deploy-staging' }}
     concurrency: dotcom-${{ (github.event_name == 'pull_request' && format('pr-{0}', github.event.number)) || (github.ref == 'refs/heads/production' && 'deploy-production') || github.ref }}
-    # Closed PRs still take labels, and a closed PR's github.ref is its base branch.
+    # Closed PRs still take labels, and a merged PR's github.ref is its base branch.
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -13,7 +13,10 @@ permissions: write-all
 env:
   CI: 1
   PRINT_GITHUB_ANNOTATIONS: 1
-  TLDRAW_ENV: ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || 'preview' }}
+  # Keyed on the event, not the ref: a pull_request event on an already-merged PR
+  # carries the base branch as github.ref, which turned a late dotcom-preview-please
+  # label into a staging deploy built from the merge commit (#10651).
+  TLDRAW_ENV: ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || 'staging' }}
 
 defaults:
   run:
@@ -21,14 +24,17 @@ defaults:
 
 jobs:
   deploy:
-    name: Deploy dotcom to ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
+    name: Deploy dotcom to ${{ (github.event_name == 'pull_request' && 'preview') || (github.ref == 'refs/heads/production' && 'production') || 'staging' }}
     timeout-minutes: 15
     runs-on: ubuntu-latest-16-cores-arm-open
-    environment: ${{ github.ref == 'refs/heads/production' && 'deploy-production' || 'deploy-staging' }}
+    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/production') && 'deploy-production' || 'deploy-staging' }}
     concurrency: dotcom-${{ github.ref == 'refs/heads/production' && 'deploy-production' || github.ref }}
+    # Labels can still be edited on a closed PR, which has no merge ref left to build.
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dotcom-preview-please'))
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.state == 'open' &&
+        contains(github.event.pull_request.labels.*.name, 'dotcom-preview-please'))
 
     steps:
       # - name: Notify initial start
@@ -52,16 +58,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/production" ]]; then
-            echo "DEPLOY_ZERO=flyio-multinode" >> $GITHUB_ENV
-          elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "DEPLOY_ZERO=flyio-multinode" >> $GITHUB_ENV
-          else
+          if [[ "${TLDRAW_ENV}" == "preview" ]]; then
             echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
+          else
+            echo "DEPLOY_ZERO=flyio-multinode" >> $GITHUB_ENV
           fi
 
       - name: Install Supabase CLI
-        if: github.event_name == 'pull_request'
+        if: env.TLDRAW_ENV == 'preview'
         uses: supabase/setup-cli@v1
         with:
           # Pinned: v2.112.0 rejects the Management API's own timestamps, which
@@ -69,7 +73,7 @@ jobs:
           version: 2.111.0
 
       - name: Delete Supabase branch
-        if: contains(github.event.pull_request.labels.*.name, 'reset-preview-db')
+        if: env.TLDRAW_ENV == 'preview' && contains(github.event.pull_request.labels.*.name, 'reset-preview-db')
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
@@ -77,7 +81,7 @@ jobs:
             --project-ref "${{ vars.SUPABASE_PREVIEW_PROJECT_ID }}" || echo "::warning::Failed to delete Supabase branch (may not exist yet)"
 
       - name: Create Supabase preview branch
-        if: github.event_name == 'pull_request'
+        if: env.TLDRAW_ENV == 'preview'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |


### PR DESCRIPTION
This PR fixes a bug where adding the `dotcom-preview-please` label to an already-merged PR redeployed staging from that PR's merge commit, with the staging sync worker and zero-cache pointed at the PR's Supabase preview branch instead of the staging database.

### Before

A `pull_request` event on a merged PR carries the base branch as `github.ref`. The [contexts reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) documents this under `github.ref`: "If the pull request was merged, this is the branch it was merged into." The job's `if` only checked the event name and the label, so the job ran. `TLDRAW_ENV` was derived from `github.ref`, so it resolved to `staging`. The Supabase preview-branch step was gated on `github.event_name == 'pull_request'`, so it ran as well, and the Deploy step prefers the branch connection strings it exports over the staging secrets.

That is what happened on #10651. The label was added three days after the merge, and run [34103605201](https://github.com/tldraw/tldraw/actions/runs/34103605201) ("Deploy dotcom to staging") rebuilt staging from a commit 20 commits behind `main` and gave `main-tldraw-multiplayer`, `staging-zero-rm`, and `staging-zero-vs` the `pr-10651` branch database.

### After

`TLDRAW_ENV`, the job name, the deployment environment, and the concurrency group are keyed on the event: a `pull_request` event is always a preview, and only a push selects staging or production. The label path additionally requires the PR to be open, so a label edit on a closed PR is skipped. The Supabase branch steps are gated on the preview environment rather than the event name, so branch credentials can only reach a preview deploy. The zero deploy target step keys on `TLDRAW_ENV` for the same reason.

Any trigger outside the three known ones leaves `TLDRAW_ENV` empty, which the deploy script rejects before deploying anything. The old expression happened to fail closed too, by falling through to `preview` without a PR number, so this keeps that property explicit for anyone adding `workflow_dispatch` later.

### Implementation notes

`deploy-analytics.yml` and `deploy-bemo.yml` derive `TLDRAW_ENV` from `github.ref` the same way, but they only listen for the default `pull_request` activity types, none of which fire on a merged PR, so they are left as they are.

The backstop error in `getDeployInfo` still describes a missing `TLDRAW_PREVIEW_ID` rather than a closed PR. It cannot be reached from this workflow any more, so that wording is left for a follow-up.

### Change type

- [x] `bugfix`

### Test plan

1. Add `dotcom-preview-please` to this PR and confirm the run is titled "Deploy dotcom to preview" and deploys to `pr-<number>-preview-deploy.tldraw.com` as before.
2. After merging, confirm the `main` push run is titled "Deploy dotcom to staging", skips the Supabase steps, and deploys with the staging secrets.

- [x] The `Deploy .com` run on this PR ([34112589442](https://github.com/tldraw/tldraw/actions/runs/34112589442)) evaluates to skipped, so the changed file parses and the label gate holds for an unlabeled open PR.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +17 / -13  |
