### PR TITLE
test(mcp-app): poll for idle expiry outcomes instead of sleeping

### DIFF
--- a/apps/mcp-app/src/idle-expiry.test.ts
+++ b/apps/mcp-app/src/idle-expiry.test.ts
@@ -21,6 +21,20 @@ import {
 // (60s) still pushes the next one out, so we only assert the row survived.
 const IDLE_TTL_MS = 3000
 
+// Alarm delivery under wrangler dev is not tied to the schedule time: on a
+// loaded runner the condemn + destroy chain has landed 8s past the TTL (#10709).
+const ALARM_DEADLINE_MS = 20_000
+
+async function waitFor<T>(probe: () => Promise<T | undefined>, what: string): Promise<T> {
+	const deadline = Date.now() + ALARM_DEADLINE_MS
+	for (;;) {
+		const value = await probe()
+		if (value !== undefined) return value
+		if (Date.now() > deadline) throw new Error(`timed out after ${ALARM_DEADLINE_MS}ms: ${what}`)
+		await new Promise((res) => setTimeout(res, 500))
+	}
+}
+
 describe('session DO idle expiry', () => {
 	const port = 8700 + (process.pid % 500)
 	let server: WranglerDevHandle | null = null
@@ -78,27 +92,29 @@ describe('session DO idle expiry', () => {
 		const [first] = await schedules(sessionId)
 		expect(first).toBeDefined()
 
-		// the TTL alarm fires inside this wait; the session was active seconds ago
-		// so expireIfIdle keeps it and must re-arm
-		await new Promise((res) => setTimeout(res, IDLE_TTL_MS + 2500))
-
-		const rows = await schedules(sessionId)
-		expect(rows).toHaveLength(1)
-		expect(rows[0].id).not.toBe(first.id)
-		expect(rows[0].time).toBeGreaterThan(first.time)
+		// the TTL alarm fires during this wait; the session was active seconds ago
+		// so expireIfIdle keeps it and must re-arm. The old row is deleted only after
+		// the callback returns, so both rows are briefly visible: wait for exactly one.
+		const [replacement] = await waitFor(async () => {
+			const current = await schedules(sessionId)
+			return current.length === 1 && current[0].id !== first.id ? current : undefined
+		}, 'expiry row replaced after the first alarm fire')
+		expect(replacement.time).toBeGreaterThan(first.time)
 	}, 30_000)
 
 	test('a session that never saves is destroyed by its own expiry alarm', async () => {
 		// No checkpoint means no lastActivity, which reads as maximally idle: the
 		// first alarm condemns it, and the subsequent destroy alarm wipes it.
 		const sessionId = await initSession(base(), 'idle-expiry')
-		await new Promise((res) => setTimeout(res, IDLE_TTL_MS + 5000))
-
-		const after = await mcpPost(
-			base(),
-			{ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} },
-			sessionId
-		)
-		expect(after.status).toBe(404)
+		const status = await waitFor(async () => {
+			const res = await mcpPost(
+				base(),
+				{ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} },
+				sessionId
+			)
+			await res.text()
+			return res.status === 200 ? undefined : res.status
+		}, 'session destroyed after the expiry alarm')
+		expect(status).toBe(404)
 	}, 30_000)
 })


### PR DESCRIPTION
This PR fixes a flaky test where the mcp-app idle-expiry suite intermittently reports a session as still alive after its idle TTL, knocking unrelated PRs out of the merge queue. Closes #10709.

### Before

`idle-expiry.test.ts` slept a fixed margin past `IDLE_TTL_MS` and then asserted once. Teardown takes two alarms in sequence (the `expireIfIdle` schedule condemns the DO, the next alarm runs `destroy()`), and under `wrangler dev` alarm delivery is not tied to the schedule time. In the merge-queue run for #10248 the file's total time was normal, yet the "never saves" case still got a 200 after 8s. The sibling re-arm case has the same shape with a tighter margin.

### After

Both alarm-driven cases poll for the outcome to a 20s deadline: the destroy case polls `tools/list` until it stops returning 200, the re-arm case polls `/admin/schedules` until exactly one row with a new id is present. A miss now fails with a named timeout instead of `expected 200 to be 404`.

### Implementation notes

Polling keeps the real SDK alarm ordering under test, which is what this file exists to guard. Driving the alarm chain through a dev-only route would have made it deterministic but would no longer catch the SDK re-arm-then-delete ordering bug the header comment describes. The re-arm predicate waits for exactly one row because the SDK inserts the replacement before deleting the executing row, so a poll can briefly see both. Polling `tools/list` is safe because `lastActivity` only updates on checkpoint saves.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `cd apps/mcp-app && yarn test run src/idle-expiry.test.ts` looped locally, all alarm cases green

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +30 / -16  |
