### PR TITLE
fix(analytics): keep host letter-spacing out of the consent dialog title

### DIFF
--- a/apps/analytics/src/styles.css
+++ b/apps/analytics/src/styles.css
@@ -145,6 +145,9 @@
 
 .tl-analytics-dialog {
 	font-family: 'Inter', sans-serif;
+	/* The dialog renders inside the host page, so reset inherited text styles
+	   like tldraw.com's letter-spacing (#9363) */
+	letter-spacing: normal;
 	color: var(--tl-analytics-text);
 	position: fixed;
 	inset: 0;


### PR DESCRIPTION
The analytics consent dialog is rendered directly into the host page's DOM, so it inherits text styles from tldraw.com's global CSS. The marketing pages set a negative `letter-spacing`, which visually squeezes the dialog's "Privacy settings" h2 title (and the rest of the dialog text).

This adds `letter-spacing: normal` to the `.tl-analytics-dialog` root, next to the existing `font-family` reset, so all text inside the dialog uses normal letter-spacing regardless of the host page's styles.

Fixes #9363

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On tldraw.com (or any page with a global `letter-spacing`), open the cookie/privacy settings dialog
2. The dialog title and body text render with normal letter-spacing

### Release notes

- Fixed the privacy settings dialog inheriting the host page's letter-spacing.
