### PR TITLE
chore(dotcom): give fly deploys a longer wait-timeout

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   deploy:
     name: Deploy dotcom to ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') || 'preview'  }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest-16-cores-arm-open
     environment: ${{ github.ref == 'refs/heads/production' && 'deploy-production' || 'deploy-staging' }}
     concurrency: dotcom-${{ github.ref == 'refs/heads/production' && 'deploy-production' || github.ref }}

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -307,6 +307,11 @@ const zeroVmSizes = {
 	preview: { single: { cpus: 2, memory: '2gb' } },
 } as const
 
+// flyctl's default --wait-timeout is 2m, counted from the start of the machine
+// update. A stop can legitimately take up to killTimeout (5m) before the new VM
+// even boots, so give the health-check wait room for a full stop + boot.
+const flyDeployWaitTimeout = '10m'
+
 const zeroConnectionLimits = {
 	staging: {
 		rm: { upstream: 1, cvr: 1, change: 3 },
@@ -864,9 +869,19 @@ async function deployZeroViaFlyIoMultiNode() {
 		],
 		{ pwd: zeroCacheFolder }
 	)
-	await exec('flyctl', ['deploy', '-a', flyioReplAppName, '-c', 'flyio-replication-manager.toml'], {
-		pwd: zeroCacheFolder,
-	})
+	await exec(
+		'flyctl',
+		[
+			'deploy',
+			'-a',
+			flyioReplAppName,
+			'-c',
+			'flyio-replication-manager.toml',
+			'--wait-timeout',
+			flyDeployWaitTimeout,
+		],
+		{ pwd: zeroCacheFolder }
+	)
 
 	// Deploy view syncer with reference to replication manager
 	const replManagerUri = `http://${flyioReplAppName}.internal:4849`
@@ -896,9 +911,19 @@ async function deployZeroViaFlyIoMultiNode() {
 		],
 		{ pwd: zeroCacheFolder }
 	)
-	await exec('flyctl', ['deploy', '-a', flyioAppName, '-c', 'flyio-view-syncer.toml'], {
-		pwd: zeroCacheFolder,
-	})
+	await exec(
+		'flyctl',
+		[
+			'deploy',
+			'-a',
+			flyioAppName,
+			'-c',
+			'flyio-view-syncer.toml',
+			'--wait-timeout',
+			flyDeployWaitTimeout,
+		],
+		{ pwd: zeroCacheFolder }
+	)
 	assert('vsMinMachines' in zeroVm, 'multi-node VM sizes required')
 	await exec(
 		'flyctl',


### PR DESCRIPTION
This PR fixes a bug where a production hotfix deploy died with `timeout reached waiting for health checks to pass for machine …` while redeploying the zero replication manager, even though the machine came up healthy seconds later.

### Before

`flyctl deploy` ran with its default `--wait-timeout` of 2m, counted from the start of the machine update. The RM and VS machines have `kill_timeout = 5m` so the old VM can drain and release `/data`, which means a stop alone can eat most of the 2m budget. In [run 34373366806](https://github.com/tldraw/tldraw/actions/runs/34373366806) the old RM took ~1m30s to stop (repeated `error umounting /data: EBUSY`), the new one was serving at +2m03s, and flyctl gave up at +2m00s. flyctl then hung after `Clearing lease` until the 15m job timeout cancelled the run, so view-syncers, sync-worker and client were never deployed.

### After

RM and VS deploys pass `--wait-timeout 10m`, enough for a full 5m stop plus boot. The job timeout goes 15m -> 30m so the longer flyctl wait can actually be used rather than being cut off by the job.

### Change type

- [x] `bugfix`

### Test plan

1. Land via hotfix and watch the production deploy complete.

### Release notes

- Internal deploy tooling only.
