### PR TITLE
fix(docs): make the link checker match heading anchors case-sensitively

### DIFF
--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -94,7 +94,7 @@ function MyApp() {
 }
 ```
 
-Comment records are opt-in, so register `commentSchemaRecords` on your server's schema too, and list the comment record types in the room's `objectTypes` (see [Comments and the object-store lane](/docs/sync#comments-and-the-object-store-lane)). Commenting is a licensed feature. See the [commenting overview](/docs/commenting) for an introduction, or the [commenting reference](/sdk-features/commenting) for anchors, options, and server setup.
+Comment records are opt-in, so register `commentSchemaRecords` on your server's schema too, and list the comment record types in the room's `objectTypes` (see [Comments and the object-store lane](/docs/sync#Comments-and-the-object-store-lane)). Commenting is a licensed feature. See the [commenting overview](/docs/commenting) for an introduction, or the [commenting reference](/sdk-features/commenting) for anchors, options, and server setup.
 
 ## Using other backends
 

--- a/apps/docs/content/docs/commenting.mdx
+++ b/apps/docs/content/docs/commenting.mdx
@@ -119,7 +119,7 @@ import { CommentTool } from '@tldraw/commenting'
 const tools = [CommentTool.configure({ enableRegions: true })]
 ```
 
-The option worth knowing about first is `history`. Comment writes default to `'ignore'`, which keeps them off the undo stack, and that default matters in a shared document: an undoable resolve would revert a thread a collaborator has since reopened. Deletes are never undoable, whatever `history` says. See [Comments and undo](/sdk-features/commenting#comments-and-undo).
+The option worth knowing about first is `history`. Comment writes default to `'ignore'`, which keeps them off the undo stack, and that default matters in a shared document: an undoable resolve would revert a thread a collaborator has since reopened. Deletes are never undoable, whatever `history` says. See [Comments and undo](/sdk-features/commenting#Comments-and-undo).
 
 ## Permissions
 
@@ -131,7 +131,7 @@ They're UI-level controls and nothing more. Comment records carry a client-suppl
 
 Comments sync like the rest of your document, with one registration on each side. Pass `records: commentSchemaRecords` to your sync hook, and the same map to `createTLSchema` on the server.
 
-On the server you can go a step further and serve comments through the room's object-store lane. Lane records are gated by their own per-session permission rather than by `isReadonly`, which is how a viewer who can't edit the document can still comment. See [Syncing comments](/sdk-features/commenting#syncing-comments).
+On the server you can go a step further and serve comments through the room's object-store lane. Lane records are gated by their own per-session permission rather than by `isReadonly`, which is how a viewer who can't edit the document can still comment. See [Syncing comments](/sdk-features/commenting#Syncing-comments).
 
 ## Related
 

--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -98,7 +98,7 @@ See [Collaboration](/sdk-features/collaboration) for production setup, custom pr
 
 When you load a snapshot from an older schema version, the store migrates it automatically. For custom shapes, you can define migrations to handle changes to their props over time.
 
-See [Persistence](/sdk-features/persistence#migrations) for details on shape props migrations and general migrations.
+See [Persistence](/sdk-features/persistence#Migrations) for details on shape props migrations and general migrations.
 
 ## Examples
 

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -323,7 +323,7 @@ function MyApp() {
 Use [createTLSchema](?) to create a store schema, and pass that into [TLSocketRoom](?). You can
 use shape/binding utils here, but the schema only reads three properties:
 [`props`](/reference/editor/ShapeUtil#props), `meta`, and
-[`migrations`](/sdk-features/persistence#migrations). You need to provide the default shape
+[`migrations`](/sdk-features/persistence#Migrations). You need to provide the default shape
 schemas if you're using them.
 
 ```tsx

--- a/apps/docs/content/releases/v4.3.0.mdx
+++ b/apps/docs/content/releases/v4.3.0.mdx
@@ -73,7 +73,7 @@ declare module 'tldraw' {
 type MyBinding = TLBinding`<'my-binding'>`
 ```
 
-See the [Custom Shapes Guide](https://tldraw.dev/docs/shapes#custom-shapes) and the [Pin Bindings example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/pin-bindings) for details.
+See the [Custom Shapes Guide](https://tldraw.dev/docs/shapes#Custom-shapes) and the [Pin Bindings example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/pin-bindings) for details.
 
 **After registering, remove the `TLBaseShape` import** — it's no longer used and will trip lint rules that flag unused imports.
 

--- a/apps/docs/content/sdk-features/attribution.mdx
+++ b/apps/docs/content/sdk-features/attribution.mdx
@@ -187,7 +187,7 @@ Custom metadata is validated and persisted alongside the standard user fields. A
 | [createCachedUserResolve](?)          | Create a cached resolve function for `TLUserStore`                      |
 | [createUserRecordType](?)             | Build a user record type with custom meta validators                    |
 
-For setting up user identity in multiplayer, see the [Collaboration](/sdk-features/collaboration#user-identity) page.
+For setting up user identity in multiplayer, see the [Collaboration](/sdk-features/collaboration#User-identity) page.
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/culling.mdx
+++ b/apps/docs/content/sdk-features/culling.mdx
@@ -99,7 +99,7 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-Shapes whose util overrides `canCull` are subscribed to individually inside the culling derivation, so a `canCull` that reads many props re-runs the derivation more often. Shapes using the default fast path don't pay this cost. Disable culling only for shapes that need it: visual effects that extend past the bounds, shapes that measure their DOM, or animations that should keep running off-screen. See [Performance](/sdk-features/performance#disable-culling-only-when-necessary) for guidance.
+Shapes whose util overrides `canCull` are subscribed to individually inside the culling derivation, so a `canCull` that reads many props re-runs the derivation more often. Shapes using the default fast path don't pay this cost. Disable culling only for shapes that need it: visual effects that extend past the bounds, shapes that measure their DOM, or animations that should keep running off-screen. See [Performance](/sdk-features/performance#Disable-culling-only-when-necessary) for guidance.
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/cursor-chat.mdx
+++ b/apps/docs/content/sdk-features/cursor-chat.mdx
@@ -179,7 +179,7 @@ export default function App() {
 }
 ```
 
-Remote users' chat messages render as part of the collaborator cursor, in the DOM cursor layer. To customize how they appear, replace the `CollaboratorCursor` component. See [Cursors](/sdk-features/cursors#rendering-collaborator-cursors) for details.
+Remote users' chat messages render as part of the collaborator cursor, in the DOM cursor layer. To customize how they appear, replace the `CollaboratorCursor` component. See [Cursors](/sdk-features/cursors#Rendering-collaborator-cursors) for details.
 
 ## Availability
 

--- a/apps/docs/content/sdk-features/default-shapes.mdx
+++ b/apps/docs/content/sdk-features/default-shapes.mdx
@@ -445,7 +445,7 @@ const ConfiguredFrameUtil = FrameShapeUtil.configure({
 })
 ```
 
-To build your own container shape that behaves like a frame, extend `BaseFrameLikeShapeUtil` rather than re-implementing every behavior on `FrameShapeUtil`. The base class provides defaults for clipping children, full-brush selection, blocking erasure from inside, and drag-and-drop reparenting — see [Shapes](/sdk-features/shapes#frames) for details and the [portal shapes example](/examples/shapes/tools/portal-shapes) for a working implementation.
+To build your own container shape that behaves like a frame, extend `BaseFrameLikeShapeUtil` rather than re-implementing every behavior on `FrameShapeUtil`. The base class provides defaults for clipping children, full-brush selection, blocking erasure from inside, and drag-and-drop reparenting — see [Shapes](/sdk-features/shapes#Frames) for details and the [portal shapes example](/examples/shapes/tools/portal-shapes) for a working implementation.
 
 ### Group
 

--- a/apps/docs/content/sdk-features/draw-shape.mdx
+++ b/apps/docs/content/sdk-features/draw-shape.mdx
@@ -199,8 +199,8 @@ The geometry uses the processed stroke points (after applying streamline and smo
 
 ## Related shapes
 
-- [Highlight](/sdk-features/default-shapes#highlight) uses the same point capture system but renders semi-transparently for marking up content
-- [Line](/sdk-features/default-shapes#line) creates editable multi-point lines with draggable handles
+- [Highlight](/sdk-features/default-shapes#Highlight) uses the same point capture system but renders semi-transparently for marking up content
+- [Line](/sdk-features/default-shapes#Line) creates editable multi-point lines with draggable handles
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/editor.mdx
+++ b/apps/docs/content/sdk-features/editor.mdx
@@ -395,7 +395,7 @@ editor.updateInstanceState({ isReadonly: true })
 editor.updateInstanceState({ isToolLocked: true })
 ```
 
-See [Tools](/sdk-features/tools#tool-lock) for more on tool lock.
+See [Tools](/sdk-features/tools#Tool-lock) for more on tool lock.
 
 Each page also has instance state ([TLInstancePageState](?)) tracking selection, hovered shape, and editing shape for that page:
 

--- a/apps/docs/content/sdk-features/embed-shape.mdx
+++ b/apps/docs/content/sdk-features/embed-shape.mdx
@@ -87,7 +87,7 @@ The shape stores the original URL and renders the embed version.
 
 ## Fallback to bookmarks
 
-When you paste a URL that no embed definition recognizes, the default URL handler creates a [bookmark shape](/sdk-features/default-shapes#bookmark) instead of an embed. An existing embed shape whose URL doesn't match any definition still renders the URL in an iframe, using the stricter sandbox for unknown sources.
+When you paste a URL that no embed definition recognizes, the default URL handler creates a [bookmark shape](/sdk-features/default-shapes#Bookmark) instead of an embed. An existing embed shape whose URL doesn't match any definition still renders the URL in an iframe, using the stricter sandbox for unknown sources.
 
 Use [getEmbedInfo](?) to check whether a URL is embeddable before creating a shape:
 
@@ -221,6 +221,6 @@ Embed shapes render as blank rectangles in SVG exports. The iframe content can't
 ## Related articles
 
 - [Default shapes](/sdk-features/default-shapes) — Overview of all built-in shape types
-- [Bookmark shape](/sdk-features/default-shapes#bookmark) — URL link cards (fallback for non-embeddable URLs)
+- [Bookmark shape](/sdk-features/default-shapes#Bookmark) — URL link cards (fallback for non-embeddable URLs)
 - [External content handling](/sdk-features/external-content) — Handling pasted and dropped content
 - [Custom embeds example](/examples/configuration/custom-embed) — Add a custom embed definition for a new service

--- a/apps/docs/content/sdk-features/frame-shape.mdx
+++ b/apps/docs/content/sdk-features/frame-shape.mdx
@@ -47,7 +47,7 @@ Empty names render as `Frame` so unnamed frames still get a label. The shape's `
 
 Frames clip their children to the frame's rectangle during rendering. A shape that extends past the frame edge is rendered up to the boundary and then cut off. Clipping doesn't change the child's geometry or its own bounds, but hit testing respects the mask: you can't click the clipped-off part of a shape, and [Editor#getShapeMaskedPageBounds](?) returns only the visible portion. Arrows are exempt from clipping so connectors can leave a frame.
 
-The [BaseFrameLikeShapeUtil](?) base class implements clipping via `getClipPath` and the arrow exemption via `shouldClipChild`. If you need clipping for a custom container shape, see the [Frames](/sdk-features/shapes#frames) section in the Shapes guide.
+The [BaseFrameLikeShapeUtil](?) base class implements clipping via `getClipPath` and the arrow exemption via `shouldClipChild`. If you need clipping for a custom container shape, see the [Frames](/sdk-features/shapes#Frames) section in the Shapes guide.
 
 ## Shape properties
 
@@ -139,8 +139,8 @@ Reach for a frame when you want a labeled, bounded region: a slide, a screen, an
 
 ## Related articles
 
-- [Shapes](/sdk-features/shapes#frames) — How to build your own container shape with `BaseFrameLikeShapeUtil`
-- [Default shapes](/sdk-features/default-shapes#frame) — Overview of all built-in shapes
+- [Shapes](/sdk-features/shapes#Frames) — How to build your own container shape with `BaseFrameLikeShapeUtil`
+- [Default shapes](/sdk-features/default-shapes#Frame) — Overview of all built-in shapes
 - [Shape clipping](/sdk-features/shape-clipping) — How custom shapes can clip their children
 - [Image export](/sdk-features/image-export) — Exporting frames and selections as images
 - [Parenting](/sdk-features/parenting) — How shapes are nested inside containers

--- a/apps/docs/content/sdk-features/instance-state.mdx
+++ b/apps/docs/content/sdk-features/instance-state.mdx
@@ -223,7 +223,7 @@ When tool lock is enabled, the current tool stays active after creating a shape 
 editor.updateInstanceState({ isToolLocked: true })
 ```
 
-Custom tools should check this property to decide whether to return to select after completing their action. See [Tools](/sdk-features/tools#tool-lock) for implementation details.
+Custom tools should check this property to decide whether to return to select after completing their action. See [Tools](/sdk-features/tools#Tool-lock) for implementation details.
 
 ### Cursor customization
 
@@ -282,7 +282,7 @@ When you switch pages, the instance's `currentPageId` changes, but each page ret
 - [Cursors](/sdk-features/cursors) — Cursor types and rotation handling
 - [Readonly mode](/sdk-features/readonly) — Disable editing with `isReadonly`
 - [Focus](/sdk-features/focus) — Editor focus state with `isFocused`
-- [Tools](/sdk-features/tools#tool-lock) — Tool lock behavior with `isToolLocked`
+- [Tools](/sdk-features/tools#Tool-lock) — Tool lock behavior with `isToolLocked`
 - [User preferences](/sdk-features/user-preferences) — Global preferences that persist across editor instances
 
 ## Related examples

--- a/apps/docs/content/sdk-features/locked-shapes.mdx
+++ b/apps/docs/content/sdk-features/locked-shapes.mdx
@@ -103,7 +103,7 @@ Even with `ignoreShapeLock: true`, some behaviors remain unchanged: locked shape
 
 Some shapes have interactive content that should remain usable even when locked. Embed shapes (YouTube videos, Figma files, interactive maps) are a good example: you might want the embed locked in place but still playable or navigable.
 
-[ShapeUtils](/sdk-features/shapes#shapeutil) can override [ShapeUtil#canEditWhileLocked](?) (default `false`) to allow editing interactions on locked shapes. The built-in embed shape returns `true` unless its embed definition says otherwise:
+[ShapeUtils](/sdk-features/shapes#ShapeUtil) can override [ShapeUtil#canEditWhileLocked](?) (default `false`) to allow editing interactions on locked shapes. The built-in embed shape returns `true` unless its embed definition says otherwise:
 
 ```typescript
 class MyInteractiveShapeUtil extends ShapeUtil<MyShape> {

--- a/apps/docs/content/sdk-features/note-shape.mdx
+++ b/apps/docs/content/sdk-features/note-shape.mdx
@@ -124,7 +124,7 @@ See the [note resizing example](/examples/configuration/resize-note) for a worki
 
 ## Dynamic resize mode
 
-When `editor.user.getIsDynamicResizeMode()` is true, new notes are created at a scale inversely proportional to the current zoom level, so they stay visually consistent regardless of zoom. [Editor#getResizeScaleFactor](?) returns that scale. See [Text shape](/sdk-features/text-shape#dynamic-resize-mode) for details.
+When `editor.user.getIsDynamicResizeMode()` is true, new notes are created at a scale inversely proportional to the current zoom level, so they stay visually consistent regardless of zoom. [Editor#getResizeScaleFactor](?) returns that scale. See [Text shape](/sdk-features/text-shape#Dynamic-resize-mode) for details.
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/options.mdx
+++ b/apps/docs/content/sdk-features/options.mdx
@@ -339,7 +339,7 @@ function App() {
 }
 ```
 
-See [Embed shape](/sdk-features/embed-shape#custom-embed-definitions) for the full embed definition API.
+See [Embed shape](/sdk-features/embed-shape#Custom-embed-definitions) for the full embed definition API.
 
 ### Editor setup
 

--- a/apps/docs/content/sdk-features/store.mdx
+++ b/apps/docs/content/sdk-features/store.mdx
@@ -328,7 +328,7 @@ Snapshots include schema version information. When you load a snapshot from an o
 const migrated = editor.store.migrateSnapshot(oldSnapshot)
 ```
 
-The migration system handles schema changes between tldraw versions. You can also define migrations for custom shape props and custom record types. See [persistence](/sdk-features/persistence#migrations) for details.
+The migration system handles schema changes between tldraw versions. You can also define migrations for custom shape props and custom record types. See [persistence](/sdk-features/persistence#Migrations) for details.
 
 ## Queries
 

--- a/apps/docs/content/sdk-features/user-preferences.mdx
+++ b/apps/docs/content/sdk-features/user-preferences.mdx
@@ -51,7 +51,7 @@ export default function App() {
 
 Preferences cover visual settings (color scheme, animation speed), interaction settings (snap mode, edge scroll speed), and identity (user name, color, locale). By default the editor stores them in localStorage and syncs them across tabs with a BroadcastChannel.
 
-To supply preferences from your own auth or state instead, pass a `user` created with [useTldrawCurrentUser](?) (or [createTLCurrentUser](?)) to the `Tldraw` component. Preferences you provide this way are yours to persist and sync. See [Collaboration](/sdk-features/collaboration#integrating-with-usetldrawcurrentuser) for a full example.
+To supply preferences from your own auth or state instead, pass a `user` created with [useTldrawCurrentUser](?) (or [createTLCurrentUser](?)) to the `Tldraw` component. Preferences you provide this way are yours to persist and sync. See [Collaboration](/sdk-features/collaboration#Integrating-with-useTldrawCurrentUser) for a full example.
 
 ## Reading preferences
 
@@ -132,7 +132,7 @@ const isDark = editor.user.getIsDarkMode()
 // true if colorScheme is 'dark', or 'system' with OS in dark mode
 ```
 
-The editor-level `colorScheme` prop sets the default color scheme. When a user preference is set, it takes priority over the prop. See [Themes](/sdk-features/themes#color-mode) for more.
+The editor-level `colorScheme` prop sets the default color scheme. When a user preference is set, it takes priority over the prop. See [Themes](/sdk-features/themes#Color-mode) for more.
 
 ## Persistence and synchronization
 

--- a/apps/docs/content/starter-kits/agent.mdx
+++ b/apps/docs/content/starter-kits/agent.mdx
@@ -581,7 +581,7 @@ If you need to add any extra setup or configuration for your provider, you can a
 
 ### Support custom shapes
 
-If your app includes [custom shapes](/docs/shapes#custom-shapes), the agent will be able to see, move, delete, resize, rotate and arrange them with no extra setup. However, you might want to also let the agent create and edit them, and read their custom properties.
+If your app includes [custom shapes](/docs/shapes#Custom-shapes), the agent will be able to see, move, delete, resize, rotate and arrange them with no extra setup. However, you might want to also let the agent create and edit them, and read their custom properties.
 
 To support custom shapes, you have two main options:
 
@@ -758,7 +758,7 @@ export function convertFocusedShapeToTldrawShape(
 
 - **[Multiplayer starter kit](/starter-kits/multiplayer)**: Use the tldraw multiplayer sync starter kit to build multi-user agent environments.
 
-- **[Shape utilities](/docs/shapes#custom-shapes)**: Learn how to create custom shapes and extend tldraw's shape system with advanced geometry, rendering, and interaction patterns.
+- **[Shape utilities](/docs/shapes#Custom-shapes)**: Learn how to create custom shapes and extend tldraw's shape system with advanced geometry, rendering, and interaction patterns.
 
 - **[Editor state management](/docs/editor)**: Learn how to work with tldraw's reactive state system, editor lifecycle, and event handling for complex canvas applications.
 

--- a/apps/docs/content/starter-kits/branching-chat.mdx
+++ b/apps/docs/content/starter-kits/branching-chat.mdx
@@ -98,7 +98,7 @@ See `client/connection/ConnectionBindingUtil.tsx` as an example. This file demon
 ## Further reading
 
 - [Workflow starter kit](/starter-kits/workflow): Learn how to build visual programming interfaces with node-based workflows on infinite canvas.
-- [Shape utilities](/docs/shapes#custom-shapes): Learn how to create custom shapes and extend tldraw's shape system with advanced geometry, rendering, and interaction patterns.
+- [Shape utilities](/docs/shapes#Custom-shapes): Learn how to create custom shapes and extend tldraw's shape system with advanced geometry, rendering, and interaction patterns.
 - [Binding system](/sdk-features/bindings): Learn more about tldraw's binding system for creating relationships between shapes, automatic updates, and connection management.
 - [Editor state management](/docs/editor): Learn how to work with tldraw's reactive state system, editor lifecycle, and event handling for complex canvas applications.
 

--- a/apps/docs/content/starter-kits/chat.mdx
+++ b/apps/docs/content/starter-kits/chat.mdx
@@ -77,7 +77,7 @@ For example, see `src/components/WhiteboardModal.tsx:92` for UI component overri
 
 ## Further reading
 
-- **[Custom shape utilities](/docs/shapes#custom-shapes)**: Learn how to create custom shapes with their own interactions.
+- **[Custom shape utilities](/docs/shapes#Custom-shapes)**: Learn how to create custom shapes with their own interactions.
 
 - **[Editor API](/docs/editor)**: Learn about the tldraw Editor.
 

--- a/apps/docs/content/starter-kits/shader.mdx
+++ b/apps/docs/content/starter-kits/shader.mdx
@@ -101,7 +101,7 @@ See [`src/fluid/FluidManager.ts`](https://github.com/tldraw/tldraw/tree/main/tem
 
 ## Further reading
 
-For multi-user shader environments, see the [Multiplayer starter kit](/starter-kits/multiplayer). To create custom shapes with advanced geometry and rendering, see [Shape utilities](/docs/shapes#custom-shapes). For working with tldraw's reactive state system and event handling, see [Editor state management](/docs/editor).
+For multi-user shader environments, see the [Multiplayer starter kit](/starter-kits/multiplayer). To create custom shapes with advanced geometry and rendering, see [Shape utilities](/docs/shapes#Custom-shapes). For working with tldraw's reactive state system and event handling, see [Editor state management](/docs/editor).
 
 ---
 

--- a/apps/docs/scripts/lib/checkBrokenLinks.ts
+++ b/apps/docs/scripts/lib/checkBrokenLinks.ts
@@ -136,6 +136,12 @@ function tryRedirect(urlPath: string): string | null {
 	return null
 }
 
+function anchorNotFoundReason(fragment: string, path: string, slugs: Set<string> | undefined) {
+	const reason = `anchor #${fragment} not found in ${path}`
+	const caseMismatch = slugs && [...slugs].find((s) => s.toLowerCase() === fragment.toLowerCase())
+	return caseMismatch ? `${reason} (heading ids are case-sensitive, use #${caseMismatch})` : reason
+}
+
 export async function checkBrokenLinks(): Promise<number> {
 	const db = await connect({ mode: 'readonly' })
 
@@ -176,24 +182,25 @@ export async function checkBrokenLinks(): Promise<number> {
 		if (a.path) articlePathById.set(a.id, a.path)
 	}
 
+	// Rendered heading ids keep their case (rehype-slug runs with `maintainCase: true`), so
+	// `#custom-shapes` is a dead anchor on a page whose heading id is `Custom-shapes` (#10256).
 	for (const h of headings) {
 		const articlePath = articlePathById.get(h.articleId)
 		if (!articlePath) continue
-		const loweredSlug = h.slug.toLowerCase()
 		let slugs = headingMap.get(articlePath)
 		if (!slugs) {
 			slugs = new Set()
 			headingMap.set(articlePath, slugs)
 		}
-		slugs.add(loweredSlug)
-		// Also index by lowercase path for case-insensitive lookups
+		slugs.add(h.slug)
+		// Also index by lowercase path for case-insensitive path lookups
 		const lowerPath = articlePath.toLowerCase()
 		let lowerSlugs = headingMap.get(lowerPath)
 		if (!lowerSlugs) {
 			lowerSlugs = new Set()
 			headingMap.set(lowerPath, lowerSlugs)
 		}
-		lowerSlugs.add(loweredSlug)
+		lowerSlugs.add(h.slug)
 	}
 
 	// Also build heading map for rewrite destinations
@@ -218,7 +225,7 @@ export async function checkBrokenLinks(): Promise<number> {
 			// Split path and fragment
 			const hashIdx = url.indexOf('#')
 			const urlPath = hashIdx >= 0 ? url.slice(0, hashIdx) : url
-			const fragment = hashIdx >= 0 ? url.slice(hashIdx + 1).toLowerCase() : null
+			const fragment = hashIdx >= 0 ? url.slice(hashIdx + 1) : null
 
 			// Skip paths served by an external system (marketing site etc.)
 			// — they will never appear in the docs DB but are still valid in production.
@@ -232,7 +239,7 @@ export async function checkBrokenLinks(): Promise<number> {
 						articlePath: article.path,
 						line,
 						url,
-						reason: `anchor #${fragment} not found in ${article.path}`,
+						reason: anchorNotFoundReason(fragment, article.path, slugs),
 					})
 				}
 				continue
@@ -280,7 +287,7 @@ export async function checkBrokenLinks(): Promise<number> {
 						articlePath: article.path,
 						line,
 						url,
-						reason: `anchor #${fragment} not found in ${resolvedPath}`,
+						reason: anchorNotFoundReason(fragment, resolvedPath, slugs),
 					})
 				}
 			}


### PR DESCRIPTION
This PR fixes a bug where `yarn check-links --fail` accepted links whose `#fragment` only matched a heading case-insensitively, so links such as `/docs/shapes#custom-shapes` passed the docs build and shipped as dead anchors on tldraw.dev (the heading renders as `<h2 id="Custom-shapes">`). Closes #10256. It also corrects the 31 links in the docs content that were in this state.

### Before

`checkBrokenLinks.ts` lowercased both the heading slugs it indexed from `content.db` and the fragment of every link before comparing them. Rendered heading ids are case-sensitive, though: `components/content/index.tsx` runs `rehype-slug-custom-id` with `maintainCase: true`, and `utils/parse-markdown.tsx`, which fills the `headings` table through `addContentToDb`, slugs with GithubSlugger's `slug(title, true)`. The stored slugs already equal the rendered ids; the checker was the only place that folded case, so `#custom-shapes` passed while `Custom-shapes` was the only id on the page.

### After

The checker compares fragments against the stored slugs exactly as the renderer emits them. When a fragment misses but a heading matches it case-insensitively, the failure names the real id so the fix is obvious:

```
anchor #custom-shapes not found in /docs/shapes (heading ids are case-sensitive, use #Custom-shapes)
```

With the stricter check, the content on `main` fails with 30 broken links. This PR corrects all of them (19 distinct targets across 22 files), plus one absolute `https://tldraw.dev/docs/shapes#custom-shapes` link in the v4.3.0 release notes that the checker skips as external but is the same dead anchor.

### Implementation notes

- Option 2 from the issue (lowercasing heading ids site-wide by dropping `maintainCase`) was deliberately not taken. It would change every existing heading id on tldraw.dev, so inbound links and bookmarks to those anchors would need redirects checked. Fixing the links and tightening the checker leaves the rendered pages unchanged.
- Every flagged link was a pure case difference against a real heading, so the links were corrected rather than headings renamed (renaming would break inbound links). None came from the generated reference pages, so no generator changes were needed.
- The case-insensitive path fallback in the checker (for macOS filesystem case collisions) is untouched; only fragment matching became case-sensitive.
- Noticed while verifying, and left for a follow-up: `extractInternalLinks` only keeps URLs that start with `/`, so same-page `[text](#fragment)` links are never checked and the same-page branch in the checker is unreachable. Enabling it would surface around 29 wrong-case same-page anchors in hand-written content, the hardcoded `#properties` and `#methods` TOC links that `getApiMarkdown.ts` writes on every reference page (the headings render as `Properties` and `Methods`), and a few TOC entries for members whose names contain underscores. That is a separate coverage gap in the checker and deserves its own issue.

### Change type

- [x] `bugfix`

### Test plan

1. From the repo root run `yarn build-api`, then in `apps/docs` run `yarn fetch-api-source && yarn create-api-markdown && yarn refresh-content`.
2. `yarn check-links --fail` in `apps/docs` passes on this branch.
3. Regression guard: with this branch's checker and `main`'s content, the same command exits 1 and lists the 30 wrong-case anchors with `use #...` hints; with `main`'s checker against the same database it reports no broken links.
4. `yarn lint` in `apps/docs` and `yarn typecheck` from the root pass.

### Release notes

- Fix docs links whose anchors pointed at wrong-case heading ids, and make the docs link checker reject them.

### Code changes

| Section                            | LOC change |
| ---------------------------------- | ---------- |
| Documentation (docs content)       | +31 / -31  |
| Config/tooling (docs link checker) | +14 / -7   |
