### PR TITLE
[HOTFIX] fix(dotcom): give the user-row preload 30s and name the stalled stage

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -34,7 +34,7 @@ describe('TldrawApp.preload', () => {
 			const rejected = vi.fn()
 			void app.preload().catch(rejected)
 
-			await vi.advanceTimersByTimeAsync(10_000)
+			await vi.advanceTimersByTimeAsync(30_000)
 
 			expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
 			expect(vi.getTimerCount()).toBe(0)
@@ -46,7 +46,7 @@ describe('TldrawApp.preload', () => {
 		const rejected = vi.fn()
 		void app.preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(10_000)
+		await vi.advanceTimersByTimeAsync(30_000)
 
 		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
 	})
@@ -56,7 +56,7 @@ describe('TldrawApp.preload', () => {
 		const rejected = vi.fn()
 		void createAppStub({ queryComplete }).preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(9_000)
+		await vi.advanceTimersByTimeAsync(29_000)
 		queryComplete.resolve()
 		await vi.advanceTimersByTimeAsync(999)
 		expect(rejected).not.toHaveBeenCalled()
@@ -66,15 +66,19 @@ describe('TldrawApp.preload', () => {
 		expect(vi.getTimerCount()).toBe(0)
 	})
 
-	it('times out a missing user after a successful init', async () => {
+	it.each([
+		['zero query', { queryComplete: promiseWithResolve<void>() }],
+		['state flush', { changesFlushed: promiseWithResolve<void>() }],
+		['user record', {}],
+	])('names the stalled %s stage after a successful init', async (stage, stub) => {
 		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
 		const rejected = vi.fn()
-		void createAppStub().preload().catch(rejected)
+		void createAppStub(stub).preload().catch(rejected)
 
-		await vi.advanceTimersByTimeAsync(10_000)
+		await vi.advanceTimersByTimeAsync(30_000)
 
 		expect(rejected).toHaveBeenCalledWith(
-			new Error('Timed out waiting for the user record after init')
+			new Error(`Timed out waiting for the ${stage} after init`)
 		)
 	})
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -72,7 +72,7 @@ import { updateLocalSessionState } from '../utils/local-session-state'
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
 
-const USER_PRELOAD_TIMEOUT_MS = 10_000
+const USER_PRELOAD_TIMEOUT_MS = 30_000
 
 let appId = 0
 
@@ -412,16 +412,20 @@ export class TldrawApp {
 			if (!res.ok) initError = new Error(`Init failed: ${res.status}`)
 		}
 		// Zero's query can itself stall, so the deadline must cover it as well as the user row.
+		// The stage is in the error so Sentry can tell a slow Zero sync from a row that never arrived.
+		let stage: 'zero query' | 'state flush' | 'user record' = 'zero query'
 		const timedOut = promiseWithResolve<never>()
 		let stopWaiting: (() => void) | undefined
 		const timeout = setTimeout(
 			() =>
-				timedOut.reject(initError ?? new Error('Timed out waiting for the user record after init')),
+				timedOut.reject(initError ?? new Error(`Timed out waiting for the ${stage} after init`)),
 			USER_PRELOAD_TIMEOUT_MS
 		)
 		try {
 			await Promise.race([this.z.preload(this.userQuery()).complete, timedOut])
+			stage = 'state flush'
 			await Promise.race([this.changesFlushed, timedOut])
+			stage = 'user record'
 			const userLoaded = promiseWithResolve<void>()
 			stopWaiting = react('wait for user', () => {
 				if (this.user$.get()) userLoaded.resolve()

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -95,7 +95,11 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 		})().catch((err) => {
 			if (didCancel) return
 			console.error('[AppState] Failed to initialize:', err)
-			captureException(err)
+			// Default grouping keys on the stack, which every preload timeout shares; the message
+			// carries the stalled stage or init status, so group on it.
+			captureException(err, {
+				fingerprint: ['{{ default }}', err instanceof Error ? err.message : String(err)],
+			})
 			setError(err)
 		})
 


### PR DESCRIPTION
This is a manual hotfix PR for dotcom deployment. The automated cherry-pick conflicted because `hotfixes` doesn't have #10072 (`this.userQuery()` vs `queries.user()`); resolved by keeping the `hotfixes` call.

**Original PR:** [#10713](https://github.com/tldraw/tldraw/pull/10713)
**Original Title:** fix(dotcom): give the user-row preload 30s and name the stalled stage
**Original Author:** @MitjaBezensek

This PR cherry-picks the changes from the original PR to the hotfixes branch for immediate dotcom deployment.
