### PR TITLE
fix(editor): stop the camera animation on pointer down so a click stays a click

### DIFF
--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -221,7 +221,6 @@ test.describe('Focus', () => {
 		// the locator resolves it before clicking.
 		await page.waitForFunction(() => editor.getCameraState() === 'idle')
 
-		// Click back into the first note
 		await page.locator('.tl-shape').first().click()
 
 		await page.waitForTimeout(1000)

--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect } from '@playwright/test'
 import { Editor } from 'tldraw'
 
+declare const editor: Editor
 declare const EDITOR_A: Editor
 declare const EDITOR_B: Editor
 declare const EDITOR_C: Editor
@@ -214,8 +215,14 @@ test.describe('Focus', () => {
 
 		// create new note next to it
 		await page.keyboard.press('Tab')
+		await expect(page.locator('.tl-shape')).toHaveCount(2)
 
-		await (await page.$('body'))?.click()
+		// Tab pans to the new note; let the camera settle so the first note is where
+		// the locator resolves it before clicking.
+		await page.waitForFunction(() => editor.getCameraState() === 'idle')
+
+		// Click back into the first note
+		await page.locator('.tl-shape').first().click()
 
 		await page.waitForTimeout(1000)
 

--- a/apps/examples/e2e/tests/test-focus.spec.ts
+++ b/apps/examples/e2e/tests/test-focus.spec.ts
@@ -212,6 +212,8 @@ test.describe('Focus', () => {
 		await (await page.$('body'))?.click()
 		await page.waitForSelector('.tl-shape')
 		await page.keyboard.type('test')
+		const firstNoteId = await page.evaluate(() => editor.getEditingShapeId())
+		const firstNote = page.locator(`.tl-shape[data-shape-id="${firstNoteId}"]`)
 
 		// create new note next to it
 		await page.keyboard.press('Tab')
@@ -221,14 +223,12 @@ test.describe('Focus', () => {
 		// the locator resolves it before clicking.
 		await page.waitForFunction(() => editor.getCameraState() === 'idle')
 
-		await page.locator('.tl-shape').first().click()
+		await firstNote.click()
 
 		await page.waitForTimeout(1000)
 
-		// First note's contenteditable should be focused.
-		expect(
-			await EditorA.evaluate(() => !!document.querySelector('.tl-shape div[contenteditable]:focus'))
-		).toBe(true)
+		// The first note, not the one Tab created, should be the focused one.
+		await expect(firstNote.locator('div[contenteditable]')).toBeFocused()
 	})
 
 	test('exits edit mode when dragging from text label with blurred input', async ({ page }) => {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11346,6 +11346,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 						inputs.setIsPointing(true)
 						inputs.setIsDragging(false)
 
+						// A camera still animating under a held pointer would shift the page
+						// point past the drag threshold and turn a click into a drag (#10706)
+						this.stopCameraAnimation()
+
 						// If pen mode is off, turn it on for direct-display pen input only (e.g. Apple
 						// Pencil on an iPad or a Surface Pen on a touchscreen). Indirect desktop tablet
 						// styluses still draw as pens, but should not auto-enable pen mode.

--- a/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
+++ b/packages/tldraw/src/test/dragDuringCameraAnimation.test.ts
@@ -1,0 +1,114 @@
+import { Box, createShapeId } from '@tldraw/editor'
+import { startEditingAdjacentNote } from '../lib/shapes/note/noteHelpers'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.user.updateUserPreferences({ animationSpeed: 1 })
+})
+
+function startPan() {
+	editor.setCamera({ x: 500, y: 500, z: 1 }, { animation: { duration: 200 } })
+	editor.forceTick(2)
+	expect(editor.getCameraState()).toBe('moving')
+}
+
+describe('pointer down during a camera animation (#10706)', () => {
+	it('stops the animation where it is', () => {
+		startPan()
+		editor.pointerDown(100, 100)
+		const cameraAtPointerDown = editor.getCamera()
+
+		editor.forceTick(20)
+
+		expect(editor.getCameraState()).toBe('idle')
+		expect(editor.getCamera()).toMatchObject({ x: cameraAtPointerDown.x, y: cameraAtPointerDown.y })
+		expect(editor.getCamera()).not.toMatchObject({ x: 500, y: 500 })
+	})
+
+	it('does not start a drag while the pointer is held still', () => {
+		startPan()
+		editor.pointerDown(100, 100)
+		editor.forceTick(20)
+
+		expect(editor.inputs.getIsDragging()).toBe(false)
+		expect(editor.getPath()).toBe('select.pointing_canvas')
+	})
+
+	it('still treats the interaction as a click on a shape', () => {
+		const id = createShapeId()
+		editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100, fill: 'solid' } })
+
+		startPan()
+		const point = editor.pageToScreen({ x: 50, y: 50 })
+		editor.pointerDown(point.x, point.y)
+		editor.forceTick(20)
+		editor.pointerUp()
+
+		expect(editor.getSelectedShapeIds()).toEqual([id])
+		expect(editor.getShape(id)).toMatchObject({ x: 0, y: 0 })
+		expect(editor.getPath()).toBe('select.idle')
+	})
+
+	it('still starts a drag once the pointer itself moves past the threshold', () => {
+		startPan()
+		editor.pointerDown(100, 100)
+		editor.forceTick(20)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+
+		editor.pointerMove(110, 110)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+	})
+
+	it('stops a fling', () => {
+		editor.slideCamera({ speed: 5, direction: { x: 1, y: 1 }, friction: 0.01 })
+		editor.forceTick(2)
+		expect(editor.getCameraState()).toBe('moving')
+
+		editor.pointerDown(100, 100)
+		const cameraAtPointerDown = editor.getCamera()
+		editor.forceTick(20)
+
+		expect(editor.getCameraState()).toBe('idle')
+		expect(editor.getCamera()).toMatchObject({ x: cameraAtPointerDown.x, y: cameraAtPointerDown.y })
+		expect(editor.inputs.getIsDragging()).toBe(false)
+	})
+})
+
+describe('clicking a note while the camera pans to an adjacent note (#10706)', () => {
+	it('moves editing into the clicked note instead of dragging it', () => {
+		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+		const a = createShapeId('a')
+		const b = createShapeId('b')
+		editor.createShapes([
+			{ id: a, type: 'note', x: 100, y: 100 },
+			{ id: b, type: 'note', x: 1500, y: 100 },
+		])
+
+		// What Tab does: edit the new note and pan to it, since it is off screen
+		startEditingAdjacentNote(editor, editor.getShape(b)!)
+		editor.expectToBeIn('select.editing_shape')
+		editor.forceTick(2)
+		expect(editor.getCameraState()).toBe('moving')
+
+		const point = editor.pageToScreen({ x: 200, y: 200 })
+		editor.pointerDown(point.x, point.y)
+		editor.forceTick(20)
+		editor.pointerUp()
+
+		expect(editor.getEditingShapeId()).toBe(a)
+		expect(editor.getShape(a)).toMatchObject({ x: 100, y: 100 })
+	})
+})
+
+describe('pointer held still while the user scrolls the wheel', () => {
+	it('starts a drag once the camera has moved past the threshold', () => {
+		editor.pointerDown(100, 100)
+		editor.wheel(2, 2)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+		editor.wheel(10, 10)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+	})
+})


### PR DESCRIPTION
This PR fixes a bug where a click made while the camera is animating registered as a drag. Closes #10706. Since #10486, pressing Tab in a note pans to the new note, and on a narrow viewport clicking during that pan ended editing and moved the note instead of moving focus into it, which is the Mobile Chrome flake in `test-focus.spec.ts`. Supersedes #10711, which re-anchored the drag origin instead.

### Before

`_setCamera` dispatches a synthetic `pointer_move` after every camera write. The drag threshold compares `originPagePoint` to `currentPagePoint`, and a camera moving under a stationary pointer shifts the current page point, so a held-still pointer crossed the threshold and the state chart went to `translating` or `brushing`. Wheel, pinch, middle-mouse pan, and right-click pan already called `stopCameraAnimation()` before moving the camera, but a plain left `pointer_down` did not, so zoom-to-selection, zoom-to-fit, the Tab pan, and a fling that was still sliding all kept running underneath the click.

### After

`pointer_down` calls `stopCameraAnimation()`, which cancels the viewport animation or slide. The camera stays where it was when the pointer went down, the synthetic move measures zero travel, and the click stays a click. A real drag started afterwards is measured from where the pointer actually is. As a side effect, touching the canvas during a fling stops the momentum, which matches native scroll views.

### Implementation notes

Following a user is not stopped on `pointer_down`: it is not a camera animation in the `stop-camera-animation` sense, and stopping it on every tap would break follow mode on touch. A click while following can still drift for the same reason. An animation that starts after the pointer is already down (a keyboard shortcut while holding the mouse) is also not covered. Both are left as is.

The e2e test now waits for the camera to settle, clicks the first note by its `data-shape-id`, and asserts that note's editor is the focused one. Even with the fix, the `body` click was timing dependent: its centre only overlaps the first note before the pan has progressed, and afterwards it lands on the new note. Shape DOM order is not creation order either, so `.tl-shape` `.first()` is the wrong target, and the old any-shape focus assertion let a click on the new note pass.

### Change type

- [x] `bugfix`

### Test plan

1. In the browser console run `editor.user.updateUserPreferences({ animationSpeed: 0.05 })` so the animation is long enough to click into.
2. Draw a filled rectangle, deselect, press shift+1, and mouse-down on the rectangle mid-animation without moving. On `main` the rectangle jumps by the pan distance; with this change the camera stops and the rectangle is selected.
3. Create a note near the right edge of the window so the Tab-created note lands off screen, type, press Tab, and click the first note during the pan. On `main` editing ends and the note is dragged; with this change editing moves into the first note.

- [x] Unit tests — 6 of the 7 new tests in `dragDuringCameraAnimation.test.ts` fail on `main` and all pass with this change
- [x] End to end tests — `test-focus.spec.ts` hardened; 100/100 on Mobile Chrome before the id-targeting change, 25/25 on both Mobile Chrome and chromium after

### Release notes

- Fix a click during a camera animation or fling being treated as a drag

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -0    |
| Tests     | +125 / -5  |
