### PR TITLE
chore(dotcom): skip the zero-cache fly deploy when its inputs are unchanged

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -148,6 +148,9 @@ jobs:
         env:
           RELEASE_COMMIT_HASH: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
+          # Set this variable to "true" on the GitHub environment to redeploy zero-cache even when its
+          # inputs are unchanged (see internal/scripts/lib/flyDeployGate.ts), then clear it.
+          ZERO_FORCE_DEPLOY: ${{ vars.ZERO_FORCE_DEPLOY || 'false' }}
 
           APP_ORIGIN: ${{ vars.APP_ORIGIN }}
           ASSET_UPLOAD: ${{ vars.ASSET_UPLOAD }}

--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -1,6 +1,4 @@
 app = "__APP_NAME"
-# Bump this number to force a redeploy of this app when nothing else changed, for example after
-# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 kill_timeout = "__KILL_TIMEOUT"
 
@@ -47,6 +45,6 @@ OTEL_TRACES_EXPORTER = "none"
 DO_NOT_TRACK = "1"
 OTEL_NODE_RESOURCE_DETECTORS = "env,host,os"
 OTEL_RESOURCE_ATTRIBUTES = "service.name=zero-rm,service.namespace=dotcom,deployment.environment=__TLDRAW_ENV,service.version=__ZERO_VERSION"
-# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
-# can tell whether the running machines already match and skip the deploy.
+# Read back by flyDeployGate.ts to skip a deploy whose inputs are unchanged. Bump the marker to
+# force one: marker 1
 TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -1,4 +1,6 @@
 app = "__APP_NAME"
+# Bump this number to force a redeploy of this app when nothing else changed, for example after
+# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 kill_timeout = "__KILL_TIMEOUT"
 
@@ -45,3 +47,6 @@ OTEL_TRACES_EXPORTER = "none"
 DO_NOT_TRACK = "1"
 OTEL_NODE_RESOURCE_DETECTORS = "env,host,os"
 OTEL_RESOURCE_ATTRIBUTES = "service.name=zero-rm,service.namespace=dotcom,deployment.environment=__TLDRAW_ENV,service.version=__ZERO_VERSION"
+# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
+# can tell whether the running machines already match and skip the deploy.
+TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
+++ b/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
@@ -1,6 +1,4 @@
 app = "__APP_NAME"
-# Bump this number to force a redeploy of this app when nothing else changed, for example after
-# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 kill_timeout = "__KILL_TIMEOUT"
 
@@ -54,6 +52,6 @@ OTEL_RESOURCE_ATTRIBUTES = "service.name=zero-vs,service.namespace=dotcom,deploy
 ZERO_LITESTREAM_CONFIG_PATH = "/etc/litestream.yml"
 ZERO_LITESTREAM_BACKUP_URL = "s3://__ZERO_R2_BUCKET_NAME/__BACKUP_PATH"
 ZERO_LITESTREAM_ENDPOINT = "__ZERO_R2_ENDPOINT"
-# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
-# can tell whether the running machines already match and skip the deploy.
+# Read back by flyDeployGate.ts to skip a deploy whose inputs are unchanged. Bump the marker to
+# force one: marker 1
 TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
+++ b/apps/dotcom/zero-cache/flyio-view-syncer.template.toml
@@ -1,4 +1,6 @@
 app = "__APP_NAME"
+# Bump this number to force a redeploy of this app when nothing else changed, for example after
+# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 kill_timeout = "__KILL_TIMEOUT"
 
@@ -52,3 +54,6 @@ OTEL_RESOURCE_ATTRIBUTES = "service.name=zero-vs,service.namespace=dotcom,deploy
 ZERO_LITESTREAM_CONFIG_PATH = "/etc/litestream.yml"
 ZERO_LITESTREAM_BACKUP_URL = "s3://__ZERO_R2_BUCKET_NAME/__BACKUP_PATH"
 ZERO_LITESTREAM_ENDPOINT = "__ZERO_R2_ENDPOINT"
+# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
+# can tell whether the running machines already match and skip the deploy.
+TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/apps/dotcom/zero-cache/flyio.template.toml
+++ b/apps/dotcom/zero-cache/flyio.template.toml
@@ -1,4 +1,6 @@
 app = "__APP_NAME"
+# Bump this number to force a redeploy of this app when nothing else changed, for example after
+# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 
 [build]
@@ -44,3 +46,6 @@ ZERO_QUERY_URL = "__ZERO_QUERY_URL"
 ZERO_ENABLE_CRUD_MUTATIONS = "false"
 ZERO_LAZY_STARTUP = 'true'
 DO_NOT_TRACK = '1'
+# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
+# can tell whether the running machines already match and skip the deploy.
+TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/apps/dotcom/zero-cache/flyio.template.toml
+++ b/apps/dotcom/zero-cache/flyio.template.toml
@@ -1,6 +1,4 @@
 app = "__APP_NAME"
-# Bump this number to force a redeploy of this app when nothing else changed, for example after
-# the base image was re-tagged under the same version. See flyDeployGate.ts. deploy marker: 1
 primary_region = "fra"
 
 [build]
@@ -46,6 +44,6 @@ ZERO_QUERY_URL = "__ZERO_QUERY_URL"
 ZERO_ENABLE_CRUD_MUTATIONS = "false"
 ZERO_LAZY_STARTUP = 'true'
 DO_NOT_TRACK = '1'
-# Stamped by deploy-dotcom.ts with the hash of every input that shaped this deploy, so the next run
-# can tell whether the running machines already match and skip the deploy.
+# Read back by flyDeployGate.ts to skip a deploy whose inputs are unchanged. Bump the marker to
+# force one: marker 1
 TLDRAW_DEPLOY_INPUT_HASH = "__DEPLOY_INPUT_HASH"

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -766,15 +766,16 @@ async function deployFlyAppIfChanged({
 }) {
 	const forced = env.ZERO_FORCE_DEPLOY === 'true' || !!previewId
 	const hash = hashFlyDeployInputs(inputs)
-	const deployedHash = forced ? null : await getDeployedInputHash(appName)
-	if (deployedHash === hash) {
+	const deployed = forced ? null : await getDeployedInputHash(appName)
+	if (deployed?.hash === hash) {
 		nicelog(`${appName}: deploy inputs unchanged (${hash.slice(0, 12)}), skipping fly deploy`)
 		await discord.message(`${appName}: deploy inputs unchanged, skipping fly deploy`)
 		return
 	}
-	nicelog(
-		`${appName}: deploying (${deployedHash?.slice(0, 12) ?? 'no stamp'} -> ${hash.slice(0, 12)}${forced ? ', forced' : ''})`
-	)
+	const from = !deployed
+		? 'not checked'
+		: (deployed.hash?.slice(0, 12) ?? `no stamp: ${deployed.reason}`)
+	nicelog(`${appName}: deploying (${from} -> ${hash.slice(0, 12)}${forced ? ', forced' : ''})`)
 	fs.writeFileSync(
 		path.join(zeroCacheFolder, configFile),
 		stampDeployInputHash(inputs.config, hash),

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -17,6 +17,12 @@ import {
 import { Discord } from './lib/discord'
 import { exec } from './lib/exec'
 import { REPO_ROOT } from './lib/file'
+import {
+	FlyDeployInputs,
+	getDeployedInputHash,
+	hashFlyDeployInputs,
+	stampDeployInputHash,
+} from './lib/flyDeployGate'
 import { makeEnv } from './lib/makeEnv'
 import { nicelog } from './lib/nicelog'
 
@@ -707,16 +713,13 @@ function withStatementTimeout(connString: string): string {
 	return `${connString}${separator}statement_timeout=1800000`
 }
 
-function updateFlyioToml(appName: string): void {
+function renderFlyioToml(appName: string): string {
 	assert('single' in zeroConns, 'single-node connection limits required')
 	const tomlTemplate = path.join(zeroCacheFolder, 'flyio.template.toml')
-	const flyioTomlFile = path.join(zeroCacheFolder, 'flyio.toml')
-
 	const fileContent = fs.readFileSync(tomlTemplate, 'utf-8')
-
 	const zeroAdminPassword = env.ZERO_ADMIN_PASSWORD
 
-	const updatedContent = fileContent
+	return fileContent
 		.replace('__APP_NAME', appName)
 		.replace('__ZERO_VERSION', zeroVersion)
 		.replaceAll(
@@ -729,35 +732,71 @@ function updateFlyioToml(appName: string): void {
 		.replaceAll('__SINGLE_UPSTREAM_MAX_CONNS', String(zeroConns.single.upstream))
 		.replaceAll('__SINGLE_CVR_MAX_CONNS', String(zeroConns.single.cvr))
 		.replaceAll('__SINGLE_CHANGE_MAX_CONNS', String(zeroConns.single.change))
+}
 
-	fs.writeFileSync(flyioTomlFile, updatedContent, 'utf-8')
+async function ensureFlyApp(appName: string, existingApps: string) {
+	if (existingApps.indexOf(appName) === -1) {
+		await exec('flyctl', ['app', 'create', appName, '-o', 'tldraw-gb-ltd'], {
+			pwd: zeroCacheFolder,
+		})
+	}
+}
+
+// Deploys the app unless its running machines were produced by exactly these inputs. Every
+// `flyctl deploy` rebuilds the image and replaces every machine, which bounces every connected Zero
+// client, and most dotcom deploys don't touch zero-cache at all. See flyDeployGate.ts.
+async function deployFlyAppIfChanged({
+	appName,
+	configFile,
+	inputs,
+}: {
+	appName: string
+	configFile: string
+	inputs: FlyDeployInputs
+}) {
+	const hash = hashFlyDeployInputs(inputs)
+	const deployedHash = await getDeployedInputHash(appName)
+	if (deployedHash === hash) {
+		nicelog(`${appName}: deploy inputs unchanged (${hash.slice(0, 12)}), skipping fly deploy`)
+		await discord.message(`${appName}: deploy inputs unchanged, skipping fly deploy`)
+		return
+	}
+	nicelog(
+		`${appName}: deploy inputs changed (${deployedHash?.slice(0, 12) ?? 'none'} -> ${hash.slice(0, 12)})`
+	)
+	fs.writeFileSync(
+		path.join(zeroCacheFolder, configFile),
+		stampDeployInputHash(inputs.config, hash),
+		'utf-8'
+	)
+	if (inputs.dockerfile) {
+		fs.writeFileSync(path.join(zeroCacheFolder, 'Dockerfile'), inputs.dockerfile.content, 'utf-8')
+	}
+	await exec('flyctl', ['deploy', '-a', appName, '-c', configFile], { pwd: zeroCacheFolder })
 }
 
 async function deployZeroViaFlyIo() {
 	if (!flyioAppName) {
 		throw new Error('Fly.io app name is not defined')
 	}
-	updateFlyioToml(flyioAppName)
 	const apps = await exec('flyctl', ['apps', 'list', '-o', 'tldraw-gb-ltd'])
-	if (apps.indexOf(flyioAppName) === -1) {
-		await exec('flyctl', ['app', 'create', flyioAppName, '-o', 'tldraw-gb-ltd'], {
-			pwd: zeroCacheFolder,
-		})
-	}
-	await exec('flyctl', ['deploy', '-a', flyioAppName, '-c', 'flyio.toml'], { pwd: zeroCacheFolder })
+	await ensureFlyApp(flyioAppName, apps)
+	await deployFlyAppIfChanged({
+		appName: flyioAppName,
+		configFile: 'flyio.toml',
+		inputs: { config: renderFlyioToml(flyioAppName) },
+	})
 }
 
 // See https://zero.rocicorp.dev/docs/deployment for Zero deployment config reference
-function updateFlyioReplicationManagerToml(appName: string, backupPath: string): void {
+function renderFlyioReplicationManagerToml(appName: string, backupPath: string): string {
 	assert('rm' in zeroConns, 'multi-node connection limits required')
 	assert('rm' in zeroVm, 'multi-node VM sizes required')
 	const tomlTemplate = path.join(zeroCacheFolder, 'flyio-replication-manager.template.toml')
-	const flyioTomlFile = path.join(zeroCacheFolder, 'flyio-replication-manager.toml')
-
 	const fileContent = fs.readFileSync(tomlTemplate, 'utf-8')
 	const zeroAdminPassword = env.ZERO_ADMIN_PASSWORD
 
-	const updatedContent = fileContent
+	return fileContent
 		.replaceAll('__APP_NAME', appName)
 		.replaceAll('__BACKUP_PATH', backupPath)
 		.replace('__ZERO_VERSION', zeroVersion)
@@ -777,24 +816,20 @@ function updateFlyioReplicationManagerToml(appName: string, backupPath: string):
 		.replaceAll('__KILL_TIMEOUT', zeroVm.killTimeout)
 		.replaceAll('__TLDRAW_ENV', env.TLDRAW_ENV)
 		.replaceAll('__ZERO_VERSION', zeroVersion)
-
-	fs.writeFileSync(flyioTomlFile, updatedContent, 'utf-8')
 }
 
-function updateFlyioViewSyncerToml(
+function renderFlyioViewSyncerToml(
 	appName: string,
 	replManagerUri: string,
 	backupPath: string
-): void {
+): string {
 	assert('vs' in zeroConns, 'multi-node connection limits required')
 	assert('vs' in zeroVm, 'multi-node VM sizes required')
 	const tomlTemplate = path.join(zeroCacheFolder, 'flyio-view-syncer.template.toml')
-	const flyioTomlFile = path.join(zeroCacheFolder, 'flyio-view-syncer.toml')
-
 	const fileContent = fs.readFileSync(tomlTemplate, 'utf-8')
 	const zeroAdminPassword = env.ZERO_ADMIN_PASSWORD
 
-	const updatedContent = fileContent
+	return fileContent
 		.replaceAll('__APP_NAME', appName)
 		.replaceAll('__BACKUP_PATH', backupPath)
 		.replace('__ZERO_VERSION', zeroVersion)
@@ -818,15 +853,32 @@ function updateFlyioViewSyncerToml(
 		.replaceAll('__KILL_TIMEOUT', zeroVm.killTimeout)
 		.replaceAll('__TLDRAW_ENV', env.TLDRAW_ENV)
 		.replaceAll('__ZERO_VERSION', zeroVersion)
+}
 
-	fs.writeFileSync(flyioTomlFile, updatedContent, 'utf-8')
-
-	// Also process the Dockerfile template to inject the Zero version
+// The view-syncer image; the replication manager runs the stock Zero image.
+function renderDockerfile(): string {
 	const dockerfileTemplate = path.join(zeroCacheFolder, 'Dockerfile.template')
-	const dockerfilePath = path.join(zeroCacheFolder, 'Dockerfile')
-	const dockerfileContent = fs.readFileSync(dockerfileTemplate, 'utf-8')
-	const updatedDockerfile = dockerfileContent.replace('__ZERO_VERSION', zeroVersion)
-	fs.writeFileSync(dockerfilePath, updatedDockerfile, 'utf-8')
+	return fs.readFileSync(dockerfileTemplate, 'utf-8').replace('__ZERO_VERSION', zeroVersion)
+}
+
+function zeroFlySecrets(): string[] {
+	return [
+		`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_ADMIN_PASSWORD=${env.ZERO_ADMIN_PASSWORD}`,
+		// Zero uses the AWS SDK to talk to R2 (S3-compatible), so it expects AWS_* env vars
+		`AWS_ACCESS_KEY_ID=${env.ZERO_R2_ACCESS_KEY_ID}`,
+		`AWS_SECRET_ACCESS_KEY=${env.ZERO_R2_SECRET_ACCESS_KEY}`,
+		`OTEL_EXPORTER_OTLP_ENDPOINT=${env.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT}`,
+		`OTEL_EXPORTER_OTLP_HEADERS=${env.ZERO_OTEL_EXPORTER_OTLP_HEADERS}`,
+	]
+}
+
+async function stageZeroFlySecrets(appName: string, secrets: string[]) {
+	await exec('flyctl', ['secrets', 'set', '--stage', ...secrets, '-a', appName], {
+		pwd: zeroCacheFolder,
+	})
 }
 
 async function deployZeroViaFlyIoMultiNode() {
@@ -835,69 +887,30 @@ async function deployZeroViaFlyIoMultiNode() {
 	}
 
 	const apps = await exec('flyctl', ['apps', 'list', '-o', 'tldraw-gb-ltd'])
+	const backupPath = previewId ?? env.TLDRAW_ENV
+	const secrets = zeroFlySecrets()
 
 	// Deploy replication manager first
-	const backupPath = previewId ?? env.TLDRAW_ENV
-	updateFlyioReplicationManagerToml(flyioReplAppName, backupPath)
-	if (apps.indexOf(flyioReplAppName) === -1) {
-		await exec('flyctl', ['app', 'create', flyioReplAppName, '-o', 'tldraw-gb-ltd'], {
-			pwd: zeroCacheFolder,
-		})
-	}
-	await exec(
-		'flyctl',
-		[
-			'secrets',
-			'set',
-			'--stage',
-			`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_ADMIN_PASSWORD=${env.ZERO_ADMIN_PASSWORD}`,
-			// Zero uses the AWS SDK to talk to R2 (S3-compatible), so it expects AWS_* env vars
-			`AWS_ACCESS_KEY_ID=${env.ZERO_R2_ACCESS_KEY_ID}`,
-			`AWS_SECRET_ACCESS_KEY=${env.ZERO_R2_SECRET_ACCESS_KEY}`,
-			`OTEL_EXPORTER_OTLP_ENDPOINT=${env.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT}`,
-			`OTEL_EXPORTER_OTLP_HEADERS=${env.ZERO_OTEL_EXPORTER_OTLP_HEADERS}`,
-			'-a',
-			flyioReplAppName,
-		],
-		{ pwd: zeroCacheFolder }
-	)
-	await exec('flyctl', ['deploy', '-a', flyioReplAppName, '-c', 'flyio-replication-manager.toml'], {
-		pwd: zeroCacheFolder,
+	await ensureFlyApp(flyioReplAppName, apps)
+	await stageZeroFlySecrets(flyioReplAppName, secrets)
+	await deployFlyAppIfChanged({
+		appName: flyioReplAppName,
+		configFile: 'flyio-replication-manager.toml',
+		inputs: { config: renderFlyioReplicationManagerToml(flyioReplAppName, backupPath), secrets },
 	})
 
 	// Deploy view syncer with reference to replication manager
 	const replManagerUri = `http://${flyioReplAppName}.internal:4849`
-	updateFlyioViewSyncerToml(flyioAppName, replManagerUri, backupPath)
-	if (apps.indexOf(flyioAppName) === -1) {
-		await exec('flyctl', ['app', 'create', flyioAppName, '-o', 'tldraw-gb-ltd'], {
-			pwd: zeroCacheFolder,
-		})
-	}
-	await exec(
-		'flyctl',
-		[
-			'secrets',
-			'set',
-			'--stage',
-			`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-			`ZERO_ADMIN_PASSWORD=${env.ZERO_ADMIN_PASSWORD}`,
-			// Zero uses the AWS SDK to talk to R2 (S3-compatible), so it expects AWS_* env vars
-			`AWS_ACCESS_KEY_ID=${env.ZERO_R2_ACCESS_KEY_ID}`,
-			`AWS_SECRET_ACCESS_KEY=${env.ZERO_R2_SECRET_ACCESS_KEY}`,
-			`OTEL_EXPORTER_OTLP_ENDPOINT=${env.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT}`,
-			`OTEL_EXPORTER_OTLP_HEADERS=${env.ZERO_OTEL_EXPORTER_OTLP_HEADERS}`,
-			'-a',
-			flyioAppName,
-		],
-		{ pwd: zeroCacheFolder }
-	)
-	await exec('flyctl', ['deploy', '-a', flyioAppName, '-c', 'flyio-view-syncer.toml'], {
-		pwd: zeroCacheFolder,
+	await ensureFlyApp(flyioAppName, apps)
+	await stageZeroFlySecrets(flyioAppName, secrets)
+	await deployFlyAppIfChanged({
+		appName: flyioAppName,
+		configFile: 'flyio-view-syncer.toml',
+		inputs: {
+			config: renderFlyioViewSyncerToml(flyioAppName, replManagerUri, backupPath),
+			dockerfile: { content: renderDockerfile(), contextDir: zeroCacheFolder },
+			secrets,
+		},
 	})
 	assert('vsMinMachines' in zeroVm, 'multi-node VM sizes required')
 	await exec(

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -744,10 +744,12 @@ async function ensureFlyApp(appName: string, appsListOutput: string) {
 }
 
 // Most dotcom deploys don't touch zero-cache; see flyDeployGate.ts for why redeploying anyway
-// hurts. The gate compares this run's inputs to the stamp on the machines, not to the machines'
-// actual state, so a change made out of band (`fly secrets set`, `fly scale`) stays unreconciled
-// until an input changes. Set the ZERO_FORCE_DEPLOY variable on the GitHub environment to push a
-// deploy through regardless.
+// hurts. Staging and production only: a preview has no connected clients to bounce, and its zero
+// app can need rebuilding for reasons no input covers, like a reset preview database leaving the
+// replica stale. The gate compares this run's inputs to the stamp on the machines, not to the
+// machines' actual state, so a change made out of band (`fly secrets set`, `fly scale`) stays
+// unreconciled until an input changes. Set the ZERO_FORCE_DEPLOY variable on the GitHub
+// environment to push a deploy through regardless.
 async function deployFlyAppIfChanged({
 	appName,
 	configFile,
@@ -757,10 +759,10 @@ async function deployFlyAppIfChanged({
 	configFile: string
 	inputs: FlyDeployInputs
 }) {
+	const forced = env.ZERO_FORCE_DEPLOY === 'true' || !!previewId
 	const hash = hashFlyDeployInputs(inputs)
-	const deployedHash = await getDeployedInputHash(appName)
-	const forced = env.ZERO_FORCE_DEPLOY === 'true'
-	if (deployedHash === hash && !forced) {
+	const deployedHash = forced ? null : await getDeployedInputHash(appName)
+	if (deployedHash === hash) {
 		nicelog(`${appName}: deploy inputs unchanged (${hash.slice(0, 12)}), skipping fly deploy`)
 		await discord.message(`${appName}: deploy inputs unchanged, skipping fly deploy`)
 		return

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -111,6 +111,11 @@ const env = makeEnv([
 	'ZERO_OTEL_EXPORTER_OTLP_HEADERS',
 ])
 
+assert(
+	env.ZERO_FORCE_DEPLOY === 'true' || env.ZERO_FORCE_DEPLOY === 'false',
+	'ZERO_FORCE_DEPLOY must be true or false'
+)
+
 // Multinode (flyio-multinode) is for staging + production, previews use single as it is faster / cheaper
 const deployZero =
 	env.DEPLOY_ZERO === 'false'

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -102,6 +102,7 @@ const env = makeEnv([
 	'PLAIN_WORKSPACE_ID',
 	'DEPLOY_ZERO',
 	'ZERO_ADMIN_PASSWORD',
+	'ZERO_FORCE_DEPLOY',
 	'ZERO_R2_ENDPOINT',
 	'ZERO_R2_BUCKET_NAME',
 	'ZERO_R2_ACCESS_KEY_ID',
@@ -734,17 +735,19 @@ function renderFlyioToml(appName: string): string {
 		.replaceAll('__SINGLE_CHANGE_MAX_CONNS', String(zeroConns.single.change))
 }
 
-async function ensureFlyApp(appName: string, existingApps: string) {
-	if (existingApps.indexOf(appName) === -1) {
+async function ensureFlyApp(appName: string, appsListOutput: string) {
+	if (appsListOutput.indexOf(appName) === -1) {
 		await exec('flyctl', ['app', 'create', appName, '-o', 'tldraw-gb-ltd'], {
 			pwd: zeroCacheFolder,
 		})
 	}
 }
 
-// Deploys the app unless its running machines were produced by exactly these inputs. Every
-// `flyctl deploy` rebuilds the image and replaces every machine, which bounces every connected Zero
-// client, and most dotcom deploys don't touch zero-cache at all. See flyDeployGate.ts.
+// Most dotcom deploys don't touch zero-cache; see flyDeployGate.ts for why redeploying anyway
+// hurts. The gate compares this run's inputs to the stamp on the machines, not to the machines'
+// actual state, so a change made out of band (`fly secrets set`, `fly scale`) stays unreconciled
+// until an input changes. Set the ZERO_FORCE_DEPLOY variable on the GitHub environment to push a
+// deploy through regardless.
 async function deployFlyAppIfChanged({
 	appName,
 	configFile,
@@ -756,13 +759,14 @@ async function deployFlyAppIfChanged({
 }) {
 	const hash = hashFlyDeployInputs(inputs)
 	const deployedHash = await getDeployedInputHash(appName)
-	if (deployedHash === hash) {
+	const forced = env.ZERO_FORCE_DEPLOY === 'true'
+	if (deployedHash === hash && !forced) {
 		nicelog(`${appName}: deploy inputs unchanged (${hash.slice(0, 12)}), skipping fly deploy`)
 		await discord.message(`${appName}: deploy inputs unchanged, skipping fly deploy`)
 		return
 	}
 	nicelog(
-		`${appName}: deploy inputs changed (${deployedHash?.slice(0, 12) ?? 'none'} -> ${hash.slice(0, 12)})`
+		`${appName}: deploying (${deployedHash?.slice(0, 12) ?? 'no stamp'} -> ${hash.slice(0, 12)}${forced ? ', forced' : ''})`
 	)
 	fs.writeFileSync(
 		path.join(zeroCacheFolder, configFile),
@@ -770,7 +774,11 @@ async function deployFlyAppIfChanged({
 		'utf-8'
 	)
 	if (inputs.dockerfile) {
-		fs.writeFileSync(path.join(zeroCacheFolder, 'Dockerfile'), inputs.dockerfile.content, 'utf-8')
+		fs.writeFileSync(
+			path.join(inputs.dockerfile.contextDir, 'Dockerfile'),
+			inputs.dockerfile.content,
+			'utf-8'
+		)
 	}
 	await exec('flyctl', ['deploy', '-a', appName, '-c', configFile], { pwd: zeroCacheFolder })
 }
@@ -861,20 +869,6 @@ function renderDockerfile(): string {
 	return fs.readFileSync(dockerfileTemplate, 'utf-8').replace('__ZERO_VERSION', zeroVersion)
 }
 
-function zeroFlySecrets(): string[] {
-	return [
-		`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-		`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-		`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
-		`ZERO_ADMIN_PASSWORD=${env.ZERO_ADMIN_PASSWORD}`,
-		// Zero uses the AWS SDK to talk to R2 (S3-compatible), so it expects AWS_* env vars
-		`AWS_ACCESS_KEY_ID=${env.ZERO_R2_ACCESS_KEY_ID}`,
-		`AWS_SECRET_ACCESS_KEY=${env.ZERO_R2_SECRET_ACCESS_KEY}`,
-		`OTEL_EXPORTER_OTLP_ENDPOINT=${env.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT}`,
-		`OTEL_EXPORTER_OTLP_HEADERS=${env.ZERO_OTEL_EXPORTER_OTLP_HEADERS}`,
-	]
-}
-
 async function stageZeroFlySecrets(appName: string, secrets: string[]) {
 	await exec('flyctl', ['secrets', 'set', '--stage', ...secrets, '-a', appName], {
 		pwd: zeroCacheFolder,
@@ -888,7 +882,17 @@ async function deployZeroViaFlyIoMultiNode() {
 
 	const apps = await exec('flyctl', ['apps', 'list', '-o', 'tldraw-gb-ltd'])
 	const backupPath = previewId ?? env.TLDRAW_ENV
-	const secrets = zeroFlySecrets()
+	const secrets = [
+		`ZERO_UPSTREAM_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_CVR_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_CHANGE_DB=${withStatementTimeout(env.BOTCOM_POSTGRES_CONNECTION_STRING)}`,
+		`ZERO_ADMIN_PASSWORD=${env.ZERO_ADMIN_PASSWORD}`,
+		// Zero uses the AWS SDK to talk to R2 (S3-compatible), so it expects AWS_* env vars
+		`AWS_ACCESS_KEY_ID=${env.ZERO_R2_ACCESS_KEY_ID}`,
+		`AWS_SECRET_ACCESS_KEY=${env.ZERO_R2_SECRET_ACCESS_KEY}`,
+		`OTEL_EXPORTER_OTLP_ENDPOINT=${env.ZERO_OTEL_EXPORTER_OTLP_ENDPOINT}`,
+		`OTEL_EXPORTER_OTLP_HEADERS=${env.ZERO_OTEL_EXPORTER_OTLP_HEADERS}`,
+	]
 
 	// Deploy replication manager first
 	await ensureFlyApp(flyioReplAppName, apps)

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -148,6 +148,12 @@ describe('parseDeployedInputHash', () => {
 		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine(undefined)]))).toBe(null)
 	})
 
+	it('does not trust a stamp on a machine that has not reported a check yet', () => {
+		const noChecks = { state: 'started', config: { env: { [DEPLOY_INPUT_HASH_ENV]: 'abc' } } }
+		expect(parseDeployedInputHash(JSON.stringify([noChecks]))).toBe(null)
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc', { checks: [] })]))).toBe(null)
+	})
+
 	it('does not trust a stamp on a machine that is stopped or failing its checks', () => {
 		expect(
 			parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc', { state: 'stopped' })]))

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -105,22 +105,43 @@ describe('stampDeployInputHash', () => {
 })
 
 describe('parseDeployedInputHash', () => {
-	const machine = (hash: string | undefined, state = 'started') => ({
-		id: 'm',
+	const machine = (
+		hash: string | undefined,
+		{ state = 'started', checks = ['passing'] }: { state?: string; checks?: string[] } = {}
+	) => ({
 		state,
+		checks: checks.map((status) => ({ name: 'keepalive', status })),
 		config: { env: hash === undefined ? {} : { [DEPLOY_INPUT_HASH_ENV]: hash } },
 	})
 
-	it('returns the hash when every machine carries the same one', () => {
+	it('returns the hash when every machine is healthy and carries the same one', () => {
 		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc')]))).toBe('abc')
 	})
 
 	it('returns null for an app with no machines', () => {
 		expect(parseDeployedInputHash('[]')).toBe(null)
+		expect(parseDeployedInputHash('null')).toBe(null)
 	})
 
-	it('returns null when machines disagree or predate the stamp, so the deploy converges them', () => {
+	it('returns null when machines predate the stamp, so the first deploy after the change runs', () => {
+		expect(parseDeployedInputHash(JSON.stringify([machine(undefined), machine(undefined)]))).toBe(
+			null
+		)
+	})
+
+	it('returns null when machines disagree, so the deploy converges them', () => {
 		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('def')]))).toBe(null)
 		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine(undefined)]))).toBe(null)
+	})
+
+	it('does not trust a stamp on a machine that is stopped or failing its checks', () => {
+		expect(
+			parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc', { state: 'stopped' })]))
+		).toBe(null)
+		expect(
+			parseDeployedInputHash(
+				JSON.stringify([machine('abc'), machine('abc', { checks: ['passing', 'critical'] })])
+			)
+		).toBe(null)
 	})
 })

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -139,39 +139,54 @@ describe('parseDeployedInputHash', () => {
 	})
 
 	it('returns the hash when every machine is healthy and carries the same one', () => {
-		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc')]))).toBe('abc')
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc')]))).toEqual({
+			hash: 'abc',
+			reason: 'stamped',
+		})
 	})
 
 	it('returns null for an app with no machines', () => {
-		expect(parseDeployedInputHash('[]')).toBe(null)
-		expect(parseDeployedInputHash('null')).toBe(null)
+		expect(parseDeployedInputHash('[]')).toEqual({ hash: null, reason: 'no-machines' })
+		expect(parseDeployedInputHash('null')).toEqual({ hash: null, reason: 'no-machines' })
 	})
 
 	it('returns null when machines predate the stamp, so the first deploy after the change runs', () => {
-		expect(parseDeployedInputHash(JSON.stringify([machine(undefined), machine(undefined)]))).toBe(
-			null
-		)
+		expect(
+			parseDeployedInputHash(JSON.stringify([machine(undefined), machine(undefined)]))
+		).toEqual({ hash: null, reason: 'unstamped' })
 	})
 
 	it('returns null when machines disagree, so the deploy converges them', () => {
-		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('def')]))).toBe(null)
-		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine(undefined)]))).toBe(null)
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('def')]))).toEqual({
+			hash: null,
+			reason: 'mixed',
+		})
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine(undefined)]))).toEqual({
+			hash: null,
+			reason: 'mixed',
+		})
 	})
 
 	it('does not trust a stamp on a machine that has not reported a check yet', () => {
 		const noChecks = { state: 'started', config: { env: { [DEPLOY_INPUT_HASH_ENV]: 'abc' } } }
-		expect(parseDeployedInputHash(JSON.stringify([noChecks]))).toBe(null)
-		expect(parseDeployedInputHash(JSON.stringify([machine('abc', { checks: [] })]))).toBe(null)
+		expect(parseDeployedInputHash(JSON.stringify([noChecks]))).toEqual({
+			hash: null,
+			reason: 'unhealthy',
+		})
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc', { checks: [] })]))).toEqual({
+			hash: null,
+			reason: 'unhealthy',
+		})
 	})
 
 	it('does not trust a stamp on a machine that is stopped or failing its checks', () => {
 		expect(
 			parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc', { state: 'stopped' })]))
-		).toBe(null)
+		).toEqual({ hash: null, reason: 'unhealthy' })
 		expect(
 			parseDeployedInputHash(
 				JSON.stringify([machine('abc'), machine('abc', { checks: ['passing', 'critical'] })])
 			)
-		).toBe(null)
+		).toEqual({ hash: null, reason: 'unhealthy' })
 	})
 })

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -41,6 +41,20 @@ describe('dockerfileCopySources', () => {
 		const dockerfile = ['FROM a AS build', 'COPY --from=build /out /out', 'COPY x /x'].join('\n')
 		expect(dockerfileCopySources(dockerfile)).toEqual(['x'])
 	})
+
+	it('follows a line continuation to the sources on the wrapped lines', () => {
+		const dockerfile = [
+			'FROM rocicorp/zero:1.0.0',
+			'COPY nginx.conf.template \\',
+			'     supervisord.conf \\',
+			'     start.sh /etc/',
+		].join('\n')
+		expect(dockerfileCopySources(dockerfile)).toEqual([
+			'nginx.conf.template',
+			'supervisord.conf',
+			'start.sh',
+		])
+	})
 })
 
 describe('hashFlyDeployInputs', () => {

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -1,0 +1,126 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+	DEPLOY_INPUT_HASH_ENV,
+	DEPLOY_INPUT_HASH_PLACEHOLDER,
+	dockerfileCopySources,
+	hashFlyDeployInputs,
+	parseDeployedInputHash,
+	stampDeployInputHash,
+} from './flyDeployGate'
+
+function makeContext(files: Record<string, string>) {
+	const dir = mkdtempSync(path.join(tmpdir(), 'fly-gate-'))
+	for (const [rel, content] of Object.entries(files)) {
+		mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true })
+		writeFileSync(path.join(dir, rel), content)
+	}
+	return dir
+}
+
+describe('dockerfileCopySources', () => {
+	it('returns every source of COPY and ADD, dropping flags and the destination', () => {
+		const dockerfile = [
+			'FROM rocicorp/zero:1.0.0',
+			'COPY nginx.conf.template /etc/nginx/nginx.conf.template',
+			'COPY --chown=zero:zero start.sh supervisord.conf /',
+			'ADD docker/ /opt/docker',
+			'RUN chmod +x /start.sh',
+		].join('\n')
+		expect(dockerfileCopySources(dockerfile)).toEqual([
+			'nginx.conf.template',
+			'start.sh',
+			'supervisord.conf',
+			'docker/',
+		])
+	})
+
+	it('ignores sources copied from another build stage', () => {
+		const dockerfile = ['FROM a AS build', 'COPY --from=build /out /out', 'COPY x /x'].join('\n')
+		expect(dockerfileCopySources(dockerfile)).toEqual(['x'])
+	})
+})
+
+describe('hashFlyDeployInputs', () => {
+	it('is stable for identical inputs and changes with any input', () => {
+		const dir = makeContext({ 'start.sh': 'echo hi', 'conf/a.ini': 'a=1' })
+		const dockerfile = 'FROM x\nCOPY start.sh /start.sh\nCOPY conf /etc/conf'
+		const base = {
+			config: 'app = "x"\n[env]\nH = "__DEPLOY_INPUT_HASH"',
+			dockerfile: { content: dockerfile, contextDir: dir },
+			secrets: ['A=1', 'B=2'],
+		}
+		const hash = hashFlyDeployInputs(base)
+		expect(hash).toMatch(/^[0-9a-f]{64}$/)
+		expect(hashFlyDeployInputs(base)).toBe(hash)
+
+		expect(hashFlyDeployInputs({ ...base, config: base.config + '\n' })).not.toBe(hash)
+		expect(hashFlyDeployInputs({ ...base, secrets: ['A=1', 'B=3'] })).not.toBe(hash)
+		expect(
+			hashFlyDeployInputs({
+				...base,
+				dockerfile: { ...base.dockerfile, content: dockerfile + ' ' },
+			})
+		).not.toBe(hash)
+
+		writeFileSync(path.join(dir, 'conf/a.ini'), 'a=2')
+		expect(hashFlyDeployInputs(base)).not.toBe(hash)
+	})
+
+	it('ignores files the Dockerfile does not copy', () => {
+		const dir = makeContext({ 'start.sh': 'echo hi', 'unrelated.txt': 'x' })
+		const inputs = {
+			config: 'app = "x"',
+			dockerfile: { content: 'FROM x\nCOPY start.sh /start.sh', contextDir: dir },
+		}
+		const hash = hashFlyDeployInputs(inputs)
+		writeFileSync(path.join(dir, 'unrelated.txt'), 'y')
+		expect(hashFlyDeployInputs(inputs)).toBe(hash)
+	})
+
+	it('fails loudly when a copied source is missing rather than silently hashing less', () => {
+		const dir = makeContext({})
+		expect(() =>
+			hashFlyDeployInputs({
+				config: '',
+				dockerfile: { content: 'COPY missing.sh /', contextDir: dir },
+			})
+		).toThrow(/missing\.sh/)
+	})
+})
+
+describe('stampDeployInputHash', () => {
+	it('replaces the placeholder with the hash', () => {
+		const config = `[env]\n${DEPLOY_INPUT_HASH_ENV} = "${DEPLOY_INPUT_HASH_PLACEHOLDER}"\n`
+		expect(stampDeployInputHash(config, 'abc')).toBe(`[env]\n${DEPLOY_INPUT_HASH_ENV} = "abc"\n`)
+	})
+
+	it('refuses a config without the placeholder, since the gate would then never match', () => {
+		expect(() => stampDeployInputHash('[env]\nX = "1"\n', 'abc')).toThrow(
+			DEPLOY_INPUT_HASH_PLACEHOLDER
+		)
+	})
+})
+
+describe('parseDeployedInputHash', () => {
+	const machine = (hash: string | undefined, state = 'started') => ({
+		id: 'm',
+		state,
+		config: { env: hash === undefined ? {} : { [DEPLOY_INPUT_HASH_ENV]: hash } },
+	})
+
+	it('returns the hash when every machine carries the same one', () => {
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('abc')]))).toBe('abc')
+	})
+
+	it('returns null for an app with no machines', () => {
+		expect(parseDeployedInputHash('[]')).toBe(null)
+	})
+
+	it('returns null when machines disagree or predate the stamp, so the deploy converges them', () => {
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine('def')]))).toBe(null)
+		expect(parseDeployedInputHash(JSON.stringify([machine('abc'), machine(undefined)]))).toBe(null)
+	})
+})

--- a/internal/scripts/lib/flyDeployGate.test.ts
+++ b/internal/scripts/lib/flyDeployGate.test.ts
@@ -55,6 +55,16 @@ describe('dockerfileCopySources', () => {
 			'start.sh',
 		])
 	})
+
+	it('does not let a trailing backslash in a comment swallow the next instruction', () => {
+		const dockerfile = ['FROM x', '# see foo \\', 'COPY start.sh /start.sh', 'COPY b /b'].join('\n')
+		expect(dockerfileCopySources(dockerfile)).toEqual(['start.sh', 'b'])
+	})
+
+	it('throws on an instruction it cannot split into sources and a destination', () => {
+		const dockerfile = ['FROM x', 'COPY ["a","/b"]'].join('\n')
+		expect(() => dockerfileCopySources(dockerfile)).toThrow(/only plain paths are supported/i)
+	})
 })
 
 describe('hashFlyDeployInputs', () => {

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -80,6 +80,14 @@ export function dockerfileCopySources(dockerfile: string): string[] {
 		// `--from` copies from another build stage, not from the context.
 		if (tokens.some((token) => token.startsWith('--from'))) continue
 		const operands = tokens.filter((token) => !token.startsWith('--'))
+		// Anything the whitespace split can't separate into sources and a destination, such as the
+		// JSON-array form, would otherwise contribute nothing to the hash and never be missed.
+		if (operands.length < 2) {
+			throw new Error(
+				`Dockerfile instruction \`${line.trim()}\` does not split into sources and a destination. ` +
+					`Only plain paths are supported: no JSON-array COPY.`
+			)
+		}
 		for (const source of operands.slice(0, -1)) {
 			if (!sources.includes(source)) sources.push(source)
 		}
@@ -87,12 +95,13 @@ export function dockerfileCopySources(dockerfile: string): string[] {
 	return sources
 }
 
-// A trailing `\` continues an instruction on the next physical line. Without joining them first,
-// the sources on the wrapped lines never reach the COPY match and escape the hash.
+// A trailing `\` continues an instruction on the next physical line; without joining them first the
+// wrapped sources never reach the COPY match. Comments are dropped first, as Docker does, or a `\`
+// ending one would swallow the instruction below it.
 function joinContinuedLines(dockerfile: string): string[] {
 	const lines: string[] = []
 	let continued = ''
-	for (const line of dockerfile.split('\n')) {
+	for (const line of dockerfile.split('\n').filter((line) => !/^\s*#/.test(line))) {
 		const trimmed = line.trimEnd()
 		if (trimmed.endsWith('\\')) {
 			continued += trimmed.slice(0, -1)

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -137,8 +137,8 @@ export interface DeployedInputHash {
 }
 
 /**
- * The hash the running machines were deployed with, or null when they don't all agree on one, so
- * that the caller deploys and converges them.
+ * What the running machines were last deployed with, plus why the stamp is unusable when it is.
+ * See DeployedInputHash.
  *
  * A machine only counts when it is started and its checks pass, and a machine that has reported no
  * check yet does not count either. A rolling update writes the new config, stamp included, before

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -1,0 +1,120 @@
+import { createHash, Hash } from 'crypto'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import path from 'path'
+import { exec } from './exec'
+
+// Every `flyctl deploy` builds a fresh image and replaces every machine, which bounces every
+// client connected to the app, even when nothing that shapes the app has changed. This gate
+// hashes those inputs, stamps the hash into the app's [env], and reads it back from the running
+// machines on the next deploy so an unchanged app is left alone.
+//
+// Not covered: a base image re-tagged under the same version. Bump the marker comment in the
+// template to force a redeploy in that case.
+
+export const DEPLOY_INPUT_HASH_ENV = 'TLDRAW_DEPLOY_INPUT_HASH'
+export const DEPLOY_INPUT_HASH_PLACEHOLDER = '__DEPLOY_INPUT_HASH'
+
+export interface FlyDeployInputs {
+	/** The rendered fly config, with DEPLOY_INPUT_HASH_PLACEHOLDER still in place. */
+	config: string
+	/** The rendered Dockerfile and its build context, for apps that build an image. */
+	dockerfile?: { content: string; contextDir: string }
+	/**
+	 * Every value passed to `flyctl secrets set --stage`. Staged secrets only take effect on the
+	 * next deploy, so a changed secret must count as a changed input or it would never apply.
+	 */
+	secrets?: string[]
+}
+
+export function hashFlyDeployInputs(inputs: FlyDeployInputs): string {
+	const hash = createHash('sha256')
+	addPart(hash, 'config', inputs.config)
+	if (inputs.dockerfile) {
+		addPart(hash, 'dockerfile', inputs.dockerfile.content)
+		for (const source of dockerfileCopySources(inputs.dockerfile.content)) {
+			addPath(hash, inputs.dockerfile.contextDir, source)
+		}
+	}
+	for (const secret of inputs.secrets ?? []) {
+		addPart(hash, 'secret', secret)
+	}
+	return hash.digest('hex')
+}
+
+// Length-prefixed so that two parts can't be re-split into the same byte stream.
+function addPart(hash: Hash, label: string, value: string | Buffer) {
+	hash.update(`${label}:${Buffer.byteLength(value)}\n`)
+	hash.update(value)
+}
+
+function addPath(hash: Hash, contextDir: string, relativePath: string) {
+	const absolutePath = path.join(contextDir, relativePath)
+	let stat
+	try {
+		stat = statSync(absolutePath)
+	} catch {
+		throw new Error(
+			`Dockerfile copies ${relativePath} but it does not exist in the build context ${contextDir}`
+		)
+	}
+	if (stat.isDirectory()) {
+		for (const entry of readdirSync(absolutePath).sort()) {
+			addPath(hash, contextDir, path.join(relativePath, entry))
+		}
+		return
+	}
+	addPart(hash, `file:${relativePath}`, readFileSync(absolutePath))
+}
+
+/**
+ * The build-context sources of every COPY/ADD instruction. Parsed from the Dockerfile rather than
+ * listed by hand so a new COPY can't silently fall outside the hash.
+ */
+export function dockerfileCopySources(dockerfile: string): string[] {
+	const sources: string[] = []
+	for (const line of dockerfile.split('\n')) {
+		const match = line.match(/^\s*(?:COPY|ADD)\s+(.*)$/i)
+		if (!match) continue
+		const tokens = match[1].trim().split(/\s+/)
+		// `--from` copies from another build stage, not from the context.
+		if (tokens.some((token) => token.startsWith('--from'))) continue
+		const operands = tokens.filter((token) => !token.startsWith('--'))
+		for (const source of operands.slice(0, -1)) {
+			if (!sources.includes(source)) sources.push(source)
+		}
+	}
+	return sources
+}
+
+export function stampDeployInputHash(config: string, hash: string): string {
+	if (!config.includes(DEPLOY_INPUT_HASH_PLACEHOLDER)) {
+		throw new Error(
+			`Fly config has no ${DEPLOY_INPUT_HASH_PLACEHOLDER} placeholder; without it the deployed machines never carry the hash and the deploy gate never matches`
+		)
+	}
+	return config.replaceAll(DEPLOY_INPUT_HASH_PLACEHOLDER, hash)
+}
+
+/**
+ * The hash the running machines were deployed with, or null when they don't all agree on one
+ * (no machines yet, a deploy that predates the stamp, or a rollout that stopped half way), so
+ * that the caller deploys and converges them.
+ */
+export function parseDeployedInputHash(machineListJson: string): string | null {
+	const machines = JSON.parse(machineListJson) as {
+		config?: { env?: Record<string, string | undefined> }
+	}[]
+	if (machines.length === 0) return null
+	const hashes = new Set(machines.map((machine) => machine.config?.env?.[DEPLOY_INPUT_HASH_ENV]))
+	if (hashes.size !== 1) return null
+	const [hash] = hashes
+	return hash ?? null
+}
+
+export async function getDeployedInputHash(appName: string): Promise<string | null> {
+	const json = await exec('flyctl', ['machine', 'list', '-a', appName, '--json'], {
+		// The machine config echoes the app's [env]; keep it out of the deploy log.
+		processStdoutLine: () => {},
+	})
+	return parseDeployedInputHash(json)
+}

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -3,10 +3,10 @@ import { readdirSync, readFileSync, statSync } from 'fs'
 import path from 'path'
 import { exec } from './exec'
 
-// Every `flyctl deploy` builds a fresh image and replaces every machine, which bounces every
-// client connected to the app, even when nothing that shapes the app has changed. This gate
-// hashes those inputs, stamps the hash into the app's [env], and reads it back from the running
-// machines on the next deploy so an unchanged app is left alone.
+// Every `flyctl deploy` updates each machine in place, bouncing the clients connected to it, even
+// when nothing that shapes the app has changed. This gate stamps a hash of those inputs into the
+// app's [env] and reads it back from the running machines next time, so an unchanged app is left
+// alone. Only the view syncer builds an image; the rest run Zero's stock registry image.
 //
 // Not covered: a base image re-tagged under the same version, or a newer apk package. Bump the
 // marker in the template, or set ZERO_FORCE_DEPLOY, to redeploy in that case.

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -125,18 +125,21 @@ interface FlyMachine {
  * (no machines yet, a deploy that predates the stamp, or a rollout that stopped half way), so
  * that the caller deploys and converges them.
  *
- * A machine only counts when it is started and its checks pass. A rolling update writes the new
- * config, stamp included, before it waits on health, and a failed check does not revert it, so
- * without this a rollout that failed on its last machine would be skipped on the retry.
+ * A machine only counts when it is started and its checks pass, and a machine that has reported no
+ * check yet does not count either. A rolling update writes the new config, stamp included, before
+ * it waits on health, and a failed check does not revert it, so without this a rollout that failed
+ * on its last machine would be skipped on the retry.
  */
 export function parseDeployedInputHash(machineListJson: string): string | null {
 	const machines = (JSON.parse(machineListJson) ?? []) as FlyMachine[]
 	if (machines.length === 0) return null
 	const hashes = new Set<string | undefined>()
 	for (const machine of machines) {
+		const checks = machine.checks ?? []
 		const healthy =
 			machine.state === 'started' &&
-			(machine.checks ?? []).every((check) => check.status === 'passing')
+			checks.length > 0 &&
+			checks.every((check) => check.status === 'passing')
 		hashes.add(healthy ? machine.config?.env?.[DEPLOY_INPUT_HASH_ENV] : undefined)
 	}
 	if (hashes.size !== 1) return null

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -8,8 +8,8 @@ import { exec } from './exec'
 // hashes those inputs, stamps the hash into the app's [env], and reads it back from the running
 // machines on the next deploy so an unchanged app is left alone.
 //
-// Not covered: a base image re-tagged under the same version. Bump the marker comment in the
-// template to force a redeploy in that case.
+// Not covered: a base image re-tagged under the same version, or a newer apk package. Bump the
+// marker in the template, or set ZERO_FORCE_DEPLOY, to redeploy in that case.
 
 export const DEPLOY_INPUT_HASH_ENV = 'TLDRAW_DEPLOY_INPUT_HASH'
 export const DEPLOY_INPUT_HASH_PLACEHOLDER = '__DEPLOY_INPUT_HASH'
@@ -17,7 +17,7 @@ export const DEPLOY_INPUT_HASH_PLACEHOLDER = '__DEPLOY_INPUT_HASH'
 export interface FlyDeployInputs {
 	/** The rendered fly config, with DEPLOY_INPUT_HASH_PLACEHOLDER still in place. */
 	config: string
-	/** The rendered Dockerfile and its build context, for apps that build an image. */
+	/** COPY/ADD sources are resolved against contextDir and hashed too. */
 	dockerfile?: { content: string; contextDir: string }
 	/**
 	 * Every value passed to `flyctl secrets set --stage`. Staged secrets only take effect on the
@@ -54,7 +54,8 @@ function addPath(hash: Hash, contextDir: string, relativePath: string) {
 		stat = statSync(absolutePath)
 	} catch {
 		throw new Error(
-			`Dockerfile copies ${relativePath} but it does not exist in the build context ${contextDir}`
+			`Dockerfile copies ${relativePath} but it does not exist in the build context ${contextDir}. ` +
+				`Only plain paths are supported: no globs, JSON-array COPY, URLs, or line continuations.`
 		)
 	}
 	if (stat.isDirectory()) {
@@ -95,26 +96,42 @@ export function stampDeployInputHash(config: string, hash: string): string {
 	return config.replaceAll(DEPLOY_INPUT_HASH_PLACEHOLDER, hash)
 }
 
+interface FlyMachine {
+	state?: string
+	checks?: { status?: string }[]
+	config?: { env?: Record<string, string | undefined> }
+}
+
 /**
  * The hash the running machines were deployed with, or null when they don't all agree on one
  * (no machines yet, a deploy that predates the stamp, or a rollout that stopped half way), so
  * that the caller deploys and converges them.
+ *
+ * A machine only counts when it is started and its checks pass. A rolling update writes the new
+ * config, stamp included, before it waits on health, and a failed check does not revert it, so
+ * without this a rollout that failed on its last machine would be skipped on the retry.
  */
 export function parseDeployedInputHash(machineListJson: string): string | null {
-	const machines = JSON.parse(machineListJson) as {
-		config?: { env?: Record<string, string | undefined> }
-	}[]
+	const machines = (JSON.parse(machineListJson) ?? []) as FlyMachine[]
 	if (machines.length === 0) return null
-	const hashes = new Set(machines.map((machine) => machine.config?.env?.[DEPLOY_INPUT_HASH_ENV]))
+	const hashes = new Set<string | undefined>()
+	for (const machine of machines) {
+		const healthy =
+			machine.state === 'started' &&
+			(machine.checks ?? []).every((check) => check.status === 'passing')
+		hashes.add(healthy ? machine.config?.env?.[DEPLOY_INPUT_HASH_ENV] : undefined)
+	}
 	if (hashes.size !== 1) return null
 	const [hash] = hashes
 	return hash ?? null
 }
 
 export async function getDeployedInputHash(appName: string): Promise<string | null> {
-	const json = await exec('flyctl', ['machine', 'list', '-a', appName, '--json'], {
-		// The machine config echoes the app's [env]; keep it out of the deploy log.
-		processStdoutLine: () => {},
+	// Collected rather than logged: on the single-node app [env] holds ZERO_ADMIN_PASSWORD and the
+	// DB connection strings. Only stdout is parsed, so a flyctl warning on stderr can't break it.
+	const stdout: string[] = []
+	await exec('flyctl', ['machine', 'list', '-a', appName, '--json'], {
+		processStdoutLine: (line) => stdout.push(line),
 	})
-	return parseDeployedInputHash(json)
+	return parseDeployedInputHash(stdout.join('\n'))
 }

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -129,19 +129,27 @@ interface FlyMachine {
 	config?: { env?: Record<string, string | undefined> }
 }
 
+export interface DeployedInputHash {
+	/** The hash every running machine was deployed with, or null when the caller must deploy. */
+	hash: string | null
+	/** Why there is no usable hash, for the deploy log: a skipped deploy is hard to explain later. */
+	reason: 'stamped' | 'no-machines' | 'unstamped' | 'mixed' | 'unhealthy'
+}
+
 /**
- * The hash the running machines were deployed with, or null when they don't all agree on one
- * (no machines yet, a deploy that predates the stamp, or a rollout that stopped half way), so
+ * The hash the running machines were deployed with, or null when they don't all agree on one, so
  * that the caller deploys and converges them.
  *
  * A machine only counts when it is started and its checks pass, and a machine that has reported no
  * check yet does not count either. A rolling update writes the new config, stamp included, before
  * it waits on health, and a failed check does not revert it, so without this a rollout that failed
- * on its last machine would be skipped on the retry.
+ * on its last machine would be skipped on the retry. An unhealthy machine is reported as such
+ * rather than as a disagreement, so the log says a rollout is in flight instead of blaming the
+ * stamps.
  */
-export function parseDeployedInputHash(machineListJson: string): string | null {
+export function parseDeployedInputHash(machineListJson: string): DeployedInputHash {
 	const machines = (JSON.parse(machineListJson) ?? []) as FlyMachine[]
-	if (machines.length === 0) return null
+	if (machines.length === 0) return { hash: null, reason: 'no-machines' }
 	const hashes = new Set<string | undefined>()
 	for (const machine of machines) {
 		const checks = machine.checks ?? []
@@ -149,14 +157,16 @@ export function parseDeployedInputHash(machineListJson: string): string | null {
 			machine.state === 'started' &&
 			checks.length > 0 &&
 			checks.every((check) => check.status === 'passing')
-		hashes.add(healthy ? machine.config?.env?.[DEPLOY_INPUT_HASH_ENV] : undefined)
+		if (!healthy) return { hash: null, reason: 'unhealthy' }
+		hashes.add(machine.config?.env?.[DEPLOY_INPUT_HASH_ENV])
 	}
-	if (hashes.size !== 1) return null
+	if (hashes.size !== 1) return { hash: null, reason: 'mixed' }
 	const [hash] = hashes
-	return hash ?? null
+	if (hash === undefined) return { hash: null, reason: 'unstamped' }
+	return { hash, reason: 'stamped' }
 }
 
-export async function getDeployedInputHash(appName: string): Promise<string | null> {
+export async function getDeployedInputHash(appName: string): Promise<DeployedInputHash> {
 	// Collected rather than logged: on the single-node app [env] holds ZERO_ADMIN_PASSWORD and the
 	// DB connection strings. Only stdout is parsed, so a flyctl warning on stderr can't break it.
 	const stdout: string[] = []

--- a/internal/scripts/lib/flyDeployGate.ts
+++ b/internal/scripts/lib/flyDeployGate.ts
@@ -55,7 +55,7 @@ function addPath(hash: Hash, contextDir: string, relativePath: string) {
 	} catch {
 		throw new Error(
 			`Dockerfile copies ${relativePath} but it does not exist in the build context ${contextDir}. ` +
-				`Only plain paths are supported: no globs, JSON-array COPY, URLs, or line continuations.`
+				`Only plain paths are supported: no globs, JSON-array COPY, or URLs.`
 		)
 	}
 	if (stat.isDirectory()) {
@@ -73,7 +73,7 @@ function addPath(hash: Hash, contextDir: string, relativePath: string) {
  */
 export function dockerfileCopySources(dockerfile: string): string[] {
 	const sources: string[] = []
-	for (const line of dockerfile.split('\n')) {
+	for (const line of joinContinuedLines(dockerfile)) {
 		const match = line.match(/^\s*(?:COPY|ADD)\s+(.*)$/i)
 		if (!match) continue
 		const tokens = match[1].trim().split(/\s+/)
@@ -85,6 +85,24 @@ export function dockerfileCopySources(dockerfile: string): string[] {
 		}
 	}
 	return sources
+}
+
+// A trailing `\` continues an instruction on the next physical line. Without joining them first,
+// the sources on the wrapped lines never reach the COPY match and escape the hash.
+function joinContinuedLines(dockerfile: string): string[] {
+	const lines: string[] = []
+	let continued = ''
+	for (const line of dockerfile.split('\n')) {
+		const trimmed = line.trimEnd()
+		if (trimmed.endsWith('\\')) {
+			continued += trimmed.slice(0, -1)
+			continue
+		}
+		lines.push(continued + line)
+		continued = ''
+	}
+	if (continued) lines.push(continued)
+	return lines
 }
 
 export function stampDeployInputHash(config: string, hash: string): string {

--- a/internal/scripts/package.json
+++ b/internal/scripts/package.json
@@ -48,10 +48,13 @@
 		"rimraf": "^4.4.1",
 		"semver": "^7.6.3",
 		"svgo": "^3.3.3",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.7"
 	},
 	"scripts": {
-		"lint": "yarn run -T tsx lint.ts"
+		"lint": "yarn run -T tsx lint.ts",
+		"test": "yarn run -T vitest --passWithNoTests",
+		"test-ci": "yarn run -T vitest run --passWithNoTests"
 	},
 	"dependencies": {
 		"@lokalise/node-api": "^12.8.0",

--- a/internal/scripts/vitest.config.ts
+++ b/internal/scripts/vitest.config.ts
@@ -2,11 +2,10 @@
 import { mergeConfig } from 'vitest/config'
 import baseConfig from '../config/vitest/node-preset'
 
-// Node env; source lives at the package root, not `src/`, so widen the include.
+// Source lives at the package root, not `src/`, so the preset's include misses it.
 export default mergeConfig(baseConfig, {
 	test: {
 		environment: 'node',
 		include: ['**/*.test.ts'],
-		exclude: ['**/node_modules/**'],
 	},
 })

--- a/internal/scripts/vitest.config.ts
+++ b/internal/scripts/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { mergeConfig } from 'vitest/config'
+import baseConfig from '../config/vitest/node-preset'
+
+// Node env; source lives at the package root, not `src/`, so widen the include.
+export default mergeConfig(baseConfig, {
+	test: {
+		environment: 'node',
+		include: ['**/*.test.ts'],
+		exclude: ['**/node_modules/**'],
+	},
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
 import { glob } from 'glob'
 import { defineConfig } from 'vitest/config'
 
-const vitestPackages = glob.sync('./{apps,packages}/**/vitest.config.ts')
+const vitestPackages = glob.sync('./{apps,packages,internal}/**/vitest.config.ts')
 
 export default defineConfig({
 	test: { projects: vitestPackages },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12279,6 +12279,7 @@ __metadata:
     tmp: "npm:^0.2.3"
     toml: "npm:^3.0.0"
     typescript: "npm:^7.0.2"
+    vitest: "npm:^4.1.7"
   bin:
     process-compose: ./process-compose-bin.cjs
   languageName: unknown


### PR DESCRIPTION
This PR improves the dotcom deploy so that a deploy which doesn't change zero-cache no longer replaces every zero-cache Fly machine and bounces every connected Zero client.

### Before

`deployZeroBackend` ran `flyctl deploy` for the replication manager and the view-syncer app on every dotcom deploy, including client-only hotfixes. Each `flyctl deploy` builds a fresh image and rolls every machine, so production's nine view-syncers were replaced in three waves (about 3.5 minutes) on every run and every Zero client reconnected up to three times, a few minutes before the sync worker upload reset every room DO on top. Sentry's `TLDRAW-SYNC-1Q` bursts line up with these windows to the second.

### After

Each Fly app is deployed only when the inputs that shape it have changed. The script hashes the rendered fly config, the rendered Dockerfile plus every file it copies, and the secret values it stages, stamps the hash into the app's `[env]` as `TLDRAW_DEPLOY_INPUT_HASH`, and on the next run reads it back from `flyctl machine list --json`. When every machine is started, passing its checks, and already carries the current hash, that app's `flyctl deploy` is skipped and the Discord step says so. Anything else (no machines, a stamp from before this change, a half-finished or failed rollout, a changed secret) deploys as before.

### Implementation notes

- The stamp lives on the machines rather than in external state, so there is nothing to keep in sync. A manual `flyctl deploy` from a laptop produces machines without a stamp, which the next CI run treats as changed.
- A machine only counts as matching when it is started and healthy. A rolling update writes the new config, stamp included, before it waits on health checks and does not revert it when they fail, so without this a retried deploy would skip the broken machine.
- Staged secrets only apply on the next deploy, so the secret strings are part of the hash; otherwise a rotated secret would stay staged until something else changed.
- COPY sources are parsed from the Dockerfile rather than listed by hand, so a new `COPY` can't silently fall outside the hash. What the hash can't see: a base image re-tagged under the same version, a newer apk package, or a change made out of band with `fly secrets set` or `fly scale`. For those, either bump the marker comment beside the env var in the template, or set `ZERO_FORCE_DEPLOY=true` as a variable on the GitHub environment for one run. The workflow defaults it to `false`; anyone running `deploy-dotcom.ts` locally now needs it in their env.
- `fly scale count` for the view-syncers still runs on every deploy; it is idempotent.
- `internal/scripts` gets a vitest project for the gate's unit tests, and the root config now discovers `internal/**/vitest.config.ts`.
- Relates to #10718, which adds `--wait-timeout` to the same two `flyctl deploy` calls. Whichever lands second rebases; on this branch the flag goes on the single call in `deployFlyAppIfChanged`.

### Change type

- [x] `improvement`

### Test plan

1. First deploy after merge: both production apps have no stamp, so they deploy and get one (`flyctl machine list -a production-zero-vs --json | jq '.[].config.env.TLDRAW_DEPLOY_INPUT_HASH'`).
2. Next deploy with no zero-cache change: the deploy log shows `production-zero-rm: deploy inputs unchanged` and `production-zero-vs: deploy inputs unchanged`, no Fly rollout, and no Zero reconnect burst ahead of the worker upload.
3. Bump the marker in a template, or change a connection limit: that app deploys again.

- [x] Unit tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Tests          | +147 / -0  |
| Apps           | +9 / -0    |
| Config/tooling | +263 / -91 |
