### PR TITLE
[do not merge] test(tldraw): arrow terminal goes stale when its bound shape is dropped on paste

### DIFF
--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -1,4 +1,5 @@
 import {
+	TLArrowShape,
 	TLBinding,
 	TLBindingId,
 	TLFrameShape,
@@ -886,6 +887,45 @@ describe('When pasting content with unsupported shape types...', () => {
 
 		expect(editor.getShape(arrow)).toBeDefined()
 		expect(editor.getBindingsFromShape(arrow, 'arrow')).toEqual([])
+	})
+
+	it('leaves an arrow pointing where its dropped target was', () => {
+		const unknown = createShapeId('unknown')
+		const arrow = createShapeId('arrow')
+		editor.createShapes([
+			{ id: unknown, type: 'geo', x: 200, y: 0, props: { w: 100, h: 100 } },
+			{ id: arrow, type: 'arrow', x: 0, y: 0, props: { end: { x: 250, y: 50 } } },
+		])
+		editor.createBindings([
+			{
+				type: 'arrow',
+				fromId: arrow,
+				toId: unknown,
+				props: {
+					terminal: 'end',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: false,
+				},
+			},
+		])
+		// a bound terminal renders from the binding, so props.end goes stale when the target moves
+		editor.updateShape({ id: unknown, type: 'geo', x: 600, y: 600 })
+
+		// copying the arrow on its own goes through onBeforeIsolateFromShape, which bakes the
+		// live terminal position into props.end; that's where the arrow should end up
+		const isolated = structuredClone(editor.getContentFromCurrentPage([arrow])!)
+		const expectedEnd = (isolated.shapes[0] as TLArrowShape).props.end
+
+		editor.putContentOntoCurrentPage(
+			contentWithUnsupported([arrow, unknown], new Map([[unknown, 'animation-camera']])),
+			{ preserveIds: true, preservePosition: true }
+		)
+
+		const pasted = editor.getShape<TLArrowShape>(arrow)!
+		expect(editor.getBindingsFromShape(arrow, 'arrow')).toEqual([])
+		expect(pasted.props.end.x).toBeCloseTo(expectedEnd.x)
+		expect(pasted.props.end.y).toBeCloseTo(expectedEnd.y)
 	})
 
 	it('drops bindings whose own type has no util', () => {


### PR DESCRIPTION
Adds a failing test on top of #10674 that shows a gap in how bindings to a dropped shape are handled. Not meant to merge as is: it's here so the fix can be discussed and landed on the parent PR.

### The gap

When #10674 drops a shape that an arrow is bound to, it filters the binding record out before `createBindings`. That does leave the arrow unbound, but the arrow lands wherever its `props.end` was last written, not where the dropped shape actually was.

A bound terminal renders from the binding, so `props.end` goes stale as soon as the target moves. The existing copy path already handles this: when an arrow is copied *without* its target, `ArrowBindingUtil.onBeforeIsolateFromShape` runs `updateArrowTerminal` and bakes the live terminal position into `props.end`. That hook never fires here because the target *is* in the selection at copy time and only gets dropped at paste time.

Test output on `guillaume/fix/issue-10127`:

```
AssertionError: expected 250 to be close to 590.4540584539816
```

`250` is the stale `props.end.x` from before the target moved; `590.45` is what the isolate path produces for the same arrow.

### Repro

1. Draw a box at (200,0), an arrow bound to it, then move the box to (600,600).
2. Copy both, relabel the box as a shape type this editor has no util for, paste.
3. The arrow pastes unbound but pointing at (250,50), where the box used to be.

### Possible fix

For bindings dropped because `fromId`/`toId` is an unsupported shape, run the equivalent of the binding util's isolate hook before filtering. The catch is that those hooks work on store shapes via `editor.getShape`, and at that point in `putContentOntoCurrentPage` the shapes are still plain records in an array, so it would need a content-level variant or a temporary store. Bindings dropped because their own *type* has no util can't do this, there's no util to ask.

### Change type

- [x] `tests`

### Test plan

- [x] `cd packages/tldraw && yarn test run src/test/paste.test.ts -t "dropped target"` fails on the parent branch
