### PR TITLE
fix(sync-core): replace values whose array-ness changes instead of patching them

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -31,6 +31,7 @@ Sections marked **internal** describe supporting machinery that has its own cont
 - **D5** When both values are strings (at any level, including top-level keys) and `next` starts with `prev`, the diff is `['append', addedSuffix, prev.length]`. Other string changes are puts. With `legacyAppendMode` enabled, string appends become puts instead; array appends (D7) are unaffected by `legacyAppendMode`.
 - **D6** Same-length arrays: if no items changed, no op. If at most `max(length/5, 1)` items changed, the op is `['patch', { [index]: op }]` where each changed index gets a recursive diff when both old and new items are truthy objects, and a put otherwise. If more items changed, the whole array is put.
 - **D7** Different-length arrays: when the shared prefix is unchanged and the array grew, the op is `['append', addedItems, prev.length]`. Any change in the shared prefix (including truncation) puts the whole array.
+- **D8** When a value changes between a plain object and an array (at any nesting level), the diff is a whole-value `['put', next]`, never a patch — applying a patch keeps the old container type (AD4/AD7), so the result would silently diverge.
 
 ## 4. Applying diffs: `applyObjectDiff` (AD)
 

--- a/packages/sync-core/src/lib/diff.test.ts
+++ b/packages/sync-core/src/lib/diff.test.ts
@@ -474,6 +474,82 @@ describe('computing diffs (D)', () => {
 		})
 	})
 
+	describe('array-ness changes (D8)', () => {
+		it('[D8] puts an array item that changed from object to array, and round-trips', () => {
+			const prev = { meta: { items: [{ value: 1 }] } }
+			const next = { meta: { items: [[1]] } }
+
+			const diff = diffRecord(prev, next)
+			expect(diff).toEqual({
+				meta: [ValueOpType.Patch, { items: [ValueOpType.Patch, { '0': [ValueOpType.Put, [1]] }] }],
+			})
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+
+		it('[D8] puts an array item that changed from array to object, and round-trips', () => {
+			const prev = { meta: { items: [[1]] } }
+			const next = { meta: { items: [{ value: 1 }] } }
+
+			const diff = diffRecord(prev, next)
+			expect(diff).toEqual({
+				meta: [
+					ValueOpType.Patch,
+					{ items: [ValueOpType.Patch, { '0': [ValueOpType.Put, { value: 1 }] }] },
+				],
+			})
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+
+		it('[D8] puts props wholesale when it changed from object to array, and round-trips', () => {
+			const prev = { id: 'test:1', props: { a: 1 } }
+			const next = { id: 'test:1', props: [1] }
+
+			const diff = diffRecord(prev, next)
+			expect(diff).toEqual({ props: [ValueOpType.Put, [1]] })
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+
+		it('[D8] puts meta wholesale when it changed from array to object, and round-trips', () => {
+			const prev = { id: 'test:1', meta: [1] }
+			const next = { id: 'test:1', meta: { a: 1 } }
+
+			const diff = diffRecord(prev, next)
+			expect(diff).toEqual({ meta: [ValueOpType.Put, { a: 1 }] })
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+
+		it('[D3] [D8] puts a top-level value whose array-ness changed, and round-trips', () => {
+			const prev = { id: 'test:1', value: { a: 1 } }
+			const next = { id: 'test:1', value: [1] }
+
+			const diff = diffRecord(prev, next)
+			expect(diff).toEqual({ value: [ValueOpType.Put, [1]] })
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+
+		it('[D8] round-trips nested rich-text-like content where a child flips container type', () => {
+			const prev = {
+				props: {
+					richText: {
+						type: 'doc',
+						content: [{ type: 'paragraph', attrs: { extra: { a: 1 } }, content: [] }],
+					},
+				},
+			}
+			const next = {
+				props: {
+					richText: {
+						type: 'doc',
+						content: [{ type: 'paragraph', attrs: { extra: [1] }, content: [] }],
+					},
+				},
+			}
+
+			const diff = diffRecord(prev, next)
+			expect(applyObjectDiff(prev, diff!)).toEqual(next)
+		})
+	})
+
 	describe('complex scenarios', () => {
 		it('[D3] [D4] [D5] handles shape-like record updates', () => {
 			const prev = {

--- a/packages/sync-core/src/lib/diff.ts
+++ b/packages/sync-core/src/lib/diff.ts
@@ -247,6 +247,11 @@ function diffValue(valueA: unknown, valueB: unknown, legacyAppendMode: boolean):
 		return [ValueOpType.Put, valueB]
 	} else if (!valueA || !valueB || typeof valueA !== 'object' || typeof valueB !== 'object') {
 		return isEqual(valueA, valueB) ? null : [ValueOpType.Put, valueB]
+	} else if (Array.isArray(valueA) !== Array.isArray(valueB)) {
+		// a patch op preserves the container type of the value it's applied to, so an
+		// object <-> array change must replace the value wholesale or the applied result
+		// silently diverges (e.g. [1] patched onto { v: 1 } yields { '0': 1 })
+		return [ValueOpType.Put, valueB]
 	} else {
 		const diff = diffObject(valueA, valueB, undefined, legacyAppendMode)
 		return diff ? [ValueOpType.Patch, diff] : null


### PR DESCRIPTION
Fixes #10675

The sync-core record diff produced a wrong result when a value inside a record changed from a plain object to an array or the other way round. In `diffValue`, both sides passed the `typeof === 'object'` check and fell through to `diffObject`, which emitted a `patch` op. Applying a patch preserves the container type of the value it is applied to, so `{ items: [{ value: 1 }] }` → `{ items: [[1]] }` ended up as `{ items: [{ "0": 1 }] }` on the receiving side, and the reverse ended up as `{ items: [[undefined]] }` — a client applying such a patch silently diverges from the server. Exposure is unvalidated free-form JSON: shape `meta` and rich text `attrs`/`content`.

The fix makes `diffValue` emit a whole-value `put` when `Array.isArray` differs between the two sides. This covers array elements (via `diffArray`'s recursive element diffing) and the `props`/`meta` values themselves. Object↔array changes at other object keys already produced whole-value puts via the deep-equality path.

Also adds rule D8 to the sync-core SPEC.md and round-trip tests covering array elements flipping container type in both directions, `props`/`meta` flipping wholesale, a top-level key flipping, and a nested rich-text-like document.

The open question in the issue about #10614 guarding itself is deferred there and not addressed here.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Run `yarn test run src/lib/diff.test.ts` in `packages/sync-core`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a sync bug where a value changing between an object and an array inside `meta` or rich text content was patched into the wrong container type, causing clients to diverge from the server.