### PR TITLE
perf(dotcom): hash a persisted snapshot once per version chain write

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -736,6 +736,10 @@ export class TLFileDurableObject extends DurableObject {
 	// the document just loaded so a cold start does not cut a keyframe; see getStorage for why that
 	// seed may be ahead of R2 and why that is safe.
 	_lastPersistedSnapshot: RoomSnapshot | null = null
+	// `chainHeadHash(_lastPersistedSnapshot)`, kept from the write that produced it so the next
+	// persist does not hash the whole board again just to check the diff base. Null when unknown
+	// (the wake seed); the write computes it once and then it is known.
+	_lastPersistedHeadHash: string | null = null
 	_versionChain: ChainState | null = null
 	_versionChainLoaded = false
 	// The open segment's deltas. Null means "not known here yet" — after an eviction they are
@@ -813,6 +817,7 @@ export class TLFileDurableObject extends DurableObject {
 				// catch the stale chain on the next persist anyway; clearing here makes the next
 				// version an intentional keyframe rather than a recovered mistake.
 				this._lastPersistedSnapshot = null
+				this._lastPersistedHeadHash = null
 				this._versionChain = null
 				this._versionChainLoaded = true
 				this._pendingDeltas = null
@@ -2134,6 +2139,7 @@ export class TLFileDurableObject extends DurableObject {
 						noChainReason,
 						pending,
 						previous: this._lastPersistedSnapshot,
+						previousHeadHash: this._lastPersistedHeadHash ?? undefined,
 						next: snapshot,
 						now: Date.now(),
 					}),
@@ -2146,6 +2152,7 @@ export class TLFileDurableObject extends DurableObject {
 		await this.storage.put(VERSION_CHAIN_STORAGE_KEY, result.chain)
 		const previous = this._lastPersistedSnapshot
 		this._lastPersistedSnapshot = snapshot
+		this._lastPersistedHeadHash = result.chain.headHash
 		this.logEvent({
 			type: 'version_chain_write',
 			bytes: result.bytes,

--- a/apps/dotcom/sync-worker/src/versionChainWrite.test.ts
+++ b/apps/dotcom/sync-worker/src/versionChainWrite.test.ts
@@ -6,6 +6,7 @@ import { createFakeR2 } from './test/fakeR2'
 import { ChainState, PendingDelta } from './versionChain'
 import { reconstructVersion } from './versionChainRead'
 import { readOpenSegment, writeVersionChainEntry } from './versionChainWrite'
+import { chainHeadHash } from './versionDelta'
 
 const roomKey = 'app_rooms/slug'
 
@@ -138,6 +139,51 @@ describe('writeVersionChainEntry', () => {
 		// The buffer resets with the new segment rather than growing without bound.
 		expect(pending).toHaveLength(1)
 		expect((await bucket.list({ prefix: roomKey })).objects).toHaveLength(3)
+	})
+
+	it('trusts a supplied previous head hash instead of hashing the previous snapshot', async () => {
+		const bucket = createFakeR2()
+		const head = snapshot(1, ['shape:a'])
+		const first = await writeVersionChainEntry({
+			bucket,
+			roomKey,
+			iso: isoAt(0),
+			chain: null,
+			pending: [],
+			previous: null,
+			next: head,
+			now: 0,
+		})
+		expect(first.chain.headHash).toBe(chainHeadHash(head))
+
+		// The hash the last write handed back is the one the DO caches; it appends.
+		const appended = await writeVersionChainEntry({
+			bucket,
+			roomKey,
+			iso: isoAt(1),
+			chain: first.chain,
+			pending: first.pending,
+			previous: head,
+			previousHeadHash: first.chain.headHash,
+			next: snapshot(2, ['shape:a', 'shape:b']),
+			now: 1000,
+		})
+		expect(appended.wrote).toBe('delta')
+
+		// A wrong one is believed, and the write recovers with a keyframe rather than recomputing:
+		// the hash is the contract, so a caller that cached it wrong never gets a delta off it.
+		const mismatched = await writeVersionChainEntry({
+			bucket,
+			roomKey,
+			iso: isoAt(2),
+			chain: first.chain,
+			pending: first.pending,
+			previous: head,
+			previousHeadHash: 'not-the-head',
+			next: snapshot(2, ['shape:a', 'shape:b']),
+			now: 2000,
+		})
+		expect(mismatched).toMatchObject({ wrote: 'keyframe', reason: 'content-mismatch' })
 	})
 
 	it('cuts a fresh keyframe when the previous state is not the chain head', async () => {

--- a/apps/dotcom/sync-worker/src/versionChainWrite.ts
+++ b/apps/dotcom/sync-worker/src/versionChainWrite.ts
@@ -10,7 +10,7 @@ import {
 	versionKey,
 } from './versionChain'
 import { decodeVersionBody, encodeVersionBody } from './versionChainCodec'
-import { buildSnapshotDelta, chainHeadHash } from './versionDelta'
+import { buildSnapshotDelta, chainHeadHash, snapshotHashes } from './versionDelta'
 
 interface VersionChainWriteResultBase {
 	chain: ChainState
@@ -31,6 +31,7 @@ export async function writeVersionChainEntry({
 	noChainReason,
 	pending,
 	previous,
+	previousHeadHash,
 	next,
 	now,
 }: {
@@ -41,13 +42,24 @@ export async function writeVersionChainEntry({
 	noChainReason?: 'no-chain' | 'segment-lost'
 	pending: PendingDelta[]
 	previous: RoomSnapshot | null
+	/**
+	 * `chainHeadHash(previous)`, when the caller kept it from the write that produced `previous`
+	 * (it is that write's `chain.headHash`); computed here otherwise. Trusted as given: a wrong value
+	 * cuts a content-mismatch keyframe, never a bad delta.
+	 */
+	previousHeadHash?: string
 	next: RoomSnapshot
 	now: number
 }): Promise<VersionChainWriteResult> {
 	const nextFingerprint = getSnapshotFingerprint(next)
 	const customMetadata = getSnapshotMetadata(next)
+	// One pass for both hashes of `next`: the delta records the envelope hash and the chain head
+	// records the head hash, and on a large board each pass is a canonicalization of every record.
+	const nextHashes = snapshotHashes(next)
 
-	const delta = previous ? buildSnapshotDelta(previous, next) : null
+	const delta = previous
+		? buildSnapshotDelta(previous, next, { envelopeHash: nextHashes.envelope })
+		: null
 	// Compressed on both sides of the size rule: comparing a raw delta against a compressed
 	// keyframe would trip the ratio on boards that simply compress well.
 	const encodedDelta = delta ? await encodeVersionBody(delta) : null
@@ -59,7 +71,7 @@ export async function writeVersionChainEntry({
 		previousFingerprint: previous ? getSnapshotFingerprint(previous) : nextFingerprint,
 		// The hash is what actually pins the diff base: tombstone pruning can change content
 		// without moving the fingerprint.
-		previousHash: previous ? chainHeadHash(previous) : '',
+		previousHash: previous ? (previousHeadHash ?? chainHeadHash(previous)) : '',
 		nextFingerprint,
 		deltaBytes: encodedDelta?.body.byteLength ?? 0,
 		now,
@@ -82,7 +94,7 @@ export async function writeVersionChainEntry({
 				keyframeBytes: encoded.body.byteLength,
 				deltaCount: 0,
 				headFingerprint: nextFingerprint,
-				headHash: chainHeadHash(next),
+				headHash: nextHashes.head,
 				openSegment: null,
 			},
 		}
@@ -118,7 +130,7 @@ export async function writeVersionChainEntry({
 			...chain!,
 			deltaCount: decision.seq,
 			headFingerprint: nextFingerprint,
-			headHash: chainHeadHash(next),
+			headHash: nextHashes.head,
 			openSegment: { ...decision.segment, bytes: encoded.body.byteLength },
 		},
 	}

--- a/apps/dotcom/sync-worker/src/versionDelta.test.ts
+++ b/apps/dotcom/sync-worker/src/versionDelta.test.ts
@@ -4,8 +4,9 @@ import { describe, expect, it } from 'vitest'
 import {
 	applySnapshotDelta,
 	buildSnapshotDelta,
-	versionEnvelopeHash,
 	chainHeadHash,
+	snapshotHashes,
+	versionEnvelopeHash,
 } from './versionDelta'
 
 function rec(id: string, props: Record<string, unknown> = {}): UnknownRecord {
@@ -232,6 +233,23 @@ describe('buildSnapshotDelta / applySnapshotDelta', () => {
 		expect(
 			versionEnvelopeHash(snapshot({ ...base, tombstoneHistoryStartsAtClock: undefined }))
 		).not.toBe(versionEnvelopeHash(base))
+	})
+
+	it('computes both hashes in one pass, and a delta takes the envelope hash as given', () => {
+		const prev = snapshot({ documents: [{ state: rec('shape:a'), lastChangedClock: 1 }] })
+		const next = snapshot({
+			clock: 2,
+			documentClock: 2,
+			documents: [{ state: rec('shape:a', { x: 1 }), lastChangedClock: 2 }],
+		})
+
+		expect(snapshotHashes(next)).toEqual({
+			envelope: versionEnvelopeHash(next),
+			head: chainHeadHash(next),
+		})
+		expect(buildSnapshotDelta(prev, next).hash).toBe(versionEnvelopeHash(next))
+		// Trusted, not checked: the caller computed it from the same snapshot in the same pass.
+		expect(buildSnapshotDelta(prev, next, { envelopeHash: 'as-given' }).hash).toBe('as-given')
 	})
 
 	it('head hash ignores documentClock and nothing else', () => {

--- a/apps/dotcom/sync-worker/src/versionDelta.ts
+++ b/apps/dotcom/sync-worker/src/versionDelta.ts
@@ -54,6 +54,12 @@ export function versionEnvelopeHash(snapshot: RoomSnapshot): string {
 	return snapshotHashes(snapshot).envelope
 }
 
+/** Both hashes of a snapshot from one pass over its records; see each accessor for what it means. */
+export interface SnapshotHashes {
+	envelope: string
+	head: string
+}
+
 /**
  * Identity of a snapshot as a chain head: the envelope hash with `documentClock` left out. That
  * clock is the storage clock shared with the object lane, so a comment write moves it without
@@ -66,7 +72,12 @@ export function chainHeadHash(snapshot: RoomSnapshot): string {
 	return snapshotHashes(snapshot).head
 }
 
-function snapshotHashes(snapshot: RoomSnapshot): { envelope: string; head: string } {
+/**
+ * Computes `versionEnvelopeHash` and `chainHeadHash` together. Each walks every record through
+ * `canonicalJson`, which on a large board is the bulk of a persist's CPU, and a write needs both of
+ * the next snapshot — so callers on the persist path take this and read the pair.
+ */
+export function snapshotHashes(snapshot: RoomSnapshot): SnapshotHashes {
 	let acc = 0n
 	for (const { state, lastChangedClock } of snapshot.documents) {
 		acc ^= BigInt('0x' + fnv1a64(canonicalJson(state) + '@' + lastChangedClock))
@@ -86,7 +97,14 @@ function snapshotHashes(snapshot: RoomSnapshot): { envelope: string; head: strin
 	}
 }
 
-export function buildSnapshotDelta(prev: RoomSnapshot, next: RoomSnapshot): SnapshotDelta {
+export function buildSnapshotDelta(
+	prev: RoomSnapshot,
+	next: RoomSnapshot,
+	options?: {
+		/** `versionEnvelopeHash(next)`, when the caller already has it; computed here otherwise. */
+		envelopeHash?: string
+	}
+): SnapshotDelta {
 	const prevDocs = new Map(prev.documents.map((d) => [d.state.id, d]))
 	const nextDocs = new Map(next.documents.map((d) => [d.state.id, d]))
 
@@ -132,7 +150,7 @@ export function buildSnapshotDelta(prev: RoomSnapshot, next: RoomSnapshot): Snap
 		tombstoneHistoryStartsAtClock: next.tombstoneHistoryStartsAtClock,
 		clock: next.clock,
 		documentClock: next.documentClock,
-		hash: versionEnvelopeHash(next),
+		hash: options?.envelopeHash ?? versionEnvelopeHash(next),
 	}
 }
 


### PR DESCRIPTION
This PR improves the version chain write so that a persist hashes the board once instead of three times. Follow-up to #10615.

### Before

Every chain write called `chainHeadHash(previous)` to pin the diff base, `versionEnvelopeHash(next)` for the delta's integrity hash, and `chainHeadHash(next)` for the new chain head. Each is a full `canonicalJson` plus FNV pass over every record, so on a large board a persist canonicalized the whole document three times. The previous head hash was already sitting in `chain.headHash` from the last write, and the two hashes of `next` differ only in whether `documentClock` is folded in, which `snapshotHashes` already computed together and threw half of away.

### After

The durable object keeps the head hash it got back from the last write next to `_lastPersistedSnapshot` and passes it into the next write as `previousHeadHash`. `writeVersionChainEntry` computes both hashes of `next` in one `snapshotHashes` call and feeds the envelope half into `buildSnapshotDelta`. One pass per persist. The first persist after a wake still pays two, because the seed's hash is not known until a write computes it.

### Implementation notes

- `previousHeadHash` is trusted, not checked: it comes from the write that produced `previous`, and a wrong value cuts a `content-mismatch` keyframe rather than a bad delta, which the new test pins.
- `buildSnapshotDelta` takes the envelope hash through an options object rather than a bare positional string, per the repo convention for new options.
- The verify path (`_verifyRetiredChain`) still hashes on its own; it runs off the persist path and is left alone here.

### Change type

- [x] `improvement`

### Test plan

1. `yarn workspace @tldraw/dotcom-worker test run`

- [x] Unit tests

### Release notes

- Internal: hash a persisted snapshot once per version chain write instead of three times.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +45 / -8   |
| Tests     | +66 / -1   |
