### PR TITLE
feat(tldraw): export the TipTap extension surface

### DIFF
--- a/apps/docs/content/sdk-features/rich-text.mdx
+++ b/apps/docs/content/sdk-features/rich-text.mdx
@@ -106,8 +106,7 @@ const extensions = getTipTapDefaultExtensions({ heading: false })
 You can add custom TipTap extensions through the `text` field of the `options` prop on the Tldraw component ([TLTextOptions](?)):
 
 ```tsx
-import { Mark, mergeAttributes } from '@tiptap/core'
-import { Tldraw, tipTapDefaultExtensions } from 'tldraw'
+import { Mark, Tldraw, mergeAttributes, tipTapDefaultExtensions } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 const CustomMark = Mark.create({
@@ -146,6 +145,26 @@ export default function App() {
 ```
 
 The `extensions` array replaces the default list entirely, so spread `tipTapDefaultExtensions` (or the result of `getTipTapDefaultExtensions`) to keep tldraw's defaults. Passing `[StarterKit, CustomMark]` alone drops highlighting and text direction, and StarterKit's default link config opens links on click while editing.
+
+### Importing TipTap
+
+Import TipTap's building blocks from `tldraw` rather than installing `@tiptap/*` alongside it. tldraw re-exports `Node`, `Mark`, `Extension`, `mergeAttributes`, `getSchema`, the `Extensions` and `JSONContent` types, and the `TaskList` and `TaskItem` extensions from the copy it bundles. Installing your own copy can resolve to a second `@tiptap/core` and ProseMirror, and ProseMirror throws when a schema is built from nodes belonging to two different instances.
+
+Task lists aren't part of the default extension set. Add them yourself, along with styles for the checkboxes, which tldraw doesn't provide:
+
+```tsx
+import { TaskItem, TaskList, tipTapDefaultExtensions } from 'tldraw'
+
+const options = {
+	text: {
+		tipTapConfig: {
+			extensions: [...tipTapDefaultExtensions, TaskList, TaskItem.configure({ nested: true })],
+		},
+	},
+}
+```
+
+Extensions tldraw doesn't re-export still need their own package. Install them at the same TipTap version tldraw depends on so your package manager dedupes `@tiptap/core` down to a single copy.
 
 ### Rich text toolbar
 
@@ -255,7 +274,7 @@ The chain API lets you compose multiple operations. Each command returns a chain
 For operations outside the editing context, you can manipulate the rich text JSON directly. `TLRichText.content` is typed as `unknown[]`, so cast to TipTap's `JSONContent` when walking the tree:
 
 ```typescript
-import { JSONContent } from '@tiptap/core'
+import { JSONContent } from 'tldraw'
 
 function makeAllTextBold(richText: TLRichText): TLRichText {
 	const content = (richText.content as JSONContent[]).map((paragraph) => {

--- a/apps/examples/src/examples/shapes/tools/outlined-text/OutlinedTextExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/outlined-text/OutlinedTextExample.tsx
@@ -1,11 +1,12 @@
-import { Mark, mergeAttributes } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import {
 	DefaultRichTextToolbar,
 	DefaultRichTextToolbarContent,
+	Mark,
 	TLComponents,
 	Tldraw,
 	TldrawUiButton,
+	mergeAttributes,
 	preventDefault,
 	tipTapDefaultExtensions,
 	useEditor,

--- a/apps/examples/src/examples/shapes/tools/rich-text-custom-extension/RichTextCustomExtension.tsx
+++ b/apps/examples/src/examples/shapes/tools/rich-text-custom-extension/RichTextCustomExtension.tsx
@@ -1,11 +1,12 @@
-import { Mark, mergeAttributes } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import {
 	DefaultRichTextToolbar,
 	DefaultRichTextToolbarContent,
+	Mark,
 	TLComponents,
 	Tldraw,
 	TldrawUiButton,
+	mergeAttributes,
 	preventDefault,
 	tipTapDefaultExtensions,
 	useEditor,

--- a/apps/examples/src/examples/shapes/tools/rich-text-font-extensions/FontSizeExtension.ts
+++ b/apps/examples/src/examples/shapes/tools/rich-text-font-extensions/FontSizeExtension.ts
@@ -1,5 +1,5 @@
 import '@tiptap/extension-text-style'
-import { Extension } from '@tiptap/core'
+import { Extension } from 'tldraw'
 
 export interface FontSizeOptions {
 	/**

--- a/apps/examples/src/examples/ui/text-mass-style-updates/TextMassStyleUpdates.tsx
+++ b/apps/examples/src/examples/ui/text-mass-style-updates/TextMassStyleUpdates.tsx
@@ -1,10 +1,11 @@
-import { getSchema, JSONContent } from '@tiptap/core'
 import { Fragment, Node, Schema } from '@tiptap/pm/model'
 import {
 	DefaultStylePanel,
 	DefaultStylePanelContent,
 	Editor,
 	ExtractShapeByProps,
+	getSchema,
+	JSONContent,
 	tipTapDefaultExtensions,
 	TLComponents,
 	Tldraw,

--- a/internal/scripts/api-check.ts
+++ b/internal/scripts/api-check.ts
@@ -22,6 +22,7 @@ const packagesOurTypesCanDependOn = [
 // We pin to the workspace's resolved versions to avoid installing broken releases.
 const pinnedPackages = [
 	'@tiptap/core',
+	'@tiptap/extension-list',
 	'@tiptap/extension-mention',
 	'@tiptap/pm',
 	'@tiptap/react',

--- a/packages/mentions/api-report.api.md
+++ b/packages/mentions/api-report.api.md
@@ -10,7 +10,7 @@ import { JsonObject } from 'tldraw';
 import { JSX } from 'react/jsx-runtime';
 import { MentionNodeAttrs } from '@tiptap/extension-mention';
 import { MentionOptions } from '@tiptap/extension-mention';
-import { Node as Node_2 } from '@tiptap/core';
+import { Node as Node_2 } from 'tldraw';
 import { ReactNode } from 'react';
 import { RefAttributes } from 'react';
 import type { SuggestionOptions } from '@tiptap/suggestion';

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -28,21 +28,26 @@ import { ForwardRefExoticComponent } from 'react';
 import { Geometry2d } from '@tldraw/editor';
 import { Geometry2dFilters } from '@tldraw/editor';
 import { Geometry2dOptions } from '@tldraw/editor';
+import { getSchema } from '@tiptap/core';
 import { Group2d } from '@tldraw/editor';
 import { HandleSnapGeometry } from '@tldraw/editor';
 import { HTMLAttributes } from 'react';
 import { IndexKey } from '@tldraw/utils';
 import { IndexKey as IndexKey_2 } from '@tldraw/editor';
+import { JSONContent } from '@tiptap/core';
 import { JsonObject } from '@tldraw/utils';
 import { JSX } from 'react/jsx-runtime';
 import { JSXElementConstructor } from 'react';
 import { LANGUAGES } from '@tldraw/editor';
+import { Mark } from '@tiptap/core';
 import { MatLike } from '@tldraw/editor';
 import { MemoExoticComponent } from 'react';
+import { mergeAttributes } from '@tiptap/core';
 import { MigrationFailureReason } from '@tldraw/editor';
 import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
-import { Node as Node_2 } from '@tiptap/pm/model';
+import { Node as Node_2 } from '@tiptap/core';
+import { Node as Node_3 } from '@tiptap/pm/model';
 import { OverlayOptionsWithDisplayValues } from '@tldraw/editor';
 import { OverlayUtil } from '@tldraw/editor';
 import { PerfectDashTerminal } from '@tldraw/editor';
@@ -72,6 +77,10 @@ import { StateNode } from '@tldraw/editor';
 import { StyleProp } from '@tldraw/editor';
 import { SvgExportContext } from '@tldraw/editor';
 import { SVGProps } from 'react';
+import { TaskItem } from '@tiptap/extension-list';
+import { TaskItemOptions } from '@tiptap/extension-list';
+import { TaskList } from '@tiptap/extension-list';
+import { TaskListOptions } from '@tiptap/extension-list';
 import { TiptapEditor } from '@tldraw/editor';
 import { TLAnyBindingUtilConstructor } from '@tldraw/editor';
 import { TLAnyShapeUtilConstructor } from '@tldraw/editor';
@@ -1134,7 +1143,7 @@ export const DefaultActionsMenu: MemoExoticComponent<({ children, }: TLUiActions
 export function DefaultActionsMenuContent(): JSX.Element;
 
 // @public (undocumented)
-export function defaultAddFontsFromNode(node: Node_2, state: RichTextFontVisitorState, addFont: (font: TLFontFace_2) => void): RichTextFontVisitorState;
+export function defaultAddFontsFromNode(node: Node_3, state: RichTextFontVisitorState, addFont: (font: TLFontFace_2) => void): RichTextFontVisitorState;
 
 // @public (undocumented)
 export const defaultAssetUtils: readonly [typeof ImageAssetUtil, typeof VideoAssetUtil, typeof BookmarkAssetUtil];
@@ -1961,6 +1970,10 @@ export interface ExportAsOptions extends TLImageExportOptions {
 // @public (undocumented)
 export function ExportFileContentSubMenu(): JSX.Element | null;
 
+export { Extension }
+
+export { Extensions }
+
 // @public (undocumented)
 export function ExtrasGroup(): JSX.Element;
 
@@ -2394,6 +2407,8 @@ export function getPointsFromDrawSegment(segment: TLDrawShapeSegment, scaleX: nu
 // @public (undocumented)
 export function getPointsFromDrawSegments(segments: TLDrawShapeSegment[], scaleX?: number, scaleY?: number): Vec[];
 
+export { getSchema }
+
 // @public
 export function getStroke(points: VecLike[], options?: StrokeOptions): Vec[];
 
@@ -2622,6 +2637,8 @@ export interface ImageShapeUtilDisplayValues {
 // @public (undocumented)
 export function InputModeMenu(): JSX.Element;
 
+export { JSONContent }
+
 // @public (undocumented)
 export const KeyboardShiftEnterTweakExtension: Extension<any, any>;
 
@@ -2800,6 +2817,10 @@ export interface LineToPathBuilderCommand extends PathBuilderCommandBase {
 // @public (undocumented)
 export function LockGroup(): JSX.Element;
 
+export { Mark }
+
+export { mergeAttributes }
+
 // @public (undocumented)
 export function MiscMenuGroup(): JSX.Element;
 
@@ -2818,6 +2839,8 @@ export interface MoveToPathBuilderCommand extends PathBuilderCommandBase {
     // (undocumented)
     type: 'move';
 }
+
+export { Node_2 as Node }
 
 // @public (undocumented)
 export interface NonePathBuilderOpts extends BasePathBuilderOpts {
@@ -3759,6 +3782,14 @@ export type StyleValuesForUi<T> = readonly {
     readonly icon: string | TLUiIconJsx;
     readonly value: T;
 }[];
+
+export { TaskItem }
+
+export { TaskItemOptions }
+
+export { TaskList }
+
+export { TaskListOptions }
 
 // @public (undocumented)
 export interface TextAreaProps {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -845,6 +845,19 @@ export {
 } from './lib/utils/text/richText'
 export { truncateStringWithEllipsis } from './lib/utils/text/text'
 export {
+	Extension,
+	getSchema,
+	Mark,
+	mergeAttributes,
+	Node,
+	TaskItem,
+	TaskList,
+	type Extensions,
+	type JSONContent,
+	type TaskItemOptions,
+	type TaskListOptions,
+} from './lib/utils/text/tiptap'
+export {
 	buildFromV1Document,
 	TLV1AlignStyle,
 	TLV1AssetType,

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -288,7 +288,11 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 		// Check if the current line or any of its parent nodes are part of a list
 		let isInList = false
 		state.doc.nodesBetween(lineStart, lineEnd, (node) => {
-			if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
+			if (
+				node.type.name === 'bulletList' ||
+				node.type.name === 'orderedList' ||
+				node.type.name === 'taskList'
+			) {
 				isInList = true
 				return false // Stop iteration
 			}

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -1,9 +1,12 @@
-import { TLRichText, toRichText } from '@tldraw/editor'
+import { Editor as TextEditor, Extensions, JSONContent } from '@tiptap/core'
+import { Editor, TLRichText, toRichText } from '@tldraw/editor'
 import {
+	isEditingRichTextList,
 	isEmptyRichText,
 	renderHtmlFromRichTextWithExtensions,
 	tipTapDefaultExtensions,
 } from './richText'
+import { TaskItem, TaskList } from './tiptap'
 
 const render = (content: TLRichText['content']) =>
 	renderHtmlFromRichTextWithExtensions(
@@ -83,5 +86,47 @@ describe('isEmptyRichText', () => {
 			],
 		}
 		expect(isEmptyRichText(richText)).toBe(false)
+	})
+})
+
+describe('isEditingRichTextList', () => {
+	const editingWith = (extensions: Extensions, content: JSONContent) => {
+		const textEditor = new TextEditor({ extensions, content })
+		return { getRichTextEditor: () => textEditor } as unknown as Editor
+	}
+
+	const listItem = (type: string, itemType: string): JSONContent => ({
+		type,
+		content: [
+			{ type: itemType, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a' }] }] },
+		],
+	})
+
+	it('is false in a plain paragraph', () => {
+		const editor = editingWith(tipTapDefaultExtensions, toRichText('a') as JSONContent)
+		expect(isEditingRichTextList(editor)).toBe(false)
+	})
+
+	it('is true in the default lists', () => {
+		for (const [list, item] of [
+			['bulletList', 'listItem'],
+			['orderedList', 'listItem'],
+		]) {
+			const editor = editingWith(tipTapDefaultExtensions, {
+				type: 'doc',
+				content: [listItem(list, item)],
+			})
+			expect(isEditingRichTextList(editor)).toBe(true)
+		}
+	})
+
+	it('is true in a task list, whose items bind Tab themselves', () => {
+		// Without this, our Tab handler runs alongside TaskItem's and one keypress both indents the
+		// text and nests the item.
+		const editor = editingWith([...tipTapDefaultExtensions, TaskList, TaskItem], {
+			type: 'doc',
+			content: [listItem('taskList', 'taskItem')],
+		})
+		expect(isEditingRichTextList(editor)).toBe(true)
 	})
 })

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -157,12 +157,21 @@ export function isEmptyRichText(richText: TLRichText) {
 }
 
 /**
- * Whether the editor's active rich text selection is inside a bullet or ordered list.
+ * Whether the editor's active rich text selection is inside a list.
+ *
+ * `taskList` isn't in the default extension set, but when it is added its list items bind Tab and
+ * Shift-Tab themselves. Leaving it out here lets our own Tab handling run alongside TipTap's, so a
+ * single keypress both indents the text and nests the item.
+ *
  * @internal
  */
 export function isEditingRichTextList(editor: Editor) {
 	const textEditor = editor.getRichTextEditor()
-	return !!(textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList'))
+	return !!(
+		textEditor?.isActive('bulletList') ||
+		textEditor?.isActive('orderedList') ||
+		textEditor?.isActive('taskList')
+	)
 }
 
 /**

--- a/packages/tldraw/src/lib/utils/text/tiptap.test.ts
+++ b/packages/tldraw/src/lib/utils/text/tiptap.test.ts
@@ -1,0 +1,40 @@
+import { renderHtmlFromRichTextWithExtensions, tipTapDefaultExtensions } from './richText'
+import { getSchema, Mark, mergeAttributes, TaskItem, TaskList } from './tiptap'
+
+describe('re-exported TipTap surface', () => {
+	it('builds a schema from tldraw defaults plus a mark made with the re-exported Mark', () => {
+		// ProseMirror throws when a schema mixes nodes from two copies of itself.
+		const Wavy = Mark.create({
+			name: 'wavy',
+			parseHTML: () => [{ tag: 'span.wavy' }],
+			renderHTML: ({ HTMLAttributes }) => [
+				'span',
+				mergeAttributes({ class: 'wavy' }, HTMLAttributes),
+				0,
+			],
+		})
+
+		const extensions = [...tipTapDefaultExtensions, Wavy]
+		expect(getSchema(extensions).marks.wavy).toBeTruthy()
+		expect(
+			renderHtmlFromRichTextWithExtensions(
+				{
+					type: 'doc',
+					content: [
+						{
+							type: 'paragraph',
+							content: [{ type: 'text', marks: [{ type: 'wavy' }], text: 'hi' }],
+						},
+					],
+				},
+				extensions
+			)
+		).toBe('<p dir="auto"><span class="wavy">hi</span></p>')
+	})
+
+	it('adds task lists to tldraw defaults', () => {
+		const schema = getSchema([...tipTapDefaultExtensions, TaskList, TaskItem])
+		expect(schema.nodes.taskList).toBeTruthy()
+		expect(schema.nodes.taskItem).toBeTruthy()
+	})
+})

--- a/packages/tldraw/src/lib/utils/text/tiptap.ts
+++ b/packages/tldraw/src/lib/utils/text/tiptap.ts
@@ -1,0 +1,18 @@
+// TipTap re-exported so extension authors don't install `@tiptap/*` themselves: a separate copy
+// brings its own ProseMirror, and ProseMirror throws when a schema mixes nodes from two instances.
+// These come out of tldraw's bundle, so they stay single-instance at the version tldraw ships.
+export {
+	Extension,
+	getSchema,
+	Mark,
+	mergeAttributes,
+	Node,
+	type Extensions,
+	type JSONContent,
+} from '@tiptap/core'
+export {
+	TaskItem,
+	TaskList,
+	type TaskItemOptions,
+	type TaskListOptions,
+} from '@tiptap/extension-list'


### PR DESCRIPTION
In order to write a custom TipTap extension against tldraw without installing `@tiptap/*` yourself, this PR re-exports the pieces you need from `tldraw`. Closes #10548.

Customizing rich text through `options.text.tipTapConfig.extensions` is public API, but the classes you need to build an extension — `Node`, `Mark`, `Extension` — weren't exported. Today you add `@tiptap/core` to your own `package.json` to get them, and a version that doesn't dedupe against the one tldraw bundles gives you a second ProseMirror. ProseMirror throws when a schema is built from nodes belonging to two instances, so the failure shows up at schema build time rather than at install time.

The re-exports come out of tldraw's bundle, so they're single-instance by construction and version-locked to the TipTap version tldraw ships.

```tsx
// Before
import { Mark, mergeAttributes } from '@tiptap/core'
import { Tldraw, tipTapDefaultExtensions } from 'tldraw'

// After
import { Mark, Tldraw, mergeAttributes, tipTapDefaultExtensions } from 'tldraw'
```

The issue also asked for commonly-requested extensions, so `TaskList` and `TaskItem` come along from `@tiptap/extension-list`, which tldraw already depends on. They aren't in the default extension set and tldraw doesn't style the checkboxes — that's noted in the docs.

`Node` and `Mark` are exported under their TipTap names so the TipTap docs copy-paste cleanly. There's no collision with anything tldraw exports today; `TiptapNode` is already taken, and means the ProseMirror node type rather than the class you call `.create()` on.

I left out `@tiptap/react`'s node-view helpers (`ReactNodeViewRenderer`, `NodeViewWrapper`, `NodeViewContent`). They have the same duplication hazard and would be a reasonable follow-up, but nothing in the issue or our examples needs them yet.

### API changes

- Added re-exports from `@tiptap/core`: `Node`, `Mark`, `Extension`, `mergeAttributes`, `getSchema`, and the `Extensions` and `JSONContent` types
- Added re-exports from `@tiptap/extension-list`: `TaskList`, `TaskItem`, and the `TaskListOptions` and `TaskItemOptions` types

### Change type

- [x] `api`

### Test plan

1. Run the [rich text custom extension](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-custom-extension) and [outlined text](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/outlined-text) examples — both now build their marks with `Mark` and `mergeAttributes` imported from `tldraw`. The toolbar buttons should still toggle the mark on selected text.
2. Run the [rich text font extensions](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-font-extensions) and [text mass style updates](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/text-mass-style-updates) examples, which now take `Extension` and `getSchema`/`JSONContent` from `tldraw`.

- [x] Unit tests

### Release notes

- Export TipTap's `Node`, `Mark`, `Extension`, `mergeAttributes` and `getSchema`, along with the `TaskList` and `TaskItem` extensions, so custom rich text extensions no longer need their own `@tiptap/*` install.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +31 / -0   |
| Tests           | +40 / -0   |
| Automated files | +34 / -3   |
| Documentation   | +29 / -7   |
| Config/tooling  | +1 / -0    |
