### PR TITLE
feat(editor): add a mark option to editor.run and make UI actions their own undo steps

### DIFF
--- a/.github/workflows/trigger-dotcom-hotfix.yml
+++ b/.github/workflows/trigger-dotcom-hotfix.yml
@@ -1,11 +1,19 @@
 name: Trigger dotcom hotfix
 
+# pull_request_target rather than push/pull_request, for the same reason as
+# trigger-sdk-hotfix.yml: release-notes PRs squash-merge with `[skip ci]` in the title, which
+# suppresses the push-to-main run entirely, and the `labeled` event fires before the merge so the
+# `merged == true` gate rejects it. Neither path ever reached the script. GitHub's skip-ci markers
+# do not apply to pull_request_target. `closed` replaces the old push trigger (which ran on every
+# merge to main just to check labels), and `labeled` allows re-triggering by re-adding the label to
+# an already-merged PR. Secrets exposure is safe here: the job only runs for merged PRs carrying a
+# maintainer-applied hotfix label, checkout uses the trusted base branch, and the only PR-derived
+# code the script builds is the PR's already-merged commit from main.
 on:
-  push:
+  pull_request_target:
+    types: [closed, labeled]
     branches:
       - main
-  pull_request:
-    types: [labeled]
 
 defaults:
   run:
@@ -23,10 +31,11 @@ jobs:
     concurrency: dotcom-hotfix
     environment: npm deploy
     if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       github.event.label.name == 'dotcom-hotfix-please')
+      github.event.pull_request.merged == true &&
+      ((github.event.action == 'closed' &&
+        contains(github.event.pull_request.labels.*.name, 'dotcom-hotfix-please')) ||
+       (github.event.action == 'labeled' &&
+        github.event.label.name == 'dotcom-hotfix-please'))
 
     steps:
       - name: Generate a token

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -80,7 +80,7 @@ See the [Signals](/sdk-features/signals) article for more on tldraw's reactive s
 
 ## Batching changes
 
-Each change to the editor happens within a transaction. You can batch multiple changes into a single transaction using the [Editor#run](?) method. Batching groups the changes into a single undo step and reduces overhead for persisting or distributing changes.
+Each change to the editor happens within a transaction. You can batch multiple changes into a single transaction using the [Editor#run](?) method. Batching reduces overhead for persisting or distributing changes.
 
 ```ts
 // myShapes is an array of shape partials, each with an id from createShapeId()
@@ -89,6 +89,18 @@ editor.run(() => {
 	editor.sendToBack(myShapes.map((shape) => shape.id))
 	editor.selectNone()
 })
+```
+
+A transaction is not an undo step on its own: changes made without a mark join whatever undo step is already open. When the function is a user action that should undo by itself, pass `mark` to start a new step first:
+
+```ts
+editor.run(
+	() => {
+		editor.createShapes(myShapes)
+		editor.selectNone()
+	},
+	{ mark: 'create shapes' }
+)
 ```
 
 The `run` method also accepts options to control history and locked shape behavior. Set `history` to `'ignore'` to leave undo/redo alone, or `'record-preserveRedoStack'` to record without clearing the redo stack:

--- a/apps/docs/content/sdk-features/actions.mdx
+++ b/apps/docs/content/sdk-features/actions.mdx
@@ -80,6 +80,7 @@ The [TLUiActionItem](?) interface defines what an action contains:
 | `readonlyOk`           | When `true`, the action works in readonly mode. Defaults to `false`                                                                                           |
 | `checkbox`             | When `true`, renders as a toggle with a checkmark indicator in menus                                                                                          |
 | `isRequiredA11yAction` | When `true`, the keyboard shortcut works even when shortcuts are normally disabled (e.g., while editing a shape). Used for accessibility actions              |
+| `mark`                 | Every action is its own undo step: `onSelect` runs inside [Editor#run](?) with a mark. Set to `false` for actions that walk the history stack, like undo      |
 | `onSelect`             | Handler called when the action is triggered. Receives a [TLUiEventSource](?) indicating the trigger origin (`'kbd'`, `'menu'`, `'toolbar'`, etc.)             |
 
 ## Accessing actions

--- a/apps/docs/content/sdk-features/history.mdx
+++ b/apps/docs/content/sdk-features/history.mdx
@@ -40,7 +40,18 @@ When you undo, the manager reverses all changes back to the previous mark, moves
 
 ## Marks and stopping points
 
-Marks define where undo and redo operations stop. Create marks with [Editor#markHistoryStoppingPoint](?) at the start of user interactions so that complex operations can be undone in one step. The optional name only shows up in the mark id, which is useful for debugging.
+Marks define where undo and redo operations stop. A change made without a mark joins whatever undo step is already open, so forgetting one means undo also reverts the previous action. The simplest way to start a step is to run the action through [Editor#run](?) with a `mark`:
+
+```typescript
+editor.run(
+	() => {
+		editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI / 4)
+	},
+	{ mark: 'rotate shapes' }
+)
+```
+
+When you need the mark's id, for example to roll a cancelled drag back with [bailToMark](#bailing), create it directly with [Editor#markHistoryStoppingPoint](?). The optional name only shows up in the mark id, which is useful for debugging.
 
 ```typescript
 const markId = editor.markHistoryStoppingPoint('rotate shapes')
@@ -49,6 +60,8 @@ editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI / 4)
 ```
 
 Each mark has a unique identifier that you can use with [bailToMark](#bailing) or [squashToMark](#squashing). Creating a mark flushes pending changes onto the undo stack. It doesn't clear the redo stack; the next recorded change does that.
+
+Some entry points mark for you. Every UI action runs inside a marked `run`, and [Editor#putExternalContent](?) marks before it handles pasted or dropped content. In the style panel, `onValueChange` and `onOpacityChange` start a new step unless you pass `{ mark: false }` to extend the current one, which is how scrubbing across swatches or dragging the opacity slider stays a single step.
 
 ## Basic operations
 

--- a/apps/examples/src/examples/ui/stroke-size-picker/StrokeSizePickerExample.tsx
+++ b/apps/examples/src/examples/ui/stroke-size-picker/StrokeSizePickerExample.tsx
@@ -57,7 +57,7 @@ const STROKE_SIZE_PRESETS = [1, 2, 3, 4, 6, 8, 10, 12, 16, 20, 26, 32]
 
 // [4]
 function StrokeSizePicker() {
-	const { styles, onValueChange, onHistoryMark } = useStylePanelContext()
+	const { styles, onValueChange } = useStylePanelContext()
 	const strokeSize = styles.get(strokeSizeStyle)
 
 	// [5]
@@ -73,10 +73,7 @@ function StrokeSizePicker() {
 					className="stroke-size-picker__preset"
 					data-active={value === size}
 					title={`Stroke size ${size}`}
-					onClick={() => {
-						onHistoryMark('set stroke size')
-						onValueChange(strokeSizeStyle, size)
-					}}
+					onClick={() => onValueChange(strokeSizeStyle, size)}
 				>
 					<div
 						className="stroke-size-picker__dot"

--- a/internal/scripts/lib/skip-ci.ts
+++ b/internal/scripts/lib/skip-ci.ts
@@ -1,0 +1,16 @@
+// GitHub skips push-triggered workflows when any of these markers appear anywhere in a commit
+// message (title or body). See
+// https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+const SKIP_CI_MARKER = /\s*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
+
+/**
+ * Remove GitHub's skip-ci markers from a commit message or PR title.
+ *
+ * Release-notes PRs carry `[skip ci]` in their title on purpose, so their squash-merge onto `main`
+ * doesn't run the push workflows. The hotfix scripts cherry-pick that same commit onto a branch
+ * whose push *must* trigger a workflow (the release branch's publish, or the hotfixes branch's
+ * production build), so the marker has to go before the push.
+ */
+export function stripSkipCiMarkers(message: string): string {
+	return message.replace(SKIP_CI_MARKER, '').trim()
+}

--- a/internal/scripts/lib/skip-ci.ts
+++ b/internal/scripts/lib/skip-ci.ts
@@ -1,7 +1,10 @@
-// GitHub skips push-triggered workflows when any of these markers appear anywhere in a commit
-// message (title or body). See
+// GitHub skips both push- and pull_request-triggered workflows when one of these markers appears
+// in a commit message, in the positions documented at
 // https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-const SKIP_CI_MARKER = /\s*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
+// `[^\S\r\n]` rather than `\s`: eating the newlines around a marker on its own body line would
+// close the blank line separating subject from body, and `git commit --amend -m` would then fold
+// the whole first paragraph into the subject.
+const SKIP_CI_MARKER = /[^\S\r\n]*\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi
 
 /**
  * Remove GitHub's skip-ci markers from a commit message or PR title.

--- a/internal/scripts/trigger-dotcom-hotfix.ts
+++ b/internal/scripts/trigger-dotcom-hotfix.ts
@@ -4,6 +4,7 @@ import { exec } from './lib/exec'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
 import { getPrDetailsAndCommitSha, getPrDetailsByNumber, labelPresent } from './lib/pr-info'
+import { stripSkipCiMarkers } from './lib/skip-ci'
 
 function getEnv() {
 	return makeEnv(['DISCORD_DEPLOY_WEBHOOK_URL', 'GITHUB_TOKEN'])
@@ -43,6 +44,15 @@ async function main() {
 		await exec('git', ['reset', '--hard', 'origin/hotfixes'])
 		await exec('git', ['checkout', '-b', hotfixBranchName])
 		await exec('git', ['cherry-pick', commitSha])
+
+		// release-notes PRs squash-merge with `[skip ci]` in the title. github honours that marker on
+		// the cherry-picked commit too, so the hotfix branch's required checks would never start and
+		// the PR below would sit in `blocked` until the timeout. strip it before pushing.
+		const message = (await exec('git', ['log', '-1', '--format=%B'])).trim()
+		const cleanedMessage = stripSkipCiMarkers(message)
+		if (cleanedMessage !== message) {
+			await exec('git', ['commit', '--amend', '-m', cleanedMessage])
+		}
 	})
 
 	await discord.step('Pushing hotfix branch to remote', async () => {
@@ -50,7 +60,11 @@ async function main() {
 	})
 
 	await discord.step('Creating hotfix PR and waiting for checks to pass', async () => {
-		const prTitle = `[HOTFIX] ${pr.title}`
+		// the squash-merge onto `hotfixes` is what triggers the production build, and github reads
+		// skip-ci markers from the whole commit message. keep them out of the title (used as the
+		// commit subject) and the body (used as the commit body when someone merges by hand).
+		const originalTitle = stripSkipCiMarkers(pr.title)
+		const prTitle = `[HOTFIX] ${originalTitle}`
 
 		// Extract API changes section from original PR if present
 		const apiChangesHeader = '### API changes'
@@ -67,7 +81,7 @@ async function main() {
 		const prBody = `This is an automated hotfix PR for dotcom deployment.
 
 **Original PR:** [#${pr.number}](https://github.com/tldraw/tldraw/pull/${pr.number})
-**Original Title:** ${pr.title}
+**Original Title:** ${originalTitle}
 **Original Author:** @${pr.user?.login}
 
 This PR cherry-picks the changes from the original PR to the hotfixes branch for immediate dotcom deployment.${apiChangesSection}
@@ -102,6 +116,8 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 		// Wait for 5 minutes initially, then check every 15 seconds (our checks take at least 5 mins)
 		await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000))
 
+		let checkedForMissingChecks = false
+
 		while (true) {
 			// Check if we've exceeded the timeout
 			const elapsedTime = Date.now() - startTime
@@ -133,7 +149,7 @@ This PR cherry-picks the changes from the original PR to the hotfixes branch for
 						repo: 'tldraw',
 						pull_number: createdPr.data.number,
 						merge_method: 'squash',
-						commit_title: `[HOTFIX] ${pr.title}`,
+						commit_title: prTitle,
 						commit_message: `This is an automated hotfix for dotcom deployment.
 
 Original PR: #${pr.number}
@@ -156,6 +172,23 @@ Original Author: @${pr.user?.login}`,
 				nicelog(`PR #${createdPr.data.number} has conflicts and cannot be merged`)
 				throw new Error(`Hotfix PR #${createdPr.data.number} has conflicts`)
 			} else {
+				// `blocked` with no check runs at all means nothing is going to change: the push didn't
+				// start any workflows (a skip-ci marker that survived, or a required check that isn't
+				// wired up). fail now with a pointer instead of spinning until the timeout.
+				if (prStatus.mergeable_state === 'blocked' && !checkedForMissingChecks) {
+					checkedForMissingChecks = true
+					const checks = await octokit.rest.checks.listForRef({
+						owner: 'tldraw',
+						repo: 'tldraw',
+						ref: prStatus.head.sha,
+						per_page: 1,
+					})
+					if (checks.data.total_count === 0) {
+						throw new Error(
+							`Hotfix PR #${createdPr.data.number} is blocked and no check runs have started on ${hotfixBranchName}. The required checks will never report, so it can't be merged automatically. Look at the commit message on that branch for a skip-ci marker: https://github.com/tldraw/tldraw/pull/${createdPr.data.number}`
+						)
+					}
+				}
 				nicelog(
 					`PR #${createdPr.data.number} merge status: ${prStatus.mergeable_state}, waiting...`
 				)

--- a/internal/scripts/trigger-sdk-hotfix.ts
+++ b/internal/scripts/trigger-sdk-hotfix.ts
@@ -7,6 +7,7 @@ import { exec } from './lib/exec'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
 import { getPrDetailsAndCommitSha, labelPresent, PullRequest } from './lib/pr-info'
+import { stripSkipCiMarkers } from './lib/skip-ci'
 import { getAllWorkspacePackages } from './lib/workspace'
 
 function getEnv() {
@@ -93,9 +94,7 @@ async function main() {
 			// merge commits (e.g. release-notes updates) carry `[skip ci]`, which would
 			// suppress it. strip skip-ci markers from the cherry-picked commit message.
 			const message = (await exec('git', ['log', '-1', '--format=%B'])).trim()
-			const cleanedMessage = message
-				.replace(/ *\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi, '')
-				.trim()
+			const cleanedMessage = stripSkipCiMarkers(message)
 			if (cleanedMessage !== message) {
 				await exec('git', ['commit', '--amend', '-m', cleanedMessage])
 			}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2203,6 +2203,8 @@ export class HistoryManager<R extends UnknownRecord> {
     getNumRedos(): number;
     // (undocumented)
     getNumUndos(): number;
+    hasRedos(): boolean;
+    hasUndos(): boolean;
     // @internal (undocumented)
     _isInBatch: boolean;
     // @internal (undocumented)
@@ -4003,6 +4005,7 @@ export interface TLEditorOptions {
 export interface TLEditorRunOptions extends TLHistoryBatchOptions {
     // (undocumented)
     ignoreShapeLock?: boolean;
+    mark?: string;
 }
 
 // @public

--- a/packages/editor/src/lib/editor/Editor.test.ts
+++ b/packages/editor/src/lib/editor/Editor.test.ts
@@ -916,6 +916,102 @@ describe('putExternalContent', () => {
 
 		expect(mockHandler).toHaveBeenCalledWith(info)
 	})
+
+	it('is its own undo step, so callers do not need to mark first', async () => {
+		const beforeId = createShapeId('before')
+		const putId = createShapeId('put')
+		editor.registerExternalContentHandler('text', () => {
+			editor.createShape({ id: putId, type: 'my-custom-shape' })
+		})
+
+		editor.createShape({ id: beforeId, type: 'my-custom-shape' })
+		await editor.putExternalContent({ type: 'text', text: 'hello' })
+		expect(editor.getShape(putId)).toBeDefined()
+
+		editor.undo()
+
+		expect(editor.getShape(putId)).toBeUndefined()
+		expect(editor.getShape(beforeId)).toBeDefined()
+	})
+})
+
+describe('run', () => {
+	const beforeId = createShapeId('before')
+	const afterId = createShapeId('after')
+
+	it('does not start a new undo step without a mark', () => {
+		editor.createShape({ id: beforeId, type: 'my-custom-shape' })
+		editor.run(() => editor.createShape({ id: afterId, type: 'my-custom-shape' }))
+
+		editor.undo()
+
+		expect(editor.getShape(afterId)).toBeUndefined()
+		expect(editor.getShape(beforeId)).toBeUndefined()
+	})
+
+	it('starts a new undo step with a mark', () => {
+		editor.createShape({ id: beforeId, type: 'my-custom-shape' })
+		editor.run(() => editor.createShape({ id: afterId, type: 'my-custom-shape' }), {
+			mark: 'create after',
+		})
+
+		editor.undo()
+
+		expect(editor.getShape(afterId)).toBeUndefined()
+		expect(editor.getShape(beforeId)).toBeDefined()
+	})
+
+	it('ignores the mark when history is ignored', () => {
+		editor.createShape({ id: beforeId, type: 'my-custom-shape' })
+		editor.run(() => editor.createShape({ id: afterId, type: 'my-custom-shape' }), {
+			mark: 'create after',
+			history: 'ignore',
+		})
+
+		editor.undo()
+
+		expect(editor.getShape(afterId)).toBeDefined()
+		expect(editor.getShape(beforeId)).toBeUndefined()
+	})
+
+	it('keeps the previous step intact when the function throws', () => {
+		editor.createShape({ id: beforeId, type: 'my-custom-shape' })
+
+		expect(() =>
+			editor.run(
+				() => {
+					throw new Error('boom')
+				},
+				{ mark: 'failed action' }
+			)
+		).toThrow('boom')
+
+		// the mark stays, so the next change is its own step and the first shape is
+		// still undoable after it
+		editor.createShape({ id: afterId, type: 'my-custom-shape' })
+		editor.undo()
+		expect(editor.getShape(afterId)).toBeUndefined()
+		expect(editor.getShape(beforeId)).toBeDefined()
+
+		editor.undo()
+		expect(editor.getShape(beforeId)).toBeUndefined()
+	})
+
+	it('only enables undo when there is a change to undo, not for a bare mark', () => {
+		expect(editor.getCanUndo()).toBe(false)
+
+		editor.run(() => {}, { mark: 'no-op action' })
+		expect(editor.getCanUndo()).toBe(false)
+
+		editor.run(() => editor.createShape({ id: afterId, type: 'my-custom-shape' }), {
+			mark: 'create after',
+		})
+		expect(editor.getCanUndo()).toBe(true)
+
+		editor.undo()
+		expect(editor.getCanUndo()).toBe(false)
+		expect(editor.getCanRedo()).toBe(true)
+	})
 })
 
 describe('replaceExternalContent', () => {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -327,6 +327,15 @@ export interface TLEditorOptions {
  */
 export interface TLEditorRunOptions extends TLHistoryBatchOptions {
 	ignoreShapeLock?: boolean
+	/**
+	 * Start a new undo step before running. This is how a user action declares itself: without a
+	 * mark, changes are appended to whatever step is already open, so undo reverts them together
+	 * with the previous action. The name only shows up in the mark id, for debugging.
+	 *
+	 * Ignored when `history` is `'ignore'`. If you need the mark id for `bailToMark` or
+	 * `squashToMark`, call `markHistoryStoppingPoint` yourself instead.
+	 */
+	mark?: string
 }
 
 /** @public */
@@ -1562,7 +1571,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed canUndo(): boolean {
-		return this.history.getNumUndos() > 0
+		return this.history.hasUndos()
 	}
 
 	getCanUndo() {
@@ -1593,7 +1602,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	@computed canRedo(): boolean {
-		return this.history.getNumRedos() > 0
+		return this.history.hasRedos()
 	}
 
 	getCanRedo() {
@@ -1702,12 +1711,21 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	/**
 	 * Run a function in a transaction with optional options for context.
-	 * You can use the options to change the way that history is treated
-	 * or allow changes to locked shapes.
+	 * You can use the options to start a new undo step, change the way that
+	 * history is treated, or allow changes to locked shapes.
+	 *
+	 * A transaction on its own is not an undo step: changes made without a mark
+	 * join whatever step is already open. Pass `mark` when the function is a
+	 * user action that should undo on its own.
 	 *
 	 * @example
 	 * ```ts
-	 * // updating with
+	 * // a user action that is its own undo step
+	 * editor.run(() => {
+	 * 	editor.updateShape({ ...myShape, x: 100 })
+	 * }, { mark: 'nudge shape' })
+	 *
+	 * // updating without recording history
 	 * editor.run(() => {
 	 * 	editor.updateShape({ ...myShape, x: 100 })
 	 * }, { history: "ignore" })
@@ -1730,6 +1748,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const previousIgnoreShapeLock = this._shouldIgnoreShapeLock
 		this._shouldIgnoreShapeLock = opts?.ignoreShapeLock ?? previousIgnoreShapeLock
 		try {
+			const mark = opts?.history === 'ignore' ? undefined : opts?.mark
+			// The mark goes outside the transaction on purpose. Marking inside it and then throwing
+			// would roll back the stacks atom but not the pending diff it had already flushed, losing
+			// the previous step. A stray mark from a failed fn is harmless: undo skips empty marks.
+			if (mark !== undefined) this.markHistoryStoppingPoint(mark)
 			this.history.batch(fn, opts)
 		} finally {
 			this._shouldIgnoreShapeLock = previousIgnoreShapeLock
@@ -9594,6 +9617,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/**
 	 * Handle external content, such as files, urls, embeds, or plain text which has been put into the app, for example by pasting external text or dropping external images onto canvas.
 	 *
+	 * Putting content is always its own undo step: a mark is placed before the handler runs, so
+	 * callers (paste, drop, insert media, the embed dialog) don't need to mark themselves.
+	 *
 	 * @param info - Info about the external content.
 	 * @param opts - Options for handling external content, including force flag to bypass readonly checks.
 	 */
@@ -9603,11 +9629,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	): Promise<void> {
 		if (!opts.force && this.getIsReadonly()) return
 
+		this.markHistoryStoppingPoint(`put external content: ${info.type}`)
 		return this.externalContentHandlers[info.type]?.(info as any)
 	}
 
 	/**
-	 * Handle replacing external content.
+	 * Handle replacing external content. Like {@link Editor.putExternalContent}, this starts its
+	 * own undo step.
 	 *
 	 * @param info - Info about the external content.
 	 * @param opts - Options for handling external content, including force flag to bypass readonly checks.
@@ -9617,6 +9645,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		opts = {} as { force?: boolean }
 	): Promise<void> {
 		if (!opts.force && this.getIsReadonly()) return
+		this.markHistoryStoppingPoint(`replace external content: ${info.type}`)
 		return this.externalContentHandlers[info.type]?.(info as any)
 	}
 

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
@@ -576,6 +576,31 @@ describe('HistoryManager getters and utilities', () => {
 			expect(manager.getNumRedos()).toBe(2) // Undo moved 2 items to redo stack (pending + mark)
 		})
 
+		it('hasUndos and hasRedos ignore marks with nothing between them', () => {
+			expect(manager.hasUndos()).toBe(false)
+			expect(manager.hasRedos()).toBe(false)
+
+			manager._mark('mark1')
+			manager._mark('mark2')
+			expect(manager.getNumUndos()).toBe(2)
+			expect(manager.hasUndos()).toBe(false)
+
+			store.update(ids.a, (s) => ({ ...s, value: 1 }))
+			expect(manager.hasUndos()).toBe(true)
+
+			manager._mark('mark3')
+			expect(manager.hasUndos()).toBe(true)
+
+			manager.undo()
+			expect(manager.hasUndos()).toBe(false)
+			expect(manager.hasRedos()).toBe(true)
+
+			// only marks are left on the redo stack after redoing the diff
+			manager.redo()
+			expect(manager.hasUndos()).toBe(true)
+			expect(manager.hasRedos()).toBe(false)
+		})
+
 		it('should count correctly after clearing redo stack', () => {
 			store.update(ids.a, (s) => ({ ...s, value: 1 }))
 			manager.undo()

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -83,6 +83,23 @@ export class HistoryManager<R extends UnknownRecord> {
 		return this.stacks.get().redos.length
 	}
 
+	/**
+	 * Whether undo would change anything. Unlike `getNumUndos`, marks alone don't count: an
+	 * action that marks a stopping point and then changes nothing (or only ephemeral state) must
+	 * not light up the undo button.
+	 */
+	hasUndos() {
+		if (!this.pendingDiff.isEmpty()) return true
+		return hasDiffEntry(this.stacks.get().undos)
+	}
+
+	/**
+	 * Whether redo would change anything. See `hasUndos` for why marks alone don't count.
+	 */
+	hasRedos() {
+		return hasDiffEntry(this.stacks.get().redos)
+	}
+
 	/** @internal */
 	private _isReplaying = false
 
@@ -417,6 +434,15 @@ class StackItem<T> {
 	push(head: T): Stack<T> {
 		return new StackItem(head, this)
 	}
+}
+
+function hasDiffEntry<R extends UnknownRecord>(stack: Stack<TLHistoryEntry<R>>) {
+	// Stops at the first diff, so this only walks the run of marks at the top of the stack.
+	while (stack.head) {
+		if (stack.head.type === 'diff') return true
+		stack = stack.tail
+	}
+	return false
 }
 
 function stackToArray<T>(stack: Stack<T>) {

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -153,7 +153,6 @@ export function useCanvasEvents() {
 				if (e.dataTransfer?.files?.length) {
 					const files = Array.from(e.dataTransfer.files)
 
-					editor.markHistoryStoppingPoint('drop')
 					await editor.putExternalContent({
 						type: 'files',
 						files,
@@ -164,7 +163,6 @@ export function useCanvasEvents() {
 
 				const url = e.dataTransfer.getData('url')
 				if (url) {
-					editor.markHistoryStoppingPoint('drop')
 					await editor.putExternalContent({
 						type: 'url',
 						url,

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3602,10 +3602,10 @@ export const StylePanelButtonPickerInline: <T extends string>(props: StylePanelB
 export interface StylePanelButtonPickerProps<T extends string> {
     // (undocumented)
     items: StyleValuesForUi<T>;
-    // (undocumented)
+    // @deprecated (undocumented)
     onHistoryMark?(id: string): void;
     // (undocumented)
-    onValueChange?(style: StyleProp<T>, value: T): void;
+    onValueChange?(style: StyleProp<T>, value: T, opts?: StylePanelValueChangeOptions): void;
     // (undocumented)
     style: StyleProp<T>;
     // (undocumented)
@@ -3623,12 +3623,12 @@ export function StylePanelColorPicker(): JSX.Element | null;
 export interface StylePanelContext {
     // (undocumented)
     enhancedA11yMode: boolean;
-    // (undocumented)
+    // @deprecated (undocumented)
     onHistoryMark(id: string): void;
     // (undocumented)
-    onOpacityChange(opacity: number): void;
+    onOpacityChange(opacity: number, opts?: StylePanelValueChangeOptions): void;
     // (undocumented)
-    onValueChange<T>(style: StyleProp<T>, value: T): void;
+    onValueChange<T>(style: StyleProp<T>, value: T, opts?: StylePanelValueChangeOptions): void;
     // (undocumented)
     styles: ReadonlySharedStyleMap;
 }
@@ -3753,6 +3753,11 @@ export interface StylePanelSubheadingProps {
 
 // @public (undocumented)
 export function StylePanelTextAlignPicker(): JSX.Element | null;
+
+// @public (undocumented)
+export interface StylePanelValueChangeOptions {
+    mark?: boolean;
+}
 
 // @public (undocumented)
 export type StyleValuesForUi<T> = readonly {
@@ -4596,6 +4601,7 @@ export interface TLUiActionItem<TransationKey extends string = string, IconType 
     label?: {
         [key: string]: TransationKey;
     } | TransationKey;
+    mark?: boolean;
     // (undocumented)
     onSelect(source: TLUiEventSource): Promise<void> | void;
     // (undocumented)
@@ -5608,6 +5614,11 @@ export interface TLUiSelectValueProps {
 }
 
 // @public (undocumented)
+export interface TLUiSliderChangeInfo {
+    mark: boolean;
+}
+
+// @public (undocumented)
 export interface TLUiSliderProps {
     // (undocumented)
     'data-testid'?: string;
@@ -5617,10 +5628,10 @@ export interface TLUiSliderProps {
     label: string;
     // (undocumented)
     min?: number;
-    // (undocumented)
+    // @deprecated (undocumented)
     onHistoryMark?(id: string): void;
     // (undocumented)
-    onValueChange(value: number): void;
+    onValueChange(value: number, info: TLUiSliderChangeInfo): void;
     // (undocumented)
     steps: number;
     // (undocumented)

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -537,7 +537,11 @@ export {
 	type TLUiSelectTriggerProps,
 	type TLUiSelectValueProps,
 } from './lib/ui/components/primitives/TldrawUiSelect'
-export { TldrawUiSlider, type TLUiSliderProps } from './lib/ui/components/primitives/TldrawUiSlider'
+export {
+	TldrawUiSlider,
+	type TLUiSliderChangeInfo,
+	type TLUiSliderProps,
+} from './lib/ui/components/primitives/TldrawUiSlider'
 export {
 	TldrawUiToolbar,
 	TldrawUiToolbarButton,
@@ -617,6 +621,7 @@ export {
 	useStylePanelContext,
 	type StylePanelContext,
 	type StylePanelContextProviderProps,
+	type StylePanelValueChangeOptions,
 } from './lib/ui/components/StylePanel/StylePanelContext'
 export {
 	StylePanelDoubleDropdownPicker,

--- a/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
@@ -493,11 +493,13 @@ export const DefaultPageMenu = memo(function DefaultPageMenu() {
 			name = result || initialName
 		}
 
-		editor.run(() => {
-			editor.markHistoryStoppingPoint('creating page')
-			editor.createPage({ name, id: newPageId })
-			editor.setCurrentPage(newPageId)
-		})
+		editor.run(
+			() => {
+				editor.createPage({ name, id: newPageId })
+				editor.setCurrentPage(newPageId)
+			},
+			{ mark: 'creating page' }
+		)
 
 		if (!shouldUseWindowPrompt) {
 			startRenamingPage(newPageId, initialName)

--- a/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
@@ -32,9 +32,8 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	const trackEvent = useUiEvents()
 
 	const onDuplicate = useCallback(() => {
-		editor.markHistoryStoppingPoint('creating page')
 		const newId = PageRecordType.createId()
-		editor.duplicatePage(item.id as TLPageId, newId)
+		editor.run(() => editor.duplicatePage(item.id as TLPageId, newId), { mark: 'creating page' })
 		trackEvent('duplicate-page', { source: 'page-menu' })
 	}, [editor, item, trackEvent])
 
@@ -47,8 +46,7 @@ export const PageItemSubmenu = track(function PageItemSubmenu({
 	}, [editor, item, index, trackEvent])
 
 	const onDelete = useCallback(() => {
-		editor.markHistoryStoppingPoint('deleting page')
-		editor.deletePage(item.id as TLPageId)
+		editor.run(() => editor.deletePage(item.id as TLPageId), { mark: 'deleting page' })
 		trackEvent('delete-page', { source: 'page-menu' })
 	}, [editor, item, trackEvent])
 

--- a/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
@@ -33,11 +33,7 @@ export function onMovePage(
 	}
 
 	if (index !== pages[from].index) {
-		editor.markHistoryStoppingPoint('moving page')
-		editor.updatePage({
-			id: id as TLPageId,
-			index,
-		})
+		editor.run(() => editor.updatePage({ id: id as TLPageId, index }), { mark: 'moving page' })
 		trackEvent('move-page', { source: 'page-menu' })
 	}
 }

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -24,7 +24,7 @@ import { defaultGeoTypeDefinitions, GeoTypeDefinition } from '../../../shapes/ge
 import { getColorStyleItems, getFontStyleItems, STYLES } from '../../../styles'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
-import { TldrawUiSlider } from '../primitives/TldrawUiSlider'
+import { TldrawUiSlider, TLUiSliderChangeInfo } from '../primitives/TldrawUiSlider'
 import { TldrawUiToolbar, TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
 import { StylePanelButtonPicker, StylePanelButtonPickerInline } from './StylePanelButtonPicker'
 import { useStylePanelContext } from './StylePanelContext'
@@ -101,14 +101,14 @@ const tldrawSupportedOpacities = [0.1, 0.25, 0.5, 0.75, 1] as const
 /** @public @react */
 export function StylePanelOpacityPicker() {
 	const editor = useEditor()
-	const { onHistoryMark, onOpacityChange, enhancedA11yMode } = useStylePanelContext()
+	const { onOpacityChange, enhancedA11yMode } = useStylePanelContext()
 
 	const opacity = useValue('opacity', () => editor.getSharedOpacity(), [editor])
 	const msg = useTranslation()
 
 	const handleOpacityValueChange = React.useCallback(
-		(value: number) => {
-			onOpacityChange(tldrawSupportedOpacities[value])
+		(value: number, info: TLUiSliderChangeInfo) => {
+			onOpacityChange(tldrawSupportedOpacities[value], info)
 		},
 		[onOpacityChange]
 	)
@@ -136,7 +136,6 @@ export function StylePanelOpacityPicker() {
 				onValueChange={handleOpacityValueChange}
 				steps={tldrawSupportedOpacities.length - 1}
 				title={msg('style-panel.opacity')}
-				onHistoryMark={onHistoryMark}
 				ariaValueModifier={25}
 			/>
 		</>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
@@ -21,7 +21,7 @@ import {
 	TldrawUiToolbarToggleGroup,
 	TldrawUiToolbarToggleItem,
 } from '../primitives/TldrawUiToolbar'
-import { useStylePanelContext } from './StylePanelContext'
+import { StylePanelValueChangeOptions, useStylePanelContext } from './StylePanelContext'
 import { StylePanelSubheading } from './StylePanelSubheading'
 
 /** @public */
@@ -31,7 +31,8 @@ export interface StylePanelButtonPickerProps<T extends string> {
 	style: StyleProp<T>
 	value: SharedStyle<T>
 	items: StyleValuesForUi<T>
-	onValueChange?(style: StyleProp<T>, value: T): void
+	onValueChange?(style: StyleProp<T>, value: T, opts?: StylePanelValueChangeOptions): void
+	/** @deprecated The context's `onValueChange` starts its own undo step. */
 	onHistoryMark?(id: string): void
 }
 
@@ -59,7 +60,8 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 		style,
 		value,
 		onValueChange = ctx.onValueChange,
-		onHistoryMark = ctx.onHistoryMark,
+		// oxlint-disable-next-line typescript/no-deprecated -- still honored for existing consumers
+		onHistoryMark,
 	} = props
 	const editor = useEditor()
 	const colors = useValue(
@@ -99,6 +101,7 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 			const { id } = e.currentTarget.dataset
 			if (value.type === 'shared' && value.value === id) return
 
+			// oxlint-disable-next-line typescript/no-deprecated
 			onHistoryMark?.('point picker item')
 			onValueChange(style, id as T)
 		}
@@ -106,6 +109,7 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 		const handleButtonPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
 			const { id } = e.currentTarget.dataset
 
+			// oxlint-disable-next-line typescript/no-deprecated
 			onHistoryMark?.('point picker item')
 			onValueChange(style, id as T)
 
@@ -118,8 +122,9 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 		const handleButtonPointerEnter = (e: React.PointerEvent<HTMLButtonElement>) => {
 			if (!rPointing.current) return
 
+			// Scrubbing continues the undo step begun on pointer down.
 			const { id } = e.currentTarget.dataset
-			onValueChange(style, id as T)
+			onValueChange(style, id as T, { mark: false })
 		}
 
 		const handleButtonPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
@@ -131,7 +136,7 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 			const { id } = e.currentTarget.dataset
 			if (value.type === 'shared' && value.value === id) return
 
-			onValueChange(style, id as T)
+			onValueChange(style, id as T, { mark: false })
 		}
 
 		return {

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelContext.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelContext.tsx
@@ -9,12 +9,26 @@ import { createContext, useCallback, useContext } from 'react'
 import { useUiEvents } from '../../context/events'
 
 /** @public */
+export interface StylePanelValueChangeOptions {
+	/**
+	 * Whether this change starts a new undo step. Defaults to `true`. Pass `false` while a gesture
+	 * is continuing (scrubbing across swatches, dragging a slider, a held key repeating) so the
+	 * change extends the step begun on pointer down or the first key press.
+	 */
+	mark?: boolean
+}
+
+/** @public */
 export interface StylePanelContext {
 	styles: ReadonlySharedStyleMap
 	enhancedA11yMode: boolean
+	/**
+	 * @deprecated `onValueChange` and `onOpacityChange` start their own undo step. Pass
+	 * `{ mark: false }` to them to extend the current step instead.
+	 */
 	onHistoryMark(id: string): void
-	onValueChange<T>(style: StyleProp<T>, value: T): void
-	onOpacityChange(opacity: number): void
+	onValueChange<T>(style: StyleProp<T>, value: T, opts?: StylePanelValueChangeOptions): void
+	onOpacityChange(opacity: number, opts?: StylePanelValueChangeOptions): void
 }
 const StylePanelContext = createContext<null | StylePanelContext>(null)
 
@@ -34,22 +48,25 @@ export function StylePanelContextProvider({ children, styles }: StylePanelContex
 		editor,
 	])
 	const onValueChange = useCallback(
-		function <T>(style: StyleProp<T>, value: T) {
+		function <T>(style: StyleProp<T>, value: T, opts?: StylePanelValueChangeOptions) {
 			// If the user is holding down the accelerator key (Ctrl on Windows/Linux, Cmd on Mac)
 			// while shapes are selected, interpret that as a wish to change the style for their
 			// current selected shapes but not for the next shapes.
 			const skipNextShapeStyle = unsafe__withoutCapture(
 				() => editor.getSelectedShapeIds().length > 0 && editor.inputs.getAccelKey()
 			)
-			editor.run(() => {
-				if (editor.isIn('select')) {
-					editor.setStyleForSelectedShapes(style, value)
-				}
-				if (!skipNextShapeStyle) {
-					editor.setStyleForNextShapes(style, value)
-				}
-				editor.updateInstanceState({ isChangingStyle: true })
-			})
+			editor.run(
+				() => {
+					if (editor.isIn('select')) {
+						editor.setStyleForSelectedShapes(style, value)
+					}
+					if (!skipNextShapeStyle) {
+						editor.setStyleForNextShapes(style, value)
+					}
+					editor.updateInstanceState({ isChangingStyle: true })
+				},
+				{ mark: opts?.mark === false ? undefined : `set style ${style.id}` }
+			)
 
 			trackEvent('set-style', { source: 'style-panel', id: style.id, value: value as string })
 		},
@@ -57,20 +74,23 @@ export function StylePanelContextProvider({ children, styles }: StylePanelContex
 	)
 
 	const onOpacityChange = useCallback(
-		function (opacity: number) {
+		function (opacity: number, opts?: StylePanelValueChangeOptions) {
 			const skipNextShapeStyle = unsafe__withoutCapture(
 				() => editor.getSelectedShapeIds().length > 0 && editor.inputs.getAccelKey()
 			)
 
-			editor.run(() => {
-				if (editor.isIn('select')) {
-					editor.setOpacityForSelectedShapes(opacity)
-				}
-				if (!skipNextShapeStyle) {
-					editor.setOpacityForNextShapes(opacity)
-				}
-				editor.updateInstanceState({ isChangingStyle: true })
-			})
+			editor.run(
+				() => {
+					if (editor.isIn('select')) {
+						editor.setOpacityForSelectedShapes(opacity)
+					}
+					if (!skipNextShapeStyle) {
+						editor.setOpacityForNextShapes(opacity)
+					}
+					editor.updateInstanceState({ isChangingStyle: true })
+				},
+				{ mark: opts?.mark === false ? undefined : 'set opacity' }
+			)
 
 			trackEvent('set-style', { source: 'style-panel', id: 'opacity', value: opacity })
 		},

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
@@ -112,7 +112,6 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 										type="icon"
 										key={item.value}
 										onClick={() => {
-											ctx.onHistoryMark('select style dropdown item')
 											onValueChange(styleA, item.value)
 											tlmenus.deleteOpenMenu(idA, editor.contextId)
 											setIsOpenA(false)
@@ -154,7 +153,6 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 										title={`${msg(labelB)} — ${msg(`${uiTypeB}-style.${item.value}` as TLUiTranslationKey)}`}
 										data-testid={`style.${uiTypeB}.${item.value}`}
 										onClick={() => {
-											ctx.onHistoryMark('select style dropdown item')
 											onValueChange(styleB, item.value)
 											tlmenus.deleteOpenMenu(idB, editor.contextId)
 											setIsOpenB(false)

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -128,7 +128,6 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 									}
 									isActive={valueInItems && icon === item.icon}
 									onClick={() => {
-										ctx.onHistoryMark('select style dropdown item')
 										onValueChange(style, item.value)
 										tlmenus.deleteOpenMenu(popoverId, editor.contextId)
 										setIsOpen(false)

--- a/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/AltTextEditor.tsx
@@ -33,14 +33,18 @@ export function AltTextEditor({ shapeId, onClose, source }: AltTextEditorProps) 
 		trackEvent('set-alt-text', { source })
 		const shape = editor.getShape<ExtractShapeByProps<{ altText: string }>>(shapeId)
 		if (!shape) return
-		editor.markHistoryStoppingPoint('set alt text')
-		editor.updateShapes([
-			{
-				id: shape.id,
-				type: shape.type,
-				props: { altText },
+		editor.run(
+			() => {
+				editor.updateShapes([
+					{
+						id: shape.id,
+						type: shape.type,
+						props: { altText },
+					},
+				])
 			},
-		])
+			{ mark: 'set alt text' }
+		)
 		onClose()
 	}, [trackEvent, source, editor, shapeId, altText, onClose])
 

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultImageToolbarContent.tsx
@@ -30,7 +30,7 @@ import {
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
 } from '../primitives/TldrawUiDropdownMenu'
-import { TldrawUiSlider } from '../primitives/TldrawUiSlider'
+import { TldrawUiSlider, TLUiSliderChangeInfo } from '../primitives/TldrawUiSlider'
 import { TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
 
 /** @public */
@@ -78,8 +78,6 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 		setMaxZoom(crop ? Math.max(zoom, 1 - 1 / MAX_ZOOM) : MAX_ZOOM)
 	}, [crop, zoom, maxZoom])
 
-	const onHistoryMark = useCallback((id: string) => editor.markHistoryStoppingPoint(id), [editor])
-
 	// Apply an easing function to smooth out the zoom curve,
 	// otherwise the zoom slider has a cubic drag feel to it which feels off.
 	const easeZoom = useCallback((value: number, maxValue: number): number => {
@@ -94,7 +92,7 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 			: 0
 
 	const handleZoomChange = useCallback(
-		(value: number) => {
+		(value: number, { mark }: TLUiSliderChangeInfo) => {
 			editor.setCurrentTool('select.crop.idle')
 			// Convert the eased slider value back to the actual zoom value
 			const sliderPercent = value / 100
@@ -117,17 +115,22 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 
 			const change = getCroppedImageDataWhenZooming(zoom, imageShape, maxZoom)
 
-			editor.updateShape({
-				id: imageShape.id,
-				type: imageShape.type,
-				x: change.x,
-				y: change.y,
-				props: {
-					w: change.w,
-					h: change.h,
-					crop: change.crop,
+			editor.run(
+				() => {
+					editor.updateShape({
+						id: imageShape.id,
+						type: imageShape.type,
+						x: change.x,
+						y: change.y,
+						props: {
+							w: change.w,
+							h: change.h,
+							crop: change.crop,
+						},
+					} as TLShapePartial)
 				},
-			} as TLShapePartial)
+				{ mark: mark ? 'image zoom' : undefined }
+			)
 
 			trackEvent('set-style', { source: 'image-toolbar', id: 'zoom', value })
 		},
@@ -147,23 +150,25 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 	const handleAspectRatioChange = (aspectRatio: ASPECT_RATIO_OPTION) => {
 		const imageShape = editor.getShape<TLImageShape>(imageShapeId)
 		if (!imageShape) return
-		editor.run(() => {
-			editor.setCurrentTool('select.crop.idle')
-			const change = getCroppedImageDataForAspectRatio(aspectRatio, imageShape)
-			editor.markHistoryStoppingPoint('aspect ratio')
-			editor.updateShape({
-				id: imageShapeId,
-				type: 'image',
-				x: change.x,
-				y: change.y,
-				props: {
-					crop: change.crop,
-					w: change.w,
-					h: change.h,
-				},
-			} as TLShapePartial)
-			kickoutOccludedShapes(editor, [imageShapeId])
-		})
+		editor.run(
+			() => {
+				editor.setCurrentTool('select.crop.idle')
+				const change = getCroppedImageDataForAspectRatio(aspectRatio, imageShape)
+				editor.updateShape({
+					id: imageShapeId,
+					type: 'image',
+					x: change.x,
+					y: change.y,
+					props: {
+						crop: change.crop,
+						w: change.w,
+						h: change.h,
+					},
+				} as TLShapePartial)
+				kickoutOccludedShapes(editor, [imageShapeId])
+			},
+			{ mark: 'aspect ratio' }
+		)
 	}
 
 	const altText = useValue(
@@ -223,7 +228,6 @@ export const DefaultImageToolbarContent = track(function DefaultImageToolbarCont
 					value={displayValue}
 					label="tool.image-zoom"
 					onValueChange={handleZoomChange}
-					onHistoryMark={onHistoryMark}
 					min={0}
 					steps={100}
 					data-testid="tool.image-zoom"

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -486,8 +486,10 @@ export function MoveToPageMenu() {
 						disabled={currentPageId === page.id}
 						label={page.name.length > 30 ? `${page.name.slice(0, 30)}…` : page.name}
 						onSelect={() => {
-							editor.markHistoryStoppingPoint('move_shapes_to_page')
-							editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId)
+							editor.run(
+								() => editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId),
+								{ mark: 'move_shapes_to_page' }
+							)
 
 							const toPage = editor.getPage(page.id)
 
@@ -500,8 +502,9 @@ export function MoveToPageMenu() {
 											label: 'Go back',
 											type: 'primary',
 											onClick: () => {
-												editor.markHistoryStoppingPoint('change-page')
-												editor.setCurrentPage(currentPageId)
+												editor.run(() => editor.setCurrentPage(currentPageId), {
+													mark: 'change-page',
+												})
 											},
 										},
 									],

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.test.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { TldrawUiSlider } from './TldrawUiSlider'
+import { TldrawUiSlider, TLUiSliderChangeInfo } from './TldrawUiSlider'
 
 function renderSlider() {
 	const calls: string[] = []
-	const onValueChange = vi.fn((value: number) => {
-		calls.push(`change:${value}`)
+	const onValueChange = vi.fn((value: number, info: TLUiSliderChangeInfo) => {
+		calls.push(`change:${value}:${info.mark ? 'mark' : 'continue'}`)
 	})
 	const onHistoryMark = vi.fn((id: string) => {
 		calls.push(`mark:${id}`)
@@ -18,6 +18,7 @@ function renderSlider() {
 			label="style-panel.opacity"
 			title="Opacity"
 			onValueChange={onValueChange}
+			// oxlint-disable-next-line typescript/no-deprecated -- covers the compatibility path
 			onHistoryMark={onHistoryMark}
 		/>
 	)
@@ -30,48 +31,47 @@ describe('TldrawUiSlider', () => {
 		vi.clearAllMocks()
 	})
 
-	it('marks a history stopping point before a keyboard change', () => {
+	it('flags a keyboard change as the start of an undo step', () => {
 		const { thumb, calls } = renderSlider()
 
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
 
-		expect(calls).toEqual(['mark:keyboard slider', 'change:1'])
+		expect(calls).toEqual(['mark:keyboard slider', 'change:1:mark'])
 	})
 
 	it.each(['ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])(
-		'marks a history stopping point for %s',
+		'flags the change for %s',
 		(key) => {
-			const { thumb, onHistoryMark, onValueChange } = renderSlider()
+			const { thumb, onValueChange } = renderSlider()
 
 			fireEvent.keyDown(thumb, { key })
 
-			expect(onHistoryMark).toHaveBeenCalledTimes(1)
 			expect(onValueChange).toHaveBeenCalledTimes(1)
+			expect(onValueChange.mock.calls[0][1]).toEqual({ mark: true })
 		}
 	)
 
-	it('marks once for a held key so the repeat run is a single undo step', () => {
-		const { thumb, onHistoryMark, onValueChange } = renderSlider()
+	it('flags only the first change of a held key so the repeat run is a single undo step', () => {
+		const { thumb, onValueChange } = renderSlider()
 
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft', repeat: true })
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft', repeat: true })
 
-		expect(onHistoryMark).toHaveBeenCalledTimes(1)
-		expect(onValueChange).toHaveBeenCalledTimes(3)
+		expect(onValueChange.mock.calls.map((call) => call[1].mark)).toEqual([true, false, false])
 	})
 
-	it('marks each separate key press', () => {
-		const { thumb, onHistoryMark } = renderSlider()
+	it('flags each separate key press', () => {
+		const { thumb, onValueChange } = renderSlider()
 
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
 		fireEvent.keyDown(thumb, { key: 'ArrowLeft' })
 
-		expect(onHistoryMark).toHaveBeenCalledTimes(3)
+		expect(onValueChange.mock.calls.map((call) => call[1].mark)).toEqual([true, true, true])
 	})
 
-	it('does not mark for keys that do not change the value', () => {
+	it('does not change the value for keys that do not move the slider', () => {
 		const { thumb, onHistoryMark, onValueChange } = renderSlider()
 
 		fireEvent.keyDown(thumb, { key: 'Tab' })
@@ -82,7 +82,7 @@ describe('TldrawUiSlider', () => {
 		expect(onValueChange).not.toHaveBeenCalled()
 	})
 
-	it('still marks a history stopping point on pointer down', () => {
+	it('still calls the deprecated onHistoryMark on pointer down', () => {
 		const { getByTestId, onHistoryMark } = renderSlider()
 
 		fireEvent.pointerDown(getByTestId('slider'))

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiSlider.tsx
@@ -1,6 +1,6 @@
 import { tltime } from '@tldraw/editor'
 import { Slider as _Slider } from 'radix-ui'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { TLUiTranslationKey } from '../../hooks/useTranslation/TLUiTranslationKey'
 import { useDirection, useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { hideAllTooltips, TldrawUiTooltip } from './TldrawUiTooltip'
@@ -17,13 +17,24 @@ const SLIDER_VALUE_KEYS = new Set([
 ])
 
 /** @public */
+export interface TLUiSliderChangeInfo {
+	/**
+	 * `true` when the change begins a gesture (a pointer down or a fresh key press), `false` when
+	 * it continues one (a drag, or a held key repeating). Start a new undo step when it is `true`
+	 * so a whole drag undoes as one step.
+	 */
+	mark: boolean
+}
+
+/** @public */
 export interface TLUiSliderProps {
 	min?: number
 	steps: number
 	value: number | null
 	label: string
 	title: string
-	onValueChange(value: number): void
+	onValueChange(value: number, info: TLUiSliderChangeInfo): void
+	/** @deprecated Use the `mark` flag passed to `onValueChange` instead. */
 	onHistoryMark?(id: string): void
 	'data-testid'?: string
 	ariaValueModifier?: number
@@ -32,6 +43,7 @@ export interface TLUiSliderProps {
 /** @public @react */
 export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(function Slider(
 	{
+		// oxlint-disable-next-line typescript/no-deprecated -- still honored for existing consumers
 		onHistoryMark,
 		title,
 		min,
@@ -56,15 +68,23 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 		setTabIndex(0)
 	}, [])
 
+	// Set on pointer down and on a fresh key press, consumed by the next value change. Radix
+	// reports drags and key repeats through the same onValueChange, so this is how the consumer
+	// tells the start of a gesture from its continuation.
+	const rNextChangeStartsGesture = useRef(false)
+
 	const handleValueChange = useCallback(
 		(value: number[]) => {
-			onValueChange(value[0])
+			onValueChange(value[0], { mark: rNextChangeStartsGesture.current })
+			rNextChangeStartsGesture.current = false
 		},
 		[onValueChange]
 	)
 
 	const handlePointerDown = useCallback(() => {
 		hideAllTooltips()
+		rNextChangeStartsGesture.current = true
+		// oxlint-disable-next-line typescript/no-deprecated
 		onHistoryMark?.('click slider')
 	}, [onHistoryMark])
 
@@ -93,13 +113,15 @@ export const TldrawUiSlider = React.forwardRef<HTMLDivElement, TLUiSliderProps>(
 		}
 	}, [])
 
-	// Capture phase so the mark lands before Radix's bubble-phase onKeyDown changes the value;
+	// Capture phase so this runs before Radix's bubble-phase onKeyDown changes the value;
 	// otherwise keyboard changes squash into the preceding history entry and undo skips past them.
 	// Repeats from a held key are skipped so the run is one undo step, like a pointer drag.
 	const handleKeyDown = useCallback(
 		(event: React.KeyboardEvent) => {
 			handleKeyEvent(event)
 			if (SLIDER_VALUE_KEYS.has(event.key) && !event.repeat) {
+				rNextChangeStartsGesture.current = true
+				// oxlint-disable-next-line typescript/no-deprecated
 				onHistoryMark?.('keyboard slider')
 			}
 		},

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -54,6 +54,12 @@ export interface TLUiActionItem<
 	readonlyOk?: boolean
 	checkbox?: boolean
 	isRequiredA11yAction?: boolean
+	/**
+	 * Every action starts its own undo step: `onSelect` runs inside `editor.run` with a mark named
+	 * after the action id, so an action never has to remember to mark. Set to `false` only for
+	 * actions that operate on the history stack itself, like undo and redo.
+	 */
+	mark?: boolean
 	onSelect(source: TLUiEventSource): Promise<void> | void
 }
 
@@ -95,6 +101,36 @@ export function supportsDownloadingOriginal(
 
 function makeActions(actions: TLUiActionItem[]) {
 	return Object.fromEntries(actions.map((action) => [action.id, action])) as TLUiActionsContextType
+}
+
+/**
+ * Wrap every action so selecting it is a single undo step. This runs after `overrides`, so
+ * actions added or replaced by SDK users get the same guarantee as the defaults.
+ */
+function markActionsAsUndoSteps(editor: Editor, actions: TLUiActionsContextType) {
+	const result: TLUiActionsContextType = {}
+	for (const [id, action] of Object.entries(actions)) {
+		if (action.mark === false) {
+			result[id] = action
+			continue
+		}
+		result[id] = {
+			...action,
+			onSelect(source) {
+				// Only the synchronous part of an async action runs in the transaction, but the
+				// mark is placed eagerly so changes made after an await still land in this step.
+				let returnValue: Promise<void> | void = undefined
+				editor.run(
+					() => {
+						returnValue = action.onSelect(source)
+					},
+					{ mark: action.id }
+				)
+				return returnValue
+			},
+		}
+	}
+	return result
 }
 
 function getExportName(editor: Editor, defaultName: string) {
@@ -143,8 +179,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			if (!canApplySelectionAction()) return
 			if (mustGoBackToSelectToolFirst()) return
 
-			editor.markHistoryStoppingPoint('resize shapes')
-
 			const selectedShapeIds = editor.getSelectedShapeIds()
 			if (selectedShapeIds.length === 0) return
 
@@ -173,7 +207,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('edit-link', { source })
-					editor.markHistoryStoppingPoint('edit-link')
 					helpers.addDialog({ component: EditLinkDialog })
 				},
 			},
@@ -211,6 +244,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.undo',
 				icon: 'undo',
 				kbd: 'cmd+z,ctrl+z',
+				mark: false,
 				onSelect(source) {
 					trackEvent('undo', { source })
 					editor.undo()
@@ -221,6 +255,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				label: 'action.redo',
 				icon: 'redo',
 				kbd: 'cmd+shift+z,ctrl+shift+z',
+				mark: false,
 				onSelect(source) {
 					trackEvent('redo', { source })
 					editor.redo()
@@ -349,7 +384,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('toggle-auto-size', { source })
-					editor.markHistoryStoppingPoint('toggling auto size')
 					editor.run(() => {
 						const shapes = editor
 							.getSelectedShapes()
@@ -508,7 +542,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							deleteList.push(shape.id)
 						}
 
-						editor.markHistoryStoppingPoint('convert shapes to embed')
 						editor.deleteShapes(deleteList)
 						editor.createShapes(createList)
 					})
@@ -546,7 +579,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 								}
 					}
 
-					editor.markHistoryStoppingPoint('duplicate shapes')
 					editor.duplicateShapes(ids, offset)
 
 					if (instanceState.duplicateProps) {
@@ -571,7 +603,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('ungroup-shapes', { source })
-					editor.markHistoryStoppingPoint('ungroup')
 					editor.ungroupShapes(editor.getSelectedShapeIds())
 				},
 			},
@@ -587,10 +618,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					trackEvent('group-shapes', { source })
 					const onlySelectedShape = editor.getOnlySelectedShape()
 					if (onlySelectedShape && editor.isShapeOfType(onlySelectedShape, 'group')) {
-						editor.markHistoryStoppingPoint('ungroup')
 						editor.ungroupShapes(editor.getSelectedShapeIds())
 					} else {
-						editor.markHistoryStoppingPoint('group')
 						editor.groupShapes(editor.getSelectedShapeIds())
 					}
 				},
@@ -611,7 +640,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						selectedShapes.every((shape) => editor.isShapeOfType(shape, 'frame'))
 					) {
 						trackEvent('remove-frame', { source })
-						editor.markHistoryStoppingPoint('remove-frame')
 						removeFrame(
 							editor,
 							selectedShapes.map((shape) => shape.id)
@@ -627,7 +655,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (!pageBounds) return
 
 					trackEvent('frame-selection', { source })
-					editor.markHistoryStoppingPoint('frame-selection')
 
 					const parentId = editor.findCommonAncestor(shapes) ?? editor.getCurrentPageId()
 
@@ -666,7 +693,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						selectedShapes.length > 0 &&
 						selectedShapes.every((shape) => editor.isShapeFrameLike(shape))
 					) {
-						editor.markHistoryStoppingPoint('remove-frame')
 						removeFrame(
 							editor,
 							selectedShapes.map((shape) => shape.id)
@@ -683,7 +709,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					trackEvent('fit-frame-to-content', { source })
 					const onlySelectedShape = editor.getOnlySelectedShape()
 					if (onlySelectedShape && editor.isShapeFrameLike(onlySelectedShape)) {
-						editor.markHistoryStoppingPoint('fit-frame-to-content')
 						fitFrameToContent(editor, onlySelectedShape.id)
 					}
 				},
@@ -698,7 +723,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'left', source })
-					editor.markHistoryStoppingPoint('align left')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'left')
@@ -719,7 +743,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-horizontal', source })
-					editor.markHistoryStoppingPoint('align center horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'center-horizontal')
@@ -737,7 +760,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'right', source })
-					editor.markHistoryStoppingPoint('align right')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'right')
@@ -758,7 +780,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'center-vertical', source })
-					editor.markHistoryStoppingPoint('align center vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'center-vertical')
@@ -776,7 +797,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'top', source })
-					editor.markHistoryStoppingPoint('align top')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'top')
@@ -794,7 +814,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('align-shapes', { operation: 'bottom', source })
-					editor.markHistoryStoppingPoint('align bottom')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.alignShapes(selectedShapeIds, 'bottom')
@@ -815,7 +834,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'horizontal', source })
-					editor.markHistoryStoppingPoint('distribute horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.distributeShapes(selectedShapeIds, 'horizontal')
@@ -836,7 +854,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('distribute-shapes', { operation: 'vertical', source })
-					editor.markHistoryStoppingPoint('distribute vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.distributeShapes(selectedShapeIds, 'vertical')
@@ -856,7 +873,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'horizontal', source })
-					editor.markHistoryStoppingPoint('stretch horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.stretchShapes(selectedShapeIds, 'horizontal')
@@ -876,7 +892,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stretch-shapes', { operation: 'vertical', source })
-					editor.markHistoryStoppingPoint('stretch vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.stretchShapes(selectedShapeIds, 'vertical')
@@ -896,7 +911,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'horizontal', source })
-					editor.markHistoryStoppingPoint('flip horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.flipShapes(selectedShapeIds, 'horizontal')
@@ -913,7 +927,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('flip-shapes', { operation: 'vertical', source })
-					editor.markHistoryStoppingPoint('flip vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.flipShapes(selectedShapeIds, 'vertical')
@@ -930,7 +943,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('pack-shapes', { source })
-					editor.markHistoryStoppingPoint('pack')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.packShapes(selectedShapeIds, editor.options.adjacentShapeMargin)
@@ -950,7 +962,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'vertical', source })
-					editor.markHistoryStoppingPoint('stack-vertical')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.stackShapes(selectedShapeIds, 'vertical', editor.options.adjacentShapeMargin)
@@ -970,7 +981,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('stack-shapes', { operation: 'horizontal', source })
-					editor.markHistoryStoppingPoint('stack-horizontal')
 					editor.run(() => {
 						const selectedShapeIds = editor.getSelectedShapeIds()
 						editor.stackShapes(selectedShapeIds, 'horizontal', editor.options.adjacentShapeMargin)
@@ -988,7 +998,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toFront', source })
-					editor.markHistoryStoppingPoint('bring to front')
 					editor.bringToFront(editor.getSelectedShapeIds())
 				},
 			},
@@ -1002,7 +1011,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'forward', source })
-					editor.markHistoryStoppingPoint('bring forward')
 					editor.bringForward(editor.getSelectedShapeIds())
 				},
 			},
@@ -1016,7 +1024,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'backward', source })
-					editor.markHistoryStoppingPoint('send backward')
 					editor.sendBackward(editor.getSelectedShapeIds())
 				},
 			},
@@ -1030,7 +1037,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('reorder-shapes', { operation: 'toBack', source })
-					editor.markHistoryStoppingPoint('send to back')
 					editor.sendToBack(editor.getSelectedShapeIds())
 				},
 			},
@@ -1118,8 +1124,10 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						?.readText()
 						.then((text) => {
 							if (text?.trim()) {
-								editor.markHistoryStoppingPoint('paste')
-								defaultHandleExternalTextContent(editor, { text, point })
+								// This bypasses putExternalContent (and its mark) on purpose, so it marks itself.
+								editor.run(() => defaultHandleExternalTextContent(editor, { text, point }), {
+									mark: 'paste',
+								})
 							}
 						})
 						.catch(() => {
@@ -1142,7 +1150,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 						trackEvent('select-all-shapes', { source })
 
-						editor.markHistoryStoppingPoint('select all kbd')
 						editor.selectAll()
 					})
 				},
@@ -1156,7 +1163,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('select-none-shapes', { source })
-					editor.markHistoryStoppingPoint('select none')
 					editor.selectNone()
 				},
 			},
@@ -1170,7 +1176,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					if (mustGoBackToSelectToolFirst()) return
 
 					trackEvent('delete-shapes', { source })
-					editor.markHistoryStoppingPoint('delete')
 					editor.deleteShapes(editor.getSelectedShapeIds())
 				},
 			},
@@ -1185,7 +1190,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					const isFine = editor.inputs.getAltKey()
 					trackEvent('rotate-cw', { source, fine: isFine })
-					editor.markHistoryStoppingPoint('rotate-cw')
 					editor.run(() => {
 						const rotation = HALF_PI / (isFine ? 96 : 6)
 						const offset = editor.getSelectionRotation() % rotation
@@ -1208,7 +1212,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					const isFine = editor.inputs.getAltKey()
 					trackEvent('rotate-ccw', { source, fine: isFine })
-					editor.markHistoryStoppingPoint('rotate-ccw')
 					editor.run(() => {
 						const rotation = HALF_PI / (isFine ? 96 : 6)
 						const offset = editor.getSelectionRotation() % rotation
@@ -1493,7 +1496,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						}
 					}
 					if (updates.length > 0) {
-						editor.markHistoryStoppingPoint('unlock all')
 						editor.updateShapes(updates)
 					}
 				},
@@ -1600,7 +1602,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				kbd: 'shift+l',
 				onSelect(source) {
 					if (!canApplySelectionAction()) return
-					editor.markHistoryStoppingPoint('locking')
 					trackEvent('toggle-lock', { source })
 					editor.toggleLock(editor.getSelectedShapeIds())
 				},
@@ -1612,7 +1613,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const newPageId = PageRecordType.createId()
 					const ids = editor.getSelectedShapeIds()
 					editor.run(() => {
-						editor.markHistoryStoppingPoint('move_shapes_to_page')
 						editor.createPage({
 							name: helpers.msg('page-menu.new-page-initial-name'),
 							id: newPageId,
@@ -1630,7 +1630,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const style = DefaultColorStyle
 					editor.run(() => {
 						editor.updateInstanceState({ isChangingStyle: true })
-						editor.markHistoryStoppingPoint('change-color')
 						if (editor.isIn('select')) {
 							editor.setStyleForSelectedShapes(style, 'white')
 						}
@@ -1647,7 +1646,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const style = DefaultFillStyle
 					editor.run(() => {
 						editor.updateInstanceState({ isChangingStyle: true })
-						editor.markHistoryStoppingPoint('change-fill')
 						if (editor.isIn('select')) {
 							editor.setStyleForSelectedShapes(style, 'fill')
 						}
@@ -1664,7 +1662,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const style = DefaultFillStyle
 					editor.run(() => {
 						editor.updateInstanceState({ isChangingStyle: true })
-						editor.markHistoryStoppingPoint('change-fill')
 						if (editor.isIn('select')) {
 							editor.setStyleForSelectedShapes(style, 'lined-fill')
 						}
@@ -1681,7 +1678,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 					const ids = editor.getSelectedShapeIds()
 					if (ids.length === 0) return
 
-					editor.markHistoryStoppingPoint('flattening to image')
 					trackEvent('flatten-to-image', { source })
 
 					const newShapeIds = await flattenShapesToImages(
@@ -1735,7 +1731,6 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						// Otherwise, create a new page
 						trackEvent('new-page', { source })
 						editor.run(() => {
-							editor.markHistoryStoppingPoint('creating page')
 							const newPageId = PageRecordType.createId()
 							editor.createPage({
 								name: helpers.msg('page-menu.new-page-initial-name'),
@@ -1974,11 +1969,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 		const actions = makeActions(actionItems)
 
-		if (overrides) {
-			return overrides(editor, actions, helpers)
-		}
-
-		return actions
+		return markActionsAsUndoSteps(editor, overrides ? overrides(editor, actions, helpers) : actions)
 	}, [
 		helpers,
 		_editor,

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
@@ -20,8 +20,6 @@ export async function pasteFiles(
 		blob instanceof File ? blob : new File([blob], 'tldrawFile', { type: blob.type })
 	)
 
-	editor.markHistoryStoppingPoint('paste')
-
 	await putPastedExternalContent(
 		editor,
 		{

--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteUrl.ts
@@ -17,8 +17,6 @@ export async function pasteUrl(
 	sources?: TLExternalContentSource[],
 	clipboardPasteSource: 'native-event' | 'clipboard-read' = 'native-event'
 ) {
-	editor.markHistoryStoppingPoint('paste')
-
 	return await putPastedExternalContent(
 		editor,
 		{

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -170,7 +170,6 @@ const handleText = (
 	} else if (isValidHttpURL(data)) {
 		pasteUrl(editor, data, point, sources, clipboardPasteSource)
 	} else if (isSvgText(data)) {
-		editor.markHistoryStoppingPoint('paste')
 		putPastedExternalContent(
 			editor,
 			{
@@ -182,7 +181,6 @@ const handleText = (
 			{ source: clipboardPasteSource, point }
 		)
 	} else {
-		editor.markHistoryStoppingPoint('paste')
 		putPastedExternalContent(
 			editor,
 			{
@@ -564,7 +562,6 @@ async function handleClipboardThings(
 	// Try to paste tldraw content
 	for (const result of results) {
 		if (result.type === 'tldraw') {
-			editor.markHistoryStoppingPoint('paste')
 			putPastedExternalContent(
 				editor,
 				{ type: 'tldraw', content: result.data, point },
@@ -577,7 +574,6 @@ async function handleClipboardThings(
 	// Try to paste excalidraw content
 	for (const result of results) {
 		if (result.type === 'excalidraw') {
-			editor.markHistoryStoppingPoint('paste')
 			putPastedExternalContent(
 				editor,
 				{ type: 'excalidraw', content: result.data, point },
@@ -596,7 +592,6 @@ async function handleClipboardThings(
 			// Check for iframe embeds in HTML before stripping content
 			const iframeInfo = extractIframeFromHtml(result.data)
 			if (iframeInfo) {
-				editor.markHistoryStoppingPoint('paste')
 				editor.putExternalContent({
 					type: 'embed',
 					url: iframeInfo.src,
@@ -642,7 +637,6 @@ async function handleClipboardThings(
 			if (results.some((r) => r.type === 'text' && r.subtype !== 'html')) {
 				const html = stripHtml(result.data) ?? ''
 				if (html) {
-					editor.markHistoryStoppingPoint('paste')
 					putPastedExternalContent(
 						editor,
 						{
@@ -664,7 +658,6 @@ async function handleClipboardThings(
 		if (result.type === 'text' && result.subtype === 'text') {
 			const iframeInfo = extractIframeFromHtml(result.data)
 			if (iframeInfo) {
-				editor.markHistoryStoppingPoint('paste')
 				editor.putExternalContent({
 					type: 'embed',
 					url: iframeInfo.src,
@@ -803,8 +796,7 @@ export function useMenuClipboardEvents() {
 
 			const didCopy = await handleNativeOrMenuCopy(editor, { operation: 'cut', source: 'menu' })
 			if (didCopy) {
-				editor.markHistoryStoppingPoint('cut')
-				editor.deleteShapes(editor.getSelectedShapeIds())
+				editor.run(() => editor.deleteShapes(editor.getSelectedShapeIds()), { mark: 'cut' })
 				trackEvent('cut', { source })
 			}
 		},
@@ -901,8 +893,7 @@ export function useNativeClipboardEvents() {
 
 			const didCopy = await handleNativeOrMenuCopy(editor, { operation: 'cut', source: 'native' })
 			if (didCopy) {
-				editor.markHistoryStoppingPoint('cut')
-				editor.deleteShapes(editor.getSelectedShapeIds())
+				editor.run(() => editor.deleteShapes(editor.getSelectedShapeIds()), { mark: 'cut' })
 				trackEvent('cut', { source: 'kbd' })
 			}
 		}
@@ -947,8 +938,10 @@ export function useNativeClipboardEvents() {
 					const point = editor.user.getIsPasteAtCursorMode()
 						? editor.inputs.getCurrentPagePoint()
 						: editor.getViewportPageBounds().center
-					editor.markHistoryStoppingPoint('paste')
-					defaultHandleExternalTextContent(editor, { text, point })
+					// Bypasses putExternalContent (and its mark) on purpose, so it marks itself.
+					editor.run(() => defaultHandleExternalTextContent(editor, { text, point }), {
+						mark: 'paste',
+					})
 					preventDefault(e)
 					trackEvent('paste', { source: 'kbd' })
 					return

--- a/packages/tldraw/src/lib/ui/overrides.ts
+++ b/packages/tldraw/src/lib/ui/overrides.ts
@@ -42,7 +42,6 @@ export function useDefaultHelpers() {
 			document: editor.getContainerDocument(),
 		})
 		if (!files.length) return
-		editor.markHistoryStoppingPoint('insert media')
 		editor.putExternalContent({
 			type: 'files',
 			files,
@@ -64,8 +63,6 @@ export function useDefaultHelpers() {
 			const shape = editor.getOnlySelectedShape()
 			if (!shape || (isImage && shape.type !== 'image') || (!isImage && shape.type !== 'video'))
 				return
-
-			editor.markHistoryStoppingPoint('replace media')
 
 			const file = files[0]
 			editor.replaceExternalContent({

--- a/packages/tldraw/src/test/ui/StylePanel.test.tsx
+++ b/packages/tldraw/src/test/ui/StylePanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
-import { createShapeId, DefaultColorStyle, Editor, TLArrowShape } from '@tldraw/editor'
+import { createShapeId, DefaultColorStyle, Editor, TLArrowShape, TLGeoShape } from '@tldraw/editor'
 import { Tldraw } from '../../lib/Tldraw'
 import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
 
@@ -72,6 +72,37 @@ describe('StylePanel', () => {
 		})
 
 		expect(editor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
+		expect(editor.getSelectedShapeIds()).toEqual([id])
+	})
+
+	it('undoes a scrub across swatches as one step and a click as another', async () => {
+		const id = createShapeId()
+		act(() => {
+			editor.createShapes([{ id, type: 'geo', x: 0, y: 0 }]).selectNone()
+			editor.markHistoryStoppingPoint('before selecting')
+			editor.select(id)
+		})
+		const getColor = () => editor.getShape<TLGeoShape>(id)!.props.color
+
+		// pointer down on one swatch, then scrub over two more before releasing
+		fireEvent.pointerDown(await screen.findByTestId('style.color.red'))
+		fireEvent.pointerEnter(screen.getByTestId('style.color.green'))
+		fireEvent.pointerEnter(screen.getByTestId('style.color.blue'))
+		fireEvent.pointerUp(screen.getByTestId('style.color.blue'))
+		expect(getColor()).toBe('blue')
+
+		fireEvent.click(screen.getByTestId('style.color.orange'))
+		expect(getColor()).toBe('orange')
+
+		act(() => {
+			editor.undo()
+		})
+		expect(getColor()).toBe('blue')
+
+		act(() => {
+			editor.undo()
+		})
+		expect(getColor()).toBe('black')
 		expect(editor.getSelectedShapeIds()).toEqual([id])
 	})
 })

--- a/packages/tldraw/src/test/ui/actions.test.tsx
+++ b/packages/tldraw/src/test/ui/actions.test.tsx
@@ -1,0 +1,118 @@
+import { act } from '@testing-library/react'
+import { createShapeId, Editor } from '@tldraw/editor'
+import { useEffect } from 'react'
+import { Tldraw } from '../../lib/Tldraw'
+import { TLUiActionsContextType, useActions } from '../../lib/ui/context/actions'
+import { TLUiOverrides } from '../../lib/ui/overrides'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+function ActionCapturer({ onCapture }: { onCapture(actions: TLUiActionsContextType): void }) {
+	const actions = useActions()
+	useEffect(() => {
+		onCapture(actions)
+	}, [actions, onCapture])
+	return null
+}
+
+const customId = createShapeId('custom')
+
+// Neither override marks a history stopping point: that is the provider's job.
+const overrides: TLUiOverrides = {
+	actions(editor, actions) {
+		actions['create-custom-shape'] = {
+			id: 'create-custom-shape',
+			onSelect() {
+				editor.createShape({ id: customId, type: 'geo', x: 0, y: 0 })
+			},
+		}
+		actions['create-custom-shape-unmarked'] = {
+			id: 'create-custom-shape-unmarked',
+			mark: false,
+			onSelect() {
+				editor.createShape({ id: customId, type: 'geo', x: 0, y: 0 })
+			},
+		}
+		return actions
+	},
+}
+
+let editor: Editor
+let actions: TLUiActionsContextType
+const earlierId = createShapeId('earlier')
+
+beforeEach(async () => {
+	const result = await renderTldrawComponentWithEditor(
+		(onMount) => (
+			<Tldraw onMount={onMount} overrides={overrides}>
+				<ActionCapturer onCapture={(a) => (actions = a)} />
+			</Tldraw>
+		),
+		{ waitForPatterns: false }
+	)
+	editor = result.editor
+	act(() => {
+		editor.createShape({ id: earlierId, type: 'geo', x: 200, y: 0 })
+	})
+})
+
+describe('actions', () => {
+	it('gives an action added through overrides its own undo step', () => {
+		act(() => {
+			actions['create-custom-shape'].onSelect('menu')
+		})
+		expect(editor.getShape(customId)).toBeDefined()
+
+		act(() => {
+			editor.undo()
+		})
+
+		expect(editor.getShape(customId)).toBeUndefined()
+		expect(editor.getShape(earlierId)).toBeDefined()
+	})
+
+	it('lets an action opt out of marking with mark: false', () => {
+		act(() => {
+			actions['create-custom-shape-unmarked'].onSelect('menu')
+		})
+
+		act(() => {
+			editor.undo()
+		})
+
+		// without a mark the action joined the previous step, so both shapes are gone
+		expect(editor.getShape(customId)).toBeUndefined()
+		expect(editor.getShape(earlierId)).toBeUndefined()
+	})
+
+	it('does not enable undo after an action that changes nothing undoable', () => {
+		act(() => {
+			editor.clearHistory()
+		})
+		expect(editor.getCanUndo()).toBe(false)
+
+		act(() => {
+			actions['zoom-in'].onSelect('menu')
+			actions['toggle-grid'].onSelect('menu')
+		})
+
+		expect(editor.getCanUndo()).toBe(false)
+	})
+
+	it('keeps undo and redo from marking on top of the history they walk', () => {
+		act(() => {
+			editor.clearHistory()
+			editor.createShape({ id: customId, type: 'geo', x: 0, y: 0 })
+		})
+
+		act(() => {
+			actions['undo'].onSelect('kbd')
+		})
+		expect(editor.getShape(customId)).toBeUndefined()
+
+		act(() => {
+			actions['redo'].onSelect('kbd')
+		})
+		expect(editor.getShape(customId)).toBeDefined()
+		expect(editor.getCanRedo()).toBe(false)
+	})
+})

--- a/templates/image-pipeline/src/nodes/types/NumberNode.tsx
+++ b/templates/image-pipeline/src/nodes/types/NumberNode.tsx
@@ -76,7 +76,6 @@ function NumberNodeComponent({ shape, node }: NodeComponentProps<NumberNode>) {
 					editor.setSelectedShapes([shape.id])
 					updateNode<NumberNode>(editor, shape, (node) => ({ ...node, value }), false)
 				}}
-				onHistoryMark={() => {}}
 			/>
 		</NodeRow>
 	)

--- a/templates/workflow/src/nodes/types/SliderNode.tsx
+++ b/templates/workflow/src/nodes/types/SliderNode.tsx
@@ -78,7 +78,6 @@ export function SliderNodeComponent({ shape, node }: NodeComponentProps<SliderNo
 					editor.setSelectedShapes([shape.id])
 					updateNode<SliderNode>(editor, shape, (node) => ({ ...node, value }))
 				}}
-				onHistoryMark={() => {}}
 			/>
 		</NodeRow>
 	)


### PR DESCRIPTION
This PR improves how undo steps are declared so that UI code can no longer forget to mark one. Nine PRs since August 10 (#10468, #10469, #10470, #10473, #10474, #10478, #9920, #10472, #10462) each fixed one overlooked `markHistoryStoppingPoint`, and the same shape of bug will keep coming back as long as every leaf handler has to remember it.

### Before

A mark is a separator you place before a change, and the pending diff accumulates until the next one. Forgetting the mark fails silently: the change merges into whatever undo step is already open, so undo reverts it together with the previous action. `editor.run` did not help, because it is a transaction, not an undo step, even though `apps/docs/content/docs/editor.mdx` claimed it grouped changes into one. The 150 hand-written marks across 50 files were each a place to get this wrong, and the Aug 22 fixes were all at the boundary where user input enters the editor: a menu action, a style picker, a slider keydown, an alt text save, a file drop.

### After

The contract is: the code that applies a user action starts a new undo step, and extending an in-progress gesture is the explicit exception.

- `editor.run(fn, { mark: 'name' })` places the mark and runs the transaction in one call. Docs now say so, and no longer claim a bare `run` is an undo step.
- Every UI action runs inside a marked `run` named after the action id. The provider wraps `onSelect` after `overrides`, so actions that SDK users add or replace get the same guarantee. Undo and redo opt out with `mark: false`. The 28 hand marks in `actions.tsx` are gone.
- `putExternalContent` and `replaceExternalContent` mark themselves, so paste, drop, insert media, replace media, and the embed dialog (which never marked) no longer need to.
- The style panel context's `onValueChange` and `onOpacityChange` mark by default. Scrubbing across swatches and dragging the opacity slider pass `{ mark: false }` to continue the step begun on pointer down. The `onHistoryMark` plumbing through five primitives is deprecated but still honored.
- `TldrawUiSlider` reports `{ mark }` with each change instead of asking consumers for an `onHistoryMark` callback, so a drag or a held key stays one step while a fresh press starts a new one.
- The remaining UI-layer `mark(); mutate()` pairs (alt text, page menu, cut, move to page) became `run(fn, { mark })`.

### Implementation notes

Marking every action means actions that change nothing undoable (zoom, toggle grid) leave a bare mark on the stack. `getNumUndos` counts marks, so `canUndo` would have lit up the undo button on a fresh document after zooming. `HistoryManager.hasUndos` and `hasRedos` ignore marks with no diff between them and `canUndo`/`canRedo` use them. `getNumUndos` is unchanged.

The mark in `run` is placed before the transaction, not inside it. Marking inside and then throwing rolls back the stacks atom but not the pending diff it flushed, which loses the previous undo step. A stray mark from a failed function is harmless.

One explicit mark remains in the UI layer: `convert-to-bookmark` keeps its own mark id for `bailToMark`. Tool states are untouched; they own their marks and need the ids for bailing.

One edge case changes: pressing select-all mid-stroke in the draw tool completes the stroke first, and that completion write now joins the action's undo step instead of the stroke's, because the action's mark is placed before it runs. Every other selection action returns early unless the select tool is active, so this is the only path that reaches it. A lint rule that flags direct mutations in `packages/tldraw/src/lib/ui` outside a marked `run` is the natural follow-up to keep this from regressing.

### Change type

- [x] `improvement`

### Test plan

1. Draw a stroke, then zoom in with the button or shortcut. The undo button stays disabled if the document was empty before the stroke, and one undo removes the stroke.
2. Select a shape, pointer down on a color swatch and drag across two more before releasing, then click a fourth. Undo once reverts to the scrubbed color, undo again reverts to the original.
3. Drop an image or paste text after drawing a stroke, then undo. Only the dropped or pasted content is removed.
4. Add an action through `overrides` that calls `editor.createShape` with no mark. Trigger it, undo, and only that shape is removed.

- [x] Unit tests

### Release notes

- Add a `mark` option to `editor.run` that starts a new undo step before the transaction
- Make every UI action its own undo step, including actions added through overrides
- Make `putExternalContent` and `replaceExternalContent` start their own undo step
- Fix the undo button enabling after actions that change nothing undoable

### API changes

- Added `mark?: string` to `TLEditorRunOptions`
- Added `HistoryManager.hasUndos()` and `hasRedos()`
- Added `mark?: boolean` to `TLUiActionItem`; actions mark by default
- Added `StylePanelValueChangeOptions` and an optional `opts` parameter to `StylePanelContext.onValueChange`, `onOpacityChange`, and `StylePanelButtonPickerProps.onValueChange`
- Added `TLUiSliderChangeInfo`; `TLUiSliderProps.onValueChange` now receives it as a second argument
- Deprecated `StylePanelContext.onHistoryMark`, `StylePanelButtonPickerProps.onHistoryMark`, and `TLUiSliderProps.onHistoryMark`

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +263 / -176 |
| Tests           | +288 / -18  |
| Automated files | +21 / -7    |
| Documentation   | +30 / -7    |
| Templates       | +0 / -2     |
