### PR TITLE
fix(docs): document @tldraw/editor React components as components

### DIFF
--- a/apps/docs/utils/TldrawApiModel.ts
+++ b/apps/docs/utils/TldrawApiModel.ts
@@ -20,7 +20,6 @@ export class TldrawApiModel extends ApiModel {
 	async preprocessReactComponents() {
 		for (const packageModel of this.members) {
 			assert(packageModel instanceof ApiPackage)
-			if (packageModel.name !== 'tldraw') continue
 
 			const entrypoint = packageModel.entryPoints[0]
 			for (const member of entrypoint.members) {

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -706,7 +706,7 @@ export function DefaultCanvas({ className }: TLCanvasComponentProps): JSX.Elemen
 export const DefaultCursor: MemoExoticComponent<({ className, zoom, point, color, name, chatMessage, }: TLCursorProps) => JSX.Element | null>;
 
 // @public (undocumented)
-export const DefaultErrorFallback: TLErrorFallbackComponent;
+export function DefaultErrorFallback({ error, editor }: TLErrorFallbackProps): JSX.Element;
 
 // @public (undocumented)
 export function DefaultGrid({ x, y, z, size }: TLGridProps): JSX.Element;
@@ -715,7 +715,7 @@ export function DefaultGrid({ x, y, z, size }: TLGridProps): JSX.Element;
 export const DefaultShapeWrapper: ForwardRefExoticComponent<TLShapeWrapperProps & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
-export function DefaultSpinner(props: React.SVGProps<SVGSVGElement>): JSX.Element;
+export function DefaultSpinner(props: TLSpinnerProps): JSX.Element;
 
 // @public (undocumented)
 export function DefaultSvgDefs(): null;
@@ -3761,7 +3761,7 @@ export interface TLDragShapesOverInfo {
     initialParentIds: Map<TLShapeId, TLParentId>;
 }
 
-// @public (undocumented)
+// @public
 export const TldrawEditor: React_3.MemoExoticComponent<({ store, components, className, user: _user, options: _options, textOptions: _textOptions, deepLinks: _deepLinks, ...rest }: TldrawEditorProps) => JSX.Element>;
 
 // @public
@@ -3797,7 +3797,7 @@ export interface TldrawEditorBaseProps {
     user?: TLCurrentUser;
 }
 
-// @public
+// @public (undocumented)
 export type TldrawEditorProps = TldrawEditorBaseProps & TldrawEditorStoreProps;
 
 // @public (undocumented)
@@ -3969,7 +3969,7 @@ export interface TLEditorComponents {
     // (undocumented)
     ShapeWrapper?: ComponentType<TLShapeWrapperProps & RefAttributes<HTMLDivElement>> | null;
     // (undocumented)
-    Spinner?: ComponentType<React.SVGProps<SVGSVGElement>> | null;
+    Spinner?: ComponentType<TLSpinnerProps> | null;
     // (undocumented)
     SvgDefs?: ComponentType | null;
 }
@@ -4082,10 +4082,13 @@ export interface TLErrorExternalContentSource {
 }
 
 // @public (undocumented)
-export type TLErrorFallbackComponent = ComponentType<{
+export type TLErrorFallbackComponent = ComponentType<TLErrorFallbackProps>;
+
+// @public (undocumented)
+export interface TLErrorFallbackProps {
     editor?: Editor;
     error: unknown;
-}>;
+}
 
 // @public (undocumented)
 export interface TLEventHandlers {
@@ -4757,6 +4760,9 @@ export interface TLShapeWrapperProps extends React.HTMLAttributes<HTMLDivElement
     isBackground: boolean;
     shape: TLShape;
 }
+
+// @public (undocumented)
+export type TLSpinnerProps = React.SVGProps<SVGSVGElement>;
 
 // @public (undocumented)
 export interface TLStateNodeConstructor {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -25,6 +25,7 @@ export {
 export {
 	DefaultErrorFallback,
 	type TLErrorFallbackComponent,
+	type TLErrorFallbackProps,
 } from './lib/components/default-components/DefaultErrorFallback'
 export { DefaultGrid, type TLGridProps } from './lib/components/default-components/DefaultGrid'
 export { type TLShapeErrorFallbackComponent } from './lib/components/default-components/DefaultShapeErrorFallback'
@@ -32,7 +33,10 @@ export {
 	DefaultShapeWrapper,
 	type TLShapeWrapperProps,
 } from './lib/components/default-components/DefaultShapeWrapper'
-export { DefaultSpinner } from './lib/components/default-components/DefaultSpinner'
+export {
+	DefaultSpinner,
+	type TLSpinnerProps,
+} from './lib/components/default-components/DefaultSpinner'
 export { DefaultSvgDefs } from './lib/components/default-components/DefaultSvgDefs'
 export {
 	EditorPortal,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -281,9 +281,9 @@ const EMPTY_TOOLS_ARRAY = [] as const
 export const TL_CONTAINER_CLASS = 'tl-container'
 
 /**
- * The editor component without any of the default shapes, tools, or UI. It renders a canvas with
- * the shape utils, binding utils, tools, and components you pass in; the `Tldraw` component in the
- * `tldraw` package wraps it with those defaults.
+ * The editor component without any of the default shapes, tools, or UI. It renders the canvas, or
+ * your own children in its place, with the shape utils, binding utils, tools, and components you
+ * pass in; the `Tldraw` component in the `tldraw` package wraps it with those defaults.
  *
  * @public @react
  */

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -106,11 +106,7 @@ export interface TldrawEditorWithoutStoreProps extends TLStoreBaseOptions {
 /** @public */
 export type TldrawEditorStoreProps = TldrawEditorWithStoreProps | TldrawEditorWithoutStoreProps
 
-/**
- * Props for the {@link tldraw#Tldraw} and {@link TldrawEditor} components.
- *
- * @public
- **/
+/** @public */
 export type TldrawEditorProps = TldrawEditorBaseProps & TldrawEditorStoreProps
 
 /**
@@ -284,7 +280,13 @@ const EMPTY_TOOLS_ARRAY = [] as const
 /** @internal */
 export const TL_CONTAINER_CLASS = 'tl-container'
 
-/** @public @react */
+/**
+ * The editor component without any of the default shapes, tools, or UI. It renders a canvas with
+ * the shape utils, binding utils, tools, and components you pass in; the `Tldraw` component in the
+ * `tldraw` package wraps it with those defaults.
+ *
+ * @public @react
+ */
 export const TldrawEditor = memo(function TldrawEditor({
 	store,
 	components,

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -17,8 +17,8 @@ export interface TLErrorFallbackProps {
 	/** The error that was caught. */
 	error: unknown
 	/**
-	 * The editor the error happened in, if there is one. When set, the fallback follows its dark
-	 * mode setting and tries to render its canvas behind the error dialog.
+	 * Only set when the caller renders the fallback with an editor; the editor's own error
+	 * boundaries pass just `error`.
 	 */
 	editor?: Editor
 }

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -13,13 +13,21 @@ import { ErrorBoundary } from '../ErrorBoundary'
 const BASE_ERROR_URL = 'https://github.com/tldraw/tldraw/issues/new'
 
 /** @public */
-export type TLErrorFallbackComponent = ComponentType<{ error: unknown; editor?: Editor }>
+export interface TLErrorFallbackProps {
+	/** The error that was caught. */
+	error: unknown
+	/**
+	 * The editor the error happened in, if there is one. When set, the fallback follows its dark
+	 * mode setting and tries to render its canvas behind the error dialog.
+	 */
+	editor?: Editor
+}
+
+/** @public */
+export type TLErrorFallbackComponent = ComponentType<TLErrorFallbackProps>
 
 /** @public @react */
-export const DefaultErrorFallback: TLErrorFallbackComponent = function DefaultErrorFallback({
-	error,
-	editor,
-}) {
+export function DefaultErrorFallback({ error, editor }: TLErrorFallbackProps) {
 	const containerRef = useRef<HTMLDivElement>(null)
 	const [shouldShowError, setShouldShowError] = useState(process.env.NODE_ENV === 'development')
 	const [didCopy, setDidCopy] = useState(false)

--- a/packages/editor/src/lib/components/default-components/DefaultSpinner.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSpinner.tsx
@@ -1,7 +1,10 @@
 import classNames from 'classnames'
 
+/** @public */
+export type TLSpinnerProps = React.SVGProps<SVGSVGElement>
+
 /** @public @react */
-export function DefaultSpinner(props: React.SVGProps<SVGSVGElement>) {
+export function DefaultSpinner(props: TLSpinnerProps) {
 	return (
 		<svg
 			width={16}

--- a/packages/editor/src/lib/hooks/EditorComponentsContext.tsx
+++ b/packages/editor/src/lib/hooks/EditorComponentsContext.tsx
@@ -5,6 +5,7 @@ import type { TLErrorFallbackComponent } from '../components/default-components/
 import type { TLGridProps } from '../components/default-components/DefaultGrid'
 import type { TLShapeErrorFallbackComponent } from '../components/default-components/DefaultShapeErrorFallback'
 import type { TLShapeWrapperProps } from '../components/default-components/DefaultShapeWrapper'
+import type { TLSpinnerProps } from '../components/default-components/DefaultSpinner'
 
 /** @public */
 export interface TLEditorComponents {
@@ -16,7 +17,7 @@ export interface TLEditorComponents {
 	LoadingScreen?: ComponentType | null
 	OnTheCanvas?: ComponentType | null
 	ShapeWrapper?: ComponentType<TLShapeWrapperProps & RefAttributes<HTMLDivElement>> | null
-	Spinner?: ComponentType<React.SVGProps<SVGSVGElement>> | null
+	Spinner?: ComponentType<TLSpinnerProps> | null
 	SvgDefs?: ComponentType | null
 
 	// These will always have defaults


### PR DESCRIPTION
This PR fixes a bug where the reference docs filed the React components exported by `@tldraw/editor`, such as `TldrawEditor`, `HTMLContainer` and `SVGContainer`, under Variable or Function with no props table. Closes #10254.

### Before

`preprocessReactComponents` in `apps/docs/utils/TldrawApiModel.ts` skipped every package except `tldraw`, so the editor package's `@react`-tagged exports never went through `isComponent()` / `getReactPropsItem()`. `TldrawEditor.mdx` generated as `group: Variable` and dumped the raw `React.MemoExoticComponent<…>` type, `HTMLContainer.mdx` generated as `group: Function` with a parameter literally named `{ children, className, ...rest }`, and the reference sidebar listed them under Variable and Function.

### After

The package filter is gone, so every package that uses the `@react` tag gets the component treatment. All 17 public editor components now generate as `group: Component` with a Properties table, the same as `Tldraw.mdx`.

Lifting the filter made three editor exports fail the generator's checks, so they change alongside it:

- `DefaultSpinner` took `React.SVGProps<SVGSVGElement>` inline, which the generator cannot turn into a props page. It now takes a new exported `TLSpinnerProps` alias, and `TLEditorComponents.Spinner` uses the same alias, matching `TLGridProps` and `TLShapeWrapperProps`.
- `DefaultErrorFallback` was a `const` typed through the `TLErrorFallbackComponent` alias, which hid its props from the generator. It is now a plain function taking a new exported `TLErrorFallbackProps` interface, and `TLErrorFallbackComponent` becomes `ComponentType<TLErrorFallbackProps>`, so existing custom fallbacks still fit.
- `TldrawEditorProps` carried a summary comment, which the generator rejects on component props because it is never rendered. The summary moved onto the `TldrawEditor` component itself, mirroring `TldrawProps`.

None of these change runtime behaviour.

### Implementation notes

`sdk-features/errors.mdx` still says the editor's inner boundary supplies the `editor` prop to the fallback, which the code does not do. That pre-existing inaccuracy is left for a separate docs fix.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn build-api` from the repo root, then `yarn fetch-api-source && yarn create-api-markdown` in `apps/docs`.
2. Check that `content/reference/TldrawEditor.mdx`, `HTMLContainer.mdx`, `SVGContainer.mdx`, `DefaultSpinner.mdx` and `DefaultErrorFallback.mdx` are `group: Component` with a Properties table. On `main` they generate as Variable or Function.
3. The generator reports no new errors. `main` logs three pre-existing "Error processing API" lines; this branch logs two, because the removed `{@link tldraw#Tldraw}` in the `TldrawEditorProps` summary was one of them.
4. `yarn refresh-content && yarn check-links --fail` in `apps/docs` passes, as do `yarn typecheck`, `yarn api-check` and `yarn lint` for `apps/docs` and `packages/editor`.

### Release notes

- Fix the reference docs for `@tldraw/editor` React components, which are now documented as components with props tables.

### API changes

- New exported types `TLErrorFallbackProps` and `TLSpinnerProps` in `@tldraw/editor`. `DefaultErrorFallback` is now declared as a function of `TLErrorFallbackProps` instead of a `const` of type `TLErrorFallbackComponent`; the component type itself is unchanged structurally.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Docs generator | +0 / -1 |
| Editor package | +32 / -14 |
| API report     | +13 / -7 |
