### PR TITLE
chore(i18n): fix the German bring-forward capitalisation in Lokalise

### DIFF
--- a/internal/scripts/i18n-fix-strings.ts
+++ b/internal/scripts/i18n-fix-strings.ts
@@ -578,7 +578,7 @@ const FIXES: StringFix[] = [
 		translations: {
 			de: {
 				value: 'Eine Ebene nach vorne',
-				note: 'Was the literal key name "action.bring-to-front", so the German reorder menu rendered a raw key instead of a label.',
+				note: 'Was "Eine Ebene nach Vorne" — "vorne" is an adverb here, so it takes no capital, and the sibling "Eine Ebene nach hinten" already writes it lowercase.',
 			},
 		},
 	},

--- a/internal/scripts/i18n-fix-strings.ts
+++ b/internal/scripts/i18n-fix-strings.ts
@@ -573,6 +573,17 @@ const FIXES: StringFix[] = [
 	},
 	{
 		project: 'sdk',
+		key: 'action.bring-forward',
+		english: 'Bring forward',
+		translations: {
+			de: {
+				value: 'Eine Ebene nach vorne',
+				note: 'Was the literal key name "action.bring-to-front", so the German reorder menu rendered a raw key instead of a label.',
+			},
+		},
+	},
+	{
+		project: 'sdk',
 		key: 'action.copy-hovered-styles',
 		english: 'Copy hovered styles',
 		translations: {


### PR DESCRIPTION
The automated i18n PR (#10693) brought back the literal key name as the German translation for `action.bring-forward`:

```json
"action.bring-forward": "action.bring-to-front",
```

#10693 carries the repo-side correction. The Lokalise side turned out to be already handled — the translator fixed it there at 15:24 UTC on 8 Sep, about an hour after the download job had cut the PR, so the bad value never needed patching upstream.

What is left is a one-character inconsistency. Lokalise now holds `Eine Ebene nach Vorne`, while the sibling string written by the same translator an hour earlier is `Eine Ebene nach hinten`. `vorne` is an adverb here and takes no capital, so this lowercases it and brings the pair back into line.

| key | Lokalise | after |
| --- | --- | --- |
| `action.bring-forward` | Eine Ebene nach **V**orne | Eine Ebene nach **v**orne |
| `action.send-backward` | Eine Ebene nach hinten | unchanged |

### Change type

- [x] `other`

### Test plan

1. `yarn i18n-fix-strings --project=sdk` and confirm the dry run prints the `action.bring-forward` / `de` correction.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Corrected the capitalisation of the German translation of "Bring forward".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01968y2S55ccwVmJ6KCEMZPv
