### PR TITLE
fix(editor): only let the owning pointer drive the menu click capture

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -29,6 +29,7 @@ export function MenuClickCapture() {
 		isDown: false,
 		isDragging: false,
 		button: 0,
+		pointerId: -1,
 		start: new Vec(),
 	})
 
@@ -69,6 +70,11 @@ export function MenuClickCapture() {
 
 	const handlePointerDown = useCallback(
 		(e: PointerEvent) => {
+			// This overlay tracks a single press. A second pointer landing while one is active —
+			// a palm resting on the glass beside a pen — must not take over the gesture, or its
+			// own cancel would end the press it stole.
+			if (rPointerState.current.isDown) return
+
 			const button = getPointerEventButton(e)
 			if (button !== 0 && button !== 2) return
 
@@ -94,6 +100,7 @@ export function MenuClickCapture() {
 				isDown: true,
 				isDragging: false,
 				button,
+				pointerId: e.pointerId,
 				start: new Vec(e.clientX, e.clientY),
 			}
 
@@ -111,7 +118,7 @@ export function MenuClickCapture() {
 	const handlePointerMove = useCallback(
 		(e: PointerEvent) => {
 			const state = rPointerState.current
-			if (!state.isDown) return
+			if (!state.isDown || state.pointerId !== e.pointerId) return
 
 			// Left-click: wait for the drag threshold before forwarding anything, then
 			// replay pointerdown at the original start so the editor records the
@@ -144,15 +151,17 @@ export function MenuClickCapture() {
 
 	const handlePointerUp = useCallback(
 		(e: PointerEvent) => {
-			const isStaticRightClick =
-				rPointerState.current.button === 2 && !rPointerState.current.isDragging
+			const state = rPointerState.current
+			if (!state.isDown || state.pointerId !== e.pointerId) return
+
+			const isStaticRightClick = state.button === 2 && !state.isDragging
 
 			editor.dispatch({
 				type: 'pointer',
 				target: 'canvas',
 				name: 'pointer_up',
 				...getPointerInfo(editor, e),
-				button: rPointerState.current.button === 2 ? 2 : getPointerEventButton(e),
+				button: state.button === 2 ? 2 : getPointerEventButton(e),
 			})
 
 			if (isStaticRightClick && editor.options.rightClickPanning) {
@@ -183,6 +192,7 @@ export function MenuClickCapture() {
 				isDown: false,
 				isDragging: false,
 				button: 0,
+				pointerId: -1,
 				start: new Vec(e.clientX, e.clientY),
 			}
 		},
@@ -192,9 +202,9 @@ export function MenuClickCapture() {
 	const handlePointerCancel = useCallback(
 		(e: PointerEvent) => {
 			const state = rPointerState.current
-			if (!state.isDown) {
-				// A right-click press was forwarded to the canvas, so let the canvas
-				// handler end it.
+			if (!state.isDown || state.pointerId !== e.pointerId) {
+				// Either a right-click press that was forwarded to the canvas, or a pointer this
+				// overlay never tracked. Neither is ours to end, so let the canvas handler decide.
 				canvasEvents.onPointerCancel?.(e)
 				return
 			}
@@ -222,6 +232,7 @@ export function MenuClickCapture() {
 				isDown: false,
 				isDragging: false,
 				button: 0,
+				pointerId: -1,
 				start: new Vec(e.clientX, e.clientY),
 			}
 		},

--- a/packages/tldraw/src/test/pointercancel-dom.test.tsx
+++ b/packages/tldraw/src/test/pointercancel-dom.test.tsx
@@ -236,6 +236,71 @@ describe('pointercancel on the menu click capture overlay', () => {
 		expect(editor.inputs.buttons.size).toBe(0)
 	})
 
+	it('ignores a cancel from a pointer it never tracked', async () => {
+		// A palm resting on the overlay beside a drawing pen: the overlay is full screen for
+		// the whole press, so the palm lands on it, and its cancel must not end the pen's stroke.
+		const { editor, pointerMove } = await setupScene()
+		editor.setCurrentTool('draw')
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+
+		// The pen presses the overlay to dismiss the menu, then drags into a stroke.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50, { pointerType: 'pen' }))
+		})
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointermove', 300, 100, { pointerType: 'pen' }))
+		})
+		await pointerMove(320, 120, { pointerType: 'pen' })
+		expect(editor.isIn('draw.drawing')).toBe(true)
+
+		// The palm lands on the overlay and the OS rejects it.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+			overlay()!.dispatchEvent(pointerEvent('pointercancel', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+		})
+
+		expect(editor.isIn('draw.drawing')).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(true)
+	})
+
+	it('does not let another pointer drag the tracked press past the threshold', async () => {
+		// The overlay defers the editor pointer_down until the press crosses the drag
+		// threshold, measured from the tracked press's start. A palm landing and sliding
+		// must not be what crosses it, or it replays a pointer_down the user never made.
+		const { editor } = await setupScene()
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = () =>
+			document.querySelector('[data-testid="menu-click-capture.content"]') as HTMLElement | null
+
+		// The pen presses to dismiss the menu but stays put, well inside the threshold.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 250, 50, { pointerType: 'pen' }))
+		})
+		expect(editor.inputs.getIsPointing()).toBe(false)
+
+		// The palm lands far away and slides.
+		await act(async () => {
+			overlay()!.dispatchEvent(pointerEvent('pointerdown', 700, 700, { pointerId: 2 }))
+			editor.emit('tick', 16)
+			overlay()!.dispatchEvent(pointerEvent('pointermove', 900, 900, { pointerId: 2 }))
+			editor.emit('tick', 16)
+		})
+
+		// No pointer_down was replayed, so the editor never started an interaction.
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.isIn('select.idle')).toBe(true)
+	})
+
 	it('unmounts the overlay when a press is cancelled before it starts dragging', async () => {
 		const { editor } = await setupScene()
 


### PR DESCRIPTION
Targets `fix/issue-10394` (#10464), not `main` — it builds on the `pointercancel` handling added there. Found while reviewing that PR; the pointer-identity half was also flagged by the cursor bot on it.

This PR fixes a bug where a palm resting on the screen ends the stroke a pen is drawing, when the stroke was started while a menu was open.

### Before

`MenuClickCapture` tracks one press in `rPointerState`, with no pointer id. The overlay stays mounted and full screen for the whole press — that's deliberate, so it still receives the pointerup for a gesture it started — which means any second pointer lands on it too.

So a palm resting on the glass beside a drawing pen went through `handlePointerDown` and overwrote the pen's record. When the OS then rejected the palm, `handlePointerCancel` read that record, saw a live press, and ended it. The pen was still on the glass; the stroke was over.

The same missing check let another pointer's moves drag the tracked press past the drag threshold, replaying a `pointer_down` at the tracked press's origin that the user never made.

Note that `useCanvasEvents` already guards its own `pointercancel` against exactly this, with a per-`pointerId` map and a pen-mode check. `MenuClickCapture` reimplements a subset of the same pipeline and had neither.

### After

The overlay records which pointer owns the press and ignores every other one: a pointerdown arriving while a press is already active, and moves, ups and cancels whose `pointerId` doesn't match.

A cancel from an untracked pointer falls through to the existing delegation branch, where the canvas handler has no record of it either, so nothing happens.

### Implementation notes

- No pen-mode check, unlike the canvas handler. The identity check subsumes it, and it also holds when pen mode is **off** — which is the case that actually bites here. `MenuClickCapture` never passes `isPenDirect`, so a stroke started on the overlay never enables pen mode, and the canvas's pen guard would not have applied to it.
- Two things this deliberately leaves alone, both pre-existing and better fixed with shared state than duplicated guards: a right-click forwarded to the canvas registers in the overlay's `useCanvasEvents` closure while its cancel arrives at the canvas's, so that cancel is dropped; and the overlay's replayed `pointer_down` not carrying `isPenDirect`, per the point above.

### Change type

- [x] `bugfix`

### Test plan

Needs a tablet and a pen: open any menu, press on the canvas with the pen to dismiss it, keep drawing, then rest a palm on the screen. The stroke should continue.

- [x] Unit tests — two added to `pointercancel-dom.test.tsx`; both fail on `fix/issue-10394` and pass with this change. The 8 existing tests in that file pass either way.

No before/after recordings: the interaction needs a second pointer and an OS-level cancel, which the recording harness can't produce.

### Release notes

- Fix a palm resting on the screen ending a pen stroke started while a menu was open.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -7   |
| Tests     | +65 / -0   |
