### PR TITLE
refactor(editor): share the translate-by-page-delta helper across the layout commands

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -341,6 +341,11 @@ export interface TLRenderingShape {
 
 const RENDERING_SHAPES_SORT_CACHE_THRESHOLD = 100
 
+const AXIS = {
+	horizontal: { val: 'x', min: 'minX', max: 'maxX', dim: 'width' },
+	vertical: { val: 'y', min: 'minY', max: 'maxY', dim: 'height' },
+} as const
+
 /** @public */
 export class Editor extends EventEmitter<TLEventMap> {
 	readonly id = uniqueId()
@@ -7013,6 +7018,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return workingShape
 	}
 
+	// Counter-rotates the page-space delta into the parent's space; without that a child of a rotated
+	// frame or group would move along its parent's axes instead of the page's.
+	// todo: a shape laid out together with its own parent moves twice, once with the parent and once
+	// on its own; the layout commands should skip shapes whose ancestors are also being laid out
+	private getChangesToTranslateShapeByPageDelta(shape: TLShape, pageDelta: VecLike): TLShape {
+		const localDelta = Vec.From(pageDelta).rot(-this.getShapeParentTransform(shape).rotation())
+		return this.getChangesToTranslateShape(shape, localDelta.add(shape))
+	}
+
 	/**
 	 * Move shapes by a delta.
 	 *
@@ -7035,10 +7049,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		for (const id of ids) {
 			const shape = this.getShape(id)!
-			const localDelta = Vec.From(offset)
-			localDelta.rot(-this.getShapeParentTransform(shape).rotation())
-
-			changes.push(this.getChangesToTranslateShape(shape, localDelta.add(shape)))
+			changes.push(this.getChangesToTranslateShapeByPageDelta(shape, offset))
 		}
 
 		this.updateShapes(changes)
@@ -7645,22 +7656,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const len = shapeClustersToStack.length
 		if ((_gap === 0 && len < 3) || len < 2) return this
 
-		let val: 'x' | 'y'
-		let min: 'minX' | 'minY'
-		let max: 'maxX' | 'maxY'
-		let dim: 'width' | 'height'
-
-		if (operation === 'horizontal') {
-			val = 'x'
-			min = 'minX'
-			max = 'maxX'
-			dim = 'width'
-		} else {
-			val = 'y'
-			min = 'minY'
-			max = 'maxY'
-			dim = 'height'
-		}
+		const { val, min, max, dim } = AXIS[operation]
 
 		let shapeGap: number = 0
 
@@ -7718,17 +7714,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			delta[val] = v + shapeGap - pageBounds[val]
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
-				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 
 			v += pageBounds[dim] + shapeGap
@@ -7844,15 +7830,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const delta = Vec.Sub(nextPageBounds.point, pageBounds.point).add(centerDelta)
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					shapeDelta.rot(-this.getShapeParentTransform(shape).rotation())
-				}
-
-				shapeDelta.add(shape)
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 		}
 
@@ -7932,17 +7910,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
-				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 		})
 
@@ -7971,22 +7939,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (shapeClustersToDistribute.length < 3) return this
 
-		let val: 'x' | 'y'
-		let min: 'minX' | 'minY'
-		let max: 'maxX' | 'maxY'
-		let dim: 'width' | 'height'
-
-		if (operation === 'horizontal') {
-			val = 'x'
-			min = 'minX'
-			max = 'maxX'
-			dim = 'width'
-		} else {
-			val = 'y'
-			min = 'minY'
-			max = 'maxY'
-			dim = 'height'
-		}
+		const { val, min, max, dim } = AXIS[operation]
 		const changes: TLShapePartial[] = []
 
 		const first = shapeClustersToDistribute.sort((a, b) => a.pageBounds[min] - b.pageBounds[min])[0]
@@ -8032,17 +7985,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			for (const shape of shapes) {
-				const shapeDelta = delta.clone()
-
-				// If the shape has another shape as its parent, and if the parent has a rotation, we need to rotate the counter-rotate delta
-				// todo: ensure that the parent isn't being aligned together with its children
-				const parent = this.getShapeParent(shape)
-				if (parent) {
-					shapeDelta.rot(-this.getShapePageTransform(parent).rotation())
-				}
-
-				shapeDelta.add(shape) // add the shape's x and y to the delta
-				changes.push(this.getChangesToTranslateShape(shape, shapeDelta))
+				changes.push(this.getChangesToTranslateShapeByPageDelta(shape, delta))
 			}
 
 			v += pageBounds[dim] + gap
@@ -8078,24 +8021,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (shapeClustersToStretch.length < 2) return this
 
 		const commonBounds = Box.Common(allBounds)
-		let val: 'x' | 'y'
-		let min: 'minX' | 'minY'
-		let dim: 'width' | 'height'
-
-		if (operation === 'horizontal') {
-			val = 'x'
-			min = 'minX'
-			dim = 'width'
-		} else {
-			val = 'y'
-			min = 'minY'
-			dim = 'height'
-		}
+		const { val, min, dim } = AXIS[operation]
 
 		this.run(() => {
 			shapeClustersToStretch.forEach(({ shapes, pageBounds }) => {
-				const localOffset = new Vec()
-				localOffset[val] = commonBounds[min] - pageBounds[min]
+				const pageOffset = new Vec()
+				pageOffset[val] = commonBounds[min] - pageBounds[min]
 
 				const scaleOrigin = pageBounds.center.clone()
 				scaleOrigin[val] = commonBounds[min]
@@ -8105,11 +8036,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				for (const shape of shapes) {
 					// First translate
-					const shapeLocalOffset = localOffset.clone()
-					shapeLocalOffset.rot(-this.getShapeParentTransform(shape).rotation())
-					shapeLocalOffset.add(shape)
-					const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
-					this.updateShape(changes)
+					this.updateShape(this.getChangesToTranslateShapeByPageDelta(shape, pageOffset))
 
 					// Then resize
 					this.resizeShape(shape.id, scale, {
@@ -8162,7 +8089,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const scale = new Vec(scaleX, scaleY)
 
 		shapeClusters.forEach(({ shapes, pageBounds }) => {
-			const localOffset = new Vec(
+			const pageOffset = new Vec(
 				targetBounds.minX -
 					commonBounds.minX +
 					(pageBounds.minX - commonBounds.minX) * (scaleX - 1),
@@ -8176,11 +8103,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			for (const shape of shapes) {
 				// First translate
-				const shapeLocalOffset = localOffset.clone()
-				shapeLocalOffset.rot(-this.getShapeParentTransform(shape).rotation())
-				shapeLocalOffset.add(shape)
-				const changes = this.getChangesToTranslateShape(shape, shapeLocalOffset)
-				this.updateShape(changes)
+				this.updateShape(this.getChangesToTranslateShapeByPageDelta(shape, pageOffset))
 
 				// Then resize
 				this.resizeShape(shape.id, scale, {


### PR DESCRIPTION
In order to stop the layout commands drifting apart — a fix to the parent-space translate had to be pasted into seven places, and a fix to the axis switch into three — this PR gives `Editor` a private `getChangesToTranslateShapeByPageDelta(shape, pageDelta)` helper next to `getChangesToTranslateShape`, plus a module-level `AXIS` table, and uses them at every site that duplicated them. Closes #10296.

The "translate a shape by a page-space delta, counter-rotating it for the shape's parent" block sat in `nudgeShapes`, `stackShapes`, `packShapes`, `alignShapes`, `distributeShapes`, `stretchShapes` and `resizeToBounds` in three spellings, and the `val` / `min` / `max` / `dim` axis-name switch was re-declared in `stackShapes`, `distributeShapes` and `stretchShapes`. The `todo: ensure that the parent isn't being aligned together with its children` caveat was pasted at three of the sites. `getShapeClusters` still does not drop shapes whose ancestors are also being laid out, so the todo is still live; it now sits once on the helper, reworded to name the symptom (such a shape moves twice, once with its parent and once on its own).

Behaviour is unchanged. The two spellings were already equivalent: `getShapeParentTransform` returns the identity matrix for a page-parented shape (and for a missing parent), `Mat.Rotation` of the identity is exactly `0`, and `Vec.rot(0)` is an early return, so the unguarded form does what the `if (parent)` guarded one did; for a shape-parented shape both read the same page-transform cache entry. The helper builds its own `Vec` from the delta, so the per-cluster delta shared across a cluster's shapes is never mutated, as before. The helper is private, so the API report does not change. The offset variable in `stretchShapes` and `resizeToBounds` is renamed from `localOffset` to `pageOffset`: it always was a page-space offset, and it is now handed to a helper whose name says so.

Two look-alike counter-rotations are deliberately left as they are: the one in `duplicateShapes` positions a brand-new shape, and the one in `putContentOntoCurrentPage` writes raw partials. Neither runs the `onTranslateStart` / `onTranslate` / `onTranslateEnd` hooks that `getChangesToTranslateShape` runs, so routing them through the helper would change behaviour.

### Change type

- [x] `other`

### Test plan

No new tests: there is no behaviour to pin down that the existing rotated-parent cases in the align, distribute, nudge, pack and stretch suites do not already cover, and they exercise the helper at every call site.

- The seven layout command suites in `packages/tldraw` (`alignShapes`, `distributeShapes`, `nudge`, `packShapes`, `resizeToBounds`, `stackShapes`, `stretch`): 80 passed
- Full `packages/tldraw` suite: 3009 passed; full `packages/editor` suite: 1217 passed
- `yarn typecheck` and `yarn api-check` from the repo root: clean, no API report changes

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +27 / -104 |
