### PR TITLE
feat(sync): let a caller wait for its changes to reach the server

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -665,6 +665,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
         store: S;
     });
     close(): void;
+    flushChanges(): Promise<void>;
+    hasUnsyncedChanges(): boolean;
     // @internal (undocumented)
     isConnectedToRoom: boolean;
     // @internal (undocumented)

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -4,6 +4,7 @@ import {
 	RecordsDiff,
 	Store,
 	UnknownRecord,
+	isRecordsDiffEmpty,
 	reverseRecordsDiff,
 	squashRecordDiffsMutable,
 } from '@tldraw/store'
@@ -395,6 +396,52 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		added: {} as any,
 		updated: {} as any,
 		removed: {} as any,
+	}
+
+	private flushWaiters: Array<{ resolve(): void; reject(reason: Error): void }> = []
+
+	/**
+	 * Whether this client is holding document changes the server has not confirmed.
+	 *
+	 * Reversing `speculativeChanges` produces the server's state, so an empty one means the two
+	 * agree. It stays true across a reconnect, when pending pushes are re-sent rather than dropped.
+	 *
+	 * @public
+	 */
+	hasUnsyncedChanges(): boolean {
+		return !isRecordsDiffEmpty(this.speculativeChanges)
+	}
+
+	/**
+	 * Sends anything this client is holding, and resolves once the server has confirmed all of it.
+	 *
+	 * Pushes are throttled — to one per second while the session is the room's only one, and not at
+	 * all in a tab the browser has stopped giving animation frames to — so a change can be minutes
+	 * old and still be nowhere but this tab. Call this before anything that reads the document from
+	 * the server and expects to see what the user just did.
+	 *
+	 * Resolves immediately when there is nothing outstanding. Rejects if the client closes while
+	 * waiting. It does not time out: a disconnected client keeps its changes and pushes them on
+	 * reconnect, so a caller that cannot wait indefinitely should race this against its own timer.
+	 *
+	 * @public
+	 */
+	flushChanges(): Promise<void> {
+		if (!this.hasUnsyncedChanges()) return Promise.resolve()
+		// Run the queued push now rather than on the frame the throttle would have chosen.
+		this.fpsScheduler.flushNow()
+		if (!this.hasUnsyncedChanges()) return Promise.resolve()
+		return new Promise((resolve, reject) => {
+			this.flushWaiters.push({ resolve, reject })
+		})
+	}
+
+	/** Settles anyone waiting on `flushChanges`, once the server has confirmed everything. */
+	private resolveFlushWaiters() {
+		if (this.flushWaiters.length === 0 || this.hasUnsyncedChanges()) return
+		const waiters = this.flushWaiters
+		this.flushWaiters = []
+		for (const waiter of waiters) waiter.resolve()
 	}
 
 	private disposables: Array<() => void> = []
@@ -873,6 +920,11 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.disposables.forEach((dispose) => dispose())
 		this.sendUnsentChanges.cancel?.()
 		this.scheduleRebase.cancel?.()
+		const waiters = this.flushWaiters
+		this.flushWaiters = []
+		for (const waiter of waiters) {
+			waiter.reject(new Error('sync client closed with changes still unsent'))
+		}
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
@@ -1014,6 +1066,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 					this.speculativeChanges = { added: {} as any, updated: {} as any, removed: {} as any }
 					this.resetConnection()
 				}
+				// The only point at which the server can have confirmed everything this client held.
+				this.resolveFlushWaiters()
 			})
 			this.lastServerClock = diffs.at(-1)?.serverClock ?? this.lastServerClock
 		} catch (e) {

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -4,7 +4,6 @@ import {
 	RecordsDiff,
 	Store,
 	UnknownRecord,
-	isRecordsDiffEmpty,
 	reverseRecordsDiff,
 	squashRecordDiffsMutable,
 } from '@tldraw/store'
@@ -401,15 +400,18 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	private flushWaiters: Array<{ resolve(): void; reject(reason: Error): void }> = []
 
 	/**
-	 * Whether this client is holding document changes the server has not confirmed.
+	 * Whether this client is still holding changes it has to send, or has sent and not had
+	 * confirmed.
 	 *
-	 * Reversing `speculativeChanges` produces the server's state, so an empty one means the two
-	 * agree. It stays true across a reconnect, when pending pushes are re-sent rather than dropped.
+	 * Deliberately not `speculativeChanges`, which is the difference between this store and the
+	 * server's and can hold a record permanently — one the server declined, or that its schema
+	 * drops — leaving a diff that never empties however long anyone waits. What can be waited on is
+	 * the queue: everything sent has been acked and there is nothing left to send.
 	 *
 	 * @public
 	 */
 	hasUnsyncedChanges(): boolean {
-		return !isRecordsDiffEmpty(this.speculativeChanges)
+		return this.pendingPushRequests.length > 0 || !!this.unsentChanges.nextDiff
 	}
 
 	/**
@@ -427,18 +429,32 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * @public
 	 */
 	flushChanges(): Promise<void> {
-		if (!this.hasUnsyncedChanges()) return Promise.resolve()
+		// Hand the store's pending history over before asking whether anything is outstanding. A
+		// change made a moment ago is not in `unsentChanges` yet, so without this the answer is
+		// "nothing to send" for the very edit the caller is waiting on. `pushPresence` does the
+		// same, for the same reason.
+		this.store._flushHistory()
+		if (this.isSettled()) return Promise.resolve()
 		// Run the queued push now rather than on the frame the throttle would have chosen.
 		this.fpsScheduler.flushNow()
-		if (!this.hasUnsyncedChanges()) return Promise.resolve()
+		if (this.isSettled()) return Promise.resolve()
 		return new Promise((resolve, reject) => {
 			this.flushWaiters.push({ resolve, reject })
 		})
 	}
 
+	/**
+	 * Connected, with nothing sent-but-unconfirmed and nothing left to send. Offline does not
+	 * qualify however empty the queue looks: changes made while offline sit in `speculativeChanges`
+	 * and are pushed on reconnect, so the server does not have them yet.
+	 */
+	private isSettled(): boolean {
+		return this.isConnectedToRoom && !this.hasUnsyncedChanges()
+	}
+
 	/** Settles anyone waiting on `flushChanges`, once the server has confirmed everything. */
 	private resolveFlushWaiters() {
-		if (this.flushWaiters.length === 0 || this.hasUnsyncedChanges()) return
+		if (this.flushWaiters.length === 0 || !this.isSettled()) return
 		const waiters = this.flushWaiters
 		this.flushWaiters = []
 		for (const waiter of waiters) waiter.resolve()
@@ -576,6 +592,11 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				: undefined
 
 			if (!diff && !presence) {
+				// Neither half survived conversion to a network diff, so neither is ever going to be
+				// sent. Leaving them queued leaves `unsentChanges` permanently non-empty, which reads
+				// as "this client still owes the server something" forever.
+				this.unsentChanges.nextDiff = undefined
+				this.unsentChanges.nextPresence = undefined
 				return
 			}
 
@@ -860,6 +881,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		})
 
 		this.lastServerClock = event.serverClock
+		this.resolveFlushWaiters()
 	}
 
 	private incomingDiffBuffer: TLSocketServerSentDataEvent<R>[] = []
@@ -1066,8 +1088,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 					this.speculativeChanges = { added: {} as any, updated: {} as any, removed: {} as any }
 					this.resetConnection()
 				}
-				// The only point at which the server can have confirmed everything this client held.
-				this.resolveFlushWaiters()
 			})
 			this.lastServerClock = diffs.at(-1)?.serverClock ?? this.lastServerClock
 		} catch (e) {
@@ -1075,5 +1095,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			this.store.ensureStoreIsUsable()
 			this.resetConnection()
 		}
+		this.resolveFlushWaiters()
 	}
 }

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -411,6 +411,10 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * @public
 	 */
 	hasUnsyncedChanges(): boolean {
+		// The store hands changes over on a frame, so an edit made a moment ago is in neither queue
+		// yet and this would answer "nothing outstanding" for the very change a caller is asking
+		// about. `pushPresence` flushes for the same reason.
+		this.store._flushHistory()
 		return this.pendingPushRequests.length > 0 || !!this.unsentChanges.nextDiff
 	}
 
@@ -429,11 +433,6 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 * @public
 	 */
 	flushChanges(): Promise<void> {
-		// Hand the store's pending history over before asking whether anything is outstanding. A
-		// change made a moment ago is not in `unsentChanges` yet, so without this the answer is
-		// "nothing to send" for the very edit the caller is waiting on. `pushPresence` does the
-		// same, for the same reason.
-		this.store._flushHistory()
 		if (this.isSettled()) return Promise.resolve()
 		// Run the queued push now rather than on the frame the throttle would have chosen.
 		this.fpsScheduler.flushNow()
@@ -597,6 +596,9 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				// as "this client still owes the server something" forever.
 				this.unsentChanges.nextDiff = undefined
 				this.unsentChanges.nextPresence = undefined
+				// Dropping them can be what leaves nothing outstanding, and no ack is coming to
+				// settle anyone waiting on it.
+				this.resolveFlushWaiters()
 				return
 			}
 

--- a/packages/sync-core/src/test/TLSyncClientFlush.test.ts
+++ b/packages/sync-core/src/test/TLSyncClientFlush.test.ts
@@ -106,6 +106,20 @@ describe('TLSyncClient.flushChanges', () => {
 		expect(client.hasUnsyncedChanges()).toBe(false)
 	})
 
+	/*
+	 * Pins the contract rather than reproducing the failure: the store's listener is synchronous
+	 * under NODE_ENV=test, so the frame the change would otherwise wait for does not exist here and
+	 * this passes with or without the `_flushHistory` that makes it true in a browser. Kept because
+	 * the contract is the point — asking must account for a change the store has not handed over.
+	 */
+	it('reports the change an edit just made', async () => {
+		const { client, store, docId } = makeInstance()
+
+		store.update(docId, (doc) => ({ ...doc, text: 'edited' }))
+
+		expect(client.hasUnsyncedChanges()).toBe(true)
+	})
+
 	// Closing abandons the socket, so a caller waiting to read the change back must be told rather
 	// than left waiting on an ack that is never coming.
 	it('rejects a pending flush when the client closes', async () => {

--- a/packages/sync-core/src/test/TLSyncClientFlush.test.ts
+++ b/packages/sync-core/src/test/TLSyncClientFlush.test.ts
@@ -1,0 +1,120 @@
+import { computed } from '@tldraw/state'
+import { BaseRecord, RecordId, Store, StoreSchema, createRecordType } from '@tldraw/store'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TLSyncClient } from '../lib/TLSyncClient'
+import { TestServer } from './TestServer'
+import { TestSocketPair } from './TestSocketPair'
+
+// `flushChanges` exists because pushes are throttled — to one per second while the session is the
+// room's only one, and not at all in a tab with no animation frames — so a change can be seconds
+// old and still be nowhere but the tab that made it. Anything reading the document from the server
+// and expecting the user's latest edit has to be able to wait for it.
+//
+// Under NODE_ENV=test the throttles are pass-through, so the push itself is synchronous and what
+// these exercise is the waiting: the promise must not settle until the server has acked, because
+// the ack is the only thing that makes the read safe.
+
+interface TestDoc extends BaseRecord<'doc', RecordId<TestDoc>> {
+	text: string
+}
+const TestDocType = createRecordType<TestDoc>('doc', {
+	scope: 'document',
+	validator: { validate: (value) => value as TestDoc },
+})
+const testSchema = StoreSchema.create<TestDoc>({ doc: TestDocType })
+
+const disposables: Array<() => void> = []
+afterEach(() => {
+	while (disposables.length) disposables.pop()!()
+})
+
+function makeInstance() {
+	const doc0 = TestDocType.create({ id: TestDocType.createId('a'), text: 'start' })
+	const server = new TestServer<TestDoc>(testSchema, {
+		documents: [{ state: doc0, lastChangedClock: 0 }],
+		clock: 0,
+		documentClock: 0,
+		schema: testSchema.serialize(),
+	})
+	const socketPair = new TestSocketPair<TestDoc>('flush-test', server)
+	socketPair.connect()
+
+	const store = new Store<TestDoc>({ schema: testSchema, props: {} })
+	const client = new TLSyncClient<TestDoc>({
+		store,
+		socket: socketPair.clientSocket,
+		presence: computed('presence', () => null),
+		onLoad: () => {},
+		onSyncError: (reason) => {
+			throw new Error(`unexpected sync error: ${reason}`)
+		},
+	})
+	disposables.push(() => client.close())
+
+	while (socketPair.getNeedsFlushing()) {
+		socketPair.flushClientSentEvents()
+		socketPair.flushServerSentEvents()
+	}
+
+	return { server, socketPair, client, store, docId: doc0.id }
+}
+
+/** Whether a promise has settled, without awaiting one that may never settle. */
+function watch(promise: Promise<void>) {
+	const state = { settled: false, rejected: false }
+	promise.then(
+		() => (state.settled = true),
+		() => {
+			state.settled = true
+			state.rejected = true
+		}
+	)
+	return state
+}
+
+describe('TLSyncClient.flushChanges', () => {
+	it('resolves straight away when the server already has everything', async () => {
+		const { client } = makeInstance()
+
+		expect(client.hasUnsyncedChanges()).toBe(false)
+		await expect(client.flushChanges()).resolves.toBeUndefined()
+	})
+
+	it('does not resolve while the server has not acked the change', async () => {
+		const { client, store, docId } = makeInstance()
+		store.update(docId, (doc) => ({ ...doc, text: 'edited' }))
+
+		expect(client.hasUnsyncedChanges()).toBe(true)
+		const flush = watch(client.flushChanges())
+		// A microtask is all an already-resolved promise would need.
+		await Promise.resolve()
+
+		expect(flush.settled).toBe(false)
+	})
+
+	it('resolves once the server acks the change', async () => {
+		const { client, socketPair, store, docId } = makeInstance()
+		store.update(docId, (doc) => ({ ...doc, text: 'edited' }))
+
+		const flushed = client.flushChanges()
+		while (socketPair.getNeedsFlushing()) {
+			socketPair.flushClientSentEvents()
+			socketPair.flushServerSentEvents()
+		}
+
+		await expect(flushed).resolves.toBeUndefined()
+		expect(client.hasUnsyncedChanges()).toBe(false)
+	})
+
+	// Closing abandons the socket, so a caller waiting to read the change back must be told rather
+	// than left waiting on an ack that is never coming.
+	it('rejects a pending flush when the client closes', async () => {
+		const { client, store, docId } = makeInstance()
+		store.update(docId, (doc) => ({ ...doc, text: 'edited' }))
+
+		const flushed = client.flushChanges()
+		client.close()
+
+		await expect(flushed).rejects.toThrow('sync client closed with changes still unsent')
+	})
+})

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -20,6 +20,7 @@ import { TLUserStore } from 'tldraw';
 export type RemoteTLStoreWithStatus = (Extract<TLStoreWithStatus, {
     status: 'synced-remote';
 }> & {
+    flushChanges(): Promise<void>;
     readonly objectAccess: TLObjectStoreAccess;
 }) | Exclude<TLStoreWithStatus, {
     status: 'not-synced';

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -91,6 +91,17 @@ export type RemoteTLStoreWithStatus =
 			 * be allowed to comment without being allowed to edit. Defaults to `'write'`.
 			 */
 			readonly objectAccess: TLObjectStoreAccess
+			/**
+			 * Sends whatever this client is still holding and resolves once the server has confirmed
+			 * it. Resolves immediately when there is nothing outstanding, and rejects if the client
+			 * closes first.
+			 *
+			 * Pushes are throttled, heavily so in a session that is the room's only one, so a change
+			 * can be seconds old and still be nowhere but this tab. Await this before anything that
+			 * reads the document from the server and expects to see what the user just did — taking
+			 * a server-side snapshot, exporting, handing a link to a reader.
+			 */
+			flushChanges(): Promise<void>
 	  })
 
 /**
@@ -430,6 +441,9 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				connectionStatus: connectionStatus === 'error' ? 'offline' : connectionStatus,
 				store: state.readyClient.store,
 				objectAccess: state.objectAccess ?? 'write',
+				// Bound to the client rather than passed as a method reference, so a caller holding
+				// this across a reconnect flushes the client that is live when they call it.
+				flushChanges: () => state.readyClient!.flushChanges(),
 			}
 		},
 		[state]

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -128,6 +128,7 @@ export function filterEntries<Key extends string, Value>(object: {
 // @public
 export class FpsScheduler {
     constructor(targetFps?: number);
+    flushNow(): void;
     fpsThrottle(fn: {
         (): void;
         cancel?(): void;

--- a/packages/utils/src/lib/throttle.ts
+++ b/packages/utils/src/lib/throttle.ts
@@ -38,6 +38,31 @@ export class FpsScheduler {
 		this.lastFlushTime = -this.targetTimePerFrame
 	}
 
+	/**
+	 * Runs everything currently queued, now, instead of on the frame the target rate would have
+	 * picked. Synchronous: once this returns, every function queued at the moment of the call has
+	 * run.
+	 *
+	 * The queue drains on an animation frame, so work can sit in it for as long as the target rate
+	 * says — and indefinitely in a tab the browser has stopped giving frames to. This is for a
+	 * caller that cannot continue until the queued work is done, such as one about to depend on a
+	 * change having been sent.
+	 *
+	 * @public
+	 */
+	flushNow() {
+		if (this.frameRaf !== undefined) {
+			cancelAnimationFrame(this.frameRaf)
+			this.frameRaf = undefined
+		}
+		if (this.flushRaf !== undefined) {
+			cancelAnimationFrame(this.flushRaf)
+			this.flushRaf = undefined
+		}
+		this.lastFlushTime = Date.now()
+		this.flush()
+	}
+
 	private flush() {
 		const queue = this.fpsQueue.splice(0, this.fpsQueue.length)
 		for (const fn of queue) {


### PR DESCRIPTION
Refs #10679.

`TLSyncClient` throttles outbound pushes through `FpsScheduler`, which drains on an animation frame.
A session that is the room's only one runs at `SOLO_MODE_FPS = 1`, and a tab with no animation
frames never drains at all. So a change can be seconds old and still exist nowhere but the tab that
made it.

That is invisible to an app reading the document through the store — the store is always current. It
is wrong for an app reading it *from the server*: taking a snapshot, exporting, or handing out a link
can all capture state the user has already moved past, with no way to know it happened.

Adds a way to wait.

```ts
await store.flushChanges()   // from useSync
// the server now has everything this tab had
```

### What's here

- **`FpsScheduler.flushNow()`** — drains the queue synchronously instead of on the frame the target
  rate would have chosen.
- **`TLSyncClient.flushChanges()`** — sends what is outstanding and resolves once the server has
  acked it. Resolves immediately when there is nothing outstanding; rejects if the client closes
  while waiting. It does not time out, because a disconnected client keeps its changes and pushes
  them on reconnect — a caller that cannot wait indefinitely should race it against its own timer.
- **`TLSyncClient.hasUnsyncedChanges()`** — the same condition, readable.
- **`useSync`** surfaces `flushChanges` on its `synced-remote` state, alongside `objectAccess`.

Additive only — the API report diff is four new members, nothing removed or changed.

### One existing bug, fixed because it blocks this

`sendUnsentChanges` returns early when `getNetworkDiff` yields nothing for the queued diff, without
clearing `unsentChanges.nextDiff`:

```ts
if (!diff && !presence) {
	return          // nextDiff stays set, and nothing else clears it
}
```

Nothing ever sends it, so the client reads as owing the server a change forever. Observed live: a
`page:page` update still queued minutes later with nothing in flight and the socket connected. Any
"am I synced?" predicate built on `unsentChanges` inherits it, which is why it is in this PR rather
than a separate one.

### What I chose and why, since the shape is arguable

**Not `speculativeChanges` as the predicate**, though its docstring makes it tempting — reversing it
yields the server's state, so an empty one means agreement. In a real app it never empties: it held a
document-scoped `user:` record permanently, because the server never confirms that record. The queue
(`pendingPushRequests` + `unsentChanges`) is what can actually be waited on.

**`flushChanges` calls `store._flushHistory()` first.** Without it, a change made moments earlier is
not yet in `unsentChanges`, so the answer is "nothing to send" for the very edit the caller is
waiting on — the method resolves instantly and does nothing. `pushPresence` already does this, for
the same reason.

**Waiters settle in `rebase()` and `didReconnect()`.** The ack is the obvious one; the connect path
also reaches a settled state, by stashing `speculativeChanges` and re-pushing.

### Relationship to #10679

This is the read-your-writes half and it does **not** replace the timer fallback proposed there — it
needs it. `flushChanges` forces the push past the throttle, but resolves on the ack, and ack
processing goes through the same rAF-driven scheduler. In a hidden tab the push goes out and the
promise then waits forever. The two are complementary; with only this one, the promise hangs in
exactly the conditions #10679 describes.

### Change type

- [x] `feature`
- [x] `bugfix` (the `unsentChanges` clear)
- [x] `api`

### Test plan

- [x] Unit tests — `packages/sync-core/src/test/TLSyncClientFlush.test.ts`, using the existing
  `TestServer`/`TestSocketPair` harness: resolves immediately when settled, stays pending until the
  server acks, resolves on the ack, rejects on close.
- [ ] End to end tests

Verified against a real app (tldraw-flash, carrying this as a patch). Editing then publishing
immediately, where publish reads the room server-side:

```
without flushChanges:  { inArtifact: false }
with flushChanges:     { inArtifact: true }
```

### Release notes

- Added `flushChanges` and `hasUnsyncedChanges`, letting an app wait for its changes to reach the
  server before reading the document back from it.
- Fixed the sync client holding queued changes forever when they produce no network diff.


### API changes

Additive only. Four new public members, nothing removed, changed or deprecated.

**`@tldraw/utils`**
- `FpsScheduler.flushNow(): void` — runs everything currently queued, synchronously, instead of on
  the frame the target rate would have chosen.

**`@tldraw/sync-core`**
- `TLSyncClient.flushChanges(): Promise<void>` — sends what is outstanding and resolves once the
  server has acked it. Resolves immediately when there is nothing outstanding; rejects if the client
  closes while waiting; does not time out on its own.
- `TLSyncClient.hasUnsyncedChanges(): boolean` — whether this client is holding changes it has to
  send, or has sent and not had confirmed.

**`@tldraw/sync`**
- `RemoteTLStoreWithStatus`'s `synced-remote` member gains `flushChanges(): Promise<void>`,
  alongside the existing `objectAccess`.

No behavioural change to existing API, with one exception worth calling out: `sendUnsentChanges` now
clears `unsentChanges` when the queued diff yields no network diff. Previously it left them set
forever. Nothing could observe that state through public API before this PR, which is why it is a fix
rather than a break.
