### PR TITLE
[HOTFIX] refactor(dotcom): drop the legacy file owner columns (#10591)

### DIFF
--- a/apps/dotcom/mcp-server-auth.md
+++ b/apps/dotcom/mcp-server-auth.md
@@ -96,7 +96,7 @@ Cons: we operate an authorization server — a KV namespace, grant storage, toke
 
 The tools used to resolve a board through `resolveSharedBoardById`, which tried it as an anonymously-shared file and then as a published board. Both paths applied a **public-viewability** gate: published boards must be `published`, shared files must pass `isFileAnonymouslyViewable` (exists, not deleted, `shared` via link). The caller was irrelevant to that decision — the same board resolved the same way for everyone.
 
-That is now `resolveSharedBoardForUser`, and the gate is "can **this user** see this board": the user owns the file (`file.ownerId`), the file belongs to a group they can access (`getRole` + `can(role, 'accessFiles')`), or it is shared via link. That is `requireWriteAccessToFile` in `getAuth.ts` minus the `sharedLinkType === 'edit'` requirement; there was no read-access equivalent in the codebase, so `hasReadAccessToFile` was written next to it rather than inlined here.
+That is now `resolveSharedBoardForUser`, and the gate is "can **this user** see this board": the file belongs to a group they can access (`getRole` + `can(role, 'accessFiles')`), or it is shared via link. That is `requireWriteAccessToFile` in `getAuth.ts` minus the `sharedLinkType === 'edit'` requirement; there was no read-access equivalent in the codebase, so `hasReadAccessToFile` was written next to it rather than inlined here.
 
 ### The scope question this raised
 

--- a/apps/dotcom/workspaces-feature.md
+++ b/apps/dotcom/workspaces-feature.md
@@ -40,10 +40,7 @@ Membership is the source of workspace-level authority. A member can see the work
 
 ### File ownership and file listing
 
-A file has exactly one owner:
-
-- Legacy files have `ownerId`.
-- Workspace files have `owningGroupId`.
+Every file is owned by exactly one workspace, `owningGroupId`. The pre-workspace `ownerId` model was removed in #10050.
 
 A workspace file also has a `group_file` row for the workspace that owns it. The only other kind of `group_file` row is a home guest link: when a user opens a shared file that none of their workspaces own, the server adds a `group_file` row into their home workspace so it shows up as a "guest file". That row's `groupId` is the user's id, and the file's `owningGroupId` stays with its real owner.
 
@@ -57,7 +54,7 @@ This distinction matters:
 
 ### File state
 
-`file_state` is per user and per file. It tracks visit and session state. In the migrated workspace model, pinned state for workspace lists is stored on `group_file.index`, not on `file_state.isPinned`.
+`file_state` is per user and per file. It tracks visit and session state. Pinned state for workspace lists is stored on `group_file.index`.
 
 When a user opens a shared file, the server upserts `file_state`. For migrated users, if the file is not in any of their current workspaces, the server also inserts a `group_file` link into their home workspace.
 

--- a/apps/dotcom/zero-cache/delete_file_states.test.ts
+++ b/apps/dotcom/zero-cache/delete_file_states.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 import pg from 'pg'
@@ -8,14 +8,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 // guest file_state rows and guest home-group file links (group_file rows) when a
 // file is unshared (shared: true -> false).
 //
-// Regression coverage for: unsharing a group-owned file (ownerId NULL,
-// owningGroupId set) used to leave guest file_states behind, because the original
-// trigger keyed on `OLD."ownerId" != "userId"` and `NULL != x` is NULL in SQL.
-// Visiting a shared file also links it into the visitor's home group via a
-// group_file row (home group id == user id) — that link is what puts the file in
-// their recent files, and nothing cleaned it up either, so the file name lingered
-// in an ex-guest's recent files after access was revoked.
-// See migration 034_fix_unshare_group_file_cleanup.sql.
+// Visiting a shared file links it into the visitor's home group via a group_file
+// row (home group id == user id) — that link is what puts the file in their recent
+// files, so unshare has to remove it as well as the file_state, or the file name
+// lingers in an ex-guest's recent files after access is revoked.
 //
 // This talks to a real postgres (the trigger is plpgsql, so fakes can't exercise
 // it). It is opt-in: set ZERO_CACHE_TEST_POSTGRES_URL (local dev stack:
@@ -29,7 +25,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 // trusted to stick — and unqualified DDL like `DROP TABLE ... CASCADE` would then
 // run against `public`. So no statement here relies on session state: everything
 // the test owns is schema-qualified explicitly, and the statements that cannot be
-// qualified (the shipped migration SQL, executed verbatim, and the UPDATEs whose
+// qualified (the shipped function definition, executed verbatim, and the UPDATEs whose
 // trigger body resolves table names at execution time) run inside a transaction
 // with `SET LOCAL search_path` — a transaction is exactly the unit a
 // transaction-mode pooler pins to a single backend, and SET LOCAL expires with it.
@@ -37,25 +33,48 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 const DIRNAME = dirname(fileURLToPath(import.meta.url))
 const CONNECTION_STRING = process.env.ZERO_CACHE_TEST_POSTGRES_URL
 
-// The real, shipped function body. We load it from the migration file so the test
-// exercises exactly what runs in production rather than a hand-copied duplicate.
-const FIXED_FUNCTION_SQL = readFileSync(
-	join(DIRNAME, 'migrations', '034_fix_unshare_group_file_cleanup.sql'),
-	'utf8'
-)
+// The real, shipped function body, sliced out of whichever migration last defined it so the test
+// exercises production's function rather than a hand-copied duplicate. Found by scanning rather
+// than by filename: a hard-coded 034 kept this suite green against a body production no longer
+// ran once 050 redefined the function.
+function loadShippedFunction(name: string): string {
+	const dir = join(DIRNAME, 'migrations')
+	const header = new RegExp(`CREATE OR REPLACE FUNCTION (public\\.)?${name}\\(\\)`)
+	const migrationFile = readdirSync(dir)
+		.filter((f) => f.endsWith('.sql'))
+		.sort()
+		.filter((f) => header.test(readFileSync(join(dir, f), 'utf8')))
+		.at(-1)
+	if (!migrationFile) {
+		throw new Error(`no migration defines ${name}()`)
+	}
+	const migration = readFileSync(join(dir, migrationFile), 'utf8')
+	const start = migration.search(header)
+	// The body is dollar-quoted with whatever tag the migration chose ($$ early on, $function$
+	// in 050), and the statement ends at the first semicolon after the closing tag.
+	const tag = /AS\s+(\$[A-Za-z_]*\$)/.exec(migration.slice(start))
+	if (!tag) {
+		throw new Error(`could not find the body of ${name}() in ${migrationFile}`)
+	}
+	const close = migration.indexOf(tag[1], start + tag.index + tag[0].length)
+	const end = close === -1 ? -1 : migration.indexOf(';', close + tag[1].length)
+	if (end === -1) {
+		throw new Error(`could not find the end of ${name}() in ${migrationFile}`)
+	}
+	// Drop the `public.` qualifier: the migration targets public, while everything here lives
+	// in a throwaway schema pinned with SET LOCAL search_path. Left in place it would
+	// CREATE OR REPLACE the *production* function whenever this test runs against a shared
+	// database — the one way this suite could reach outside its own schema.
+	const sql = migration
+		.slice(start, end + 1)
+		.replace(header, `CREATE OR REPLACE FUNCTION ${name}()`)
+	if (sql.includes('public.')) {
+		throw new Error(`refusing to run ${name}(): a public. reference survived unqualifying`)
+	}
+	return sql
+}
 
-// The original (buggy) function body, kept here so we can prove the bug exists and
-// that the fix is what closes it.
-const BUGGY_FUNCTION_SQL = `
-CREATE OR REPLACE FUNCTION delete_file_states() RETURNS TRIGGER AS $$
-BEGIN
-  IF OLD.shared = TRUE AND NEW.shared = FALSE THEN
-    DELETE FROM file_state WHERE "fileId" = OLD.id AND OLD."ownerId" != "userId";
-  END IF;
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-`
+const DELETE_FILE_STATES_SQL = loadShippedFunction('delete_file_states')
 
 const schemaName = `tldraw_test_${process.pid}`
 
@@ -75,11 +94,9 @@ CREATE TABLE "${schemaName}"."group_user" (
 );
 CREATE TABLE "${schemaName}"."file" (
   "id" TEXT PRIMARY KEY,
-  "ownerId" TEXT,
-  "owningGroupId" TEXT,
-  "shared" BOOLEAN NOT NULL,
-  -- mirror the production XOR invariant so the test seed stays realistic
-  CHECK (("ownerId" IS NULL) != ("owningGroupId" IS NULL))
+  -- NOT NULL mirrors production: since 050 every file belongs to a workspace
+  "owningGroupId" TEXT NOT NULL,
+  "shared" BOOLEAN NOT NULL
 );
 CREATE TABLE "${schemaName}"."file_state" (
   "userId" TEXT NOT NULL,
@@ -107,11 +124,10 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 	let client: pg.Client
 
 	// Runs statements inside one transaction with search_path pinned to the test
-	// schema. This is for SQL we execute verbatim (the shipped migration and the
-	// original buggy function) and for statements whose trigger body resolves
-	// unqualified table names at execution time. SET LOCAL scopes the setting to
-	// the transaction, so it works through transaction-mode poolers and cannot
-	// leak to or from other sessions.
+	// schema. This is for SQL we execute verbatim (the shipped function definition)
+	// and for statements whose trigger body resolves unqualified table names at
+	// execution time. SET LOCAL scopes the setting to the transaction, so it works
+	// through transaction-mode poolers and cannot leak to or from other sessions.
 	async function inTestSchema(...statements: string[]) {
 		await client.query('BEGIN')
 		try {
@@ -153,27 +169,22 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 	})
 
 	async function seed() {
-		// group g1 with an owner and a member; guest is NOT a member
+		// group g1 with two members; guest is NOT a member
 		await client.query(`INSERT INTO "${schemaName}"."group" ("id") VALUES ('g1')`)
 		await client.query(
 			`INSERT INTO "${schemaName}"."group_user" ("userId", "groupId") VALUES ('uOwner', 'g1'), ('uMember', 'g1')`
 		)
 
-		// group-owned shared file: ownerId NULL, owningGroupId set
 		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fGroup', NULL, 'g1', true)`
-		)
-		// legacy user-owned shared file: ownerId set, owningGroupId NULL
-		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fLegacy', 'uOwner', NULL, true)`
+			`INSERT INTO "${schemaName}"."file" ("id", "owningGroupId", "shared") VALUES ('fGroup', 'g1', true)`
 		)
 		// a shared file we will NOT unshare, as a control
 		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fControl', 'uOwner', NULL, true)`
+			`INSERT INTO "${schemaName}"."file" ("id", "owningGroupId", "shared") VALUES ('fControl', 'g1', true)`
 		)
 
 		// everyone has a file_state on every file
-		for (const fileId of ['fGroup', 'fLegacy', 'fControl']) {
+		for (const fileId of ['fGroup', 'fControl']) {
 			await client.query(
 				`INSERT INTO "${schemaName}"."file_state" ("userId", "fileId") VALUES ('uOwner', $1), ('uMember', $1), ('uGuest', $1)`,
 				[fileId]
@@ -187,8 +198,7 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 				('fGroup', 'g1'),
 				('fGroup', 'uMember'),
 				('fGroup', 'uGuest'),
-				('fLegacy', 'uOwner'),
-				('fLegacy', 'uGuest'),
+				('fControl', 'g1'),
 				('fControl', 'uGuest')`
 		)
 	}
@@ -218,63 +228,29 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 		return res.rows.map((r) => r.groupId)
 	}
 
-	describe('with the fixed function (migration 034)', () => {
-		beforeEach(async () => {
-			await inTestSchema(FIXED_FUNCTION_SQL)
-			await client.query(SCHEMA_SQL)
-			await seed()
-		})
-
-		it('removes the guest state but keeps group members when a group-owned file is unshared', async () => {
-			await unshare('fGroup')
-			// owner + member of the owning group keep access; guest is cleaned up
-			expect(await statesFor('fGroup')).toEqual(['uMember', 'uOwner'])
-		})
-
-		it('removes the guest file link but keeps the owning group row and member links', async () => {
-			await unshare('fGroup')
-			// the file still lives in its owning group, and the member keeps their
-			// home-group link (they retain access); the guest's link is cleaned up
-			// so the file stops showing in their recent files
-			expect(await linksFor('fGroup')).toEqual(['g1', 'uMember'])
-		})
-
-		it('removes the guest state but keeps the owner when a legacy file is unshared', async () => {
-			await unshare('fLegacy')
-			expect(await statesFor('fLegacy')).toEqual(['uOwner'])
-		})
-
-		it('removes the guest file link but keeps the owner link when a legacy file is unshared', async () => {
-			await unshare('fLegacy')
-			expect(await linksFor('fLegacy')).toEqual(['uOwner'])
-		})
-
-		it('leaves still-shared files untouched', async () => {
-			await unshare('fGroup')
-			expect(await statesFor('fControl')).toEqual(['uGuest', 'uMember', 'uOwner'])
-			expect(await linksFor('fControl')).toEqual(['uGuest'])
-		})
+	beforeEach(async () => {
+		await inTestSchema(DELETE_FILE_STATES_SQL)
+		await client.query(SCHEMA_SQL)
+		await seed()
 	})
 
-	describe('with the original buggy function (regression guard)', () => {
-		beforeEach(async () => {
-			await inTestSchema(BUGGY_FUNCTION_SQL)
-			await client.query(SCHEMA_SQL)
-			await seed()
-		})
+	it('removes the guest state but keeps group members when a group-owned file is unshared', async () => {
+		await unshare('fGroup')
+		// owner + member of the owning group keep access; guest is cleaned up
+		expect(await statesFor('fGroup')).toEqual(['uMember', 'uOwner'])
+	})
 
-		it('demonstrates the bug: group-owned guest state survives because ownerId is NULL', async () => {
-			await unshare('fGroup')
-			// NULL != "userId" is NULL, so the old DELETE matched nothing: the guest lingers
-			expect(await statesFor('fGroup')).toEqual(['uGuest', 'uMember', 'uOwner'])
-			// and the old function never touched group_file at all, so the guest's
-			// home-group link (their recent-files entry) survived too
-			expect(await linksFor('fGroup')).toEqual(['g1', 'uGuest', 'uMember'])
-		})
+	it('removes the guest file link but keeps the owning group row and member links', async () => {
+		await unshare('fGroup')
+		// the file still lives in its owning group, and the member keeps their
+		// home-group link (they retain access); the guest's link is cleaned up
+		// so the file stops showing in their recent files
+		expect(await linksFor('fGroup')).toEqual(['g1', 'uMember'])
+	})
 
-		it('still works for legacy files (so the regression is group-specific)', async () => {
-			await unshare('fLegacy')
-			expect(await statesFor('fLegacy')).toEqual(['uOwner'])
-		})
+	it('leaves still-shared files untouched', async () => {
+		await unshare('fGroup')
+		expect(await statesFor('fControl')).toEqual(['uGuest', 'uMember', 'uOwner'])
+		expect(await linksFor('fControl')).toEqual(['g1', 'uGuest'])
 	})
 })

--- a/apps/dotcom/zero-cache/effect_outbox.test.ts
+++ b/apps/dotcom/zero-cache/effect_outbox.test.ts
@@ -93,6 +93,8 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 		await client.query(`TRUNCATE "user", "file", "group", effect_outbox CASCADE`)
 	})
 
+	// Also creates the user's home workspace, mirroring production, where a home group's id is
+	// the user's own id. `file."owningGroupId"` is NOT NULL since 050, so every file needs one.
 	async function seedUser(id: string) {
 		await client.query(
 			`INSERT INTO "user" ("id", "name", "email", "avatar", "color", "exportFormat", "exportTheme",
@@ -100,20 +102,17 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 			 VALUES ($1, $1, $1, '', '', 'png', 'auto', false, false, 0, 0, '')`,
 			[id]
 		)
+		await client.query(`INSERT INTO "group" ("id", "name") VALUES ($1, $1)`, [id])
 	}
 
-	async function seedFile(
-		id: string,
-		overrides: { ownerId?: string | null; owningGroupId?: string | null } = {}
-	) {
-		const ownerId = overrides.ownerId !== undefined ? overrides.ownerId : 'u1'
-		const owningGroupId = overrides.owningGroupId !== undefined ? overrides.owningGroupId : null
+	async function seedFile(id: string, overrides: { owningGroupId?: string } = {}) {
+		const owningGroupId = overrides.owningGroupId ?? 'u1'
 		await client.query(
-			`INSERT INTO "file" ("id", "name", "ownerId", "owningGroupId", "thumbnail", "shared",
+			`INSERT INTO "file" ("id", "name", "owningGroupId", "thumbnail", "shared",
 			   "sharedLinkType", "published", "lastPublished", "publishedSlug", "createdAt",
 			   "updatedAt", "isEmpty")
-			 VALUES ($1, $1, $2, $3, '', false, 'view', false, 0, $1, 0, 0, false)`,
-			[id, ownerId, owningGroupId]
+			 VALUES ($1, $1, $2, '', false, 'view', false, 0, $1, 0, 0, false)`,
+			[id, owningGroupId]
 		)
 	}
 
@@ -184,7 +183,7 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 		expect(updateRow.prevPayload.lastPublished).toBe(0)
 		expect(updateRow.prevPayload.id).toBe('f1')
 		expect(updateRow.prevPayload.name).toBe('f1')
-		expect(updateRow.prevPayload.ownerId).toBe('u1')
+		expect(updateRow.prevPayload.owningGroupId).toBe('u1')
 	})
 
 	it('file DELETE produces a delete row with the OLD row as payload and no prevPayload', async () => {
@@ -204,7 +203,7 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 	it('deleting a group cascades to a soft-delete update on its files, and the outbox trigger fires for it', async () => {
 		await seedUser('u1')
 		await client.query(`INSERT INTO "group" ("id", "name") VALUES ('g1', 'g1')`)
-		await seedFile('fGroup', { ownerId: null, owningGroupId: 'g1' })
+		await seedFile('fGroup', { owningGroupId: 'g1' })
 
 		// The real cleanup_deleted_group_trigger (023_groups.sql) fires inside this
 		// UPDATE and soft-deletes fGroup, which in turn must fire

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync } from 'fs'
 import { createServer } from 'http'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
+import { hasTransactionBlock } from './migrationSql'
 
 const postgresConnectionString: string =
 	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
@@ -123,6 +124,13 @@ async function migrate(summary: string[], dryRun: boolean) {
 			)
 		}
 
+		// DDL on a replicated table takes ACCESS EXCLUSIVE. Without a lock timeout, one long-running
+		// reader makes the deploy hang while every room persist queues behind the waiting DDL.
+		// Failing here aborts the deploy before Zero and the sync-worker roll, and a rerun picks up
+		// where it left off. SET LOCAL is transaction-scoped, so it holds through a
+		// transaction-mode pooler.
+		await sql`SET LOCAL lock_timeout = '10s'`.execute(tx)
+
 		let appliedNewMigration = false
 		for (const migration of migrations) {
 			if (appliedMigrations.rows.some((m: any) => m.filename === migration)) {
@@ -131,8 +139,8 @@ async function migrate(summary: string[], dryRun: boolean) {
 			}
 
 			try {
-				const migrationSql = readFileSync(`${migrationsPath}/${migration}`, 'utf8').toString()
-				if (migrationSql.match(/(BEGIN|COMMIT);/)) {
+				const migrationSql = readFileSync(`${migrationsPath}/${migration}`, 'utf8')
+				if (hasTransactionBlock(migrationSql)) {
 					throw new Error(
 						`Migration ${migration} contains a transaction block. Migrations run in transactions, so you don't need to include them in the migration file.`
 					)

--- a/apps/dotcom/zero-cache/migrationSql.test.ts
+++ b/apps/dotcom/zero-cache/migrationSql.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+import { hasTransactionBlock } from './migrationSql'
+
+// migrate.ts rejects a migration that opens its own transaction, but it only finds out at deploy
+// time, against a real database. The integration suites do not cover it either: they apply
+// migration files straight through `client.query(sql)`, bypassing the runner, and they skip
+// entirely without ZERO_CACHE_TEST_POSTGRES_URL — which is how CI runs them. So a migration
+// carrying a BEGIN/COMMIT reached review green.
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), 'migrations')
+
+describe('hasTransactionBlock', () => {
+	it('finds a transaction block', () => {
+		expect(hasTransactionBlock('BEGIN;\nALTER TABLE foo DROP COLUMN bar;\nCOMMIT;')).toBe(true)
+	})
+
+	// A lowercase or long-form commit is the dangerous one: it ends the runner's transaction
+	// silently, so a dry run applies everything after it for real.
+	it.each([
+		'commit;',
+		'COMMIT WORK;',
+		'COMMIT TRANSACTION;',
+		'ROLLBACK;',
+		'START TRANSACTION;',
+		'BEGIN TRANSACTION;',
+		'END TRANSACTION;',
+		'begin ;',
+	])('finds %s', (statement) => {
+		expect(hasTransactionBlock(`ALTER TABLE foo DROP COLUMN bar;\n${statement}`)).toBe(true)
+	})
+
+	it('does not mistake a DO block or a plpgsql END for one', () => {
+		expect(hasTransactionBlock(`DO $$\nBEGIN\n  RAISE NOTICE 'x';\nEND $$;`)).toBe(false)
+		expect(hasTransactionBlock(`IF x THEN\n  y;\nEND IF;\nEND;`)).toBe(false)
+	})
+
+	// The reason the check is punctuation-sensitive rather than word-based: every plpgsql function
+	// body opens with a bare BEGIN, so a word-based check would reject most trigger migrations.
+	it('does not mistake a plpgsql function body for one', () => {
+		expect(
+			hasTransactionBlock(
+				`CREATE OR REPLACE FUNCTION f() RETURNS trigger AS $$\nBEGIN\n  RETURN NEW;\nEND;\n$$ LANGUAGE plpgsql;`
+			)
+		).toBe(false)
+	})
+})
+
+describe('the migrations checked into this package', () => {
+	const filenames = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'))
+
+	it.each(filenames)('%s opens no transaction of its own', (filename) => {
+		const sql = readFileSync(join(MIGRATIONS_DIR, filename), 'utf8')
+		expect(hasTransactionBlock(sql)).toBe(false)
+	})
+})

--- a/apps/dotcom/zero-cache/migrationSql.ts
+++ b/apps/dotcom/zero-cache/migrationSql.ts
@@ -1,0 +1,18 @@
+/**
+ * The runner applies every migration inside a transaction it opens itself, so a migration that
+ * opens its own leaves the runner's transaction in a state it did not expect. migrate.ts refuses
+ * one rather than trying to reconcile that.
+ *
+ * Only a statement counts: BEGIN, START TRANSACTION, COMMIT, ROLLBACK or END TRANSACTION, with or
+ * without WORK/TRANSACTION, in any case, followed by a semicolon. plpgsql function bodies open with
+ * a bare `BEGIN` and no semicolon, and a migration defining a trigger function is full of them.
+ *
+ * A miss is worse than a false positive. The runner sends each file with the simple query
+ * protocol, so a stray `commit;` ends the runner's transaction mid-file and everything after it,
+ * `--dry-run` included, applies for real.
+ */
+export function hasTransactionBlock(migrationSql: string): boolean {
+	return /\b(begin|start\s+transaction|commit|rollback|end\s+transaction)(\s+(work|transaction))?\s*;/i.test(
+		migrationSql
+	)
+}

--- a/apps/dotcom/zero-cache/migrations/050_drop_legacy_owner_columns.sql
+++ b/apps/dotcom/zero-cache/migrations/050_drop_legacy_owner_columns.sql
@@ -1,0 +1,179 @@
+-- Drops the legacy user-owns-file model (issue #10050).
+--
+-- Every file has lived in a workspace since the groups migration, `file."ownerId"` has been
+-- NULL throughout production since then, and #10391 removed the last code that read it. What
+-- remains is the schema itself plus the trigger functions that still maintain it.
+--
+-- Postgres tracks dependencies for indexes, foreign keys, check constraints and a trigger's
+-- `UPDATE OF` column list, so those drop or block on their own. It does NOT parse plpgsql
+-- bodies: a function still naming a dropped column survives the DDL and fails at runtime on
+-- the next write. That is why the function work below is explicit, and comes before the
+-- column drops.
+--
+-- The runner puts the whole migration in one transaction (migrate.ts). A transaction with any
+-- DDL on a replicated table resets every view-syncer pipeline and rehydrates connected clients,
+-- once per transaction rather than per statement, and Zero is notified once after all of it.
+-- Deploy off-peak, and only after #10653 has shipped: a client whose schema still declares
+-- these columns is disconnected the moment they drop.
+
+-- Fails before any lock is taken if a file still has no workspace, with a message that says
+-- so. Without this the SET NOT NULL below fails with a bare "contains null values".
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public."file" WHERE "owningGroupId" IS NULL) THEN
+    RAISE EXCEPTION 'files without an owningGroupId remain; every file must belong to a workspace before the legacy owner columns can be dropped';
+  END IF;
+END $$;
+
+-- Lock order. An app transaction that changes a user's name or avatar holds `user` and then
+-- writes `file` through update_file_owner_details_trigger, which is installed until this
+-- migration drops it, and every `file_state` writer reads `file` first. The DDL below takes
+-- ACCESS EXCLUSIVE on all three, and locks are held to the end of the transaction, so taking
+-- them in any other order than `user`, `file`, `file_state` can deadlock with a mutator that
+-- is mid-flight when the deploy runs. Statement order is not enough to guarantee that, so the
+-- first two are taken here explicitly. `file_state` is not: nothing needs it until after the
+-- scan below, and it stays writable until then.
+LOCK TABLE public."user", public."file" IN ACCESS EXCLUSIVE MODE;
+
+-- The one statement here that does real work: a full scan of `file`. It comes first so that
+-- `user` is held for the scan plus catalog writes rather than for the scan plus everything
+-- else, and `file_state` is not held for the scan at all. With the legacy model gone, every
+-- file belongs to a workspace.
+ALTER TABLE public."file" ALTER COLUMN "owningGroupId" SET NOT NULL;
+
+-- These exist only to maintain the legacy columns.
+
+DROP TRIGGER IF EXISTS trigger_update_file_state_on_file_change ON public."file";
+DROP FUNCTION IF EXISTS public.update_file_state_on_file_change();
+
+DROP TRIGGER IF EXISTS trigger_update_is_file_owner ON public."file_state";
+DROP FUNCTION IF EXISTS public.update_is_file_owner();
+
+DROP TRIGGER IF EXISTS update_file_owner_details_trigger ON public."user";
+DROP FUNCTION IF EXISTS public.update_file_owner_details();
+
+-- The runtime backfill that moved users onto the groups model, and the source of the
+-- `owningGroupId`-without-`group_file` orphans repaired ahead of this migration: it set
+-- `owningGroupId` for every file a user owned but created links only for files the user had a
+-- `file_state` row for, so a file its owner had never opened got the id and no link.
+DROP FUNCTION IF EXISTS public.migrate_user_to_groups(text, text);
+
+-- Was two arms, one per ownership model. Only the group arm is reachable now, its
+-- `"ownerAvatar" = ''` assignment goes with the column, and its null check goes with the
+-- NOT NULL constraint above.
+CREATE OR REPLACE FUNCTION public.set_file_owner_details()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  UPDATE "file"
+  SET "ownerName" = g."name"
+  FROM public."group" g
+  WHERE g."id" = NEW."owningGroupId" AND "file"."id" = NEW."id";
+  RETURN NEW;
+END;
+$function$;
+
+-- Redefined rather than left alone: its column list still named "ownerId".
+CREATE OR REPLACE TRIGGER set_file_owner_details_trigger
+AFTER INSERT OR UPDATE OF "owningGroupId" ON public."file"
+FOR EACH ROW EXECUTE FUNCTION set_file_owner_details();
+
+CREATE OR REPLACE FUNCTION public.update_file_group_details()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  UPDATE "file"
+  SET "ownerName" = NEW.name
+  WHERE "owningGroupId" = NEW.id;
+  RETURN NEW;
+END;
+$function$;
+
+-- Both dropped guards were already no-ops: `ownerId` is NULL on every row, and
+-- `NULL IS DISTINCT FROM x` is TRUE, so neither ever excluded anything. The `group_user`
+-- membership checks are what actually protect an owner's own state on unshare.
+CREATE OR REPLACE FUNCTION public.delete_file_states()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF OLD.shared = TRUE AND NEW.shared = FALSE THEN
+    DELETE FROM file_state fs
+    WHERE fs."fileId" = OLD.id
+      -- not a current member of the owning group
+      AND NOT EXISTS (
+        SELECT 1 FROM group_user gu
+        WHERE gu."groupId" = OLD."owningGroupId"
+          AND gu."userId" = fs."userId"
+      );
+
+    DELETE FROM group_file gf
+    WHERE gf."fileId" = OLD.id
+      -- never the owning group's own row: that's where the file lives
+      AND gf."groupId" <> OLD."owningGroupId"
+      -- not a home-group link of a current owning-group member
+      AND NOT EXISTS (
+        SELECT 1 FROM group_user gu
+        WHERE gu."groupId" = OLD."owningGroupId"
+          AND gu."userId" = gf."groupId"
+      );
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- Only the no-op short-circuit changes: "ownerId" leaves the list of columns whose change is
+-- worth an outbox row. Miss this and every file write starts producing effects again.
+CREATE OR REPLACE FUNCTION public.file_effect_outbox_fn()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload)
+		VALUES ('file', NEW.id, 'insert', to_jsonb(NEW));
+		RETURN NEW;
+	ELSIF TG_OP = 'UPDATE' THEN
+		-- Skip no-op updates: room persists bump "updatedAt" every few seconds per active
+		-- room; only effect-relevant columns should produce outbox rows.
+		IF NEW.name IS NOT DISTINCT FROM OLD.name
+			AND NEW.shared IS NOT DISTINCT FROM OLD.shared
+			AND NEW."sharedLinkType" IS NOT DISTINCT FROM OLD."sharedLinkType"
+			AND NEW.published IS NOT DISTINCT FROM OLD.published
+			AND NEW."lastPublished" IS NOT DISTINCT FROM OLD."lastPublished"
+			AND NEW."publishedSlug" IS NOT DISTINCT FROM OLD."publishedSlug"
+			AND NEW."isDeleted" IS NOT DISTINCT FROM OLD."isDeleted"
+			AND NEW."owningGroupId" IS NOT DISTINCT FROM OLD."owningGroupId"
+		THEN
+			RETURN NEW;
+		END IF;
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload, "prevPayload")
+		VALUES ('file', NEW.id, 'update', to_jsonb(NEW), to_jsonb(OLD));
+		RETURN NEW;
+	ELSE
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload)
+		VALUES ('file', OLD.id, 'delete', to_jsonb(OLD));
+		RETURN OLD;
+	END IF;
+END;
+$function$;
+
+-- Postgres would drop all three with the column; spelled out so reviewing this does not
+-- require knowing that.
+
+DROP INDEX IF EXISTS public.file_owner_index;
+ALTER TABLE public."file" DROP CONSTRAINT IF EXISTS "file_owner_xor_check";
+ALTER TABLE public."file" DROP CONSTRAINT IF EXISTS "file_ownerId_fkey";
+
+-- `file_state."isPinned"` needs no backfill: the client has read pin state from
+-- `group_file."index"` since groups landed, so the ~331 rows still saying `true` have had no
+-- effect for months. Copying them into `index` would re-pin boards that are currently
+-- unpinned, and `unpinFile` writes the same `index = NULL` those rows would be matched by, so
+-- a deliberate unpin is indistinguishable from a never-migrated pin.
+
+ALTER TABLE public."file" DROP COLUMN IF EXISTS "ownerId";
+ALTER TABLE public."file" DROP COLUMN IF EXISTS "ownerAvatar";
+ALTER TABLE public."file_state" DROP COLUMN IF EXISTS "isFileOwner";
+ALTER TABLE public."file_state" DROP COLUMN IF EXISTS "isPinned";


### PR DESCRIPTION
Manual hotfix PR for #10591, standing in for the automated one. The trigger's cherry-pick of 75cd361d94 onto `hotfixes` conflicted in `apps/dotcom/zero-cache/migrate.ts`: `hotfixes` does not carry #10072, which tidied the lines the transaction-block guard replaced. Resolved by keeping the guard; the file now differs from main's only by the #10072 tidy-ups that were never hotfixed. Every other file cherry-picked cleanly.

Staging deployed this commit successfully from main (run 34443778818), including migration 050.

Cherry-picks the changes from the original PR to the hotfixes branch for immediate dotcom deployment.