### PR TITLE
fix(tlschema): keep large draw strokes from emitting NUL characters in SVG path data

### DIFF
--- a/packages/tldraw/src/test/freehand/wellformed.test.ts
+++ b/packages/tldraw/src/test/freehand/wellformed.test.ts
@@ -1,3 +1,4 @@
+import { b64Vecs } from '@tldraw/editor'
 import { describe, expect, it } from 'vitest'
 import { getStrokePoints } from '../../lib/shapes/shared/freehand/getStrokePoints'
 import { getSvgPathFromStrokePoints } from '../../lib/shapes/shared/freehand/svg'
@@ -27,4 +28,26 @@ describe('svg path data is well formed', () => {
 		// only valid path characters
 		expect(svg).toMatch(/^[MLQTACZmlqtacz0-9 ,.-]+$/)
 	})
+})
+
+// A draw shape stores its points b64Vecs-delta-encoded. A stroke spanning hundreds of thousands
+// of units has point deltas beyond the Float16 range; these used to decode as Infinity/NaN,
+// which the fast path writer emitted as NUL characters, so the browser rejected the whole `d`
+// attribute and the stroke rendered nothing. See #10662.
+describe('a stroke spanning hundreds of thousands of units', () => {
+	it.each(CORPUS.filter((c) => c.kind === 'draw').map((c) => [c.id, c] as const))(
+		'%s scaled up and roundtripped through b64Vecs renders well-formed path data',
+		(_id, c) => {
+			const scaled = c.points.map((p) => ({ x: p.x * 1500, y: p.y * 1250, z: p.z }))
+			const decoded = b64Vecs.decodePoints(b64Vecs.encodePoints(scaled))
+			for (const p of decoded) {
+				expect(Number.isFinite(p.x)).toBe(true)
+				expect(Number.isFinite(p.y)).toBe(true)
+			}
+			const svg = svgInk(decoded, c.options)
+			expect(svg.startsWith('M')).toBe(true)
+			expect(svg).not.toContain('\0')
+			expect(svg).toMatch(/^[MLQTACZmlqtacz0-9 ,.-]+$/)
+		}
+	)
 })

--- a/packages/tlschema/src/misc/b64Vecs.test.ts
+++ b/packages/tlschema/src/misc/b64Vecs.test.ts
@@ -245,6 +245,68 @@ describe('b64Vecs delta encoding', () => {
 			expect(decoded[1].y).toBeCloseTo(-198, 2)
 		})
 
+		it('saturates deltas beyond the Float16 range instead of decoding to Infinity/NaN', () => {
+			// A delta larger than 65504 (Float16 max) used to overflow to Infinity when
+			// stored, poisoning every later point on decode: Infinity accumulates, and an
+			// opposite-signed delta after it produces NaN. See #10662.
+			const points: VecModel[] = [
+				{ x: 0, y: 0, z: 0.5 },
+				{ x: 70000, y: 80000, z: 0.5 },
+				{ x: 0, y: 0, z: 0.5 },
+			]
+
+			const decoded = b64Vecs.decodePoints(b64Vecs.encodePoints(points))
+
+			expect(decoded).toHaveLength(3)
+			for (const p of decoded) {
+				expect(Number.isFinite(p.x)).toBe(true)
+				expect(Number.isFinite(p.y)).toBe(true)
+			}
+			expect(decoded[1].x).toBe(65504)
+			expect(decoded[1].y).toBe(65504)
+			// The return delta saturates too, so the endpoint lands back at the origin.
+			expect(decoded[2].x).toBe(0)
+			expect(decoded[2].y).toBe(0)
+		})
+
+		it('carries the saturation shortfall so later points converge to the true positions', () => {
+			// One oversized jump, then small steps: the clamped stroke should catch up
+			// within a couple of points rather than staying offset for the rest of the path.
+			const points: VecModel[] = [
+				{ x: 0, y: 0, z: 0.5 },
+				{ x: 100000, y: 0, z: 0.5 },
+				{ x: 100001, y: 1, z: 0.5 },
+				{ x: 100002, y: 2, z: 0.5 },
+			]
+
+			const decoded = b64Vecs.decodePoints(b64Vecs.encodePoints(points))
+
+			// 100000 - 65504 = 34496 shortfall, plus the next 1-unit step, recovered at
+			// the next delta (Float16 precision at ~34000 is 32).
+			expect(decoded[1].x).toBe(65504)
+			expect(decoded[2].x).toBeCloseTo(100001, -2)
+			expect(decoded[3].x).toBeCloseTo(100002, -2)
+		})
+
+		it('saturates deltas in the 2D encoding too', () => {
+			const points: VecModel[] = [
+				{ x: 0, y: 0 },
+				{ x: -90000, y: 70000 },
+				{ x: 0, y: 0 },
+			]
+
+			const decoded = b64Vecs.decodePoints2D(b64Vecs.encodePoints2D(points))
+
+			for (const p of decoded) {
+				expect(Number.isFinite(p.x)).toBe(true)
+				expect(Number.isFinite(p.y)).toBe(true)
+			}
+			expect(decoded[1].x).toBe(-65504)
+			expect(decoded[1].y).toBe(65504)
+			expect(decoded[2].x).toBe(0)
+			expect(decoded[2].y).toBe(0)
+		})
+
 		it('handles zero deltas', () => {
 			const points: VecModel[] = [
 				{ x: 100, y: 100, z: 0.5 },

--- a/packages/tlschema/src/misc/b64Vecs.ts
+++ b/packages/tlschema/src/misc/b64Vecs.ts
@@ -12,6 +12,19 @@ const FIRST_POINT_2D_B64_LENGTH = 12
 // Pressure value supplied when decoding non-pressure (2D) paths
 const DEFAULT_PRESSURE = 0.5
 
+// The largest finite Float16. A delta beyond this would overflow to Infinity when stored,
+// and a single non-finite delta poisons every later point on decode: Infinity accumulates,
+// and an opposite-signed delta after it produces NaN. Those coordinates then render as
+// invalid svg path data and the whole stroke silently disappears (#10662).
+const FLOAT16_MAX = 65504
+
+// Saturate a coordinate delta to the finite Float16 range before storing it. Values just
+// above FLOAT16_MAX would still round to a finite Float16, but clamping at the exactly
+// representable maximum keeps native and fallback setFloat16 behavior identical.
+function clampDeltaToFloat16(d: number): number {
+	return d > FLOAT16_MAX ? FLOAT16_MAX : d < -FLOAT16_MAX ? -FLOAT16_MAX : d
+}
+
 /** Draw segment path encoded with 2 dimensions, XY — the constant pressure Z is dropped. @public */
 export const DIM_2D = 2
 /** Draw segment path encoded with 3 dimensions, XYZ. @public */
@@ -384,7 +397,11 @@ export class b64Vecs {
 		dataView.setFloat32(4, first.y, true)
 		dataView.setFloat32(8, first.z ?? 0.5, true)
 
-		// Subsequent points are Float16 deltas from the previous point
+		// Subsequent points are Float16 deltas from the previous point. `prevX`/`prevY`
+		// track the decoder's accumulated position, which only differs from the input
+		// point when a delta had to be saturated to stay a finite Float16 — the shortfall
+		// then carries into the next delta so the stroke converges back toward the true
+		// positions instead of staying offset for the rest of the path.
 		let prevX = first.x
 		let prevY = first.y
 		let prevZ = first.z ?? 0.5
@@ -393,13 +410,18 @@ export class b64Vecs {
 			const p = points[i]
 			const z = p.z ?? 0.5
 
+			const rawDx = p.x - prevX
+			const rawDy = p.y - prevY
+			const dx = clampDeltaToFloat16(rawDx)
+			const dy = clampDeltaToFloat16(rawDy)
+
 			const offset = firstPointBytes + (i - 1) * 6
-			setFloat16(dataView, offset, p.x - prevX)
-			setFloat16(dataView, offset + 2, p.y - prevY)
+			setFloat16(dataView, offset, dx)
+			setFloat16(dataView, offset + 2, dy)
 			setFloat16(dataView, offset + 4, z - prevZ)
 
-			prevX = p.x
-			prevY = p.y
+			prevX = dx === rawDx ? p.x : prevX + dx
+			prevY = dy === rawDy ? p.y : prevY + dy
 			prevZ = z
 		}
 
@@ -523,16 +545,21 @@ export class b64Vecs {
 		dataView.setFloat32(0, first.x, true)
 		dataView.setFloat32(4, first.y, true)
 
+		// See encodePoints for why deltas are saturated and how the shortfall carries.
 		let prevX = first.x
 		let prevY = first.y
 
 		for (let i = 1; i < points.length; i++) {
 			const p = points[i]
+			const rawDx = p.x - prevX
+			const rawDy = p.y - prevY
+			const dx = clampDeltaToFloat16(rawDx)
+			const dy = clampDeltaToFloat16(rawDy)
 			const offset = firstPointBytes + (i - 1) * 4
-			setFloat16(dataView, offset, p.x - prevX)
-			setFloat16(dataView, offset + 2, p.y - prevY)
-			prevX = p.x
-			prevY = p.y
+			setFloat16(dataView, offset, dx)
+			setFloat16(dataView, offset + 2, dy)
+			prevX = dx === rawDx ? p.x : prevX + dx
+			prevY = dy === rawDy ? p.y : prevY + dy
 		}
 
 		return uint8ArrayToBase64(buffer)


### PR DESCRIPTION
A draw stroke whose points span very large page-space distances (roughly 300,000 by 150,000 units in the report) rendered nothing on the canvas and in `editor.toImage`, with the browser rejecting the shape's path data:

```
Error: <path> attribute d: Expected number, "…8.82,-8523.72 .0\^@,.0\^@ .0\^@,.0\^@ a.…".
```

### Root cause

Draw segment paths are stored delta-encoded by `b64Vecs`: a Float32 first point followed by Float16 deltas between consecutive points. A delta larger than the largest finite Float16 (65,504) overflows to Infinity when stored — both in the native `DataView.setFloat16` and in the fallback `numberToFloat16Bits`. On decode the Infinity delta accumulates into every subsequent coordinate, and the first opposite-signed delta after it produces NaN (`Infinity + -Infinity`).

Those non-finite coordinates then reach the freehand path writer, whose fast byte-buffer formatter computes digit bytes as `48 + digit`; for NaN/Infinity input the digit arithmetic yields NaN, which a `Uint8Array` stores as byte 0 — the NUL characters in the `d` attribute. The browser rejects the whole attribute and the stroke silently disappears. This is why ordinary strokes and strokes merely offset to far coordinates were unaffected: the first point is Float32, and only the size of the deltas within the stroke matters.

### Fix

Saturate deltas to the finite Float16 range (±65,504) in `b64Vecs.encodePoints` and `encodePoints2D`, and carry the saturation shortfall forward by measuring the next delta from the decoder's accumulated position rather than the raw input point. A clamped stroke converges back to the true positions as soon as deltas drop back into range, instead of staying offset for the rest of the path — and it always decodes to finite coordinates, so it renders (degraded at the clamp, rather than vanishing entirely). Unclamped strokes encode bit-identically to before.

### Change type

- [x] `bugfix`

### Test plan

1. Decode/encode round-trip tests in `packages/tlschema/src/misc/b64Vecs.test.ts`: oversized deltas decode finite and saturate at ±65,504, the shortfall carry converges later points, and the 2D encoding saturates too.
2. Render pipeline regression tests in `packages/tldraw/src/test/freehand/wellformed.test.ts`: every corpus draw stroke scaled by 1,500 × 1,250 (the report's repro) and round-tripped through `b64Vecs` produces well-formed svg path data with no NUL characters.

All new tests fail without the fix and pass with it.

- [x] Unit tests

### Release notes

- Fixed very large draw strokes emitting invalid SVG path data (NUL characters) and rendering nothing.

Fixes #10662