### PR TITLE
fix(tldraw): skip locked shapes when moving focus to the canvas

### DIFF
--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -25,9 +25,12 @@ export function SkipToMainContent() {
 		(e: MouseEvent | KeyboardEvent) => {
 			editor.markEventAsHandled(e)
 			button.current?.blur()
-			const shapes = editor.getCurrentPageShapesInReadingOrder()
-			if (!shapes.length) return
-			editor.setSelectedShapes([shapes[0].id])
+			// Locked shapes can't be selected by clicking or select all, so skip them here too
+			const firstShape = editor
+				.getCurrentPageShapesInReadingOrder()
+				.find((shape) => !editor.isShapeOrAncestorLocked(shape))
+			if (!firstShape) return
+			editor.setSelectedShapes([firstShape.id])
 			suppressBackToContent(editor, editor.options.animationMediumMs)
 			editor.zoomToSelectionIfOffscreen(256, {
 				animation: {

--- a/packages/tldraw/src/test/ui/SkipToMainContent.test.tsx
+++ b/packages/tldraw/src/test/ui/SkipToMainContent.test.tsx
@@ -1,0 +1,61 @@
+import { act, fireEvent } from '@testing-library/react'
+import { createShapeId, Editor } from '@tldraw/editor'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+let editor: Editor
+
+beforeEach(async () => {
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+})
+
+function moveFocusToCanvas() {
+	act(() => {
+		fireEvent.click(document.querySelector('.tl-skip-to-main-content')!)
+	})
+}
+
+describe('Move focus to canvas', () => {
+	it('selects the first shape in reading order', () => {
+		const box1 = createShapeId()
+		const box2 = createShapeId()
+		act(() => {
+			editor.createShapes([
+				{ id: box1, type: 'geo', x: 0, y: 0 },
+				{ id: box2, type: 'geo', x: 200, y: 0 },
+			])
+		})
+
+		moveFocusToCanvas()
+
+		expect(editor.getSelectedShapeIds()).toEqual([box1])
+	})
+
+	it('skips locked shapes', () => {
+		const locked = createShapeId()
+		const unlocked = createShapeId()
+		act(() => {
+			editor.createShapes([
+				{ id: locked, type: 'geo', x: 0, y: 0, isLocked: true },
+				{ id: unlocked, type: 'geo', x: 200, y: 0 },
+			])
+		})
+
+		moveFocusToCanvas()
+
+		expect(editor.getSelectedShapeIds()).toEqual([unlocked])
+	})
+
+	it('selects nothing when every shape is locked', () => {
+		act(() => {
+			editor.createShapes([{ id: createShapeId(), type: 'geo', x: 0, y: 0, isLocked: true }])
+		})
+
+		moveFocusToCanvas()
+
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where the "Move focus to canvas" skip link selected a locked shape when a locked shape came first in reading order. Relates to #10421: #10482 made Tab and Ctrl/Cmd+arrow traversal skip locked shapes, but the skip link picks its target separately and still landed on them.

### Before

`SkipToMainContent` selected the first entry of `getCurrentPageShapesInReadingOrder()` with no lock check. Tabbing to the skip link and pressing Enter next to a locked rectangle selected it (outline, no handles), a selection that clicking and select all never produce.

### After

The skip link selects the first unlocked shape in reading order, and selects nothing when every shape on the page is locked, so keyboard users land on the same shapes they can reach with the mouse.

### Implementation notes

With every shape locked the skip link now takes the same early return as an empty page, so focus is left where the button's blur put it rather than on the canvas container. That is the existing empty-page behavior, left for a separate change.

### Change type

- [x] `bugfix`

### Test plan

1. Draw two rectangles and lock the left one.
2. Press Tab until "Move focus to canvas" is focused, then press Enter; the unlocked rectangle should be selected.
3. Lock both rectangles and repeat; nothing should be selected.

- [x] Unit tests — the two locked-shape tests in `SkipToMainContent.test.tsx` fail on `main` and pass with this change

### Release notes

- Fix the "Move focus to canvas" skip link selecting locked shapes

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -3    |
| Tests     | +61 / -0   |
