### PR TITLE
fix(packages): declare MIT license for utils and validate

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "SEE LICENSE IN LICENSE.md",
+	"license": "MIT",
 	"tldraw_product": {
 		"stableId": "tldraw:sdk-core",
 		"name": "SDK",

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -7,7 +7,7 @@
 		"email": "hello@tldraw.com"
 	},
 	"homepage": "https://tldraw.dev",
-	"license": "SEE LICENSE IN LICENSE.md",
+	"license": "MIT",
 	"tldraw_product": {
 		"stableId": "tldraw:sdk-core",
 		"name": "SDK",


### PR DESCRIPTION
This PR fixes a bug where the package metadata for `@tldraw/utils` and `@tldraw/validate` did not explicitly identify their MIT licenses.

### Before

Both manifests declared `SEE LICENSE IN LICENSE.md`, requiring readers to open the license files to identify MIT.

### After

Both manifests declare `MIT`, matching their existing license files.

### Change type

- [x] `bugfix`

### Test plan

- Verified both JSON manifests match their existing MIT license files.
- `git diff --check` passed; commit-hook type and API builds passed.

### Release notes

- Fix package metadata to explicitly identify the MIT licenses of `@tldraw/utils` and `@tldraw/validate`.

### Code changes

| Section | LOC change |
| --- | --- |
| Config/tooling | +2 / -2 |
