### PR TITLE
fix(dotcom): pause the bootstrap deadline in hidden tabs and attach Zero diagnostics to timeouts

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -1,25 +1,38 @@
 import { atom, promiseWithResolve } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { TldrawApp } from './TldrawApp'
+import { TldrawApp, ZeroLogBuffer } from './TldrawApp'
 
 function createAppStub({
 	queryComplete = Promise.resolve(),
 	changesFlushed = Promise.resolve(),
 	user = undefined as { id: string } | undefined,
+	zeroLog = new ZeroLogBuffer(),
 } = {}) {
 	return Object.assign(Object.create(TldrawApp.prototype), {
 		userId: 'user:test',
 		getToken: async () => 'token',
-		z: { preload: () => ({ complete: queryComplete }) },
+		z: {
+			preload: () => ({ complete: queryComplete }),
+			connection: { state: { current: { name: 'connecting' } } },
+		},
 		changesFlushed,
 		user$: atom('user', user),
+		zeroLog,
 	}) as TldrawApp
+}
+
+let visibilityState: DocumentVisibilityState = 'visible'
+function setVisibility(state: DocumentVisibilityState) {
+	visibilityState = state
+	document.dispatchEvent(new Event('visibilitychange'))
 }
 
 describe('TldrawApp.preload', () => {
 	beforeEach(() => {
 		vi.useFakeTimers()
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+		visibilityState = 'visible'
+		vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibilityState)
 	})
 
 	afterEach(() => {
@@ -36,7 +49,9 @@ describe('TldrawApp.preload', () => {
 
 			await vi.advanceTimersByTimeAsync(30_000)
 
-			expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+			expect(rejected).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'Init failed: 503' })
+			)
 			expect(vi.getTimerCount()).toBe(0)
 		}
 	)
@@ -48,7 +63,7 @@ describe('TldrawApp.preload', () => {
 
 		await vi.advanceTimersByTimeAsync(30_000)
 
-		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+		expect(rejected).toHaveBeenCalledWith(expect.objectContaining({ message: 'Init failed: 503' }))
 	})
 
 	it('shares the deadline between the query and user-record waits', async () => {
@@ -62,7 +77,7 @@ describe('TldrawApp.preload', () => {
 		expect(rejected).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1)
 
-		expect(rejected).toHaveBeenCalledWith(new Error('Init failed: 503'))
+		expect(rejected).toHaveBeenCalledWith(expect.objectContaining({ message: 'Init failed: 503' }))
 		expect(vi.getTimerCount()).toBe(0)
 	})
 
@@ -78,12 +93,81 @@ describe('TldrawApp.preload', () => {
 		await vi.advanceTimersByTimeAsync(30_000)
 
 		expect(rejected).toHaveBeenCalledWith(
-			new Error(`Timed out waiting for the ${stage} after init`)
+			expect.objectContaining({
+				message: `Timed out waiting for the ${stage} after init (zero connecting)`,
+			})
 		)
+	})
+
+	it('attaches diagnostics to the timeout error', async () => {
+		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+		const zeroLog = new ZeroLogBuffer()
+		zeroLog.log('info', { clientID: 'c1' }, 'Connecting...')
+		const rejected = vi.fn()
+		void createAppStub({ zeroLog }).preload().catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(30_000)
+
+		expect(rejected.mock.calls[0][0].diagnostics).toEqual(
+			expect.objectContaining({
+				stage: 'user record',
+				connection: 'connecting',
+				visibilityState: 'visible',
+				hiddenMs: 0,
+				zeroLog: [expect.stringContaining('info clientID=c1 Connecting...')],
+			})
+		)
+	})
+
+	it('only counts visible time against the deadline', async () => {
+		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+		const rejected = vi.fn()
+		visibilityState = 'hidden'
+		void createAppStub().preload().catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(rejected).not.toHaveBeenCalled()
+
+		setVisibility('visible')
+		await vi.advanceTimersByTimeAsync(10_000)
+		setVisibility('hidden')
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(rejected).not.toHaveBeenCalled()
+
+		setVisibility('visible')
+		await vi.advanceTimersByTimeAsync(19_999)
+		expect(rejected).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(1)
+
+		expect(rejected.mock.calls[0][0].diagnostics).toEqual(
+			expect.objectContaining({ hiddenMs: 120_000, visibilityState: 'visible' })
+		)
+		expect(vi.getTimerCount()).toBe(0)
 	})
 
 	it('loads an existing user after an init error and clears the deadline', async () => {
 		await expect(createAppStub({ user: { id: 'user:test' } }).preload()).resolves.toBeUndefined()
 		expect(vi.getTimerCount()).toBe(0)
+	})
+})
+
+describe('ZeroLogBuffer', () => {
+	it('keeps the most recent lines and forwards warnings and errors to the console', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const buffer = new ZeroLogBuffer()
+
+		for (let i = 0; i < 70; i++) buffer.log('info', undefined, `line ${i}`)
+		buffer.log('warn', { wsid: 'w1' }, 'slow', { ms: 12 })
+		buffer.log('error', undefined, new Error('boom'))
+
+		const lines = buffer.recent()
+		expect(lines).toHaveLength(60)
+		expect(lines[0]).toContain('info  line 12')
+		expect(lines.at(-2)).toContain('warn wsid=w1 slow {"ms":12}')
+		expect(lines.at(-1)).toContain('error  Error: boom')
+		expect(warn).toHaveBeenCalledWith({ wsid: 'w1' }, 'slow', { ms: 12 })
+		expect(error).toHaveBeenCalledWith(expect.any(Error))
+		expect(buffer.recent()).not.toBe(lines)
 	})
 })

--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -1,6 +1,7 @@
 import { atom, promiseWithResolve } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { TldrawApp, ZeroLogBuffer } from './TldrawApp'
+import { TldrawApp } from './TldrawApp'
+import { ZeroLogBuffer } from './ZeroLogBuffer'
 
 function createAppStub({
 	queryComplete = Promise.resolve(),

--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -39,6 +39,7 @@ describe('TldrawApp.preload', () => {
 	afterEach(() => {
 		vi.useRealTimers()
 		vi.unstubAllGlobals()
+		vi.restoreAllMocks()
 	})
 
 	it.each([undefined, { id: 'user:test' }])(
@@ -95,7 +96,7 @@ describe('TldrawApp.preload', () => {
 
 		expect(rejected).toHaveBeenCalledWith(
 			expect.objectContaining({
-				message: `Timed out waiting for the ${stage} after init (zero connecting)`,
+				message: `Timed out waiting for the ${stage} after init`,
 			})
 		)
 	})
@@ -120,7 +121,7 @@ describe('TldrawApp.preload', () => {
 		)
 	})
 
-	it('only counts visible time against the deadline', async () => {
+	it('only counts visible time and restarts the deadline on return from hidden', async () => {
 		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
 		const rejected = vi.fn()
 		visibilityState = 'hidden'
@@ -130,19 +131,36 @@ describe('TldrawApp.preload', () => {
 		expect(rejected).not.toHaveBeenCalled()
 
 		setVisibility('visible')
-		await vi.advanceTimersByTimeAsync(10_000)
+		await vi.advanceTimersByTimeAsync(29_000)
 		setVisibility('hidden')
 		await vi.advanceTimersByTimeAsync(60_000)
 		expect(rejected).not.toHaveBeenCalled()
 
 		setVisibility('visible')
-		await vi.advanceTimersByTimeAsync(19_999)
+		await vi.advanceTimersByTimeAsync(29_999)
 		expect(rejected).not.toHaveBeenCalled()
 		await vi.advanceTimersByTimeAsync(1)
 
 		expect(rejected.mock.calls[0][0].diagnostics).toEqual(
 			expect.objectContaining({ hiddenMs: 120_000, visibilityState: 'visible' })
 		)
+		expect(vi.getTimerCount()).toBe(0)
+	})
+
+	it('settles without diagnostics when the caller aborts a hidden bootstrap', async () => {
+		vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+		const rejected = vi.fn()
+		const abort = new AbortController()
+		visibilityState = 'hidden'
+		void createAppStub().preload(abort.signal).catch(rejected)
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(rejected).not.toHaveBeenCalled()
+		abort.abort()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(rejected).toHaveBeenCalledWith(expect.objectContaining({ name: 'AbortError' }))
+		expect(rejected.mock.calls[0][0].diagnostics).toBeUndefined()
 		expect(vi.getTimerCount()).toBe(0)
 	})
 
@@ -153,28 +171,49 @@ describe('TldrawApp.preload', () => {
 })
 
 describe('ZeroLogBuffer', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
 	it('keeps the most recent lines and forwards warnings and errors to the console', () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {})
 		const buffer = new ZeroLogBuffer()
 
-		for (let i = 0; i < 70; i++) buffer.log('info', undefined, `line ${i}`)
+		for (let i = 0; i < 50; i++) buffer.log('info', undefined, `line ${i}`)
 		buffer.log('warn', { wsid: 'w1' }, 'slow', { ms: 12 })
 		buffer.log(
 			'error',
 			undefined,
-			Object.assign(new Error('boom'), { kind: 'TransformFailed', errorBody: { status: 401 } })
+			Object.assign(new Error('boom'), {
+				kind: 'TransformFailed',
+				errorBody: { status: 401 },
+				cause: new Error('why'),
+			})
 		)
 
 		const lines = buffer.recent()
-		expect(lines).toHaveLength(60)
-		expect(lines[0]).toContain('info  line 12')
-		expect(lines.at(-2)).toContain('warn wsid=w1 slow {"ms":12}')
-		expect(lines.at(-1)).toContain(
-			'error  Error: boom {"kind":"TransformFailed","errorBody":{"status":401}}'
+		expect(lines).toHaveLength(40)
+		expect(lines[0]).toMatch(/^\+\d+ms info line 12$/)
+		expect(lines.at(-2)).toMatch(/ warn wsid=w1 slow {"ms":12}$/)
+		expect(lines.at(-1)).toMatch(
+			/ error Error: boom {"kind":"TransformFailed","errorBody":{"status":401}} \(cause: Error: why\)$/
 		)
 		expect(warn).toHaveBeenCalledWith({ wsid: 'w1' }, 'slow', { ms: 12 })
 		expect(error).toHaveBeenCalledWith(expect.any(Error))
 		expect(buffer.recent()).not.toBe(lines)
+	})
+
+	it('redacts tokens and truncates long lines', () => {
+		const buffer = new ZeroLogBuffer()
+		const jwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyXzEifQ.c2lnbmF0dXJl'
+		buffer.log('info', undefined, `["updateAuth",{"auth":"${jwt}"}]`)
+		buffer.log('info', undefined, 'x'.repeat(300))
+
+		const [auth, long] = buffer.recent()
+		expect(auth).toContain('"auth":"eyJ<redacted>.eyJ<redacted>.c2lnbmF0dXJl"')
+		expect(auth).not.toContain('eyJhbGci')
+		expect(long).toHaveLength(251)
+		expect(long.endsWith('…')).toBe(true)
 	})
 })

--- a/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.test.ts
@@ -160,13 +160,19 @@ describe('ZeroLogBuffer', () => {
 
 		for (let i = 0; i < 70; i++) buffer.log('info', undefined, `line ${i}`)
 		buffer.log('warn', { wsid: 'w1' }, 'slow', { ms: 12 })
-		buffer.log('error', undefined, new Error('boom'))
+		buffer.log(
+			'error',
+			undefined,
+			Object.assign(new Error('boom'), { kind: 'TransformFailed', errorBody: { status: 401 } })
+		)
 
 		const lines = buffer.recent()
 		expect(lines).toHaveLength(60)
 		expect(lines[0]).toContain('info  line 12')
 		expect(lines.at(-2)).toContain('warn wsid=w1 slow {"ms":12}')
-		expect(lines.at(-1)).toContain('error  Error: boom')
+		expect(lines.at(-1)).toContain(
+			'error  Error: boom {"kind":"TransformFailed","errorBody":{"status":401}}'
+		)
 		expect(warn).toHaveBeenCalledWith({ wsid: 'w1' }, 'slow', { ms: 12 })
 		expect(error).toHaveBeenCalledWith(expect.any(Error))
 		expect(buffer.recent()).not.toBe(lines)

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -442,7 +442,6 @@ export class TldrawApp {
 		// cmd-clicked tab would burn the deadline before it gets a chance. Only count visible time,
 		// and start over on return: Zero drops the socket after five minutes hidden, so whatever was
 		// left of the budget would cover a cold reconnect only by luck.
-		let remainingMs = USER_PRELOAD_TIMEOUT_MS
 		let timeout: ReturnType<typeof setTimeout> | undefined
 		let hiddenSince = 0
 		const resumeDeadline = () => {
@@ -450,9 +449,8 @@ export class TldrawApp {
 			if (hiddenSince) {
 				hiddenMs += Date.now() - hiddenSince
 				hiddenSince = 0
-				remainingMs = USER_PRELOAD_TIMEOUT_MS
 			}
-			timeout = setTimeout(fail, remainingMs)
+			timeout = setTimeout(fail, USER_PRELOAD_TIMEOUT_MS)
 		}
 		const pauseDeadline = () => {
 			if (timeout === undefined) return

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -69,7 +69,7 @@ import { getDateFormat } from '../utils/dates'
 import { FeatureFlags } from '../utils/FeatureFlagPoller'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
 import { updateLocalSessionState } from '../utils/local-session-state'
-import { ZeroLogBuffer } from './ZeroLogBuffer'
+import { ZeroLogBuffer, formatLogArg } from './ZeroLogBuffer'
 
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
@@ -409,7 +409,7 @@ export class TldrawApp {
 				diagnostics: {
 					stage,
 					connection: connection.name,
-					connectionReason: connection.reason?.message,
+					connectionReason: 'reason' in connection ? formatLogArg(connection.reason) : undefined,
 					visibilityState: document.visibilityState,
 					hiddenMs,
 					online: navigator.onLine,

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -69,52 +69,12 @@ import { getDateFormat } from '../utils/dates'
 import { FeatureFlags } from '../utils/FeatureFlagPoller'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
 import { updateLocalSessionState } from '../utils/local-session-state'
+import { ZeroLogBuffer } from './ZeroLogBuffer'
 
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
 
 const USER_PRELOAD_TIMEOUT_MS = 30_000
-
-type ZeroLogSink = NonNullable<ConstructorParameters<typeof Zero>[0]['logSink']>
-type ZeroLogLevel = Parameters<ZeroLogSink['log']>[0]
-const ZERO_LOG_BUFFER_LINES = 60
-
-/**
- * Keeps Zero's recent info-level log lines so a bootstrap timeout can carry them to Sentry: the
- * connect/disconnect/poke lifecycle is only logged at info, and the console sink would print all of
- * it. Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
- */
-export class ZeroLogBuffer implements ZeroLogSink {
-	private readonly lines: string[] = []
-
-	log(level: ZeroLogLevel, context: Record<string, unknown> | undefined, ...args: unknown[]) {
-		if (level === 'warn' || level === 'error') {
-			console[level](...(context ? [context] : []), ...args)
-		}
-		const ctx = context
-			? Object.entries(context)
-					.map(([k, v]) => `${k}=${String(v)}`)
-					.join(' ')
-			: ''
-		const line = `+${Math.round(performance.now())}ms ${level} ${ctx} ${args.map(formatLogArg).join(' ')}`
-		this.lines.push(line.slice(0, 400))
-		if (this.lines.length > ZERO_LOG_BUFFER_LINES) this.lines.shift()
-	}
-
-	recent(): string[] {
-		return this.lines.slice()
-	}
-}
-
-function formatLogArg(arg: unknown): string {
-	if (arg instanceof Error) return `${arg.name}: ${arg.message}`
-	if (typeof arg === 'string') return arg
-	try {
-		return JSON.stringify(arg)
-	} catch {
-		return String(arg)
-	}
-}
 
 let appId = 0
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -69,12 +69,28 @@ import { getDateFormat } from '../utils/dates'
 import { FeatureFlags } from '../utils/FeatureFlagPoller'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
 import { updateLocalSessionState } from '../utils/local-session-state'
-import { ZeroLogBuffer, formatLogArg } from './ZeroLogBuffer'
+import { ZeroLogBuffer, formatLogArg, redactTokens } from './ZeroLogBuffer'
 
 export const TLDR_FILE_ENDPOINT = `/api/app/tldr`
 export const PUBLISH_ENDPOINT = `/api/app/publish`
 
 const USER_PRELOAD_TIMEOUT_MS = 30_000
+
+export interface PreloadDiagnostics {
+	stage: string
+	connection: string
+	connectionReason: string | undefined
+	visibilityState: DocumentVisibilityState
+	hiddenMs: number
+	online: boolean
+	msSinceNavigation: number
+	msSinceInit: number
+	zeroLog: string[]
+}
+
+export function getPreloadDiagnostics(error: unknown): PreloadDiagnostics | undefined {
+	return (error as { diagnostics?: PreloadDiagnostics } | null)?.diagnostics
+}
 
 let appId = 0
 
@@ -381,7 +397,7 @@ export class TldrawApp {
 		}
 	}
 
-	async preload() {
+	async preload(signal?: AbortSignal) {
 		// Ensure user exists in DB before Zero can query
 		const token = await this.getToken()
 		if (!token) throw new Error('No auth token available for init')
@@ -400,44 +416,48 @@ export class TldrawApp {
 		const initReturnedAt = Date.now()
 		let hiddenMs = 0
 		const fail = () => {
-			const connection = this.z.connection.state.current
-			const error =
-				initError ??
-				new Error(`Timed out waiting for the ${stage} after init (zero ${connection.name})`)
-			// ExtraErrorData picks these up as Sentry extras.
-			Object.assign(error, {
-				diagnostics: {
-					stage,
-					connection: connection.name,
-					connectionReason: 'reason' in connection ? formatLogArg(connection.reason) : undefined,
-					visibilityState: document.visibilityState,
-					hiddenMs,
-					online: navigator.onLine,
-					msSinceNavigation: Math.round(performance.now()),
-					msSinceInit: Date.now() - initReturnedAt,
-					zeroLog: this.zeroLog.recent(),
-				},
-			})
-			timedOut.reject(error)
+			const error = initError ?? new Error(`Timed out waiting for the ${stage} after init`)
+			try {
+				const connection = this.z.connection.state.current
+				// Sentry's ExtraErrorData integration copies this onto the event.
+				Object.assign(error, {
+					diagnostics: {
+						stage,
+						connection: connection.name,
+						connectionReason:
+							'reason' in connection ? redactTokens(formatLogArg(connection.reason)) : undefined,
+						visibilityState: document.visibilityState,
+						hiddenMs,
+						online: navigator.onLine,
+						msSinceNavigation: Math.round(performance.now()),
+						msSinceInit: Date.now() - initReturnedAt,
+						zeroLog: this.zeroLog.recent(),
+					} satisfies PreloadDiagnostics,
+				})
+			} finally {
+				timedOut.reject(error)
+			}
 		}
-		// Zero never opens its socket while the tab is hidden, so a background tab (session restore,
-		// cmd-click) would burn the whole deadline before getting a chance. Only count visible time.
+		// Zero built in a hidden tab waits for visibility before connecting, so a restored or
+		// cmd-clicked tab would burn the deadline before it gets a chance. Only count visible time,
+		// and start over on return: Zero drops the socket after five minutes hidden, so whatever was
+		// left of the budget would cover a cold reconnect only by luck.
 		let remainingMs = USER_PRELOAD_TIMEOUT_MS
 		let timeout: ReturnType<typeof setTimeout> | undefined
-		let runningSince = 0
 		let hiddenSince = 0
 		const resumeDeadline = () => {
 			if (timeout !== undefined) return
-			if (hiddenSince) hiddenMs += Date.now() - hiddenSince
-			hiddenSince = 0
-			runningSince = Date.now()
+			if (hiddenSince) {
+				hiddenMs += Date.now() - hiddenSince
+				hiddenSince = 0
+				remainingMs = USER_PRELOAD_TIMEOUT_MS
+			}
 			timeout = setTimeout(fail, remainingMs)
 		}
 		const pauseDeadline = () => {
 			if (timeout === undefined) return
 			clearTimeout(timeout)
 			timeout = undefined
-			remainingMs -= Date.now() - runningSince
 			hiddenSince = Date.now()
 		}
 		const onVisibilityChange = () =>
@@ -445,6 +465,11 @@ export class TldrawApp {
 		document.addEventListener('visibilitychange', onVisibilityChange)
 		if (document.visibilityState === 'visible') resumeDeadline()
 		else hiddenSince = Date.now()
+		// A hidden tab can sit here indefinitely, so the caller needs a way to settle this and let
+		// create() dispose the half-built app when it gives up on it.
+		const onAbort = () => timedOut.reject(new DOMException('Bootstrap cancelled', 'AbortError'))
+		signal?.addEventListener('abort', onAbort)
+		if (signal?.aborted) onAbort()
 		try {
 			await Promise.race([this.z.preload(queries.user()).complete, timedOut])
 			stage = 'state flush'
@@ -456,6 +481,7 @@ export class TldrawApp {
 			})
 			await Promise.race([userLoaded, timedOut])
 		} finally {
+			signal?.removeEventListener('abort', onAbort)
 			document.removeEventListener('visibilitychange', onVisibilityChange)
 			clearTimeout(timeout)
 			stopWaiting?.()
@@ -1050,6 +1076,8 @@ export class TldrawApp {
 		onClientTooOld(): void
 		trackEvent: TLAppUiContextType
 		navigate: ReturnType<typeof useNavigate>
+		/** Settles a bootstrap the caller no longer wants, e.g. a tab that never became visible. */
+		signal?: AbortSignal
 	}) {
 		// This is an issue: we may have a user record but not in the store.
 		// Could be just old accounts since before the server had a version
@@ -1072,7 +1100,7 @@ export class TldrawApp {
 		// @ts-expect-error
 		window.app = app
 		try {
-			await app.preload()
+			await app.preload(opts.signal)
 		} catch (e) {
 			// Don't leave the half-built app's Zero connection and timers running behind the
 			// error page the caller shows for this.

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -75,6 +75,47 @@ export const PUBLISH_ENDPOINT = `/api/app/publish`
 
 const USER_PRELOAD_TIMEOUT_MS = 30_000
 
+type ZeroLogSink = NonNullable<ConstructorParameters<typeof Zero>[0]['logSink']>
+type ZeroLogLevel = Parameters<ZeroLogSink['log']>[0]
+const ZERO_LOG_BUFFER_LINES = 60
+
+/**
+ * Keeps Zero's recent info-level log lines so a bootstrap timeout can carry them to Sentry: the
+ * connect/disconnect/poke lifecycle is only logged at info, and the console sink would print all of
+ * it. Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
+ */
+export class ZeroLogBuffer implements ZeroLogSink {
+	private readonly lines: string[] = []
+
+	log(level: ZeroLogLevel, context: Record<string, unknown> | undefined, ...args: unknown[]) {
+		if (level === 'warn' || level === 'error') {
+			console[level](...(context ? [context] : []), ...args)
+		}
+		const ctx = context
+			? Object.entries(context)
+					.map(([k, v]) => `${k}=${String(v)}`)
+					.join(' ')
+			: ''
+		const line = `+${Math.round(performance.now())}ms ${level} ${ctx} ${args.map(formatLogArg).join(' ')}`
+		this.lines.push(line.slice(0, 400))
+		if (this.lines.length > ZERO_LOG_BUFFER_LINES) this.lines.shift()
+	}
+
+	recent(): string[] {
+		return this.lines.slice()
+	}
+}
+
+function formatLogArg(arg: unknown): string {
+	if (arg instanceof Error) return `${arg.name}: ${arg.message}`
+	if (typeof arg === 'string') return arg
+	try {
+		return JSON.stringify(arg)
+	} catch {
+		return String(arg)
+	}
+}
+
 let appId = 0
 
 /**
@@ -185,6 +226,7 @@ export class TldrawApp {
 
 	changes: Map<Atom<any, unknown>, any> = new Map()
 	changesFlushed = null as null | ReturnType<typeof promiseWithResolve>
+	private readonly zeroLog = new ZeroLogBuffer()
 
 	// Track new room creation timestamps and sources
 	private newRoomCreationStartTimes: Map<string, { startTime: number; source: string }> = new Map()
@@ -257,6 +299,8 @@ export class TldrawApp {
 			cacheURL: ZERO_SERVER,
 			mutators: createMutators(userId),
 			context: { userId } satisfies ZeroContext,
+			logLevel: 'info',
+			logSink: this.zeroLog,
 			onUpdateNeeded(reason) {
 				console.error('update needed', reason)
 				onClientTooOld()
@@ -393,11 +437,54 @@ export class TldrawApp {
 		let stage: 'zero query' | 'state flush' | 'user record' = 'zero query'
 		const timedOut = promiseWithResolve<never>()
 		let stopWaiting: (() => void) | undefined
-		const timeout = setTimeout(
-			() =>
-				timedOut.reject(initError ?? new Error(`Timed out waiting for the ${stage} after init`)),
-			USER_PRELOAD_TIMEOUT_MS
-		)
+		const initReturnedAt = Date.now()
+		let hiddenMs = 0
+		const fail = () => {
+			const connection = this.z.connection.state.current
+			const error =
+				initError ??
+				new Error(`Timed out waiting for the ${stage} after init (zero ${connection.name})`)
+			// ExtraErrorData picks these up as Sentry extras.
+			Object.assign(error, {
+				diagnostics: {
+					stage,
+					connection: connection.name,
+					connectionReason: connection.reason?.message,
+					visibilityState: document.visibilityState,
+					hiddenMs,
+					online: navigator.onLine,
+					msSinceNavigation: Math.round(performance.now()),
+					msSinceInit: Date.now() - initReturnedAt,
+					zeroLog: this.zeroLog.recent(),
+				},
+			})
+			timedOut.reject(error)
+		}
+		// Zero never opens its socket while the tab is hidden, so a background tab (session restore,
+		// cmd-click) would burn the whole deadline before getting a chance. Only count visible time.
+		let remainingMs = USER_PRELOAD_TIMEOUT_MS
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		let runningSince = 0
+		let hiddenSince = 0
+		const resumeDeadline = () => {
+			if (timeout !== undefined) return
+			if (hiddenSince) hiddenMs += Date.now() - hiddenSince
+			hiddenSince = 0
+			runningSince = Date.now()
+			timeout = setTimeout(fail, remainingMs)
+		}
+		const pauseDeadline = () => {
+			if (timeout === undefined) return
+			clearTimeout(timeout)
+			timeout = undefined
+			remainingMs -= Date.now() - runningSince
+			hiddenSince = Date.now()
+		}
+		const onVisibilityChange = () =>
+			document.visibilityState === 'visible' ? resumeDeadline() : pauseDeadline()
+		document.addEventListener('visibilitychange', onVisibilityChange)
+		if (document.visibilityState === 'visible') resumeDeadline()
+		else hiddenSince = Date.now()
 		try {
 			await Promise.race([this.z.preload(queries.user()).complete, timedOut])
 			stage = 'state flush'
@@ -409,6 +496,7 @@ export class TldrawApp {
 			})
 			await Promise.race([userLoaded, timedOut])
 		} finally {
+			document.removeEventListener('visibilitychange', onVisibilityChange)
 			clearTimeout(timeout)
 			stopWaiting?.()
 		}

--- a/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
+++ b/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
@@ -31,7 +31,7 @@ export class ZeroLogBuffer implements ZeroLogSink {
 	}
 }
 
-function formatLogArg(arg: unknown): string {
+export function formatLogArg(arg: unknown): string {
 	if (arg instanceof Error) return `${arg.name}: ${arg.message}`
 	if (typeof arg === 'string') return arg
 	try {

--- a/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
+++ b/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
@@ -1,0 +1,42 @@
+import { Zero } from '@rocicorp/zero'
+
+type ZeroLogSink = NonNullable<ConstructorParameters<typeof Zero>[0]['logSink']>
+type ZeroLogLevel = Parameters<ZeroLogSink['log']>[0]
+const ZERO_LOG_BUFFER_LINES = 60
+
+/**
+ * Keeps Zero's recent info-level log lines so a bootstrap timeout can carry them to Sentry: the
+ * connect/disconnect/poke lifecycle is only logged at info, and the console sink would print all of
+ * it. Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
+ */
+export class ZeroLogBuffer implements ZeroLogSink {
+	private readonly lines: string[] = []
+
+	log(level: ZeroLogLevel, context: Record<string, unknown> | undefined, ...args: unknown[]) {
+		if (level === 'warn' || level === 'error') {
+			console[level](...(context ? [context] : []), ...args)
+		}
+		const ctx = context
+			? Object.entries(context)
+					.map(([k, v]) => `${k}=${String(v)}`)
+					.join(' ')
+			: ''
+		const line = `+${Math.round(performance.now())}ms ${level} ${ctx} ${args.map(formatLogArg).join(' ')}`
+		this.lines.push(line.slice(0, 400))
+		if (this.lines.length > ZERO_LOG_BUFFER_LINES) this.lines.shift()
+	}
+
+	recent(): string[] {
+		return this.lines.slice()
+	}
+}
+
+function formatLogArg(arg: unknown): string {
+	if (arg instanceof Error) return `${arg.name}: ${arg.message}`
+	if (typeof arg === 'string') return arg
+	try {
+		return JSON.stringify(arg)
+	} catch {
+		return String(arg)
+	}
+}

--- a/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
+++ b/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
@@ -32,7 +32,11 @@ export class ZeroLogBuffer implements ZeroLogSink {
 }
 
 export function formatLogArg(arg: unknown): string {
-	if (arg instanceof Error) return `${arg.name}: ${arg.message}`
+	if (arg instanceof Error) {
+		// Zero's errors carry their kind and errorBody (http status, reason) as own properties.
+		const extra = Object.keys(arg).length ? ` ${formatLogArg({ ...arg })}` : ''
+		return `${arg.name}: ${arg.message}${extra}`
+	}
 	if (typeof arg === 'string') return arg
 	try {
 		return JSON.stringify(arg)

--- a/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
+++ b/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
@@ -2,12 +2,14 @@ import { Zero } from '@rocicorp/zero'
 
 type ZeroLogSink = NonNullable<ConstructorParameters<typeof Zero>[0]['logSink']>
 type ZeroLogLevel = Parameters<ZeroLogSink['log']>[0]
-const ZERO_LOG_BUFFER_LINES = 60
+// Sentry trims context values around 16KB, and it does so silently in exactly the noisy cases.
+const ZERO_LOG_BUFFER_LINES = 40
+const ZERO_LOG_LINE_CHARS = 250
 
 /**
  * Keeps Zero's recent info-level log lines so a bootstrap timeout can carry them to Sentry: the
- * connect/disconnect/poke lifecycle is only logged at info, and the console sink would print all of
- * it. Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
+ * connection lifecycle is only logged at info, and the console sink would print all of it.
+ * Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
  */
 export class ZeroLogBuffer implements ZeroLogSink {
 	private readonly lines: string[] = []
@@ -16,13 +18,14 @@ export class ZeroLogBuffer implements ZeroLogSink {
 		if (level === 'warn' || level === 'error') {
 			console[level](...(context ? [context] : []), ...args)
 		}
-		const ctx = context
-			? Object.entries(context)
-					.map(([k, v]) => `${k}=${String(v)}`)
-					.join(' ')
-			: ''
-		const line = `+${Math.round(performance.now())}ms ${level} ${ctx} ${args.map(formatLogArg).join(' ')}`
-		this.lines.push(line.slice(0, 400))
+		const ctx = context ? Object.entries(context).map(([k, v]) => `${k}=${String(v)}`) : []
+		const line = [
+			`+${Math.round(performance.now())}ms`,
+			level,
+			...ctx,
+			...args.map(formatLogArg),
+		].join(' ')
+		this.lines.push(truncate(redactTokens(line), ZERO_LOG_LINE_CHARS))
 		if (this.lines.length > ZERO_LOG_BUFFER_LINES) this.lines.shift()
 	}
 
@@ -34,8 +37,10 @@ export class ZeroLogBuffer implements ZeroLogSink {
 export function formatLogArg(arg: unknown): string {
 	if (arg instanceof Error) {
 		// Zero's errors carry their kind and errorBody (http status, reason) as own properties.
-		const extra = Object.keys(arg).length ? ` ${formatLogArg({ ...arg })}` : ''
-		return `${arg.name}: ${arg.message}${extra}`
+		const { cause: _cause, ...own } = arg as Error & Record<string, unknown>
+		const extra = Object.keys(own).length ? ` ${formatLogArg(own)}` : ''
+		const cause = arg.cause !== undefined ? ` (cause: ${formatLogArg(arg.cause)})` : ''
+		return `${arg.name}: ${arg.message}${extra}${cause}`
 	}
 	if (typeof arg === 'string') return arg
 	try {
@@ -43,4 +48,13 @@ export function formatLogArg(arg: unknown): string {
 	} catch {
 		return String(arg)
 	}
+}
+
+/** Zero echoes recent sent messages, `updateAuth` included, into some close errors. */
+export function redactTokens(text: string): string {
+	return text.replace(/eyJ[A-Za-z0-9_-]{10,}/g, 'eyJ<redacted>')
+}
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text
 }

--- a/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
+++ b/apps/dotcom/client/src/tla/app/ZeroLogBuffer.ts
@@ -7,7 +7,7 @@ const ZERO_LOG_BUFFER_LINES = 40
 const ZERO_LOG_LINE_CHARS = 250
 
 /**
- * Keeps Zero's recent info-level log lines so a bootstrap timeout can carry them to Sentry: the
+ * Keeps Zero's recent log lines so a bootstrap timeout can carry them to Sentry: the
  * connection lifecycle is only logged at info, and the console sink would print all of it.
  * Warnings and errors still reach the console (and Sentry breadcrumbs) as before.
  */

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -4,7 +4,7 @@ import { ReactNode, createContext, useContext, useEffect, useState } from 'react
 import { useNavigate } from 'react-router-dom'
 import { assertExists, atom } from 'tldraw'
 import { ErrorPage } from '../../components/ErrorPage/ErrorPage'
-import { TldrawApp } from '../app/TldrawApp'
+import { TldrawApp, getPreloadDiagnostics } from '../app/TldrawApp'
 import { useTldrawAppUiEvents } from '../utils/app-ui-events'
 import {
 	DEFAULT_FLAGS,
@@ -38,6 +38,7 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		let _app: TldrawApp
 		let didCancel = false
+		const abort = new AbortController()
 		setError(null)
 
 		const FETCH_TIMEOUT = 5000
@@ -79,6 +80,7 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 				},
 				trackEvent,
 				navigate,
+				signal: abort.signal,
 			})
 			if (didCancel) {
 				app.dispose()
@@ -90,15 +92,19 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 			if (didCancel) return
 			console.error('[AppState] Failed to initialize:', err)
 			// Default grouping keys on the stack, which every preload timeout shares; the message
-			// carries the stalled stage or init status, so group on it.
+			// carries the stalled stage or init status, so group on it. The Zero connection state
+			// goes on a tag rather than the fingerprint so one stage stays one issue.
+			const diagnostics = getPreloadDiagnostics(err)
 			captureException(err, {
 				fingerprint: ['{{ default }}', err instanceof Error ? err.message : String(err)],
+				tags: diagnostics && { zero_connection: diagnostics.connection },
 			})
 			setError(err)
 		})
 
 		return () => {
 			didCancel = true
+			abort.abort()
 			if (_app) {
 				_app.dispose()
 			}


### PR DESCRIPTION
This PR fixes a bug where a tldraw.com tab loaded in the background (session restore, cmd-click, switching away mid-load) shows the "Something went wrong" page instead of the app. It also attaches enough context to the remaining bootstrap timeouts to tell them apart in Sentry.

### Before

Zero's run loop does not open its WebSocket while `document.visibilityState` is `hidden`; it waits for the tab to become visible. `TldrawApp.preload` started its 30s deadline immediately, so a background tab burned the whole deadline before Zero ever tried to connect, then rendered the error page the user saw when they switched to it. `LITE-7CV` has ~80 events/hour with a flat rate across deploys and network conditions, and the per-user data shows clusters of 2 to 6 events landing within the same second from one IP, which is consistent with a multi-tab restore where only one tab can be visible. The hidden-tab bug is confirmed from Zero's run loop; what share of the production events it explains is not, which is what the diagnostics below are for.

The timeout error also carried nothing but the stage name. Zero logs its connect/disconnect lifecycle at `info`, below our `warn` console level, so breadcrumbs were empty and the remaining cases (broken IndexedDB, `ClientNotFound` reloads, slow hydration) were indistinguishable.

### After

The deadline only counts time while the tab is visible: it pauses on `visibilitychange` to hidden and starts over with the full 30s on return, since Zero drops its socket after five minutes hidden and whatever was left of the budget would only cover a cold reconnect by luck. A tab that never becomes visible never times out, which matches Zero never connecting; `AppStateProvider` now passes an `AbortSignal` so unmounting or a Clerk user change settles that wait and `create()` disposes the half-built app instead of leaking it.

Zero now runs with `logLevel: 'info'` into a `ZeroLogBuffer` sink that keeps the last 40 lines in memory (250 chars each, JWTs redacted, Zero error kind/body/cause preserved) and forwards `warn`/`error` to the console as before. On timeout the error gets a `diagnostics` object (stage, Zero connection state and reason, visibility, hidden time, `navigator.onLine`, time since navigation and since `/init`, and the log buffer) which Sentry's `ExtraErrorData` integration copies onto the event. The connection state also goes on a `zero_connection` tag, so the issue stays one-per-stage and the tag bar shows the `connecting` / `disconnected` / `needs-auth` / `error` split.

### Implementation notes

- Any hide/show cycle restarts the full 30s, not only stretches long enough for Zero to have dropped the socket. A genuinely stuck client that keeps switching tabs sees the error page later, never wrongly, and the alternative needed a threshold coupled to Zero's internal `hiddenTabDisconnectDelay`. Read `LITE-7CV` volume after this ships with that in mind: it drops for both reasons, so look at the `zero_connection` tag split rather than the count.
- The connection state deliberately stays out of the message. Fingerprinting on it would fan the issue out to stages × states; a tag gives the same breakdown on one issue per stage.
- The buffer is capped at 40 × 250 chars because Sentry trims context values around 16KB silently, which would hit exactly the noisy cases.
- Not in this PR: falling back to `kvStore: 'mem'` when IndexedDB fails to open. The heaviest repeat offenders in `LITE-7CV` also report `Internal error opening backing store for indexedDB.open`; they will now show up as `connecting` with the IDB error in the log buffer, which is enough to size that follow-up.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the hidden-tab and diagnostics tests fail on `main` and pass with this change

### Release notes

- Fix an error page when tldraw.com is opened in a background tab

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +149 / -9  |
| Tests   | +135 / -5  |
