### PR TITLE
fix(editor): keep a click during a camera animation from becoming a drag

### DIFF
--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect } from '@playwright/test'
 import { Editor } from 'tldraw'
 
+declare const editor: Editor
 declare const EDITOR_A: Editor
 declare const EDITOR_B: Editor
 declare const EDITOR_C: Editor
@@ -214,8 +215,14 @@ test.describe('Focus', () => {
 
 		// create new note next to it
 		await page.keyboard.press('Tab')
+		await expect(page.locator('.tl-shape')).toHaveCount(2)
 
-		await (await page.$('body'))?.click()
+		// Tab pans to the new note; let the camera settle so the click below isn't
+		// dispatched against a moving canvas.
+		await page.waitForFunction(() => editor.getCameraState() === 'idle')
+
+		// Click back into the first note
+		await page.locator('.tl-shape').first().click()
 
 		await page.waitForTimeout(1000)
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2357,6 +2357,8 @@ export class InputsManager extends EditorManager {
     // @internal
     updateFromEvent(info: TLPinchEventInfo | TLPointerEventInfo | TLWheelEventInfo): void;
     // @internal
+    updateOriginPagePointFromCamera(): void;
+    // @internal
     updatePointerVelocity(elapsed: number): void;
 }
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -3540,7 +3540,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/** @internal */
-	private _setCamera(point: VecLike, opts?: TLCameraMoveOptions): this {
+	private _setCamera(
+		point: VecLike,
+		opts?: TLCameraMoveOptions & {
+			/**
+			 * The camera moved because of the user's own wheel input. Only that kind of camera move
+			 * may push a held-still pointer past the drag threshold; an animation, follow, or
+			 * programmatic move re-anchors the pointer-down origin instead so a click stays a click.
+			 */
+			fromWheel?: boolean
+		}
+	): this {
 		const currentCamera = this.getCamera()
 
 		const { x, y, z } = this.getConstrainedCamera(point, opts)
@@ -3557,6 +3567,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				},
 				{ history: 'ignore' }
 			)
+
+			if (!opts?.fromWheel && this.inputs.getIsPointing() && !this.inputs.getIsDragging()) {
+				this.inputs.updateOriginPagePointFromCamera()
+			}
 
 			// Dispatch a new pointer move because the pointer's page will have changed
 			// (its screen position will compute to a new page position given the new camera position)
@@ -11251,6 +11265,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							const zoom = cz + finalDelta * zoomSpeed * cz
 							this._setCamera(new Vec(cx + x / zoom - x / cz, cy + y / zoom - y / cz, zoom), {
 								immediate: true,
+								fromWheel: true,
 							})
 							this.maybeTrackPerformance('Zooming')
 							this.performance._notifyCameraOperation('zooming')
@@ -11262,6 +11277,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							// Pan the camera based on the wheel delta
 							this._setCamera(new Vec(cx + (dx * panSpeed) / cz, cy + (dy * panSpeed) / cz, cz), {
 								immediate: true,
+								fromWheel: true,
 							})
 							this.maybeTrackPerformance('Panning')
 							this.performance._notifyCameraOperation('panning')

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -105,6 +105,13 @@ export class InputsManager extends EditorManager {
 		return this._originPagePoint.get()
 	}
 	/**
+	 * @deprecated Use `getOriginPagePoint()` instead.
+	 */
+	// eslint-disable-next-line tldraw/no-setter-getter
+	get originPagePoint() {
+		return this.getOriginPagePoint()
+	}
+	/**
 	 * Re-derive the pointer down's page position from its screen position under the current
 	 * camera. Used when the camera moves on its own (animation, follow, programmatic set) so that
 	 * the move isn't measured as pointer travel.
@@ -116,13 +123,6 @@ export class InputsManager extends EditorManager {
 		const { x: sx, y: sy } = this._originScreenPoint.__unsafe__getWithoutCapture()
 		const { z } = this._originPagePoint.__unsafe__getWithoutCapture()
 		this._originPagePoint.set(new Vec(sx / cz - cx, sy / cz - cy, z))
-	}
-	/**
-	 * @deprecated Use `getOriginPagePoint()` instead.
-	 */
-	// eslint-disable-next-line tldraw/no-setter-getter
-	get originPagePoint() {
-		return this.getOriginPagePoint()
 	}
 
 	private _originScreenPoint = atom<Vec>('originScreenPoint', new Vec())

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -105,6 +105,19 @@ export class InputsManager extends EditorManager {
 		return this._originPagePoint.get()
 	}
 	/**
+	 * Re-derive the pointer down's page position from its screen position under the current
+	 * camera. Used when the camera moves on its own (animation, follow, programmatic set) so that
+	 * the move isn't measured as pointer travel.
+	 *
+	 * @internal
+	 */
+	updateOriginPagePointFromCamera() {
+		const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.editor.getCamera())
+		const { x: sx, y: sy } = this._originScreenPoint.__unsafe__getWithoutCapture()
+		const { z } = this._originPagePoint.__unsafe__getWithoutCapture()
+		this._originPagePoint.set(new Vec(sx / cz - cx, sy / cz - cy, z))
+	}
+	/**
 	 * @deprecated Use `getOriginPagePoint()` instead.
 	 */
 	// eslint-disable-next-line tldraw/no-setter-getter

--- a/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
+++ b/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
@@ -1,4 +1,5 @@
-import { InstancePresenceRecordType, createShapeId, createUserId } from '@tldraw/editor'
+import { Box, InstancePresenceRecordType, createShapeId, createUserId } from '@tldraw/editor'
+import { startEditingAdjacentNote } from '../lib/shapes/note/noteHelpers'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -52,6 +53,31 @@ describe('pointer held still while the camera animates', () => {
 		editor.pointerMove(70, 50).pointerUp()
 
 		expect(editor.getShape(id)).toMatchObject({ x: 20, y: 0 })
+	})
+})
+
+describe('clicking a note while the camera pans to an adjacent note (#10706)', () => {
+	it('moves editing into the clicked note instead of dragging it', () => {
+		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+		const a = createShapeId('a')
+		const b = createShapeId('b')
+		editor.createShapes([
+			{ id: a, type: 'note', x: 100, y: 100 },
+			{ id: b, type: 'note', x: 1500, y: 100 },
+		])
+
+		// What Tab does: edit the new note and pan to it, since it is off screen
+		startEditingAdjacentNote(editor, editor.getShape(b)!)
+		editor.expectToBeIn('select.editing_shape')
+		editor.forceTick(2)
+		expect(editor.getCameraState()).toBe('moving')
+
+		editor.pointerDown(200, 200)
+		editor.forceTick(5)
+		editor.pointerUp()
+
+		expect(editor.getEditingShapeId()).toBe(a)
+		expect(editor.getShape(a)).toMatchObject({ x: 100, y: 100 })
 	})
 })
 

--- a/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
+++ b/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
@@ -79,6 +79,15 @@ describe('pointer held still while the camera moves for other reasons', () => {
 		expect(editor.inputs.getIsDragging()).toBe(false)
 	})
 
+	it('does not start a drag while the camera slides after a fling', () => {
+		editor.slideCamera({ speed: 5, direction: { x: 1, y: 1 }, friction: 0.01 })
+		editor.pointerDown(100, 100)
+		editor.forceTick(20)
+
+		expect(editor.getCamera()).not.toMatchObject({ x: 0, y: 0 })
+		expect(editor.inputs.getIsDragging()).toBe(false)
+	})
+
 	it('does not start a drag on an immediate camera jump', () => {
 		editor.pointerDown(100, 100)
 		editor.setCamera({ x: 500, y: 500, z: 1 }, { immediate: true })

--- a/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
+++ b/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
@@ -1,0 +1,99 @@
+import { InstancePresenceRecordType, createShapeId, createUserId } from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+})
+
+describe('pointer held still while the camera animates', () => {
+	it('does not start a drag', () => {
+		editor.pointerDown(100, 100)
+		editor.setCamera({ x: 500, y: 500, z: 1 }, { animation: { duration: 200 } })
+		editor.forceTick(5)
+
+		expect(editor.getCamera()).not.toMatchObject({ x: 0, y: 0 })
+		expect(editor.inputs.getIsDragging()).toBe(false)
+	})
+
+	it('still treats the interaction as a click on a shape', () => {
+		const id = createShapeId()
+		editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100, fill: 'solid' } })
+
+		editor.pointerDown(50, 50)
+		editor.setCamera({ x: 500, y: 500, z: 1 }, { animation: { duration: 200 } })
+		editor.forceTick(5)
+		editor.pointerUp()
+
+		expect(editor.getSelectedShapeIds()).toEqual([id])
+		expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+		expect(editor.getPath()).toBe('select.idle')
+	})
+
+	it('still starts a drag once the pointer itself moves past the threshold', () => {
+		editor.pointerDown(100, 100)
+		editor.setCamera({ x: 500, y: 500, z: 1 }, { animation: { duration: 200 } })
+		editor.forceTick(5)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+
+		editor.pointerMove(110, 110)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+	})
+
+	it('measures a later drag from where the pointer actually is, not from before the camera moved', () => {
+		const id = createShapeId()
+		editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100, fill: 'solid' } })
+
+		editor.pointerDown(50, 50)
+		editor.setCamera({ x: 500, y: 500, z: 1 }, { animation: { duration: 200 } })
+		editor.forceTick(20)
+		editor.pointerMove(70, 50).pointerUp()
+
+		expect(editor.getShape(id)).toMatchObject({ x: 20, y: 0 })
+	})
+})
+
+describe('pointer held still while the camera moves for other reasons', () => {
+	it('does not start a drag when following a user', () => {
+		const leaderId = createUserId('leader')
+		editor.store.put([
+			InstancePresenceRecordType.create({
+				id: InstancePresenceRecordType.createId(leaderId),
+				userId: leaderId,
+				userName: leaderId,
+				currentPageId: editor.getCurrentPageId(),
+				followingUserId: null,
+				camera: { x: 500, y: 500, z: 1 },
+				screenBounds: { x: 0, y: 0, w: 1080, h: 720 },
+				lastActivityTimestamp: Date.now(),
+			}),
+		])
+
+		editor.pointerDown(100, 100)
+		editor.startFollowingUser(leaderId)
+		editor.forceTick(20)
+
+		expect(editor.getCamera()).not.toMatchObject({ x: 0, y: 0 })
+		expect(editor.inputs.getIsDragging()).toBe(false)
+	})
+
+	it('does not start a drag on an immediate camera jump', () => {
+		editor.pointerDown(100, 100)
+		editor.setCamera({ x: 500, y: 500, z: 1 }, { immediate: true })
+
+		expect(editor.getCamera()).toMatchObject({ x: 500, y: 500 })
+		expect(editor.inputs.getIsDragging()).toBe(false)
+	})
+})
+
+describe('pointer held still while the user scrolls the wheel', () => {
+	it('starts a drag once the camera has moved past the threshold', () => {
+		editor.pointerDown(100, 100)
+		editor.wheel(2, 2)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+		editor.wheel(10, 10)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where a click made while the camera is animating registered as a drag. Closes #10706. Since #10486, pressing Tab in a note pans to the new note, and on a narrow viewport clicking the first note during that pan ended editing instead of moving focus into it, which is the Mobile Chrome flake in `test-focus.spec.ts`.

### Before

`_setCamera` dispatches a synthetic `pointer_move` after every camera write so tools track the camera. The drag threshold compares `originPagePoint` to `currentPagePoint`, and a camera moving under a stationary pointer shifts the current page point, so a held-still click crossed the threshold and the state chart went to `translating` or `brushing`. Every programmatic camera move triggered it: zoom-to-selection, zoom-to-fit, follow-user, a fling that's still sliding, plain `setCamera`.

### After

When the camera moves on its own while the pointer is down and not yet dragging, `_setCamera` re-derives `originPagePoint` from `originScreenPoint` under the new camera. The synthetic move then measures zero travel, so a click stays a click, and a real drag that starts after the camera settles is measured from where the pointer actually is instead of from pre-pan coordinates.

Wheel-driven camera moves are the one exception: holding the pointer and scrolling is a deliberate way to extend a brush selection off screen (`Begins dragging from wheel` in `Editor.test.tsx`), so the two wheel calls pass `fromWheel: true` and skip the re-anchor.

The e2e test now waits for the camera to settle and clicks the first note element instead of `body`, so it no longer depends on animation timing.

### Change type

- [x] `bugfix`

### Test plan

1. In the browser console run `editor.user.updateUserPreferences({ animationSpeed: 0.05 })` so the animation is long enough to click into.
2. Draw a filled rectangle, deselect, press shift+1, and mouse-down on the rectangle mid-animation without moving. On `main` the rectangle jumps by the pan distance; with this change it is selected.
3. Create a note near the right edge of the window so the Tab-created note lands off screen, type, press Tab, and click the first note during the pan. On `main` editing ends and the note is dragged; with this change editing moves into the first note.

- [x] Unit tests — the new tests in `dragDuringCameraAnimation.test.ts` fail on `main` and pass with this change
- [x] End to end tests — `test-focus.spec.ts` hardened

### Release notes

- Fix a click during a camera animation, follow, or fling being treated as a drag

### API changes

- Added `@internal` `InputsManager.updateOriginPagePointFromCamera()`

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +30 / -1   |
| Tests           | +142 / -1  |
| Automated files | +2 / -0    |
