### PR TITLE
fix(store): apply side-effect handler removal immediately during dispatch

### DIFF
--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -66,7 +66,7 @@ Sections marked **internal** describe supporting machinery (`ImmutableMap`, `Inc
 
 ## 7. Side effect handlers (SE)
 
-- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all. Removing or registering a handler while handlers are being dispatched takes effect from the next dispatch: every handler registered when an event started is still called for it.
+- **SE1** Handlers are registered per type name and called in registration order; each `register*Handler` call returns a remover. `register({ type: { beforeCreate, ... } })` registers many at once and returns one cleanup that removes them all. Removing a handler while handlers are being dispatched takes effect immediately: a removed handler that has not yet run is skipped for that event, and removing a handler never causes a different handler to be skipped. Registering a handler during dispatch takes effect from the next dispatch.
 - **SE2** `beforeCreate` runs before validation on create; its return value is what gets validated and stored. Multiple handlers chain, each receiving the previous one's output.
 - **SE3** `beforeChange` runs before validation on update, receiving `(prev, next, source)`; its return value is stored. Returning `prev` blocks the update (with a reference-preserving validator this makes the put a complete no-op per S3).
 - **SE4** `beforeDelete` may return `false` to prevent that record's deletion; other records in the same `remove` call are still deleted.

--- a/packages/store/src/lib/StoreSideEffects.test.ts
+++ b/packages/store/src/lib/StoreSideEffects.test.ts
@@ -654,4 +654,36 @@ describe('handler removal during dispatch (SE)', () => {
 		store.put([book1])
 		expect(calls).toEqual(['A', 'B'])
 	})
+
+	it('[SE1] a handler that removes a later handler suppresses it for the current event', () => {
+		const calls: string[] = []
+		let removeB = () => {}
+		store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			removeB()
+		})
+		removeB = store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+
+		store.put([book1])
+		expect(calls).toEqual(['A'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'A'])
+	})
+
+	it('[SE1] a handler registered during dispatch waits for the next event', () => {
+		const calls: string[] = []
+		store.sideEffects.registerAfterCreateHandler('book', () => {
+			calls.push('A')
+			if (calls.length === 1) {
+				store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))
+			}
+		})
+
+		store.put([book1])
+		expect(calls).toEqual(['A'])
+
+		store.put([book2])
+		expect(calls).toEqual(['A', 'A', 'B'])
+	})
 })

--- a/packages/store/src/lib/StoreSideEffects.ts
+++ b/packages/store/src/lib/StoreSideEffects.ts
@@ -264,6 +264,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		if (handlers) {
 			let r = record
 			for (const handler of handlers) {
+				if (!isLive(this._beforeCreateHandlers[record.typeName], handlers, handler)) continue
 				r = handler(r, source)
 			}
 			return r
@@ -286,6 +287,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		const handlers = this._afterCreateHandlers[record.typeName] as StoreAfterCreateHandler<R>[]
 		if (handlers) {
 			for (const handler of handlers) {
+				if (!isLive(this._afterCreateHandlers[record.typeName], handlers, handler)) continue
 				handler(record, source)
 			}
 		}
@@ -308,6 +310,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		if (handlers) {
 			let r = next
 			for (const handler of handlers) {
+				if (!isLive(this._beforeChangeHandlers[next.typeName], handlers, handler)) continue
 				r = handler(prev, r, source)
 			}
 			return r
@@ -331,6 +334,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		const handlers = this._afterChangeHandlers[next.typeName] as StoreAfterChangeHandler<R>[]
 		if (handlers) {
 			for (const handler of handlers) {
+				if (!isLive(this._afterChangeHandlers[next.typeName], handlers, handler)) continue
 				handler(prev, next, source)
 			}
 		}
@@ -351,6 +355,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		const handlers = this._beforeDeleteHandlers[record.typeName] as StoreBeforeDeleteHandler<R>[]
 		if (handlers) {
 			for (const handler of handlers) {
+				if (!isLive(this._beforeDeleteHandlers[record.typeName], handlers, handler)) continue
 				if (handler(record, source) === false) {
 					return false
 				}
@@ -373,6 +378,7 @@ export class StoreSideEffects<R extends UnknownRecord> {
 		const handlers = this._afterDeleteHandlers[record.typeName] as StoreAfterDeleteHandler<R>[]
 		if (handlers) {
 			for (const handler of handlers) {
+				if (!isLive(this._afterDeleteHandlers[record.typeName], handlers, handler)) continue
 				handler(record, source)
 			}
 		}
@@ -388,7 +394,9 @@ export class StoreSideEffects<R extends UnknownRecord> {
 	handleOperationComplete(source: 'remote' | 'user') {
 		if (!this._isEnabled) return
 
-		for (const handler of this._operationCompleteHandlers) {
+		const handlers = this._operationCompleteHandlers
+		for (const handler of handlers) {
+			if (!isLive(this._operationCompleteHandlers, handlers, handler)) continue
 			handler(source)
 		}
 	}
@@ -675,6 +683,14 @@ export class StoreSideEffects<R extends UnknownRecord> {
 			this._operationCompleteHandlers = withoutFirst(this._operationCompleteHandlers, handler)
 		}
 	}
+}
+
+// Dispatch walks the array it looked up, so a removal during dispatch (which swaps in a new array)
+// would otherwise not take effect until the next event: a handler that cancels a later one would
+// still see it run once. Same contract as DOM EventTarget: removals apply immediately, additions
+// wait for the next dispatch. The identity check keeps the no-change case free.
+function isLive<H>(live: H[] | undefined, snapshot: H[], handler: H) {
+	return live === snapshot || (live !== undefined && live.includes(handler))
 }
 
 function withoutFirst<T>(array: T[], item: T): T[] {


### PR DESCRIPTION
This PR fixes a behaviour change introduced by #10231, where a side-effect handler that removes a later handler while running no longer stops that handler from firing for the current event. It is based on the #10231 branch so the diff shows only the delta.

### Before

On `main`, handler lists are mutated in place, so when handler A calls the remover for handler B (registered after A) during a `put`, the splice hits the array the dispatch loop is walking and B does not run for that event. #10231 makes the lists copy-on-write: the remover swaps in a new array, the loop keeps walking the old one, and B fires once before disappearing on the next `put`. The same applies to `operationComplete` handlers.

```ts
let removeB = () => {}
store.sideEffects.registerAfterCreateHandler('book', () => {
	calls.push('A')
	removeB()
})
removeB = store.sideEffects.registerAfterCreateHandler('book', () => calls.push('B'))

store.put([book1])
// main:   ['A']
// #10231: ['A', 'B']
```

### After

Dispatch still walks the array it looked up, but re-reads the live list before each call and skips any handler that is no longer in it. Removals take effect immediately, registrations during dispatch wait for the next event, and removing a handler never shifts an unrelated one out from under the loop. This is the same contract as DOM `EventTarget`. `packages/store/SPEC.md` SE1 is updated to say so.

### Implementation notes

The check is an identity comparison first, so the common case where nothing changes during dispatch costs nothing. Only when a removal has swapped the array does it fall through to `includes`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the new cancel test fails on the #10231 branch and passes with this change; the #10231 tests still pass

### Release notes

- Fix a side-effect handler still firing once for the event in which an earlier handler removed it

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +17 / -1   |
| Tests         | +32 / -0   |
| Documentation | +1 / -1    |
