### PR TITLE
chore(dotcom): notify discord when the deploy job is cancelled

### DIFF
--- a/.github/actions/discord-fail-notify/action.yml
+++ b/.github/actions/discord-fail-notify/action.yml
@@ -5,6 +5,10 @@ inputs:
   webhook-url:
     description: Discord webhook URL
     required: true
+  status:
+    description: What happened to the workflow, used in the message verb
+    required: false
+    default: failed
 
 runs:
   using: composite
@@ -15,6 +19,7 @@ runs:
         DISCORD_WEBHOOK_URL: ${{ inputs.webhook-url }}
         WORKFLOW: ${{ github.workflow }}
         REF: ${{ github.ref_name }}
+        STATUS: ${{ inputs.status }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         if [ -z "$DISCORD_WEBHOOK_URL" ]; then
@@ -22,6 +27,6 @@ runs:
           exit 0
         fi
         payload=$(jq -nc \
-          --arg content "<@&1414904550917144586> ❌ **${WORKFLOW}** failed on \`${REF}\`: <${RUN_URL}>" \
+          --arg content "<@&1414904550917144586> ❌ **${WORKFLOW}** ${STATUS} on \`${REF}\`: <${RUN_URL}>" \
           '{content: $content}')
         curl -fsS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -200,3 +200,12 @@ jobs:
           ZERO_R2_SECRET_ACCESS_KEY: ${{ secrets.ZERO_R2_SECRET_ACCESS_KEY }}
           ZERO_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT }}
           ZERO_OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.ZERO_OTEL_EXPORTER_OTLP_HEADERS }}
+
+      # The deploy script posts its own "Deploy failed" message, but a job timeout
+      # kills it without running that handler, so cover the cancelled case here.
+      - name: Notify Discord on cancelled deploy
+        if: cancelled() && github.event_name == 'push'
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+          status: was cancelled (job timeout?)


### PR DESCRIPTION
This PR fixes a bug where a production dotcom deploy that hit the job timeout posted nothing to Discord.

### Before

`deploy-dotcom.ts` posts `Deploy failed` from its own catch handler, but a job timeout cancels the job and kills the process without running it. In [run 34373366806](https://github.com/tldraw/tldraw/actions/runs/34373366806) flyctl hung after a health-check error until the 15m timeout, the run ended as `cancelled`, and the deploy channel stayed quiet even though the hotfix never shipped.

### After

The workflow runs the existing `discord-fail-notify` action when the job is cancelled on a push (staging or production), with a `status` input so the message reads `Deploy .com was cancelled (job timeout?)` instead of `failed`. Script failures keep their existing message so we don't double-post.

### Change type

- [x] `bugfix`

### Test plan

1. Cancel a staging deploy run and check the deploy channel.

### Release notes

- Internal deploy tooling only.
