### PR TITLE
fix(dotcom): give the user-row preload 30s and name the stalled stage

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -34,7 +34,7 @@ describe('TldrawApp.preload', () => {
 			const rejected = vi.fn()
 			void app.preload().catch(rejected)
 
-			await vi.advanceTimersByTimeAsync(10_000)
+			await vi.advanceTimersByTimeAsync(30_000)
 
 			expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
 			expect(vi.getTimerCount()).toBe(0)
@@ -46,7 +46,7 @@ describe('TldrawApp.preload', () => {
 		const rejected = vi.fn()
 		void app.preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(10_000)
+		await vi.advanceTimersByTimeAsync(30_000)
 
 		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
 	})
@@ -56,7 +56,7 @@ describe('TldrawApp.preload', () => {
 		const rejected = vi.fn()
 		void createAppStub({ queryComplete }).preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(9_000)
+		await vi.advanceTimersByTimeAsync(29_000)
 		queryComplete.resolve()
 		await vi.advanceTimersByTimeAsync(999)
 		expect(rejected).not.toHaveBeenCalled()
@@ -66,15 +66,19 @@ describe('TldrawApp.preload', () => {
 		expect(vi.getTimerCount()).toBe(0)
 	})
 
-	it('times out a missing user after a successful init', async () => {
+	it.each([
+		['zero query', { queryComplete: promiseWithResolve<void>() }],
+		['state flush', { changesFlushed: promiseWithResolve<void>() }],
+		['user record', {}],
+	])('names the stalled %s stage after a successful init', async (stage, stub) => {
 		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
 		const rejected = vi.fn()
-		void createAppStub().preload().catch(rejected)
+		void createAppStub(stub).preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(10_000)
+		await vi.advanceTimersByTimeAsync(30_000)
 
 		expect(rejected).toHaveBeenCalledWith(
-			new Error('Timed out waiting for the user record after init')
+			new Error(`Timed out waiting for the ${stage} after init`)
 		)
 	})
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -73,7 +73,7 @@ import { updateLocalSessionState } from '../utils/local-session-state'
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
 
-const USER_PRELOAD_TIMEOUT_MS = 10_000
+const USER_PRELOAD_TIMEOUT_MS = 30_000
 
 let appId = 0
 
@@ -389,16 +389,20 @@ export class TldrawApp {
 		// already exists should still load through a transient worker error.
 		const initError = res.ok ? undefined : new Error(`Init failed: ${res.status}`)
 		// Zero's query can itself stall, so the deadline must cover it as well as the user row.
+		// The stage is in the error so Sentry can tell a slow Zero sync from a row that never arrived.
+		let stage: 'zero query' | 'state flush' | 'user record' = 'zero query'
 		const timedOut = promiseWithResolve<never>()
 		let stopWaiting: (() => void) | undefined
 		const timeout = setTimeout(
 			() =>
-				timedOut.reject(initError ?? new Error('Timed out waiting for the user record after init')),
+				timedOut.reject(initError ?? new Error(`Timed out waiting for the ${stage} after init`)),
 			USER_PRELOAD_TIMEOUT_MS
 		)
 		try {
 			await Promise.race([this.z.preload(queries.user()).complete, timedOut])
+			stage = 'state flush'
 			await Promise.race([this.changesFlushed, timedOut])
+			stage = 'user record'
 			const userLoaded = promiseWithResolve<void>()
 			stopWaiting = react('wait for user', () => {
 				if (this.user$.get()) userLoaded.resolve()

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -89,7 +89,11 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 		})().catch((err) => {
 			if (didCancel) return
 			console.error('[AppState] Failed to initialize:', err)
-			captureException(err)
+			// Default grouping keys on the stack, which every preload timeout shares; the message
+			// carries the stalled stage or init status, so group on it.
+			captureException(err, {
+				fingerprint: ['{{ default }}', err instanceof Error ? err.message : String(err)],
+			})
 			setError(err)
 		})
 


### PR DESCRIPTION
This PR fixes a bug where users on slow connections get the "Something went wrong" error page instead of the app.

### Before

#10311 capped the user-row wait in `TldrawApp.preload` at 10s and surfaced the timeout as an error page. That deadline covers the Zero WebSocket connect, IDB open, and the first user query sync, which on a slow link can take longer than 10s even when `/init` returned 200. Since it shipped this morning, Sentry has ~800 events from ~500 users, at a steady rate across the day rather than a spike. The error message also didn't say which of the three waits stalled, so it wasn't possible to tell a slow sync from a row that never replicated.

### After

The deadline is 30s, and the timeout error names the stalled stage: `zero query`, `state flush`, or `user record`. Bootstrap errors are also fingerprinted on their message in `AppStateProvider`, since the default stack-based grouping put every preload timeout in one issue; the three stages and the `Init failed: <status>` variants now show up as separate Sentry issues.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the stage tests fail on `main` and pass with this change

### Release notes

- Fix an error page on slow connections when opening tldraw.com

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +11 / -3   |
| Tests   | +11 / -7   |
