### PR TITLE
fix(dotcom): skip version chain verification for oversized keyframes

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -71,7 +71,7 @@ import {
 	planCommentDrain,
 	planMentionReconciles,
 } from './commentRows'
-import { PERSIST_INTERVAL_MS } from './config'
+import { MAX_VERIFY_KEYFRAME_BYTES, PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import {
 	ensureMcpClusterIndexTable,
@@ -1369,7 +1369,8 @@ export class TLFileDurableObject extends DurableObject {
 			}
 			case 'version_chain_verify': {
 				this.writeEvent(event.type, {
-					blobs: [event.ok ? 'ok' : 'fail', event.ok ? '' : event.reason],
+					blobs: [event.outcome, event.outcome === 'ok' ? '' : event.reason],
+					doubles: event.outcome === 'skipped' ? [event.keyframeBytes] : [],
 				})
 				break
 			}
@@ -2161,10 +2162,23 @@ export class TLFileDurableObject extends DurableObject {
 		if (
 			result.wrote === 'keyframe' &&
 			(result.reason === 'delta-count' || result.reason === 'chain-age') &&
+			chain &&
 			previous &&
 			pending.length > 0
 		) {
-			this.ctx.waitUntil(this._verifyRetiredChain(pending[pending.length - 1].t, previous))
+			// Skipped, not deferred: reconstructing a big chain is the one thing on this path that can
+			// take the live room down with it (see MAX_VERIFY_KEYFRAME_BYTES), and there is no later
+			// moment where the object holds fewer copies of the board.
+			if (chain.keyframeBytes > MAX_VERIFY_KEYFRAME_BYTES) {
+				this.logEvent({
+					type: 'version_chain_verify',
+					outcome: 'skipped',
+					reason: 'keyframe-size',
+					keyframeBytes: chain.keyframeBytes,
+				})
+			} else {
+				this.ctx.waitUntil(this._verifyRetiredChain(pending[pending.length - 1].t, previous))
+			}
 		}
 		return iso
 	}
@@ -2194,11 +2208,11 @@ export class TLFileDurableObject extends DurableObject {
 						: null
 			this.logEvent(
 				reason === null
-					? { type: 'version_chain_verify', ok: true }
-					: { type: 'version_chain_verify', ok: false, reason }
+					? { type: 'version_chain_verify', outcome: 'ok' }
+					: { type: 'version_chain_verify', outcome: 'fail', reason }
 			)
 		} catch (error) {
-			this.logEvent({ type: 'version_chain_verify', ok: false, reason: 'error' })
+			this.logEvent({ type: 'version_chain_verify', outcome: 'fail', reason: 'error' })
 			this.reportError(error)
 		}
 	}

--- a/apps/dotcom/sync-worker/src/config.ts
+++ b/apps/dotcom/sync-worker/src/config.ts
@@ -206,6 +206,21 @@ export const MAX_SEGMENT_SIZE_RATIO = 1
 export const MIN_SIZE_RULE_DELTA_BYTES = 4096
 
 /**
+ * A retired chain is only verified when its keyframe is at most this many (gzipped) bytes.
+ *
+ * Verification reconstructs the whole chain inside the live durable object: the keyframe decoded,
+ * every segment decoded, and the replayed snapshot, all held alongside the SQLite board, the live
+ * room, and the two persisted snapshots the write already keeps. That is four or five board-sized
+ * copies at once, and the segment size rule bounds only the open segment, not this. Gzip takes
+ * tldraw JSON down roughly 5-10x and the decoded objects are a few times the JSON again, so a 1MB
+ * keyframe is tens of MB per copy — comfortably inside the isolate's 128MB with room for the rest,
+ * where a keyframe near the 25MB room limit would not be. The chain itself is still cut and served
+ * as usual; only the check is skipped, and it says so (`version_chain_verify` with outcome
+ * `skipped`) so the threshold can be tuned against how many boards it excludes.
+ */
+export const MAX_VERIFY_KEYFRAME_BYTES = 1024 * 1024
+
+/**
  * Deltas per segment object. Bounds three things at once: how much the durable object rewrites on
  * each persist (~140KB worst case at this cap), how many GETs a restore costs (1 keyframe + 4
  * segments at kf64), and how many ISO timestamps have to fit in the segment's R2 custom metadata

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -222,13 +222,16 @@ export type TLServerEvent =
 			bytes: number
 			depth: number
 	  } & ({ wrote: 'keyframe'; reason: KeyframeReason } | { wrote: 'delta' }))
-	// Discriminated on `ok`: only a failure carries the reason it failed.
+	// Discriminated on `outcome`: only a failure or a skip carries a reason.
 	| ({
 			/** A cadence keyframe retired a chain; did that chain reconstruct the state it claims? */
 			type: 'version_chain_verify'
 	  } & (
-			| { ok: true }
-			| { ok: false; reason: 'missing' | 'legacy-fallback' | 'head-mismatch' | 'error' }
+			| { outcome: 'ok' }
+			| { outcome: 'fail'; reason: 'missing' | 'legacy-fallback' | 'head-mismatch' | 'error' }
+			// Not a failure: the chain was left unchecked because reconstructing it here would risk
+			// the isolate's memory. Carries the keyframe size so the threshold can be tuned.
+			| { outcome: 'skipped'; reason: 'keyframe-size'; keyframeBytes: number }
 	  ))
 	| {
 			/** A chain write failed in dual mode and was swallowed so the persist could complete. */


### PR DESCRIPTION
This PR improves version chain verification so that a large board cannot take its own durable object down while proving a retired chain. Follow-up to #10615.

### Before

When a cadence keyframe retired a chain, `_verifyRetiredChain` reconstructed the whole chain inside the live durable object: the keyframe decoded, every segment decoded, and the replayed snapshot, held alongside the SQLite board, the live room, and the two persisted snapshots the write already keeps. That is four or five board-sized copies at once. The segment size rule bounds only the open segment, not this path, so a board near the 25MB room limit could hit the isolate's 128MB cap every 64 deltas or every 24 hours, and the OOM kills the room, not just the check.

### After

Verification is skipped when the retired chain's keyframe is over `MAX_VERIFY_KEYFRAME_BYTES` (1MB gzipped). The chain is still cut and served as before; only the check is dropped. The skip is reported as a distinct `version_chain_verify` outcome (`skipped` / `keyframe-size`) carrying the keyframe size, so the threshold can be tuned against how many boards it actually excludes.

### Implementation notes

- The `version_chain_verify` event now discriminates on `outcome: 'ok' | 'fail' | 'skipped'` instead of `ok: boolean`. The analytics blob columns keep their meaning (`blob1` is the outcome, `blob2` the reason); `double1` is new and only set for skips.
- The threshold is on the keyframe alone because that is what the DO knows before spending any R2 ops. A chain's segments are each bounded to one keyframe's worth by the segment size rule, so the keyframe is the dominant and the cheapest term.
- 1MB is a first guess from gzip ratios on tldraw JSON, not a measurement. The point of the metric is to correct it.

### Change type

- [x] `improvement`

### Test plan

1. `yarn workspace @tldraw/dotcom-worker test run`

- [x] Unit tests

### Release notes

- Internal: skip version chain verification on oversized keyframes so the check cannot OOM the durable object.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +41 / -9   |
| Tests     | +0 / -0    |
