### PR TITLE
fix(mcp-app): keep the destroy alarm off the running alarm's timestamp

### DIFF
--- a/apps/mcp-app/src/agents-canary.test.ts
+++ b/apps/mcp-app/src/agents-canary.test.ts
@@ -46,6 +46,9 @@ describe('agents SDK assumptions behind session idle expiry', () => {
 	it('_scheduleNextAlarmBody short-circuits to setAlarm(now) when the destroy marker is set (so the condemn setAlarm cannot be clobbered)', () => {
 		const body = between(agentsDist, 'async _scheduleNextAlarmBody() {', 'const nowMs = Date.now()')
 		expect(body).toContain('_hasPendingDestroy()')
+		// setAlarm(Date.now()) can equal the running alarm's own time and get
+		// dropped; TldrawMCP.alarm() moves it. If the SDK starts adding its
+		// DESTROY_ALARM_DELAY_MS here, that override can go.
 		expect(body).toContain('setAlarm(Date.now())')
 	})
 

--- a/apps/mcp-app/src/idle-expiry.test.ts
+++ b/apps/mcp-app/src/idle-expiry.test.ts
@@ -31,7 +31,9 @@ async function waitFor<T>(probe: () => Promise<T | undefined>, what: string): Pr
 		const value = await probe()
 		if (value !== undefined) return value
 		if (Date.now() > deadline) throw new Error(`timed out after ${ALARM_DEADLINE_MS}ms: ${what}`)
-		await new Promise((res) => setTimeout(res, 500))
+		// 1s keeps a full deadline of polls under the worker's 30 req/min
+		// per-session rate limit.
+		await new Promise((res) => setTimeout(res, 1000))
 	}
 }
 
@@ -113,7 +115,8 @@ describe('session DO idle expiry', () => {
 				sessionId
 			)
 			await res.text()
-			return res.status === 200 ? undefined : res.status
+			// 429 is the rate limiter, not the DO: keep waiting
+			return res.status === 200 || res.status === 429 ? undefined : res.status
 		}, 'session destroyed after the expiry alarm')
 		expect(status).toBe(404)
 	}, 30_000)

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -45,6 +45,12 @@ interface Env {
 	IDLE_TTL_MS_OVERRIDE?: string
 }
 
+/**
+ * Grace period before a condemned object's alarm runs destroy(). Also keeps that
+ * alarm off the running alarm's own timestamp: see TldrawMCP.alarm.
+ */
+const DESTROY_ALARM_DELAY_MS = 1000
+
 // Gated on MCP_IS_DEV so no deployed env can shorten the TTL. idle-expiry.test.ts
 // needs it: the real TTL is seven days, and the test has to see an alarm fire.
 function idleTtlMs(env: Env): number {
@@ -377,6 +383,22 @@ export class TldrawMCP extends McpAgent<Env> {
 	}
 
 	/**
+	 * After a schedule callback condemns this object, the SDK re-arms the destroy
+	 * alarm with `setAlarm(Date.now())`. Inside an alarm handler `Date.now()` is
+	 * frozen until the next I/O, and the handler can start on the scheduled
+	 * millisecond itself, so that write can equal the running alarm's time. An
+	 * unchanged alarm is a no-op to storage, and the alarm scheduler then drops
+	 * the alarm when the handler returns: the object stays condemned forever
+	 * (#10709). Moving the alarm a full delay out is always a real change.
+	 */
+	override async alarm() {
+		await super.alarm()
+		if (await this.ctx.storage.get('cf_agents_destroy_pending')) {
+			await this.ctx.storage.setAlarm(Date.now() + DESTROY_ALARM_DELAY_MS)
+		}
+	}
+
+	/**
 	 * Condemns this DO if it has been idle for `maxIdleMs`, and reports whether it
 	 * was kept. Never calls destroy() inline: it writes the SDK's own durable
 	 * destroy marker, and Agent.alarm() runs destroy() from its marker branch, which
@@ -388,7 +410,7 @@ export class TldrawMCP extends McpAgent<Env> {
 	 * The setAlarm calls are a fallback. The SDK re-arms after every schedule
 	 * callback returns, and that path sees the marker and calls `setAlarm(now)`
 	 * itself, so any delay we asked for is overwritten — these writes only matter
-	 * if that re-arm never runs.
+	 * if that re-arm never runs. `alarm()` above then moves whichever value won.
 	 */
 	async destroyIfIdle(maxIdleMs: number): Promise<{ kept: boolean }> {
 		if (await this.ctx.storage.get('cf_agents_destroy_pending')) {


### PR DESCRIPTION
This PR fixes a bug where an idle mcp-app session DO is condemned but never destroyed, which surfaced as the idle-expiry test intermittently seeing a 200 after the TTL (#10709). #10712 only changed the failure message: with polling to a 20s deadline the suite still failed 4 times in 100 local runs, every time with the session still alive.

### Before

`expireIfIdle` fires, `destroyIfIdle` writes the SDK's `cf_agents_destroy_pending` marker, and after the callback returns the SDK's `_scheduleNextAlarmBody` sees the marker and re-arms with `setAlarm(Date.now())`. Inside an alarm handler `Date.now()` is frozen until the next I/O, and under `wrangler dev` the handler starts on the scheduled millisecond itself, so that write can equal the running alarm's own time. An unchanged alarm is a no-op to storage, the local alarm scheduler never hears about it, and it deletes its entry when the handler completes. The DO's metadata still says an alarm is set, nothing will ever fire it, and the session stays condemned forever.

Instrumented wrangler logs from 60 sessions: the 2 that were never destroyed both re-armed at exactly the scheduled time. The 58 that were destroyed had all re-armed 1–2ms later.

| | scheduled | re-armed at |
| --- | --- | --- |
| lost (2/60) | T | T |
| destroyed (58/60) | T | T+1..2ms |

### After

`TldrawMCP.alarm()` runs the SDK's alarm, then if the destroy marker is set moves the alarm to `Date.now() + 1000`, the same delay the SDK uses on its own `_cf_scheduleDestroy` path. That is always a real change, so the scheduler picks it up. Across 100 instrumented sessions, 12 hit the exact-millisecond case and all 12 were destroyed. The idle-expiry test passed 100/100 runs in a row.

### Implementation notes

The override runs after `super.alarm()` rather than changing `destroyIfIdle`'s own `setAlarm`, because the SDK overwrites that value on the way out. Fixing the final state is the only placement that does not depend on which write wins.

The canary test that pins `_scheduleNextAlarmBody`'s `setAlarm(Date.now())` now says why: when the SDK adds its delay there, the override can go. Worth reporting upstream to both `agents` (use `DESTROY_ALARM_DELAY_MS` on the marker branch) and `workerd` (a `setAlarm` to the running alarm's time from inside the handler is silently dropped by the local scheduler).

Also in the test: poll at 1s instead of 500ms and treat 429 as "not yet", since a 20s deadline at 500ms exceeds the worker's 30 req/min per-session rate limit.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — `cd apps/mcp-app && yarn test run src/idle-expiry.test.ts` looped 100 times: 100 pass. On `main` the same loop fails ~4/100.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +23 / -1   |
| Tests   | +8 / -2    |
