### PR TITLE
[HOTFIX] feat(dotcom): read board history through delta chain reconstruction

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -80,7 +80,7 @@ import {
 	writeMcpClusterIndexRow,
 } from './mcpClusterIndexStorage'
 import { TLPostgresPool } from './postgres'
-import { deleteAllObjectsWithPrefix, getR2KeyForRoom } from './r2'
+import { deleteAllObjectsWithPrefix, getR2KeyForRoom, R2ReadScheduler } from './r2'
 import {
 	BootStage,
 	FileEffectStallError,
@@ -117,7 +117,12 @@ import {
 	resolveVersionChainMode,
 	VersionChainRollout,
 } from './versionChainConfig'
-import { deleteAllVersions, reconstructVersion } from './versionChainRead'
+import {
+	deleteAllVersions,
+	loadChainIndex,
+	openWholeVersionStream,
+	reconstructVersion,
+} from './versionChainRead'
 import { readOpenSegment, writeVersionChainEntry } from './versionChainWrite'
 import { chainHeadHash } from './versionDelta'
 import { resolveWelcomeSnapshot } from './welcome/resolveWelcomeSnapshot'
@@ -151,7 +156,9 @@ type R2OperationType =
 	| 'asset_copy'
 	| 'snapshot_upload'
 	| 'version_chain_write'
+	| 'version_chain_read'
 	| 'version_chain_verify'
+	| 'version_chain_delete'
 
 // Transient R2 failures worth retrying — dropped connections and the connection-limit error the
 // shared budget exists to avoid. Anything else (a bad request, missing object, etc.) is permanent,
@@ -799,11 +806,58 @@ export class TLFileDurableObject extends DurableObject {
 			if (!timestamp) {
 				return new Response('Missing timestamp', { status: 400 })
 			}
-			const data = await this.r2.versionCache.get(`${roomKey}/${timestamp}`)
-			if (!data) {
-				return new Response('Version not found', { status: 400 })
+			// Reconstructs from the chain, falling back to the legacy full copy both when the chain
+			// has nothing for this version and when it is broken — an admin who can preview a version
+			// must be able to restore it while the full copies exist.
+			// Whole objects (keyframes, legacy copies) are read as text once — the same cost as the
+			// handler this replaces — and only a delta replay materializes a snapshot, which is then
+			// reused below rather than re-parsed. Parsing, re-serializing and parsing again a large
+			// board is what pushes a 128MB isolate over.
+			let dataText: string
+			let restored: RoomSnapshot | undefined
+			try {
+				// Each read is its own queued operation rather than the whole restore holding one
+				// slot — a slot is sized for an asset copy's two connections, and reconstruction
+				// fans out to the keyframe plus every segment (see _verifyRetiredChain). Every read
+				// is one idempotent get or list, so each retries transient errors on its own.
+				const schedule: R2ReadScheduler = (read) =>
+					this.addR2Operation('version_chain_read', () =>
+						retry(read, { attempts: 3, waitDuration: 500, matchError: isTransientConnectionError })
+					)
+				const buckets = {
+					chainBucket: this.r2.versionChain,
+					legacyBucket: this.r2.versionCache,
+				}
+				const { entries: index } = await loadChainIndex(this.r2.versionChain, roomKey, schedule)
+				const whole = await openWholeVersionStream({
+					...buckets,
+					roomKey,
+					timestamp,
+					index,
+					schedule,
+				})
+				if (whole) {
+					dataText = await new Response(whole).text()
+				} else {
+					const reconstruction = await reconstructVersion({
+						...buckets,
+						roomKey,
+						timestamp,
+						index,
+						schedule,
+					})
+					if (!reconstruction) {
+						return new Response('Version not found', { status: 400 })
+					}
+					restored = reconstruction.snapshot
+					dataText = JSON.stringify(restored)
+				}
+			} catch (error) {
+				const legacy = await this.r2.versionCache.get(`${roomKey}/${timestamp}`)
+				if (!legacy) throw error
+				this.reportError(error)
+				dataText = await legacy.text()
 			}
-			const dataText = await data.text()
 
 			// The put deliberately carries no version metadata, so null ("looked up, no usable
 			// stamp") is the truth about R2 and the next persist re-uploads and re-stamps.
@@ -857,7 +911,7 @@ export class TLFileDurableObject extends DurableObject {
 			// retries and let the dropped comments resurrect on the next fresh-SQLite load.
 			// follow-up: a durable wipe-marker recorded alongside the outbox would let the DO
 			// itself retry the fileId-wide delete, closing the dependence on caller retries.
-			const snapshot = JSON.parse(dataText) as RoomSnapshot
+			const snapshot = restored ?? (JSON.parse(dataText) as RoomSnapshot)
 
 			const storage = await this.getStorage()
 			storage.transaction((txn) => {
@@ -3137,10 +3191,14 @@ export class TLFileDurableObject extends DurableObject {
 
 			// remove edit history
 			const r2Key = getR2KeyForRoom({ slug: id, isApp: true })
+			// Each list page and delete batch is its own queued operation: the sweep runs both
+			// buckets concurrently, and unqueued beside two asset copies that is the whole
+			// six-connection budget.
 			await deleteAllVersions({
 				chainBucket: this.env.ROOMS_HISTORY,
 				legacyBucket: this.env.ROOMS_HISTORY_EPHEMERAL,
 				roomKey: r2Key,
+				schedule: (op) => this.addR2Operation('version_chain_delete', op),
 			})
 
 			// remove main file
@@ -3368,6 +3426,7 @@ export class TLFileDurableObject extends DurableObject {
 				chainBucket: this.env.ROOMS_HISTORY,
 				legacyBucket: this.env.ROOMS_HISTORY_EPHEMERAL,
 				roomKey,
+				schedule: (op) => this.addR2Operation('version_chain_delete', op),
 			})
 
 			// remove main file

--- a/apps/dotcom/sync-worker/src/r2.ts
+++ b/apps/dotcom/sync-worker/src/r2.ts
@@ -26,21 +26,65 @@ export function getR2KeyForSnapshot({
 }
 
 /**
+ * Runs one R2 operation. Operations default to running inline; a caller inside a shared connection
+ * budget (the durable object's R2 queue) passes its queue, so each operation is one budgeted slot
+ * and a fan-out never holds more connections than the budget allows.
+ */
+export type R2ReadScheduler = <T>(read: () => Promise<T>) => Promise<T>
+
+export function runInline<T>(read: () => Promise<T>): Promise<T> {
+	return read()
+}
+
+// R2 has honored `include` on list() since compat date 2022-08-04 (this worker's is far past it),
+// but the repo's ambient workers-types entrypoint predates the option — declared locally, same
+// pattern as types.ts.
+type R2ListOptionsWithInclude = R2ListOptions & {
+	include?: Array<'httpMetadata' | 'customMetadata'>
+}
+
+/**
+ * Every object under `prefix` with its custom metadata, plus the number of list calls the walk
+ * spent — callers inside a read budget account for the listing too.
+ */
+export async function listAllObjects(
+	bucket: R2Bucket,
+	prefix: string,
+	schedule: R2ReadScheduler = runInline
+): Promise<{ objects: R2Object[]; ops: number }> {
+	const objects: R2Object[] = []
+	let cursor: string | undefined
+	let ops = 0
+
+	do {
+		// Including metadata makes R2 return shorter pages, so a short page does not mean the
+		// listing is done — `truncated` is the only safe stop condition.
+		const options: R2ListOptionsWithInclude = { prefix, cursor, include: ['customMetadata'] }
+		const page = await schedule(() => bucket.list(options as R2ListOptions))
+		ops++
+		objects.push(...page.objects)
+		cursor = page.truncated ? page.cursor : undefined
+	} while (cursor)
+
+	return { objects, ops }
+}
+
+/**
  * Every key under `prefix`, or the first `limit` of them. The limit is passed to R2 too, so a
  * capped listing is a single page rather than a full walk sliced afterwards.
  */
 export async function listAllObjectKeys(
 	bucket: R2Bucket,
 	prefix: string,
-	limit?: number
+	limit?: number,
+	schedule: R2ReadScheduler = runInline
 ): Promise<string[]> {
 	const keys: string[] = []
 	let cursor: string | undefined
 
 	do {
-		const result = await bucket.list(
-			limit === undefined ? { prefix, cursor } : { prefix, cursor, limit }
-		)
+		const options = limit === undefined ? { prefix, cursor } : { prefix, cursor, limit }
+		const result = await schedule(() => bucket.list(options))
 		keys.push(...result.objects.map((o) => o.key))
 		if (limit !== undefined && keys.length >= limit) return keys.slice(0, limit)
 		cursor = result.truncated ? result.cursor : undefined
@@ -54,9 +98,14 @@ export async function listAllObjectKeys(
 // that called it is left half-done.
 const MAX_R2_DELETE_KEYS = 1000
 
-export async function deleteAllObjectsWithPrefix(bucket: R2Bucket, prefix: string) {
-	const keys = await listAllObjectKeys(bucket, prefix)
+export async function deleteAllObjectsWithPrefix(
+	bucket: R2Bucket,
+	prefix: string,
+	schedule: R2ReadScheduler = runInline
+) {
+	const keys = await listAllObjectKeys(bucket, prefix, undefined, schedule)
 	for (let i = 0; i < keys.length; i += MAX_R2_DELETE_KEYS) {
-		await bucket.delete(keys.slice(i, i + MAX_R2_DELETE_KEYS))
+		const batch = keys.slice(i, i + MAX_R2_DELETE_KEYS)
+		await schedule(() => bucket.delete(batch))
 	}
 }

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.test.ts
@@ -1,9 +1,41 @@
 import { IRequest } from 'itty-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createFakeR2 } from '../test/fakeR2'
 import { Environment } from '../types'
+import { segmentCustomMetadata } from '../versionChain'
+import { listVersionTimestamps } from '../versionChainRead'
 import { getMonthPrefix, getPreviousMonth, getRoomHistory } from './getRoomHistory'
 
 vi.mock('../utils/tla/getAuth', () => ({ requireAdminAccessToRequest: vi.fn() }))
+
+describe('history listing during the transition', () => {
+	it('shows legacy versions, keyframes and every version inside a segment as one list', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const roomKey = 'app_rooms/slug'
+
+		await legacyBucket.put(`${roomKey}/2026-08-01T00:00:00.000Z`, '{}')
+		await chainBucket.put(`${roomKey}/2026-09-01T00:00:00.000Z.k`, '{}')
+		// One segment object standing for two versions — the listing must expand it, not report
+		// the segment's own key as a version.
+		await chainBucket.put(`${roomKey}/2026-09-01T00:00:08.000Z.s`, '{}', {
+			customMetadata: segmentCustomMetadata({
+				keyframeKey: `${roomKey}/2026-09-01T00:00:00.000Z.k`,
+				firstSeq: 1,
+				timestamps: ['2026-09-01T00:00:08.000Z', '2026-09-01T00:00:16.000Z'],
+			}),
+		})
+
+		expect(
+			await listVersionTimestamps({ chainBucket, legacyBucket, roomKey, prefix: '2026-0' })
+		).toEqual([
+			'2026-09-01T00:00:16.000Z',
+			'2026-09-01T00:00:08.000Z',
+			'2026-09-01T00:00:00.000Z',
+			'2026-08-01T00:00:00.000Z',
+		])
+	})
+})
 
 describe('getMonthPrefix', () => {
 	it('uses the UTC month at a local month boundary', () => {
@@ -36,7 +68,11 @@ async function listHistory(timestamps: string[], offset: string) {
 	}))
 	const response = await getRoomHistory(
 		{ params: { roomId: 'board' }, query: { offset } } as unknown as IRequest,
-		{ ROOMS_HISTORY_EPHEMERAL: { list } } as unknown as Environment,
+		{
+			// An empty chain bucket: these tests cover the month walk over legacy copies alone.
+			ROOMS_HISTORY: { list: async () => ({ objects: [], truncated: false }) },
+			ROOMS_HISTORY_EPHEMERAL: { list },
+		} as unknown as Environment,
 		true
 	)
 	expect(response.status).toBe(200)

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -6,6 +6,7 @@ import { Environment } from '../types'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
+import { ChainIndexEntry, listVersionTimestamps, loadChainIndex } from '../versionChainRead'
 
 export function getMonthPrefix(date: Date): string {
 	return date.toISOString().split('T')[0].substring(0, 7)
@@ -16,54 +17,34 @@ export function getPreviousMonth(date: Date): Date {
 	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))
 }
 
-async function fetchTimestampsFromBatch(
-	bucket: R2Bucket,
-	roomKey: string,
-	prefix: string,
-	limit: number,
-	cursor?: string
-): Promise<{ timestamps: string[]; batch: any }> {
-	const fullPrefix = `${roomKey}/${prefix}`
-	const batch = await bucket.list({
-		prefix: fullPrefix,
-		limit,
-		cursor,
-	})
-
-	const timestamps = batch.objects
-		.map((o) => o.key.replace(roomKey + '/', ''))
-		.filter((timestamp) => timestamp && timestamp !== roomKey)
-
-	return { timestamps, batch }
+/**
+ * The chain index is listed once per request and threaded through: this handler probes up to
+ * three dozen month prefixes, and each probe re-listing the whole chain (plus an uncapped legacy
+ * walk) turned a ~7-listing request into hundreds on rooms with long histories.
+ */
+interface HistorySource {
+	env: Environment
+	roomKey: string
+	index: ChainIndexEntry[]
 }
 
 async function fetchTimestampsForPrefix(
-	bucket: R2Bucket,
-	roomKey: string,
+	source: HistorySource,
 	prefix: string,
 	limit?: number
 ): Promise<string[]> {
-	const batchLimit = limit || 1000
-	// eslint-disable-next-line prefer-const
-	let { timestamps, batch } = await fetchTimestampsFromBatch(bucket, roomKey, prefix, batchLimit)
-
-	// Continue listing if there are more objects
-	while (batch.truncated && timestamps.length < (limit || Infinity)) {
-		const next = await fetchTimestampsFromBatch(bucket, roomKey, prefix, batchLimit, batch.cursor)
-		timestamps.push(...next.timestamps)
-		batch = next.batch
-	}
-
-	// Sort
-	return timestamps.sort((a, b) => b.localeCompare(a))
+	return await listVersionTimestamps({
+		chainBucket: source.env.ROOMS_HISTORY,
+		legacyBucket: source.env.ROOMS_HISTORY_EPHEMERAL,
+		roomKey: source.roomKey,
+		prefix,
+		index: source.index,
+		limit,
+	})
 }
 
-async function monthHasEntries(
-	bucket: R2Bucket,
-	roomKey: string,
-	monthPrefix: string
-): Promise<boolean> {
-	const timestamps = await fetchTimestampsForPrefix(bucket, roomKey, monthPrefix, 1)
+async function monthHasEntries(source: HistorySource, monthPrefix: string): Promise<boolean> {
+	const timestamps = await fetchTimestampsForPrefix(source, monthPrefix, 1)
 	return timestamps.length > 0
 }
 
@@ -85,8 +66,12 @@ export async function getRoomHistory(
 
 	let offset = request.query?.offset as string // offset is the earliest timestamp from the previous page
 
-	const versionCacheBucket = env.ROOMS_HISTORY_EPHEMERAL
 	const bucketKey = getR2KeyForRoom({ slug: roomId, isApp })
+	const source: HistorySource = {
+		env,
+		roomKey: bucketKey,
+		index: (await loadChainIndex(env.ROOMS_HISTORY, bucketKey)).entries,
+	}
 
 	let allTimestamps: string[] = []
 
@@ -102,12 +87,7 @@ export async function getRoomHistory(
 		offset = currentMonth.toISOString()
 	} else {
 		// If we don't have an offset we can check if the room doesn't have too many entries
-		const allTimestampsForRoom = await fetchTimestampsForPrefix(
-			versionCacheBucket,
-			bucketKey,
-			'',
-			1000
-		)
+		const allTimestampsForRoom = await fetchTimestampsForPrefix(source, '', 1000)
 
 		// If we have fewer than 1000 entries, return them all
 		if (allTimestampsForRoom.length < 1000) {
@@ -125,7 +105,7 @@ export async function getRoomHistory(
 	let foundMonthWithEntries = false
 	while (!foundMonthWithEntries && monthsChecked < maxMonthsToCheck) {
 		const monthPrefix = getMonthPrefix(currentMonth)
-		const hasEntries = await monthHasEntries(versionCacheBucket, bucketKey, monthPrefix)
+		const hasEntries = await monthHasEntries(source, monthPrefix)
 
 		if (hasEntries) {
 			foundMonthWithEntries = true
@@ -143,11 +123,7 @@ export async function getRoomHistory(
 		// Collect timestamps from multiple months until we reach the target count
 		while (allTimestamps.length < targetEntryCount && monthsCollected < maxMonthsToCollect) {
 			const monthPrefix = getMonthPrefix(currentMonth)
-			const monthTimestamps = await fetchTimestampsForPrefix(
-				versionCacheBucket,
-				bucketKey,
-				monthPrefix
-			)
+			const monthTimestamps = await fetchTimestampsForPrefix(source, monthPrefix)
 
 			let filteredTimestamps = monthTimestamps
 			if (offset) {
@@ -173,11 +149,7 @@ export async function getRoomHistory(
 
 		while (monthsToCheck > 0) {
 			const previousMonthPrefix = getMonthPrefix(checkMonth)
-			const hasMoreEntries = await monthHasEntries(
-				versionCacheBucket,
-				bucketKey,
-				previousMonthPrefix
-			)
+			const hasMoreEntries = await monthHasEntries(source, previousMonthPrefix)
 
 			if (hasMoreEntries) {
 				hasMore = true

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.test.ts
@@ -1,0 +1,136 @@
+import { UnknownRecord } from '@tldraw/store'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { IRequest } from 'itty-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createFakeR2 } from '../test/fakeR2'
+import { Environment } from '../types'
+import { segmentCustomMetadata, versionKey } from '../versionChain'
+import { encodeVersionBody } from '../versionChainCodec'
+import { buildSnapshotDelta } from '../versionDelta'
+import { getRoomHistorySnapshot } from './getRoomHistorySnapshot'
+
+vi.mock('../utils/tla/getAuth', () => ({ requireAdminAccessToRequest: vi.fn() }))
+
+const captureException = vi.fn()
+vi.mock('@tldraw/worker-shared', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@tldraw/worker-shared')>()),
+	createSentry: vi.fn(() => ({ captureException })),
+}))
+
+const roomKey = 'app_rooms/board'
+
+function snapshot(clock: number, ids: string[]): RoomSnapshot {
+	return {
+		clock,
+		documentClock: clock,
+		documents: ids.map((id) => ({
+			state: { id, typeName: 'shape' } as UnknownRecord,
+			lastChangedClock: clock,
+		})),
+		tombstones: {},
+		tombstoneHistoryStartsAtClock: 0,
+		schema: { schemaVersion: 2, sequences: {} } as any,
+	}
+}
+
+function isoAt(i: number) {
+	return `2026-09-01T00:00:${String(i).padStart(2, '0')}.000Z`
+}
+
+async function fetchSnapshot(env: Environment, timestamp: string, ctx?: ExecutionContext) {
+	return await getRoomHistorySnapshot(
+		{ params: { roomId: 'board', timestamp } } as unknown as IRequest,
+		env,
+		true,
+		ctx
+	)
+}
+
+describe('getRoomHistorySnapshot', () => {
+	beforeEach(() => captureException.mockClear())
+
+	it('counts the chain listing in x-version-chain-ops on both serve paths', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const env = {
+			ROOMS_HISTORY: chainBucket,
+			ROOMS_HISTORY_EPHEMERAL: legacyBucket,
+		} as unknown as Environment
+
+		// A keyframe at iso 0 and one segment holding deltas for isos 1 and 2.
+		const versions = [snapshot(1, ['shape:a']), snapshot(2, ['shape:a', 'shape:b'])]
+		const keyframeKey = versionKey(roomKey, isoAt(0), 'keyframe')
+		const encodedKeyframe = await encodeVersionBody(versions[0])
+		await chainBucket.put(keyframeKey, encodedKeyframe.body, {
+			customMetadata: encodedKeyframe.metadata,
+		})
+		const encodedSegment = await encodeVersionBody({
+			v: 1,
+			deltas: [{ t: isoAt(1), delta: buildSnapshotDelta(versions[0], versions[1]) }],
+		})
+		await chainBucket.put(versionKey(roomKey, isoAt(1), 'segment'), encodedSegment.body, {
+			customMetadata: {
+				...encodedSegment.metadata,
+				...segmentCustomMetadata({ keyframeKey, firstSeq: 1, timestamps: [isoAt(1)] }),
+			},
+		})
+
+		// Whole-object path: one listing page plus the keyframe get.
+		const whole = await fetchSnapshot(env, isoAt(0))
+		expect({
+			status: whole.status,
+			ops: whole.headers.get('x-version-chain-ops'),
+			depth: whole.headers.get('x-version-chain-depth'),
+		}).toEqual({ status: 200, ops: '2', depth: '0' })
+		expect(await whole.json()).toEqual(versions[0])
+
+		// Replay path: the listing page, the keyframe and one segment.
+		const replayed = await fetchSnapshot(env, isoAt(1))
+		expect({
+			status: replayed.status,
+			ops: replayed.headers.get('x-version-chain-ops'),
+			depth: replayed.headers.get('x-version-chain-depth'),
+		}).toEqual({ status: 200, ops: '3', depth: '1' })
+		expect(await replayed.json()).toEqual(versions[1])
+	})
+
+	it('serves the legacy copy and reports when the chain read throws', async () => {
+		const legacyBucket = createFakeR2()
+		const timestamp = isoAt(3)
+		await legacyBucket.put(`${roomKey}/${timestamp}`, JSON.stringify(snapshot(3, ['shape:a'])))
+		const boom = new Error('chain listing failed')
+		const env = {
+			ROOMS_HISTORY: {
+				list: vi.fn(async () => {
+					throw boom
+				}),
+			},
+			ROOMS_HISTORY_EPHEMERAL: legacyBucket,
+		} as unknown as Environment
+
+		const response = await fetchSnapshot(env, timestamp, {} as ExecutionContext)
+
+		expect({
+			status: response.status,
+			ops: response.headers.get('x-version-chain-ops'),
+			body: await response.json(),
+		}).toEqual({ status: 200, ops: null, body: snapshot(3, ['shape:a']) })
+		expect(captureException).toHaveBeenCalledWith(boom)
+	})
+
+	it('rethrows without reporting when there is no legacy copy to serve', async () => {
+		const boom = new Error('chain listing failed')
+		const env = {
+			ROOMS_HISTORY: {
+				list: vi.fn(async () => {
+					throw boom
+				}),
+			},
+			ROOMS_HISTORY_EPHEMERAL: createFakeR2(),
+		} as unknown as Environment
+
+		// The worker's catch-all reports what escapes, so a capture here would file it twice.
+		await expect(fetchSnapshot(env, isoAt(4), {} as ExecutionContext)).rejects.toBe(boom)
+		expect(captureException).not.toHaveBeenCalled()
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.ts
@@ -1,16 +1,18 @@
-import { notFound } from '@tldraw/worker-shared'
+import { createSentry, notFound } from '@tldraw/worker-shared'
 import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../r2'
 import { Environment } from '../types'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
+import { loadChainIndex, openWholeVersionStream, reconstructVersion } from '../versionChainRead'
 
 // Get a snapshot of the room at a given point in time
 export async function getRoomHistorySnapshot(
 	request: IRequest,
 	env: Environment,
-	isApp: boolean
+	isApp: boolean,
+	ctx?: ExecutionContext
 ): Promise<Response> {
 	const roomId = request.params.roomId
 
@@ -24,18 +26,68 @@ export async function getRoomHistorySnapshot(
 	}
 
 	const timestamp = request.params.timestamp
+	const roomKey = getR2KeyForRoom({ slug: roomId, isApp })
 
-	const versionCacheBucket = env.ROOMS_HISTORY_EPHEMERAL
-
-	const result = await versionCacheBucket.get(
-		getR2KeyForRoom({ slug: roomId, isApp }) + '/' + timestamp
-	)
+	const buckets = { chainBucket: env.ROOMS_HISTORY, legacyBucket: env.ROOMS_HISTORY_EPHEMERAL }
+	let result
+	let listOps = 0
+	try {
+		const { entries: index, ops } = await loadChainIndex(env.ROOMS_HISTORY, roomKey)
+		// The listing is part of this request's R2 cost: reconstructVersion counts zero listing
+		// ops for a pre-loaded index, so leaving these out under-reports the header below.
+		listOps = ops
+		// Keyframes and legacy full copies stream straight through — openWholeVersionStream states
+		// the parse-cost rationale. Only a delta replay materializes.
+		const whole = await openWholeVersionStream({ ...buckets, roomKey, timestamp, index })
+		if (whole) {
+			return new Response(whole, {
+				headers: {
+					'content-type': 'application/json',
+					// The listing plus the one whole-object get, so the metric reads the same
+					// across both serve paths.
+					'x-version-chain-ops': String(listOps + 1),
+					'x-version-chain-depth': '0',
+				},
+			})
+		}
+		result = await reconstructVersion({ ...buckets, roomKey, timestamp, index })
+	} catch (error) {
+		// A broken chain must not take history down while the legacy full copies still exist.
+		// Serve the copy — the verifier is how the chain gets fixed.
+		const legacy = await env.ROOMS_HISTORY_EPHEMERAL.get(`${roomKey}/${timestamp}`)
+		if (!legacy) throw error
+		// Only the served fallback swallows the error, so only it has to report: a chain that
+		// stopped reconstructing would stay invisible for as long as the copies last. The rethrow
+		// above reaches the worker's catch-all, which reports it; capturing here too files it twice.
+		try {
+			// No ctx in unit tests, and createSentry throws when its env vars are unset; neither may
+			// turn the degraded-but-fine fallback into a 500.
+			const sentry = ctx ? createSentry(ctx, env) : null
+			if (sentry) {
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				sentry.captureException(error)
+			} else {
+				console.error(error)
+			}
+		} catch {
+			console.error(error)
+		}
+		return new Response(legacy.body, {
+			headers: { 'content-type': 'application/json' },
+		})
+	}
 
 	if (!result) {
 		return new Response('Not found', { status: 404 })
 	}
 
-	return new Response(result.body, {
-		headers: { 'content-type': 'application/json' },
+	return new Response(JSON.stringify(result.snapshot), {
+		headers: {
+			'content-type': 'application/json',
+			// Replay cost is a product metric once history is user-facing: the segment cap is the
+			// lever, and this is what says whether it needs moving.
+			'x-version-chain-ops': String(listOps + result.ops),
+			'x-version-chain-depth': String(result.deltaCount),
+		},
 	})
 }

--- a/apps/dotcom/sync-worker/src/routes/verifyVersionChain.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/verifyVersionChain.test.ts
@@ -1,0 +1,486 @@
+import { UnknownRecord } from '@tldraw/store'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { IRequest } from 'itty-router'
+import { describe, expect, it, vi } from 'vitest'
+import { createFakeR2 } from '../test/fakeR2'
+import { Environment } from '../types'
+import { ChainState, PendingDelta, segmentCustomMetadata, versionKey } from '../versionChain'
+import { encodeVersionBody } from '../versionChainCodec'
+import { writeVersionChainEntry } from '../versionChainWrite'
+import { buildSnapshotDelta } from '../versionDelta'
+import { verifyRoomVersions, verifyVersionChainRoute } from './verifyVersionChain'
+
+vi.mock('../utils/tla/getAuth', () => ({ requireAdminAccessToRequest: vi.fn() }))
+
+const roomKey = 'app_rooms/slug'
+
+function snapshot(clock: number, ids: string[]): RoomSnapshot {
+	return {
+		clock,
+		documentClock: clock,
+		documents: ids.map((id) => ({
+			state: { id, typeName: 'shape' } as UnknownRecord,
+			lastChangedClock: clock,
+		})),
+		tombstones: {},
+		tombstoneHistoryStartsAtClock: 0,
+		schema: { schemaVersion: 2, sequences: {} } as any,
+	}
+}
+
+/** Mirrors what dual-write produces: a chain in one bucket, full copies in the other. */
+async function seedDualWrite(
+	chainBucket: R2Bucket,
+	legacyBucket: R2Bucket,
+	versions: RoomSnapshot[]
+) {
+	let chain: ChainState | null = null
+	let pending: PendingDelta[] = []
+
+	for (let i = 0; i < versions.length; i++) {
+		const iso = `2026-09-01T00:00:0${i}.000Z`
+		const result = await writeVersionChainEntry({
+			bucket: chainBucket,
+			roomKey,
+			iso,
+			chain,
+			pending,
+			previous: i === 0 ? null : versions[i - 1],
+			next: versions[i],
+			now: i * 1000,
+		})
+		chain = result.chain
+		pending = result.pending
+		await legacyBucket.put(`${roomKey}/${iso}`, JSON.stringify(versions[i]))
+	}
+}
+
+describe('verifyRoomVersions under clock skew', () => {
+	it('verifies a chain whose later segment has an earlier key', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const versions = [
+			snapshot(1, ['shape:a']),
+			snapshot(2, ['shape:a', 'shape:b']),
+			snapshot(3, ['shape:a', 'shape:b', 'shape:c']),
+		]
+		const iso = (s: number) => `2026-09-01T00:00:${String(s).padStart(2, '0')}.000Z`
+		const keyframeKey = versionKey(roomKey, iso(10), 'keyframe')
+		const kf = await encodeVersionBody(versions[0])
+		await chainBucket.put(keyframeKey, kf.body, { customMetadata: kf.metadata })
+		await legacyBucket.put(`${roomKey}/${iso(10)}`, JSON.stringify(versions[0]))
+		const put = async (at: number, firstSeq: number, prev: RoomSnapshot, next: RoomSnapshot) => {
+			const deltas = [{ t: iso(at), delta: buildSnapshotDelta(prev, next) }]
+			const encoded = await encodeVersionBody({ v: 1, deltas })
+			await chainBucket.put(versionKey(roomKey, iso(at), 'segment'), encoded.body, {
+				customMetadata: {
+					...encoded.metadata,
+					...segmentCustomMetadata({ keyframeKey, firstSeq, timestamps: [iso(at)] }),
+				},
+			})
+			await legacyBucket.put(`${roomKey}/${iso(at)}`, JSON.stringify(next))
+		}
+		// Sequence 1 at :20, then the clock steps back: sequence 2 lands under :15.
+		await put(20, 1, versions[0], versions[1])
+		await put(15, 2, versions[1], versions[2])
+
+		expect(await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })).toEqual({
+			checked: 3,
+			replayed: 3,
+			// One listing, then a get and a legacy get for the keyframe and for each segment.
+			reads: 7,
+			complete: true,
+			mismatches: [],
+			errors: [],
+		})
+	})
+})
+
+describe('verifyRoomVersions after cut-over', () => {
+	it('stops on the read budget when no legacy copy answers', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		// Chain only, as the bucket looks once dual-write is off: nothing increments a comparison
+		// counter, so a budget keyed off one would walk all twenty chains.
+		for (let i = 0; i < 20; i++) {
+			const iso = `2026-09-01T00:00:${String(i).padStart(2, '0')}.000Z`
+			const kf = await encodeVersionBody(snapshot(i + 1, [`shape:${i}`]))
+			await chainBucket.put(versionKey(roomKey, iso, 'keyframe'), kf.body, {
+				customMetadata: kf.metadata,
+			})
+		}
+
+		// One listing, then two reads per keyframe: three keyframes fit, the fourth never starts.
+		expect(await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 7 })).toEqual({
+			checked: 0,
+			replayed: 3,
+			reads: 7,
+			complete: false,
+			mismatches: [],
+			errors: [],
+		})
+	})
+})
+
+describe('verifyRoomVersions with a limit', () => {
+	it('spends the budget on the newest chain first', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		// Two chains: an old one whose legacy copy is wrong, and a new one that is fine.
+		const old = snapshot(1, ['shape:old'])
+		const recent = snapshot(2, ['shape:new'])
+		for (const [iso, version, legacy] of [
+			['2026-08-01T00:00:00.000Z', old, snapshot(9, ['shape:tampered'])],
+			['2026-09-01T00:00:00.000Z', recent, recent],
+		] as const) {
+			const kf = await encodeVersionBody(version)
+			await chainBucket.put(versionKey(roomKey, iso, 'keyframe'), kf.body, {
+				customMetadata: kf.metadata,
+			})
+			await legacyBucket.put(`${roomKey}/${iso}`, JSON.stringify(legacy))
+		}
+
+		// One listing plus the two reads the first keyframe costs, so the second never starts.
+		const limited = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 3 })
+		const full = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		// With budget for one version, the newest chain is the one that gets checked.
+		expect(limited).toEqual({
+			checked: 1,
+			replayed: 1,
+			reads: 3,
+			complete: false,
+			mismatches: [],
+			errors: [],
+		})
+		expect(full.mismatches).toEqual(['2026-08-01T00:00:00.000Z'])
+	})
+
+	it('marks a run the listing alone exhausted as incomplete', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedDualWrite(chainBucket, legacyBucket, [snapshot(1, ['shape:a'])])
+
+		// The listing spends the whole budget before the keyframe is read: nothing is verified, and
+		// `complete: false` is the only thing separating this result from a clean room.
+		expect(await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 1 })).toEqual({
+			checked: 0,
+			replayed: 0,
+			reads: 1,
+			complete: false,
+			mismatches: [],
+			errors: [],
+		})
+	})
+})
+
+describe('verifyRoomVersions on a segment the read path rejects', () => {
+	const versions = [
+		snapshot(1, ['shape:a']),
+		snapshot(2, ['shape:a', 'shape:b']),
+		snapshot(3, ['shape:a', 'shape:b', 'shape:c']),
+	]
+
+	async function seedAndFindSegment() {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedDualWrite(chainBucket, legacyBucket, versions)
+		const listing = await chainBucket.list({ prefix: `${roomKey}/` })
+		const segment = listing.objects.find((o) => o.key.endsWith('.s'))!
+		const object = (await chainBucket.get(segment.key))!
+		return { chainBucket, legacyBucket, segment, metadata: object.customMetadata! }
+	}
+
+	it('reports a body that does not begin with what its metadata lists', async () => {
+		const { chainBucket, legacyBucket, segment, metadata } = await seedAndFindSegment()
+		// Same first delta, then a version the listing never promised in place of the second.
+		const torn = await encodeVersionBody({
+			v: 1,
+			deltas: [
+				{ t: '2026-09-01T00:00:01.000Z', delta: buildSnapshotDelta(versions[0], versions[1]) },
+				{ t: '2026-09-01T00:00:09.000Z', delta: buildSnapshotDelta(versions[1], versions[2]) },
+			],
+		})
+		await chainBucket.put(segment.key, torn.body, { customMetadata: metadata })
+
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		expect(result.errors.map((e) => e.message)).toEqual([
+			expect.stringMatching(/does not match its metadata/),
+		])
+	})
+
+	it('reports a segment written in an unknown format', async () => {
+		const { chainBucket, legacyBucket, segment, metadata } = await seedAndFindSegment()
+		const future = await encodeVersionBody({ v: 2, deltas: [] })
+		await chainBucket.put(segment.key, future.body, { customMetadata: metadata })
+
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		expect(result.errors.map((e) => e.message)).toEqual([
+			expect.stringMatching(/unknown version segment format/),
+		])
+	})
+})
+
+describe('verifyRoomVersions on an orphaned segment', () => {
+	it('reports a segment whose keyframe is not in the index', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const versions = [snapshot(1, ['shape:a']), snapshot(2, ['shape:a', 'shape:b'])]
+		await seedDualWrite(chainBucket, legacyBucket, versions)
+		// A segment left behind by a chain whose keyframe object is gone.
+		const orphanIso = '2026-08-01T00:00:01.000Z'
+		const missingKeyframeKey = versionKey(roomKey, '2026-08-01T00:00:00.000Z', 'keyframe')
+		const encoded = await encodeVersionBody({
+			v: 1,
+			deltas: [{ t: orphanIso, delta: buildSnapshotDelta(versions[0], versions[1]) }],
+		})
+		await chainBucket.put(versionKey(roomKey, orphanIso, 'segment'), encoded.body, {
+			customMetadata: {
+				...encoded.metadata,
+				...segmentCustomMetadata({
+					keyframeKey: missingKeyframeKey,
+					firstSeq: 1,
+					timestamps: [orphanIso],
+				}),
+			},
+		})
+
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		expect(result.errors).toEqual([
+			{
+				timestamp: orphanIso,
+				message: expect.stringMatching(/references missing keyframe/),
+			},
+		])
+		// The intact chain still verifies clean around the orphan.
+		expect(result.mismatches).toEqual([])
+		expect(result.checked).toBe(2)
+	})
+
+	it('reports the orphan even when the budget stops the walk', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const orphanIso = '2026-08-01T00:00:01.000Z'
+		const encoded = await encodeVersionBody({
+			v: 1,
+			deltas: [
+				{
+					t: orphanIso,
+					delta: buildSnapshotDelta(snapshot(1, ['shape:a']), snapshot(2, ['shape:a', 'shape:b'])),
+				},
+			],
+		})
+		await chainBucket.put(versionKey(roomKey, orphanIso, 'segment'), encoded.body, {
+			customMetadata: {
+				...encoded.metadata,
+				...segmentCustomMetadata({
+					keyframeKey: versionKey(roomKey, '2026-08-01T00:00:00.000Z', 'keyframe'),
+					firstSeq: 1,
+					timestamps: [orphanIso],
+				}),
+			},
+		})
+
+		// The listing alone exhausts the budget; the orphan check costs no reads and still runs.
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 1 })
+
+		expect(result.errors.map((e) => e.message)).toEqual([
+			expect.stringMatching(/references missing keyframe/),
+		])
+		expect(result.replayed).toBe(0)
+	})
+})
+
+describe('verifyRoomVersions on an unreadable segment', () => {
+	const iso = (s: number) => `2026-09-01T00:00:0${s}.000Z`
+	const versions = [
+		snapshot(1, ['shape:a']),
+		snapshot(2, ['shape:a', 'shape:b']),
+		snapshot(3, ['shape:a', 'shape:b', 'shape:c']),
+	]
+
+	/** A keyframe and two segments, where the one at `brokenSeq` has lost its chain reference. */
+	async function seedWithBrokenSegment(
+		chainBucket: R2Bucket,
+		legacyBucket: R2Bucket,
+		brokenSeq: 1 | 2
+	) {
+		const keyframeKey = versionKey(roomKey, iso(0), 'keyframe')
+		const kf = await encodeVersionBody(versions[0])
+		await chainBucket.put(keyframeKey, kf.body, { customMetadata: kf.metadata })
+		await legacyBucket.put(`${roomKey}/${iso(0)}`, JSON.stringify(versions[0]))
+
+		for (const firstSeq of [1, 2] as const) {
+			const encoded = await encodeVersionBody({
+				v: 1,
+				deltas: [
+					{
+						t: iso(firstSeq),
+						delta: buildSnapshotDelta(versions[firstSeq - 1], versions[firstSeq]),
+					},
+				],
+			})
+			// The broken one keeps its body metadata and loses the chain reference, the way a
+			// half-written custom metadata set would.
+			await chainBucket.put(versionKey(roomKey, iso(firstSeq), 'segment'), encoded.body, {
+				customMetadata:
+					firstSeq === brokenSeq
+						? encoded.metadata
+						: {
+								...encoded.metadata,
+								...segmentCustomMetadata({
+									keyframeKey,
+									firstSeq,
+									timestamps: [iso(firstSeq)],
+								}),
+							},
+			})
+			await legacyBucket.put(`${roomKey}/${iso(firstSeq)}`, JSON.stringify(versions[firstSeq]))
+		}
+	}
+
+	it('reports a trailing segment that leaves no sequence gap behind it', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedWithBrokenSegment(chainBucket, legacyBucket, 2)
+
+		// Without the rejection report this is a clean room: the walk replays the keyframe and
+		// sequence 1, then simply ends, and nothing is left to trip the sequence check.
+		expect(await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })).toEqual({
+			checked: 2,
+			replayed: 2,
+			reads: 5,
+			complete: true,
+			mismatches: [],
+			errors: [
+				{
+					timestamp: iso(2),
+					message: expect.stringMatching(/has no readable chain reference/),
+				},
+			],
+		})
+	})
+
+	it('reports a mid-chain segment directly, not only as the gap it leaves', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedWithBrokenSegment(chainBucket, legacyBucket, 1)
+
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		expect(result.errors).toEqual([
+			{ timestamp: iso(1), message: expect.stringMatching(/has no readable chain reference/) },
+			{ timestamp: iso(2), message: expect.stringMatching(/expected at sequence 1, found 2/) },
+		])
+		expect(result.mismatches).toEqual([])
+	})
+
+	it('reports the segment even when the budget stops the walk', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const encoded = await encodeVersionBody({
+			v: 1,
+			deltas: [{ t: iso(1), delta: buildSnapshotDelta(versions[0], versions[1]) }],
+		})
+		await chainBucket.put(versionKey(roomKey, iso(1), 'segment'), encoded.body, {
+			customMetadata: encoded.metadata,
+		})
+
+		// The listing alone exhausts the budget; reading the index is what found this, so it is
+		// reported whether or not the walk gets to run.
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 1 })
+
+		expect(result.errors.map((e) => e.message)).toEqual([
+			expect.stringMatching(/has no readable chain reference/),
+		])
+		expect(result.replayed).toBe(0)
+	})
+})
+
+describe('verifyRoomVersions', () => {
+	it('reports no mismatches when reconstruction matches the full copies', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedDualWrite(chainBucket, legacyBucket, [
+			snapshot(1, ['shape:a']),
+			snapshot(2, ['shape:a', 'shape:b']),
+		])
+
+		expect(await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })).toEqual({
+			checked: 2,
+			replayed: 2,
+			reads: 5,
+			complete: true,
+			mismatches: [],
+			errors: [],
+		})
+	})
+
+	it('keeps replaying the chain when a legacy read fails', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedDualWrite(chainBucket, legacyBucket, [
+			snapshot(1, ['shape:a']),
+			snapshot(2, ['shape:a', 'shape:b']),
+		])
+		const flakyIso = '2026-09-01T00:00:00.000Z'
+		const flakyLegacy = {
+			...legacyBucket,
+			get: async (key: string) => {
+				if (key === `${roomKey}/${flakyIso}`) throw new Error('network connection lost')
+				return legacyBucket.get(key)
+			},
+		} as unknown as R2Bucket
+
+		// The failed read is an error naming the legacy side, not a broken chain: the replay
+		// carries on and the next version still gets compared.
+		expect(
+			await verifyRoomVersions({ chainBucket, legacyBucket: flakyLegacy, roomKey, limit: 20 })
+		).toEqual({
+			checked: 1,
+			replayed: 2,
+			reads: 5,
+			complete: true,
+			mismatches: [],
+			errors: [
+				{
+					timestamp: flakyIso,
+					message: expect.stringMatching(/^legacy copy read failed: network connection lost/),
+				},
+			],
+		})
+	})
+
+	it('names the timestamp when a reconstruction disagrees', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await seedDualWrite(chainBucket, legacyBucket, [
+			snapshot(1, ['shape:a']),
+			snapshot(2, ['shape:a', 'shape:b']),
+		])
+		await legacyBucket.put(
+			`${roomKey}/2026-09-01T00:00:01.000Z`,
+			JSON.stringify(snapshot(2, ['shape:wrong']))
+		)
+
+		const result = await verifyRoomVersions({ chainBucket, legacyBucket, roomKey, limit: 20 })
+
+		expect(result.mismatches).toEqual(['2026-09-01T00:00:01.000Z'])
+	})
+})
+
+describe('verifyVersionChainRoute', () => {
+	it('skips test rooms without touching R2', async () => {
+		const list = vi.fn()
+		const response = await verifyVersionChainRoute(
+			{ params: { roomId: 'test_board' }, query: {} } as unknown as IRequest,
+			{ ROOMS_HISTORY: { list }, ROOMS_HISTORY_EPHEMERAL: { list } } as unknown as Environment,
+			true
+		)
+		expect(response.status).toBe(404)
+		expect(list).not.toHaveBeenCalled()
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/verifyVersionChain.ts
+++ b/apps/dotcom/sync-worker/src/routes/verifyVersionChain.ts
@@ -1,0 +1,240 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { notFound } from '@tldraw/worker-shared'
+import { IRequest } from 'itty-router'
+import { getR2KeyForRoom } from '../r2'
+import { canonicalJson } from '../snapshotUtils'
+import { Environment } from '../types'
+import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
+import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
+import { isTestFile } from '../utils/tla/isTestFile'
+import { decodeVersionBody } from '../versionChainCodec'
+import { loadChainIndex, readSegmentDeltas, SegmentIndexEntry } from '../versionChainRead'
+import { applySnapshotDelta, versionEnvelopeHash } from '../versionDelta'
+
+export interface VerifyResult {
+	/** Versions compared against a legacy full copy. Zero once dual-write is off. */
+	checked: number
+	/** Versions replayed, whether or not a legacy copy existed to compare them against. */
+	replayed: number
+	/** R2 reads spent, listing included. */
+	reads: number
+	/**
+	 * False when the read budget stopped the walk with index entries still unvisited. On a room
+	 * whose listing alone exhausts the budget, `mismatches` and `errors` come back empty having
+	 * verified nothing — this is what says that result is not a clean room.
+	 */
+	complete: boolean
+	mismatches: string[]
+	errors: Array<{ timestamp: string; message: string }>
+}
+
+/**
+ * Compares every reconstructable version against the full copy dual-write left in the legacy
+ * bucket. This is the gate on turning the full copies off — until it runs clean on live traffic,
+ * the only evidence the encoding is exact comes from a 16-room sample.
+ *
+ * It keeps running after cut-over on the recorded hash alone, which is why `limit` counts R2 reads
+ * and not comparisons: with no legacy copies left to compare against, a comparison counter never
+ * moves and the walk would never stop.
+ */
+export async function verifyRoomVersions({
+	chainBucket,
+	legacyBucket,
+	roomKey,
+	limit,
+}: {
+	chainBucket: R2Bucket
+	legacyBucket: R2Bucket
+	roomKey: string
+	limit: number
+}): Promise<VerifyResult> {
+	const { entries, ops, rejected } = await loadChainIndex(chainBucket, roomKey)
+
+	// A set: a version can fail both the hash check and the legacy comparison, and it is one
+	// mismatch, not two.
+	const mismatches = new Set<string>()
+	const errors: Array<{ timestamp: string; message: string }> = []
+	let checked = 0
+	let replayed = 0
+	// Flagged at the break sites, not derived from `reads >= limit` at the end: the budget may
+	// overshoot on the version in flight, and a run that replayed everything is complete even so.
+	let complete = true
+	// Seeded with the listing: those pages are subrequests too, and on a room with a long history
+	// they are a real share of the budget.
+	let reads = ops
+	// Checked between versions rather than in front of each read, so a run can overshoot by the two
+	// reads one version costs. That is noise against the subrequest cap; an unbounded walk is not.
+	const withinBudget = () => reads < limit
+
+	const compareToLegacy = async (snapshot: RoomSnapshot, timestamp: string) => {
+		let expected: RoomSnapshot
+		try {
+			reads++
+			const legacyObject = await legacyBucket.get(`${roomKey}/${timestamp}`)
+			// Nothing to compare against for versions written before dual-write started, or for any
+			// version at all once it stops.
+			if (!legacyObject) return
+			expected = (await decodeVersionBody(legacyObject)) as RoomSnapshot
+		} catch (e: any) {
+			// Caught here, not in the callers: their catches mark the chain broken and stop the
+			// replay, and a flaky legacy read is neither.
+			errors.push({ timestamp, message: `legacy copy read failed: ${String(e?.message ?? e)}` })
+			return
+		}
+		checked++
+		if (canonical(snapshot) !== canonical(expected)) mismatches.add(timestamp)
+	}
+
+	// Each chain replays once, front to back, comparing every intermediate state against the
+	// legacy full copy at the same timestamp. Reconstructing per version would refetch the same
+	// keyframe and segments once per version — quadratic over a chain for no extra coverage,
+	// since this fold is exactly the fold reconstruction performs.
+	//
+	// Segments are grouped under their keyframe and ordered by sequence, exactly as reconstruction
+	// orders them — never by key. Keys are wall-clock timestamps, and a durable object re-created
+	// on a host whose clock runs behind opens a later segment under an earlier key; walking the
+	// index in key order would fail the rollout gate on a chain that history reads serve fine.
+	// Newest chain first: the budget bounds the work, and the versions a rollout gate must see are
+	// the ones the current write path just produced. An active room writes ~2,000 versions a day,
+	// so oldest-first would spend the whole budget on history and never reach today's code.
+	const keyframes = entries
+		.filter((entry) => entry.kind === 'keyframe')
+		.sort((a, b) => b.key.localeCompare(a.key))
+
+	// A segment whose keyframe is not in the index belongs to no walk below, so without this a
+	// clean result would hide versions that 500 once the legacy copies are off. Judged against the
+	// index rather than what the walk claimed, and before the budget can stop anything: it costs no
+	// reads, and an early break must not misreport unwalked segments as orphans.
+	const keyframeKeys = new Set(keyframes.map((keyframe) => keyframe.key))
+	for (const entry of entries) {
+		if (entry.kind === 'segment' && !keyframeKeys.has(entry.keyframeKey)) {
+			errors.push({
+				timestamp: entry.timestamps[0],
+				message: `segment ${entry.key} references missing keyframe ${entry.keyframeKey}`,
+			})
+		}
+	}
+
+	// The same class as the orphans above, one step earlier: these never reached the index, so the
+	// check above cannot see them and the walk below never misses them. A rejected segment at the
+	// end of a chain leaves no sequence gap behind it, which is exactly how an unreadable tail
+	// passes as a clean room.
+	for (const object of rejected) {
+		errors.push({
+			timestamp: object.timestamp,
+			message: `segment ${object.key} has no readable chain reference`,
+		})
+	}
+
+	for (const keyframe of keyframes) {
+		if (!withinBudget()) {
+			complete = false
+			break
+		}
+		const segments = entries
+			.filter(
+				(entry): entry is SegmentIndexEntry =>
+					entry.kind === 'segment' && entry.keyframeKey === keyframe.key
+			)
+			.sort((a, b) => a.firstSeq - b.firstSeq)
+
+		let state: RoomSnapshot
+		try {
+			reads++
+			const object = await chainBucket.get(keyframe.key)
+			if (!object) throw new Error(`keyframe ${keyframe.key} is missing`)
+			state = (await decodeVersionBody(object)) as RoomSnapshot
+			replayed++
+			await compareToLegacy(state, keyframe.timestamps[0])
+		} catch (e: any) {
+			errors.push({ timestamp: keyframe.timestamps[0], message: String(e?.message ?? e) })
+			continue
+		}
+
+		let expectedSeq = 1
+		for (const segment of segments) {
+			if (!withinBudget()) {
+				complete = false
+				break
+			}
+			try {
+				if (segment.firstSeq !== expectedSeq) {
+					throw new Error(
+						`segment ${segment.key} expected at sequence ${expectedSeq}, found ${segment.firstSeq}`
+					)
+				}
+				reads++
+				// The same read as reconstruction, so a segment that verifies here also reads.
+				const deltas = await readSegmentDeltas(chainBucket, segment)
+				for (const { t, delta } of deltas) {
+					if (!withinBudget()) {
+						complete = false
+						break
+					}
+					state = applySnapshotDelta(state, delta)
+					replayed++
+					// Intra-chain check, independent of the legacy copies — after cut-over the
+					// recorded hash is the only witness (see versionEnvelopeHash).
+					if (delta.hash !== versionEnvelopeHash(state)) mismatches.add(t)
+					await compareToLegacy(state, t)
+				}
+				expectedSeq += segment.timestamps.length
+			} catch (e: any) {
+				errors.push({ timestamp: segment.timestamps[0], message: String(e?.message ?? e) })
+				// A broken link invalidates every later state in this chain; the next keyframe
+				// starts a fresh replay.
+				break
+			}
+		}
+	}
+
+	return { checked, replayed, reads, complete, mismatches: [...mismatches], errors }
+}
+
+/** Record order is unstable between persists, so compare content and not serialization order. */
+function canonical(snapshot: RoomSnapshot): string {
+	return JSON.stringify({
+		clock: snapshot.clock,
+		documentClock: snapshot.documentClock,
+		// The schema decides how a restore migrates, so a reconstruction that dropped or swapped
+		// it must read as a mismatch, not a pass.
+		schema: canonicalJson(snapshot.schema ?? null),
+		tombstoneHistoryStartsAtClock: snapshot.tombstoneHistoryStartsAtClock,
+		tombstones: Object.fromEntries(Object.entries(snapshot.tombstones ?? {}).sort()),
+		documents: [...snapshot.documents]
+			.sort((a, b) => String(a.state.id).localeCompare(String(b.state.id)))
+			.map((d) => [d.state.id, d.lastChangedClock, canonicalJson(d.state)]),
+	})
+}
+
+export async function verifyVersionChainRoute(
+	request: IRequest,
+	env: Environment,
+	isApp: boolean
+): Promise<Response> {
+	const roomId = request.params.roomId
+	if (!roomId) return notFound()
+	if (isRoomIdTooLong(roomId)) return roomIdIsTooLong()
+
+	await requireAdminAccessToRequest(request, env)
+
+	if (isTestFile(roomId)) {
+		return new Response('Not found', { status: 404 })
+	}
+
+	// R2 reads, not versions: an unbounded run walks into the per-invocation subrequest cap mid-way
+	// and reports nothing. Capped below that limit rather than at it, to leave room for the reads
+	// the last version in the budget is already spending.
+	const requested = Number(request.query.limit ?? 200)
+	const limit = Math.min(Number.isFinite(requested) && requested > 0 ? requested : 200, 900)
+	const result = await verifyRoomVersions({
+		chainBucket: env.ROOMS_HISTORY,
+		legacyBucket: env.ROOMS_HISTORY_EPHEMERAL,
+		roomKey: getR2KeyForRoom({ slug: roomId, isApp }),
+		limit,
+	})
+
+	return new Response(JSON.stringify(result), {
+		headers: { 'content-type': 'application/json' },
+	})
+}

--- a/apps/dotcom/sync-worker/src/versionChain.test.ts
+++ b/apps/dotcom/sync-worker/src/versionChain.test.ts
@@ -17,7 +17,7 @@ import {
 	segmentCustomMetadata,
 	versionKey,
 } from './versionChain'
-import { chainHeadHash } from './versionDelta'
+import { chainHeadHash, SNAPSHOT_DELTA_VERSION } from './versionDelta'
 
 const roomKey = 'app_rooms/slug'
 const fingerprint: SnapshotFingerprint = { lastDocumentChangeClock: 10, schemaHash: 'abc' }
@@ -32,6 +32,7 @@ function chain(partial: Partial<ChainState> = {}): ChainState {
 		deltaCount: 0,
 		headFingerprint: fingerprint,
 		headHash: 'h0',
+		deltaVersion: SNAPSHOT_DELTA_VERSION,
 		openSegment: null,
 		...partial,
 	}
@@ -61,6 +62,29 @@ describe('decideVersionWrite', () => {
 			kind: 'keyframe',
 			reason: 'segment-lost',
 		})
+	})
+
+	it('retires a chain whose deltas are in another format, newer or older', () => {
+		// Older: this build was rolled back past a format bump and cannot write what the chain holds.
+		expect(decide({ deltaVersion: SNAPSHOT_DELTA_VERSION + 1 })).toEqual({
+			kind: 'keyframe',
+			reason: 'delta-format',
+		})
+		expect(decide({ deltaVersion: SNAPSHOT_DELTA_VERSION - 1 })).toEqual({
+			kind: 'keyframe',
+			reason: 'delta-format',
+		})
+	})
+
+	it('retires a chain stored before the format was recorded', () => {
+		// Reported ahead of the schema change it also carries: a format bump moves every room at
+		// once, and the metric has to show that rather than a plausible per-room cause.
+		expect(
+			decide(
+				{ deltaVersion: undefined },
+				{ nextFingerprint: { lastDocumentChangeClock: 11, schemaHash: 'different' } }
+			)
+		).toEqual({ kind: 'keyframe', reason: 'delta-format' })
 	})
 
 	it('cuts a keyframe when the incoming snapshot moved the schema hash', () => {

--- a/apps/dotcom/sync-worker/src/versionChain.ts
+++ b/apps/dotcom/sync-worker/src/versionChain.ts
@@ -8,7 +8,7 @@ import {
 	SEGMENT_CAP,
 } from './config'
 import { getSnapshotFingerprint, isSameFingerprint, SnapshotFingerprint } from './snapshotUtils'
-import { chainHeadHash, SnapshotDelta } from './versionDelta'
+import { chainHeadHash, SNAPSHOT_DELTA_VERSION, SnapshotDelta } from './versionDelta'
 
 /** One version inside a segment: the timestamp it was persisted at, and the change it encodes. */
 export interface PendingDelta {
@@ -60,6 +60,12 @@ export interface ChainState {
 	 * base that passes the fingerprint check yet differs from what the chain encodes.
 	 */
 	headHash: string
+	/**
+	 * The delta format the chain's deltas are written in. Absent on chain state stored before this
+	 * field existed, which reads as a bumped format and retires the chain — one keyframe per live
+	 * room, once.
+	 */
+	deltaVersion?: number
 	openSegment: OpenSegment | null
 }
 
@@ -80,6 +86,10 @@ export type KeyframeReason =
 	| 'fingerprint-mismatch'
 	| 'content-mismatch'
 	| 'schema-change'
+	// This build writes a delta format the chain's existing deltas are not in. Appending would
+	// leave the open segment holding both, unreplayable from its first delta with no segment-lost
+	// keyframe to heal it, so the chain is retired instead. See SNAPSHOT_DELTA_VERSION.
+	| 'delta-format'
 	| 'delta-count'
 	| 'chain-age'
 	| 'delta-size'
@@ -118,6 +128,13 @@ export function decideVersionWrite({
 	now: number
 }): VersionWriteDecision {
 	if (!chain) return { kind: 'keyframe', reason: noChainReason ?? 'no-chain' }
+	// First, and on any difference rather than only an older version: a rollback puts a chain of
+	// newer deltas in front of a build that cannot write them, which is the same hazard. A format
+	// bump moves every room at once, so reporting it as one of the per-room reasons below would
+	// bury the deploy that caused it.
+	if (chain.deltaVersion !== SNAPSHOT_DELTA_VERSION) {
+		return { kind: 'keyframe', reason: 'delta-format' }
+	}
 	// Against NEXT, not previous: in an intact chain the head and the diff base are the same
 	// state, so a migration landing in this very persist is only visible on the next snapshot.
 	// Checked before the head check so the metric distinguishes a migration from a chain that

--- a/apps/dotcom/sync-worker/src/versionChainDelete.test.ts
+++ b/apps/dotcom/sync-worker/src/versionChainDelete.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { createFakeR2 } from './test/fakeR2'
+import { deleteAllVersions } from './versionChainRead'
+
+describe('deleteAllVersions', () => {
+	it('clears both buckets for the room', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const roomKey = 'app_rooms/slug'
+
+		await chainBucket.put(`${roomKey}/2026-09-01T00:00:00.000Z.k`, '{}')
+		await chainBucket.put(`${roomKey}/2026-09-01T00:00:08.000Z.s`, '{}')
+		await legacyBucket.put(`${roomKey}/2026-08-01T00:00:00.000Z`, '{}')
+		await chainBucket.put('app_rooms/other/2026-09-01T00:00:00.000Z.k', '{}')
+		// A sibling room whose slug starts with ours must survive the sweep.
+		await chainBucket.put(`${roomKey}2/2026-09-01T00:00:00.000Z.k`, '{}')
+
+		await deleteAllVersions({ chainBucket, legacyBucket, roomKey })
+
+		expect((await chainBucket.list({ prefix: `${roomKey}/` })).objects).toHaveLength(0)
+		expect((await legacyBucket.list({ prefix: `${roomKey}/` })).objects).toHaveLength(0)
+		expect((await chainBucket.list({ prefix: 'app_rooms/other' })).objects).toHaveLength(1)
+		expect((await chainBucket.list({ prefix: `${roomKey}2` })).objects).toHaveLength(1)
+	})
+})

--- a/apps/dotcom/sync-worker/src/versionChainRead.test.ts
+++ b/apps/dotcom/sync-worker/src/versionChainRead.test.ts
@@ -492,6 +492,31 @@ describe('openWholeVersionStream', () => {
 		expect(JSON.parse(await text(legacyStream!))).toEqual(legacy)
 		expect(delta).toBeNull()
 	})
+
+	it('runs its get through the scheduler', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		const versions = [snapshot(1, ['shape:a'])]
+		const timestamps = await seedChain(chainBucket, versions)
+		const { entries: index } = await loadChainIndex(chainBucket, roomKey)
+
+		let scheduled = 0
+		const schedule = async <T>(read: () => Promise<T>) => {
+			scheduled++
+			return await read()
+		}
+		const stream = await openWholeVersionStream({
+			chainBucket,
+			legacyBucket,
+			roomKey,
+			timestamp: timestamps[0],
+			index,
+			schedule,
+		})
+
+		expect(JSON.parse(await text(stream!))).toEqual(versions[0])
+		expect(scheduled).toBe(1)
+	})
 })
 
 describe('listVersionTimestamps with a limit', () => {
@@ -541,6 +566,45 @@ describe('deleteAllVersions', () => {
 
 		expect((await legacyBucket.list({ prefix: `${roomKey}/` })).objects).toHaveLength(0)
 		expect(deleteCalls).toBe(2)
+	})
+
+	it('runs every list page and delete batch through the scheduler', async () => {
+		const chainBucket = createFakeR2()
+		const legacyBucket = createFakeR2()
+		await chainBucket.put(`${roomKey}/2026-09-01T00:00:00.000Z.k`, '{}')
+		await legacyBucket.put(`${roomKey}/2026-08-01T00:00:00.000Z`, '{}')
+
+		// A bucket call outside a scheduled operation is a connection the caller's budget never saw.
+		let scheduledDepth = 0
+		let unscheduledCalls = 0
+		for (const bucket of [chainBucket, legacyBucket]) {
+			for (const method of ['list', 'delete'] as const) {
+				const original = (bucket[method] as any).bind(bucket)
+				;(bucket as any)[method] = (...args: unknown[]) => {
+					if (scheduledDepth === 0) unscheduledCalls++
+					return original(...args)
+				}
+			}
+		}
+		let scheduled = 0
+		const schedule = async <T>(op: () => Promise<T>) => {
+			scheduled++
+			scheduledDepth++
+			try {
+				return await op()
+			} finally {
+				scheduledDepth--
+			}
+		}
+
+		await deleteAllVersions({ chainBucket, legacyBucket, roomKey, schedule })
+
+		// One listing and one delete batch per bucket, each its own scheduled operation. Counters
+		// first: the verification lists below run outside the sweep on purpose.
+		expect(scheduled).toBe(4)
+		expect(unscheduledCalls).toBe(0)
+		expect((await chainBucket.list({ prefix: `${roomKey}/` })).objects).toHaveLength(0)
+		expect((await legacyBucket.list({ prefix: `${roomKey}/` })).objects).toHaveLength(0)
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/versionChainRead.ts
+++ b/apps/dotcom/sync-worker/src/versionChainRead.ts
@@ -1,15 +1,14 @@
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { deleteAllObjectsWithPrefix, listAllObjectKeys } from './r2'
+import {
+	deleteAllObjectsWithPrefix,
+	listAllObjectKeys,
+	listAllObjects,
+	R2ReadScheduler,
+	runInline,
+} from './r2'
 import { parseVersionKey, PendingDelta, readSegmentRef, SegmentBody } from './versionChain'
 import { decodeVersionBody, isGzippedVersionBody } from './versionChainCodec'
 import { applySnapshotDelta, versionEnvelopeHash } from './versionDelta'
-
-// R2 has honored `include` on list() since compat date 2022-08-04 (this worker's is far past it),
-// but the repo's ambient workers-types entrypoint predates the option — declared locally, same
-// pattern as types.ts.
-type R2ListOptionsWithInclude = R2ListOptions & {
-	include?: Array<'httpMetadata' | 'customMetadata'>
-}
 
 /** A keyframe object: one whole snapshot, and the single version it is. */
 export interface KeyframeIndexEntry {
@@ -35,13 +34,13 @@ export interface SegmentIndexEntry {
 export type ChainIndexEntry = KeyframeIndexEntry | SegmentIndexEntry
 
 /**
- * Runs one R2 read. Reads default to running inline; a caller inside a shared connection budget
- * (the durable object's R2 queue) passes its queue, so each read is one budgeted operation and the
- * fan-out never holds more connections than the budget allows.
+ * A segment object R2 holds that carries no readable chain reference, so nothing can place it. The
+ * timestamp comes from its key, which names its first delta.
  */
-export type R2ReadScheduler = <T>(read: () => Promise<T>) => Promise<T>
-
-const runInline: R2ReadScheduler = (read) => read()
+export interface RejectedChainObject {
+	key: string
+	timestamp: string
+}
 
 export interface VersionReconstruction {
 	snapshot: RoomSnapshot
@@ -56,7 +55,8 @@ export interface VersionReconstruction {
 }
 
 /**
- * Every chain object for a room, in key order, with the versions each one holds.
+ * Every chain object for a room, in key order, with the versions each one holds, plus the segments
+ * that could not be placed at all — the verifier reports those, since nothing downstream can.
  *
  * A segment is keyed by its first delta only, so a version's timestamp does not say which object
  * holds it. Listing with `customMetadata` answers that for the whole room in one operation, without
@@ -66,45 +66,37 @@ export async function loadChainIndex(
 	bucket: R2Bucket,
 	roomKey: string,
 	schedule: R2ReadScheduler = runInline
-): Promise<{ entries: ChainIndexEntry[]; ops: number }> {
+): Promise<{ entries: ChainIndexEntry[]; ops: number; rejected: RejectedChainObject[] }> {
+	const { objects, ops } = await listAllObjects(bucket, `${roomKey}/`, schedule)
 	const entries: ChainIndexEntry[] = []
-	let cursor: string | undefined
-	let ops = 0
-
-	do {
-		// Including metadata makes R2 return shorter pages, so a short page does not mean the
-		// listing is done — `truncated` is the only safe stop condition.
-		const options: R2ListOptionsWithInclude = {
-			prefix: `${roomKey}/`,
-			cursor,
-			include: ['customMetadata'],
+	const rejected: RejectedChainObject[] = []
+	for (const object of objects) {
+		const parsed = parseVersionKey(object.key)
+		if (!parsed) continue
+		if (parsed.kind === 'keyframe') {
+			entries.push({ kind: 'keyframe', key: object.key, timestamps: [parsed.timestamp] })
+			continue
 		}
-		const page: R2Objects = await schedule(() => bucket.list(options as R2ListOptions))
-		ops++
-		for (const object of page.objects) {
-			const parsed = parseVersionKey(object.key)
-			if (!parsed) continue
-			if (parsed.kind === 'keyframe') {
-				entries.push({ kind: 'keyframe', key: object.key, timestamps: [parsed.timestamp] })
-				continue
-			}
-			const ref = readSegmentRef(object.customMetadata)
-			// A segment with no readable reference cannot be placed in a chain. Skipping it here
-			// surfaces as a sequence gap rather than as a silently short replay.
-			if (!ref) continue
-			entries.push({
-				kind: 'segment',
-				key: object.key,
-				timestamps: ref.timestamps,
-				keyframeKey: ref.keyframeKey,
-				firstSeq: ref.firstSeq,
-			})
+		const ref = readSegmentRef(object.customMetadata)
+		// A segment with no readable reference cannot be placed in a chain. Dropping it only shows
+		// up as a sequence gap when it sits mid-chain; a trailing one leaves the replay ending early
+		// and the verifier passing a chain whose tail is unreadable. Collected so it is reported
+		// outright instead.
+		if (!ref) {
+			rejected.push({ key: object.key, timestamp: parsed.timestamp })
+			continue
 		}
-		cursor = page.truncated ? page.cursor : undefined
-	} while (cursor)
+		entries.push({
+			kind: 'segment',
+			key: object.key,
+			timestamps: ref.timestamps,
+			keyframeKey: ref.keyframeKey,
+			firstSeq: ref.firstSeq,
+		})
+	}
 
 	entries.sort((a, b) => a.key.localeCompare(b.key))
-	return { entries, ops }
+	return { entries, ops, rejected }
 }
 
 /**
@@ -300,19 +292,21 @@ export async function openWholeVersionStream({
 	roomKey,
 	timestamp,
 	index,
+	schedule = runInline,
 }: {
 	chainBucket: R2Bucket
 	legacyBucket: R2Bucket
 	roomKey: string
 	timestamp: string
 	index: ChainIndexEntry[]
+	schedule?: R2ReadScheduler
 }): Promise<ReadableStream<Uint8Array> | null> {
 	const target = index.find((entry) => entry.timestamps.includes(timestamp))
 	if (target && target.kind !== 'keyframe') return null
 
 	const object = target
-		? await chainBucket.get(target.key)
-		: await legacyBucket.get(`${roomKey}/${timestamp}`)
+		? await schedule(() => chainBucket.get(target.key))
+		: await schedule(() => legacyBucket.get(`${roomKey}/${timestamp}`))
 	if (!object) {
 		if (target) throw new Error(`version chain keyframe ${target.key} is missing`)
 		return null
@@ -330,14 +324,18 @@ export async function deleteAllVersions({
 	chainBucket,
 	legacyBucket,
 	roomKey,
+	schedule = runInline,
 }: {
 	chainBucket: R2Bucket
 	legacyBucket: R2Bucket
 	roomKey: string
+	schedule?: R2ReadScheduler
 }): Promise<void> {
 	// Trailing slash: a bare roomKey prefix also matches sibling rooms whose slug is a prefix of
 	// this one (deleting "abc" must not sweep "abcd").
 	await Promise.all(
-		[chainBucket, legacyBucket].map((bucket) => deleteAllObjectsWithPrefix(bucket, `${roomKey}/`))
+		[chainBucket, legacyBucket].map((bucket) =>
+			deleteAllObjectsWithPrefix(bucket, `${roomKey}/`, schedule)
+		)
 	)
 }

--- a/apps/dotcom/sync-worker/src/versionChainWrite.test.ts
+++ b/apps/dotcom/sync-worker/src/versionChainWrite.test.ts
@@ -6,7 +6,7 @@ import { createFakeR2 } from './test/fakeR2'
 import { ChainState, PendingDelta } from './versionChain'
 import { reconstructVersion } from './versionChainRead'
 import { readOpenSegment, writeVersionChainEntry } from './versionChainWrite'
-import { chainHeadHash } from './versionDelta'
+import { chainHeadHash, SNAPSHOT_DELTA_VERSION } from './versionDelta'
 
 const roomKey = 'app_rooms/slug'
 
@@ -346,6 +346,33 @@ describe('writeVersionChainEntry', () => {
 		// The chain head fingerprint is `before`'s, so the schema move is what the decision sees.
 		expect(second).toMatchObject({ wrote: 'keyframe', reason: 'schema-change' })
 	})
+
+	it('retires a chain rather than appending a delta of another format to its segment', async () => {
+		const bucket = createFakeR2()
+		const versions = [snapshot(1, ['shape:a']), snapshot(2, ['shape:a', 'shape:b'])]
+		const { chain, pending } = await persistAll(bucket, versions)
+		const segmentKey = chain!.openSegment!.key
+
+		const result = await writeVersionChainEntry({
+			bucket,
+			roomKey,
+			// The chain state a build that bumped the delta format finds in durable object storage.
+			chain: { ...chain!, deltaVersion: SNAPSHOT_DELTA_VERSION - 1 },
+			iso: isoAt(2),
+			pending,
+			previous: versions[1],
+			next: snapshot(3, ['shape:a', 'shape:b', 'shape:c']),
+			now: 2000,
+		})
+
+		expect(result).toMatchObject({ wrote: 'keyframe', reason: 'delta-format' })
+		expect(result.chain.deltaVersion).toBe(SNAPSHOT_DELTA_VERSION)
+		// The fresh chain has no open segment, and the old one still holds exactly what it did —
+		// the mixed segment this rule exists to prevent is the segment never being rewritten.
+		expect(result.chain.openSegment).toBeNull()
+		expect(result.pending).toEqual([])
+		expect(await readOpenSegment(bucket, segmentKey)).toEqual(pending)
+	})
 })
 
 describe('readOpenSegment', () => {
@@ -369,6 +396,22 @@ describe('readOpenSegment', () => {
 		expect(await readOpenSegment(bucket, `${roomKey}/garbage.s`)).toBeNull()
 		expect(await readOpenSegment(bucket, `${roomKey}/future.s`)).toBeNull()
 		expect(await readOpenSegment(bucket, `${roomKey}/shape.s`)).toBeNull()
+	})
+
+	it('returns deltas of another format rather than refusing them', async () => {
+		const bucket = createFakeR2()
+		const { chain, pending } = await persistAll(bucket, [
+			snapshot(1, ['shape:a']),
+			snapshot(2, ['shape:a', 'shape:b']),
+		])
+		const key = chain!.openSegment!.key
+		// Retiring a chain on a format bump is decideVersionWrite's job, and it names the reason
+		// `delta-format`. Nulling here would null the chain one step earlier and report every room
+		// the bump touched as `segment-lost` instead.
+		const stale = pending.map((d) => ({ ...d, delta: { ...d.delta, v: 1 } }))
+		await bucket.put(key, JSON.stringify({ v: 1, deltas: stale }))
+
+		expect(await readOpenSegment(bucket, key)).toEqual(stale)
 	})
 
 	it('throws on a failed get instead of discarding the segment', async () => {

--- a/apps/dotcom/sync-worker/src/versionChainWrite.ts
+++ b/apps/dotcom/sync-worker/src/versionChainWrite.ts
@@ -10,7 +10,12 @@ import {
 	versionKey,
 } from './versionChain'
 import { decodeVersionBody, encodeVersionBody } from './versionChainCodec'
-import { buildSnapshotDelta, chainHeadHash, snapshotHashes } from './versionDelta'
+import {
+	buildSnapshotDelta,
+	chainHeadHash,
+	SNAPSHOT_DELTA_VERSION,
+	snapshotHashes,
+} from './versionDelta'
 
 interface VersionChainWriteResultBase {
 	chain: ChainState
@@ -90,6 +95,7 @@ export async function writeVersionChainEntry({
 			pending: [],
 			chain: {
 				keyframeKey: key,
+				deltaVersion: SNAPSHOT_DELTA_VERSION,
 				keyframeAt: now,
 				keyframeBytes: encoded.body.byteLength,
 				deltaCount: 0,
@@ -139,6 +145,10 @@ export async function writeVersionChainEntry({
 /**
  * The deltas an open segment holds, for a durable object that lost its in-memory buffer, or null
  * when the object cannot be used as one: missing, undecodable, or not a v1 segment body.
+ *
+ * Deltas of a superseded format are returned rather than refused. `decideVersionWrite` retires such
+ * a chain with a `delta-format` keyframe; refusing here would null the chain first and report the
+ * whole bump as `segment-lost`, which is the per-room signal that reason has to stay.
  *
  * Null means the segment is unusable and the caller starts a fresh chain, which costs one keyframe.
  * A failed `get` throws instead: the segment may be intact and only the network was not, and null

--- a/apps/dotcom/sync-worker/src/versionDelta.test.ts
+++ b/apps/dotcom/sync-worker/src/versionDelta.test.ts
@@ -5,6 +5,7 @@ import {
 	applySnapshotDelta,
 	buildSnapshotDelta,
 	chainHeadHash,
+	SnapshotDelta,
 	snapshotHashes,
 	versionEnvelopeHash,
 } from './versionDelta'
@@ -330,5 +331,144 @@ describe('buildSnapshotDelta / applySnapshotDelta', () => {
 
 		const replayed = applySnapshotDelta(keyframe, delta)
 		expect(versionEnvelopeHash(replayed)).toBe(delta.hash)
+	})
+})
+/**
+ * A v2 delta exactly as chains already in R2 hold one, frozen as a literal rather than built here.
+ *
+ * Every other test in this file round-trips through the current build, so all of them keep passing
+ * when the format moves — which is how the diff codec, the hash inputs, or an `applyObjectDiff`
+ * change in `@tldraw/sync-core` can land without anyone bumping `SNAPSHOT_DELTA_VERSION` and every
+ * chain in R2 quietly starts replaying under rules it was not written for.
+ *
+ * When this fails, the format moved. Bump `SNAPSHOT_DELTA_VERSION` and re-pin this fixture at the
+ * new version; re-pinning alone, without the bump, is what it exists to prevent.
+ */
+describe('the v2 format, pinned', () => {
+	const schema = { schemaVersion: 2, sequences: { 'com.tldraw.shape': 1 } } as any
+	// The brand on `RecordId` is the only reason these literals need a cast at all.
+	const record = (state: object) => state as UnknownRecord
+	const steady = record({ id: 'shape:d', typeName: 'shape', x: 7 })
+
+	// Written out in full rather than through `snapshot()` and `rec()`: a pin that moves when a
+	// test helper moves is not a pin.
+	const base: RoomSnapshot = {
+		clock: 10,
+		documentClock: 10,
+		documents: [
+			{
+				state: record({
+					id: 'shape:a',
+					typeName: 'shape',
+					x: 1,
+					props: { text: 'hi', segments: [1, 2] },
+					meta: { tags: ['one'], nested: { keep: true, drop: 1 } },
+				}),
+				lastChangedClock: 4,
+			},
+			{ state: record({ id: 'shape:b', typeName: 'shape', x: 5 }), lastChangedClock: 6 },
+			// Clock moves in `next` while the content stays identical, so the delta carries a clock
+			// for it and no diff entry at all — the one path `applySnapshotDelta`'s trailing clocks
+			// loop exists for, and dead weight in a fixture without it.
+			{ state: steady, lastChangedClock: 7 },
+		],
+		tombstones: { 'shape:gone': 3, 'shape:older': 2 },
+		tombstoneHistoryStartsAtClock: 2,
+		schema,
+	}
+
+	const next: RoomSnapshot = {
+		clock: 12,
+		documentClock: 12,
+		documents: [
+			{
+				state: record({
+					id: 'shape:a',
+					typeName: 'shape',
+					x: 2,
+					props: { text: 'hi there', segments: [1, 2, 3] },
+					meta: { tags: ['one', 'two'], nested: { keep: true } },
+				}),
+				lastChangedClock: 11,
+			},
+			{ state: steady, lastChangedClock: 12 },
+			{ state: record({ id: 'shape:c', typeName: 'shape', x: 9 }), lastChangedClock: 12 },
+		],
+		tombstones: { 'shape:gone': 3, 'shape:b': 12 },
+		tombstoneHistoryStartsAtClock: 3,
+		schema,
+	}
+
+	// The append ops are the point of the string and array edits: `applyObjectDiff` has changed
+	// what an offset means before (diffRecord's legacyAppendMode), and that change is silent.
+	const delta: SnapshotDelta = {
+		v: 2,
+		diff: {
+			'shape:c': ['put', record({ id: 'shape:c', typeName: 'shape', x: 9 })],
+			'shape:a': [
+				'patch',
+				{
+					x: ['put', 2],
+					props: ['patch', { text: ['append', ' there', 2], segments: ['append', [3], 2] }],
+					meta: ['patch', { tags: ['append', ['two'], 1], nested: ['put', { keep: true }] }],
+				},
+			],
+			'shape:b': ['remove'],
+		},
+		clocks: { 'shape:a': 11, 'shape:d': 12, 'shape:c': 12 },
+		tombstones: { set: { 'shape:b': 12 }, removed: ['shape:older'] },
+		tombstoneHistoryStartsAtClock: 3,
+		clock: 12,
+		documentClock: 12,
+		hash: '75c37fef0c2b6587',
+	}
+
+	// The bytes a segment object holds, as text. `encodeVersionBody` only gzips this, and gzip
+	// output is a zlib-version detail rather than part of the format, so the JSON is what is pinned.
+	//
+	// Not redundant with the object pin below: `toEqual` reads `{ a: undefined }` and `{}` as the
+	// same object and the hash sorts keys before digesting, so a field that quietly turns undefined,
+	// or moves, changes what R2 stores while both of those stay green.
+	const stored =
+		'{"v":1,' +
+		'"deltas":[{"t":"2026-09-01T00:00:05.000Z","delta":{"v":2,' +
+		'"diff":{"shape:c":["put",{"id":"shape:c","typeName":"shape","x":9}],' +
+		'"shape:a":["patch",{"x":["put",2],"props":["patch",{"text":["append"," there",2],"segments":["append",[3],2]}],"meta":["patch",{"tags":["append",["two"],1],"nested":["put",{"keep":true}]}]}],' +
+		'"shape:b":["remove"]},' +
+		'"clocks":{"shape:a":11,"shape:d":12,"shape:c":12},' +
+		'"tombstones":{"set":{"shape:b":12},"removed":["shape:older"]},"tombstoneHistoryStartsAtClock":3,' +
+		'"clock":12,"documentClock":12,"hash":"75c37fef0c2b6587"}}]}'
+
+	it('serializes to the exact text a v2 segment holds', () => {
+		const segment = {
+			v: 1,
+			deltas: [{ t: '2026-09-01T00:00:05.000Z', delta: buildSnapshotDelta(base, next) }],
+		}
+
+		expect(JSON.stringify(segment)).toBe(stored)
+	})
+
+	it('replays that text, parsed as R2 hands it back', () => {
+		const [{ delta: parsed }] = JSON.parse(stored).deltas
+
+		expect(applySnapshotDelta(base, parsed)).toEqual(next)
+		expect(versionEnvelopeHash(applySnapshotDelta(base, parsed))).toBe(parsed.hash)
+	})
+
+	it('writes the delta v2 pins', () => {
+		expect(buildSnapshotDelta(base, next)).toEqual(delta)
+	})
+
+	it('replays the pinned delta, not just one it built itself', () => {
+		expect(applySnapshotDelta(base, delta)).toEqual(next)
+	})
+
+	it('hashes the pinned snapshots to the pinned digests', () => {
+		// A chain verifies against the hash recorded in the delta, so these strings are as much a
+		// part of the stored format as the delta body is.
+		expect(versionEnvelopeHash(base)).toBe('aab866b16f9ac1e1')
+		expect(versionEnvelopeHash(next)).toBe('75c37fef0c2b6587')
+		expect(chainHeadHash(base)).toBe('b584c037db4dc24f')
+		expect(chainHeadHash(next)).toBe('3d1266a3f7235c23')
 	})
 })

--- a/apps/dotcom/sync-worker/src/versionDelta.ts
+++ b/apps/dotcom/sync-worker/src/versionDelta.ts
@@ -9,6 +9,17 @@ import {
 import { canonicalJson, fnv1a64 } from './snapshotUtils'
 
 /**
+ * The delta format this build writes and can replay. Bumping it invalidates every chain already
+ * written, so a bump has to cut keyframes: chains record the format they hold, and one that does
+ * not match is retired by `decideVersionWrite` rather than appended to.
+ *
+ * A format change has to arrive here rather than slip past, so `versionDelta.test.ts` pins a frozen
+ * v2 delta and its hashes: the semantics cannot move — here, or in `@tldraw/sync-core`'s diff codec
+ * underneath — without failing that test.
+ */
+export const SNAPSHOT_DELTA_VERSION = 2
+
+/**
  * One version of a board expressed as a change from the previous one.
  *
  * `getNetworkDiff` only covers `documents[].state`, so everything else a `RoomSnapshot` carries —
@@ -21,7 +32,7 @@ import { canonicalJson, fnv1a64 } from './snapshotUtils'
  * shape. v2: the hash canonicalizes exactly as `JSON.stringify` does (see `canonicalJson`).
  */
 export interface SnapshotDelta {
-	v: 2
+	v: typeof SNAPSHOT_DELTA_VERSION
 	diff: NetworkDiff<UnknownRecord> | null
 	clocks: Record<string, number>
 	tombstones: { set: Record<string, number>; removed: string[] } | null
@@ -143,7 +154,7 @@ export function buildSnapshotDelta(
 	const tombstones = Object.keys(set).length === 0 && removed.length === 0 ? null : { set, removed }
 
 	return {
-		v: 2,
+		v: SNAPSHOT_DELTA_VERSION,
 		diff: getNetworkDiff(recordsDiff),
 		clocks,
 		tombstones,
@@ -157,7 +168,11 @@ export function buildSnapshotDelta(
 export function applySnapshotDelta(prev: RoomSnapshot, delta: SnapshotDelta): RoomSnapshot {
 	// The diff codec has changed semantics before (diffRecord's legacyAppendMode); applying a
 	// future format with today's rules would corrupt quietly, which is worse than failing.
-	if (delta.v !== 2) throw new Error(`unsupported snapshot delta version ${delta.v}, expected 2`)
+	if (delta.v !== SNAPSHOT_DELTA_VERSION) {
+		throw new Error(
+			`unsupported snapshot delta version ${delta.v}, expected ${SNAPSHOT_DELTA_VERSION}`
+		)
+	}
 	// The envelope hash would catch this too, as a mismatch; checked up front so a restore that
 	// would seed the storage clock from `undefined` fails with a reason.
 	if (typeof delta.documentClock !== 'number') {

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -55,6 +55,7 @@ import { mcpServer } from './routes/tla/mcpServer'
 import { handleOgImageRenderMessage } from './routes/tla/ogImageQueue'
 import { putThumbnailRenderResult } from './routes/tla/putThumbnailRenderResult'
 import { upload } from './routes/tla/uploads'
+import { verifyVersionChainRoute } from './routes/verifyVersionChain'
 import { testRoutes } from './testRoutes'
 import { Environment, OgImageRenderQueueMessage, QueueMessage, isDebugLogging } from './types'
 import { getFileEffectProcessor, getLogger } from './utils/durableObjects'
@@ -124,13 +125,22 @@ const router = createRouter<Environment>()
 		joinExistingRoom(req, env, ROOM_OPEN_MODE.READ_ONLY)
 	)
 	.get(`/${ROOM_PREFIX}/:roomId/history`, (req, env) => getRoomHistory(req, env, false))
-	.get(`/${ROOM_PREFIX}/:roomId/history/:timestamp`, (req, env) =>
-		getRoomHistorySnapshot(req, env, false)
+	// Legacy rooms dual-write chains too; without this the rollout gate has a blind spot.
+	.get(`/${ROOM_PREFIX}/:roomId/history/verify`, (req, env) =>
+		verifyVersionChainRoute(req, env, false)
+	)
+	.get(`/${ROOM_PREFIX}/:roomId/history/:timestamp`, (req, env, ctx) =>
+		getRoomHistorySnapshot(req, env, false, ctx)
 	)
 
 	.get(`/${FILE_PREFIX}/:roomId/history`, (req, env) => getRoomHistory(req, env, true))
-	.get(`/${FILE_PREFIX}/:roomId/history/:timestamp`, (req, env) =>
-		getRoomHistorySnapshot(req, env, true)
+	// Before the :timestamp route — itty-router matches in order, and `verify` would otherwise be
+	// read as a timestamp.
+	.get(`/${FILE_PREFIX}/:roomId/history/verify`, (req, env) =>
+		verifyVersionChainRoute(req, env, true)
+	)
+	.get(`/${FILE_PREFIX}/:roomId/history/:timestamp`, (req, env, ctx) =>
+		getRoomHistorySnapshot(req, env, true, ctx)
 	)
 
 	.get('/readonly-slug/:roomId', getReadonlySlug)

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -3616,6 +3616,597 @@ spec:
                 mode: multi
                 sort: desc
           version: 13.2.0-29854286369
+    panel-49:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as wrote, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, wrote
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as wrote, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, wrote
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: version_chain_write events split keyframe vs delta. A healthy
+          chain writes mostly deltas with an occasional keyframe.
+        id: 49
+        links: []
+        title: Version chain writes
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-50:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as reason, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob3 = 'keyframe'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, reason
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as reason, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob3 = 'keyframe'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, reason
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: "Why keyframes were cut. 'segment-lost' is the lost-open-segment
+          recovery and 'fingerprint-mismatch' a dead-incarnation seed divergence —
+          spikes in either deserve a look."
+        id: 50
+        links: []
+        title: Keyframe reasons
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-51:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, if(blob3 = 'ok', 'ok', concat('fail:', blob4))
+                        as result, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_verify'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, result
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, if(blob3 = 'ok', 'ok', concat('fail:', blob4))
+                        as result, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_verify'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, result
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Retired-chain verification. Fail reasons: missing | legacy-fallback
+          | head-mismatch | error. Any fail means a reconstruction did not reproduce
+          the persisted state.'
+        id: 51
+        links: []
+        title: Verify results
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-52:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as errors
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_error'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as errors
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_error'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Chain writes that failed and fell back to the legacy copy. Anything
+          above zero deserves a look.
+        id: 52
+        links: []
+        title: Chain write errors
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 1
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-53:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as wrote, sum(double1) as bytes
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, wrote
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as wrote, sum(double1) as bytes
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'version_chain_write'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, wrote
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Encoded bytes uploaded to the chain bucket, split by write type
+          (double1 is the encoded body size).
+        id: 53
+        links: []
+        title: Chain bytes written
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 30
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: bytes
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
   layout:
     kind: GridLayout
     spec:
@@ -3908,6 +4499,51 @@ spec:
             width: 12
             x: 0
             y: 98
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-49
+            height: 8
+            width: 12
+            x: 0
+            y: 106
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-50
+            height: 8
+            width: 12
+            x: 12
+            y: 106
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-51
+            height: 8
+            width: 12
+            x: 0
+            y: 114
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-53
+            height: 8
+            width: 12
+            x: 12
+            y: 114
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-52
+            height: 4
+            width: 6
+            x: 0
+            y: 122
   links: []
   liveNow: false
   preload: false


### PR DESCRIPTION
This is a hotfix PR for dotcom deployment, created by hand because the automated flow could not complete it.

**Original PR:** [#10616](https://github.com/tldraw/tldraw/pull/10616)
**Original Title:** feat(dotcom): read board history through delta chain reconstruction
**Original Author:** @driev

`Trigger dotcom hotfix` failed cherry-picking `369f18cc33` onto `hotfixes`:

```
CONFLICT (content): Merge conflict in apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
```

`hotfixes` is 13 commits behind `main`, and one of them — #10072 — refactored `fetchTimestampsForPrefix` in that file. #10616's squash was computed against a `main` that already had #10072, so replaying it onto `hotfixes` reopens the conflict the merge had already settled.

The conflict is spurious: #10072 refactored `fetchTimestampsForPrefix`, and #10616 deletes it, moving the listing walk into `r2.ts` as `listAllObjectKeys`. Neither side needs the other, so this resolves in favour of #10616 — `getRoomHistory.ts` here is byte-identical to its state on `main`.

Nothing else in the cherry-pick conflicted. #10614 and #10615 (the stacked parents) are already on `hotfixes`.

Validation on this branch: `yarn workspace @tldraw/dotcom-worker test run` 43 files / 721 tests pass, `yarn typecheck` clean, oxfmt and oxlint clean.

/cc @driev
