### PR TITLE
refactor(editor): make PerformanceManager extend EditorManager

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1724,7 +1724,7 @@ export const EditorContext: React_3.Context<Editor | null>;
 // @public
 export abstract class EditorManager {
     constructor(editor: Editor);
-    protected addEditorEvent<E extends keyof TLEventMap>(event: E, fn: (...args: TLEventMap[E]) => void): void;
+    protected addEditorEvent<E extends keyof TLEventMap>(event: E, fn: (...args: TLEventMap[E]) => void): () => void;
     // (undocumented)
     protected readonly disposables: Set<() => void>;
     // @internal (undocumented)
@@ -1732,6 +1732,7 @@ export abstract class EditorManager {
     // (undocumented)
     protected readonly editor: Editor;
     protected register(dispose: () => void): () => void;
+    protected unregister(dispose: () => void): void;
 }
 
 // @public
@@ -2755,8 +2756,7 @@ export class PerformanceApiAdapter {
 }
 
 // @public
-export class PerformanceManager {
-    constructor(editor: Editor);
+export class PerformanceManager extends EditorManager {
     // @internal (undocumented)
     dispose(): void;
     // @internal (undocumented)

--- a/packages/editor/src/lib/editor/managers/EditorManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.test.ts
@@ -4,15 +4,23 @@ import { EditorManager } from './EditorManager'
 
 class TestManager extends EditorManager {
 	onTestEvent = vi.fn()
+	removeTestEvent: () => void
 
 	constructor(editor: Editor) {
 		super(editor)
-		this.addEditorEvent('frame', this.onTestEvent)
+		this.removeTestEvent = this.addEditorEvent('frame', this.onTestEvent)
+	}
+
+	detachTestEvent() {
+		this.unregister(this.removeTestEvent)
 	}
 
 	cancelRaf = vi.fn()
 	startRaf() {
 		this.register(this.cancelRaf)
+	}
+	stopRaf() {
+		this.unregister(this.cancelRaf)
 	}
 }
 
@@ -47,5 +55,28 @@ describe('EditorManager', () => {
 	it('dispose is safe to call twice', () => {
 		manager.dispose()
 		expect(() => manager.dispose()).not.toThrow()
+	})
+
+	it('unregister runs the disposable now and drops it from dispose', () => {
+		manager.startRaf()
+		manager.stopRaf()
+		expect(manager.cancelRaf).toHaveBeenCalledTimes(1)
+		manager.dispose()
+		expect(manager.cancelRaf).toHaveBeenCalledTimes(1)
+	})
+
+	it('unregister ignores a disposable that already ran', () => {
+		manager.startRaf()
+		manager.dispose()
+		manager.stopRaf()
+		expect(manager.cancelRaf).toHaveBeenCalledTimes(1)
+	})
+
+	it('addEditorEvent returns the registered unsubscribe so it can be detached early', () => {
+		manager.detachTestEvent()
+		expect(off).toHaveBeenCalledTimes(1)
+		expect(off).toHaveBeenCalledWith('frame', manager.onTestEvent)
+		manager.dispose()
+		expect(off).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/editor/src/lib/editor/managers/EditorManager.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.ts
@@ -16,6 +16,8 @@ import type { TLEventMap } from '../types/emit-types'
  * - Reaction (`react(...)` from `@tldraw/state`): `this.register(react(...))`
  * - DOM listener: `this.register(() => el.removeEventListener(...))`
  * - Other resource (cache, index, child manager): `this.register(() => x.dispose())`
+ * - Resource held only part of the time (a listener attached while subscribers exist):
+ *   `this.register(...)` on attach and `this.unregister(...)` on detach, see `PerformanceManager`
  *
  * For timeouts, intervals, and animation frames prefer `editor.timers` (context-grouped
  * and auto-disposed) over raw `setTimeout`. For cleanup on the editor itself rather than a
@@ -41,15 +43,25 @@ export abstract class EditorManager {
 	}
 
 	/**
+	 * Run a registered teardown now instead of at `dispose()`. A teardown that is no longer
+	 * registered (already run by `dispose()`, or never registered) is skipped, so nothing is
+	 * torn down twice.
+	 */
+	protected unregister(dispose: () => void): void {
+		if (this.disposables.delete(dispose)) dispose()
+	}
+
+	/**
 	 * Subscribe to an editor bus event and register the matching unsubscribe, so the listener
-	 * is removed automatically on `dispose()`.
+	 * is removed automatically on `dispose()`. Returns that unsubscribe, for passing to
+	 * {@link EditorManager.unregister} to detach it before `dispose()`.
 	 */
 	protected addEditorEvent<E extends keyof TLEventMap>(
 		event: E,
 		fn: (...args: TLEventMap[E]) => void
-	): void {
+	): () => void {
 		this.editor.on(event, fn as any)
-		this.register(() => this.editor.off(event, fn as any))
+		return this.register(() => this.editor.off(event, fn as any))
 	}
 
 	/** @internal */

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.test.ts
@@ -94,6 +94,85 @@ describe('PerformanceManager', () => {
 		})
 	})
 
+	describe('dispose()', () => {
+		it('removes every lazily attached editor listener', () => {
+			const editor = createMockEditor()
+			const pm = new PerformanceManager(editor)
+			pm.on('interaction-end', vi.fn())
+			pm.on('shapes-created', vi.fn())
+			pm.on('shapes-updated', vi.fn())
+			pm.on('shapes-deleted', vi.fn())
+			expect(editor._listeners['frame']).toHaveLength(1)
+			expect(editor._listeners['created-shapes']).toHaveLength(1)
+			expect(editor._listeners['edited-shapes']).toHaveLength(1)
+			expect(editor._listeners['deleted-shapes']).toHaveLength(1)
+
+			pm.dispose()
+
+			expect(editor._listeners).toEqual({
+				frame: [],
+				'created-shapes': [],
+				'edited-shapes': [],
+				'deleted-shapes': [],
+			})
+		})
+
+		it('disconnects the LoAF observer', () => {
+			const origPO = globalThis.PerformanceObserver
+			const mockDisconnect = vi.fn()
+			globalThis.PerformanceObserver = class MockPO {
+				constructor(_cb: any) {}
+				observe() {}
+				disconnect = mockDisconnect
+				static supportedEntryTypes = ['long-animation-frame']
+			} as any
+
+			const editor = createMockEditor()
+			const pm = new PerformanceManager(editor)
+			pm.on('interaction-end', vi.fn())
+			expect(mockDisconnect).not.toHaveBeenCalled()
+
+			pm.dispose()
+			expect(mockDisconnect).toHaveBeenCalledTimes(1)
+
+			globalThis.PerformanceObserver = origPO
+		})
+
+		it('does not tear down a listener that was already detached', () => {
+			const editor = createMockEditor()
+			const off = vi.spyOn(editor, 'off')
+			const pm = new PerformanceManager(editor)
+			pm.on('shapes-created', vi.fn())()
+			expect(off).toHaveBeenCalledTimes(1)
+
+			pm.dispose()
+			expect(off).toHaveBeenCalledTimes(1)
+		})
+
+		it('makes a stale unsubscribe a no-op after dispose', () => {
+			const editor = createMockEditor()
+			const off = vi.spyOn(editor, 'off')
+			const pm = new PerformanceManager(editor)
+			const unsub = pm.on('interaction-end', vi.fn())
+
+			pm.dispose()
+			expect(off).toHaveBeenCalledTimes(1)
+			unsub()
+			expect(off).toHaveBeenCalledTimes(1)
+		})
+
+		it('attaches again for a subscriber added after dispose', () => {
+			const editor = createMockEditor()
+			const pm = new PerformanceManager(editor)
+			pm.on('shapes-created', vi.fn())
+			pm.dispose()
+			expect(editor._listeners['created-shapes']).toHaveLength(0)
+
+			pm.on('shapes-created', vi.fn())
+			expect(editor._listeners['created-shapes']).toHaveLength(1)
+		})
+	})
+
 	describe('interaction tracking', () => {
 		it('emits interaction-start when notified', () => {
 			const editor = createMockEditor()

--- a/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
+++ b/packages/editor/src/lib/editor/managers/PerformanceManager/PerformanceManager.ts
@@ -1,7 +1,7 @@
 import type { TLRecord, TLShapeId } from '@tldraw/tlschema'
 import { bind } from '@tldraw/utils'
 import EventEmitter from 'eventemitter3'
-import type { Editor } from '../../Editor'
+import { EditorManager } from '../EditorManager'
 import type {
 	TLCameraEndPerfEvent,
 	TLCameraStartPerfEvent,
@@ -13,6 +13,9 @@ import type {
 	TLShapeOperationPerfEvent,
 	TLUndoRedoPerfEvent,
 } from './perf-types'
+
+// The editor listeners and observer that are attached only while a subscriber needs them
+type LazyListener = 'frame' | 'loaf' | 'shapes-created' | 'shapes-updated' | 'shapes-deleted'
 
 function percentile(sorted: number[], p: number): number {
 	const idx = Math.ceil(p * sorted.length) - 1
@@ -71,11 +74,9 @@ function toLoafEntry(entry: PerformanceEntry): TLPerfLongAnimationFrame | null {
  *
  * @public
  */
-export class PerformanceManager {
+export class PerformanceManager extends EditorManager {
 	/** @internal */
 	readonly emitter = new EventEmitter<TLPerfEventMap>()
-
-	private editor: Editor
 
 	// Active interaction tracking
 	private activeInteraction: {
@@ -96,18 +97,8 @@ export class PerformanceManager {
 		loafEntries: TLPerfLongAnimationFrame[]
 	} | null = null
 
-	// Lazy listener cleanup functions
-	private frameCleanup: (() => void) | null = null
-	private shapeCreatedCleanup: (() => void) | null = null
-	private shapeEditedCleanup: (() => void) | null = null
-	private shapeDeletedCleanup: (() => void) | null = null
-
-	// LoAF observer
-	private loafObserver: PerformanceObserver | null = null
-
-	constructor(editor: Editor) {
-		this.editor = editor
-	}
+	// Cleanups for whatever is currently attached, keyed so a detach unregisters only its own
+	private readonly lazyCleanups = new Map<LazyListener, () => void>()
 
 	/**
 	 * Subscribe to a performance event. Returns an unsubscribe function.
@@ -161,16 +152,9 @@ export class PerformanceManager {
 		if (this.activeCamera?.timeout) clearTimeout(this.activeCamera.timeout)
 		this.activeInteraction = null
 		this.activeCamera = null
-		this.frameCleanup?.()
-		this.frameCleanup = null
-		this.shapeCreatedCleanup?.()
-		this.shapeCreatedCleanup = null
-		this.shapeEditedCleanup?.()
-		this.shapeEditedCleanup = null
-		this.shapeDeletedCleanup?.()
-		this.shapeDeletedCleanup = null
-		this._stopLoafObserver()
+		this.lazyCleanups.clear()
 		this.emitter.removeAllListeners()
+		super.dispose()
 	}
 
 	// --- Internal notification methods ---
@@ -444,7 +428,7 @@ export class PerformanceManager {
 			return
 		}
 
-		this.loafObserver = new PerformanceObserver((list) => {
+		const observer = new PerformanceObserver((list) => {
 			const isInteractionActive = this.activeInteraction !== null
 			const isCameraActive = this.activeCamera !== null
 
@@ -463,14 +447,11 @@ export class PerformanceManager {
 			}
 		})
 
-		this.loafObserver.observe({ type: 'long-animation-frame', buffered: false })
-	}
-
-	private _stopLoafObserver() {
-		if (this.loafObserver) {
-			this.loafObserver.disconnect()
-			this.loafObserver = null
-		}
+		observer.observe({ type: 'long-animation-frame', buffered: false })
+		this.lazyCleanups.set(
+			'loaf',
+			this.register(() => observer.disconnect())
+		)
 	}
 
 	// --- Lazy listener management ---
@@ -495,7 +476,7 @@ export class PerformanceManager {
 	private _maybeAttachLazyListeners(event: keyof TLPerfEventMap) {
 		// Frame listener needed for frame event + interaction/camera frame time tracking
 		if (
-			!this.frameCleanup &&
+			!this.lazyCleanups.has('frame') &&
 			(event === 'frame' ||
 				event === 'interaction-start' ||
 				event === 'interaction-end' ||
@@ -503,81 +484,73 @@ export class PerformanceManager {
 				event === 'camera-end')
 		) {
 			if (this._needsFrameListener()) {
-				this.editor.on('frame', this._onFrame)
-				this.frameCleanup = () => this.editor.off('frame', this._onFrame)
+				this.lazyCleanups.set('frame', this.addEditorEvent('frame', this._onFrame))
 			}
 		}
 
 		// LoAF observer needed when interaction-end or camera-end listeners exist
-		if (!this.loafObserver && (event === 'interaction-end' || event === 'camera-end')) {
+		if (!this.lazyCleanups.has('loaf') && (event === 'interaction-end' || event === 'camera-end')) {
 			if (this._needsLoafObserver()) {
 				this._startLoafObserver()
 			}
 		}
 
-		if (!this.shapeCreatedCleanup && event === 'shapes-created') {
-			this.editor.on('created-shapes', this._onShapesCreated)
-			this.shapeCreatedCleanup = () => this.editor.off('created-shapes', this._onShapesCreated)
+		if (!this.lazyCleanups.has('shapes-created') && event === 'shapes-created') {
+			this.lazyCleanups.set(
+				'shapes-created',
+				this.addEditorEvent('created-shapes', this._onShapesCreated)
+			)
 		}
 
-		if (!this.shapeEditedCleanup && event === 'shapes-updated') {
-			this.editor.on('edited-shapes', this._onShapesEdited)
-			this.shapeEditedCleanup = () => this.editor.off('edited-shapes', this._onShapesEdited)
+		if (!this.lazyCleanups.has('shapes-updated') && event === 'shapes-updated') {
+			this.lazyCleanups.set(
+				'shapes-updated',
+				this.addEditorEvent('edited-shapes', this._onShapesEdited)
+			)
 		}
 
-		if (!this.shapeDeletedCleanup && event === 'shapes-deleted') {
-			this.editor.on('deleted-shapes', this._onShapesDeleted)
-			this.shapeDeletedCleanup = () => this.editor.off('deleted-shapes', this._onShapesDeleted)
+		if (!this.lazyCleanups.has('shapes-deleted') && event === 'shapes-deleted') {
+			this.lazyCleanups.set(
+				'shapes-deleted',
+				this.addEditorEvent('deleted-shapes', this._onShapesDeleted)
+			)
 		}
 	}
 
 	private _maybeDetachLazyListeners(event: keyof TLPerfEventMap) {
 		if (
-			this.frameCleanup &&
 			(event === 'frame' ||
 				event === 'interaction-start' ||
 				event === 'interaction-end' ||
 				event === 'camera-start' ||
-				event === 'camera-end')
+				event === 'camera-end') &&
+			!this._needsFrameListener()
 		) {
-			if (!this._needsFrameListener()) {
-				this.frameCleanup()
-				this.frameCleanup = null
-			}
+			this._detachLazy('frame')
 		}
 
 		// Stop LoAF observer when no longer needed
-		if (this.loafObserver && (event === 'interaction-end' || event === 'camera-end')) {
-			if (!this._needsLoafObserver()) {
-				this._stopLoafObserver()
-			}
+		if ((event === 'interaction-end' || event === 'camera-end') && !this._needsLoafObserver()) {
+			this._detachLazy('loaf')
 		}
 
-		if (
-			this.shapeCreatedCleanup &&
-			event === 'shapes-created' &&
-			this.emitter.listenerCount('shapes-created') === 0
-		) {
-			this.shapeCreatedCleanup()
-			this.shapeCreatedCleanup = null
+		if (event === 'shapes-created' && this.emitter.listenerCount('shapes-created') === 0) {
+			this._detachLazy('shapes-created')
 		}
 
-		if (
-			this.shapeEditedCleanup &&
-			event === 'shapes-updated' &&
-			this.emitter.listenerCount('shapes-updated') === 0
-		) {
-			this.shapeEditedCleanup()
-			this.shapeEditedCleanup = null
+		if (event === 'shapes-updated' && this.emitter.listenerCount('shapes-updated') === 0) {
+			this._detachLazy('shapes-updated')
 		}
 
-		if (
-			this.shapeDeletedCleanup &&
-			event === 'shapes-deleted' &&
-			this.emitter.listenerCount('shapes-deleted') === 0
-		) {
-			this.shapeDeletedCleanup()
-			this.shapeDeletedCleanup = null
+		if (event === 'shapes-deleted' && this.emitter.listenerCount('shapes-deleted') === 0) {
+			this._detachLazy('shapes-deleted')
 		}
+	}
+
+	private _detachLazy(key: LazyListener) {
+		const cleanup = this.lazyCleanups.get(key)
+		if (!cleanup) return
+		this.unregister(cleanup)
+		this.lazyCleanups.delete(key)
 	}
 }


### PR DESCRIPTION
This PR improves `PerformanceManager`'s teardown so that a lazily attached listener can no longer outlive the editor, by making it extend `EditorManager` as `AGENTS.md` asks of any manager that holds a subscription or resource. Closes #10291.

### Before

`PerformanceManager` was a plain class. It attached its editor listeners (`frame`, `created-shapes`, `edited-shapes`, `deleted-shapes`) and its `PerformanceObserver` lazily, only while someone was subscribed, and tore them down in a hand-written `dispose()` that had to name every one of them. Any new lazy listener added to `_maybeAttachLazyListeners` without a matching line in `dispose()` outlived the editor: the setup-here, teardown-elsewhere asymmetry that `EditorManager` exists to prevent (#8892).

### After

`PerformanceManager` extends `EditorManager`. Each lazy listener is registered with the base class while it is attached and unregistered when it detaches, so whatever is still attached at `dispose()` is torn down by `super.dispose()` without being listed. The override only resets the manager's own state and clears its emitter, then defers to the base class, the same shape as `TickManager`.

### Implementation notes

Register-until-dispose alone does not fit listeners that come and go by subscriber count, so `EditorManager` gains a `protected unregister(fn)` counterpart to `register`: it drops the teardown from the dispose list and runs it, and skips a teardown that already ran, so nothing is torn down twice, including an unsubscribe called after dispose. `addEditorEvent` now returns the unsubscribe it registered, so a lazy attach is one call (`this.addEditorEvent('frame', this._onFrame)`) instead of a manual `on`/`off` pair. Using the protected `disposables` set directly would have avoided touching the API report, but the issue's point is a named pair that other managers can reach for.

The five per-listener cleanup fields became one map keyed by lazy listener, so `dispose()` resets the lazy state with a single `clear()` rather than nulling each field. A subscriber added after dispose therefore attaches again, as on `main`.

`UserPreferencesManager` has a similar hand-rolled disposables set, but its constructor takes no `Editor`, so adopting the base class there would be a signature change and is left out, as the issue suggests.

Relates to #10069, which reshapes the same lazy-listener section of this file but keeps an enumerating `dispose()`; whichever lands second needs a small rebase.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests. `EditorManager.test.ts` covers `unregister` and the returned unsubscribe; these fail on `main`, where neither exists. The new `dispose()` tests in `PerformanceManager.test.ts` pin the teardown contract: every lazily attached listener and the LoAF observer are torn down, none twice, a stale unsubscribe is a no-op, and a subscriber added after dispose attaches again (that last one fails without the `clear()` in `dispose()`). The first three pass on `main` as well, where the enumerating `dispose()` still covered every listener. The full `packages/editor` suite passes, as do `yarn typecheck` and `yarn api-check`.

### Release notes

- Make `PerformanceManager` extend `EditorManager`, add `EditorManager.unregister()` for resources that come and go within a manager's lifetime, and return the unsubscribe from `EditorManager.addEditorEvent()`.

### API changes

- Changed `PerformanceManager` to extend `EditorManager`
- Added `EditorManager.unregister(dispose)`, which runs a registered teardown early and drops it from the dispose list
- Changed `EditorManager.addEditorEvent()` to return the unsubscribe it registered (was `void`)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +66 / -81  |
| Tests           | +111 / -1  |
| Automated files | +3 / -3    |
