### PR TITLE
fix(ci): retry extension publishing and preserve cleanup actions

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -29,6 +29,7 @@ jobs:
           private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
 
       - name: Check out code
+        id: checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -55,9 +56,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      # Preserve the setup action for post-job cleanup when checkout already succeeded.
       - name: Check out Discord notify action
-        if: failure()
+        if: failure() && steps.checkout.outcome != 'success'
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions/discord-fail-notify

--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     name: Publish editor extensions
     environment: vsce publish
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -48,6 +48,7 @@ jobs:
         run: yarn build-types
 
       - name: Publish extension
+        timeout-minutes: 10
         run: yarn tsx ./internal/scripts/publish-editor-extensions.ts
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -32,6 +32,7 @@ jobs:
           private-key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
 
       - name: Check out code
+        id: checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -54,9 +55,9 @@ jobs:
           TLDRAW_ENV: ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      # Preserve the setup action for post-job cleanup when checkout already succeeded.
       - name: Check out Discord notify action
-        if: failure()
+        if: failure() && steps.checkout.outcome != 'success'
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions/discord-fail-notify

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     name: Publish VSCE/OVX
     environment: vsce publish
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -45,6 +45,7 @@ jobs:
         run: yarn build-types
 
       - name: Publish extension
+        timeout-minutes: 10
         run: yarn tsx ./internal/scripts/publish-editor-extensions.ts
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -29,6 +29,7 @@ jobs:
           private-key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
 
       - name: Check out code
+        id: checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -51,9 +52,9 @@ jobs:
           TLDRAW_ENV: production
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      # Preserve the setup action for post-job cleanup when checkout already succeeded.
       - name: Check out Discord notify action
-        if: failure()
+        if: failure() && steps.checkout.outcome != 'success'
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions/discord-fail-notify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,6 +171,7 @@ jobs:
           private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
 
       - name: Check out code
+        id: checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -250,9 +251,9 @@ jobs:
             https://api.github.com/repos/tldraw/tldraw-internal/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
-      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      # Preserve the setup action for post-job cleanup when checkout already succeeded.
       - name: Check out Discord notify action
-        if: failure()
+        if: failure() && steps.checkout.outcome != 'success'
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions/discord-fail-notify

--- a/apps/vscode/extension/scripts/publish.ts
+++ b/apps/vscode/extension/scripts/publish.ts
@@ -14,7 +14,7 @@ async function publishWithRetry(command: string) {
 			return
 		} catch (err) {
 			const error = err as Error & { stdout?: string; stderr?: string }
-			// Version conflicts need a new package version from the calling script.
+			// Marketplace version conflicts need a new package version from the calling script.
 			if (
 				attempt === MAX_REGISTRY_PUBLISH_ATTEMPTS ||
 				[error.message, error.stdout, error.stderr].some((text) => text?.includes('already exists'))
@@ -52,8 +52,10 @@ async function publishToOpenVSX(preRelease: boolean) {
 	const vsixPath = getVsixPath()
 	// eslint-disable-next-line no-console
 	console.log('Publishing to Open VSX...')
-	// OVSX_PAT is read from environment variable by ovsx CLI
-	await publishWithRetry(`npx ovsx publish${preRelease ? ' --pre-release' : ''} ${vsixPath}`)
+	// An upload can succeed even if its response is lost; retrying must accept that version.
+	await publishWithRetry(
+		`npx ovsx publish --skip-duplicate${preRelease ? ' --pre-release' : ''} ${vsixPath}`
+	)
 	// eslint-disable-next-line no-console
 	console.log('Successfully published to Open VSX')
 }

--- a/apps/vscode/extension/scripts/publish.ts
+++ b/apps/vscode/extension/scripts/publish.ts
@@ -4,10 +4,11 @@ import { join } from 'path'
 import { promisify } from 'util'
 
 const execAsync = promisify(exec)
+const MAX_REGISTRY_PUBLISH_ATTEMPTS = 3
+const REGISTRY_PUBLISH_RETRY_DELAY_MS = 10_000
 
 async function publishWithRetry(command: string) {
-	const maxAttempts = 3
-	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+	for (let attempt = 1; attempt <= MAX_REGISTRY_PUBLISH_ATTEMPTS; attempt++) {
 		try {
 			await execAsync(command)
 			return
@@ -15,13 +16,16 @@ async function publishWithRetry(command: string) {
 			const error = err as Error & { stdout?: string; stderr?: string }
 			// Version conflicts need a new package version from the calling script.
 			if (
-				attempt === maxAttempts ||
+				attempt === MAX_REGISTRY_PUBLISH_ATTEMPTS ||
 				[error.message, error.stdout, error.stderr].some((text) => text?.includes('already exists'))
 			) {
 				throw err
 			}
-			console.error(`Publish attempt ${attempt}/${maxAttempts} failed; retrying in 10s...`, err)
-			await new Promise((resolve) => setTimeout(resolve, 10_000))
+			console.error(
+				`Publish attempt ${attempt}/${MAX_REGISTRY_PUBLISH_ATTEMPTS} failed; retrying in ${REGISTRY_PUBLISH_RETRY_DELAY_MS / 1000}s...`,
+				err
+			)
+			await new Promise((resolve) => setTimeout(resolve, REGISTRY_PUBLISH_RETRY_DELAY_MS))
 		}
 	}
 }

--- a/apps/vscode/extension/scripts/publish.ts
+++ b/apps/vscode/extension/scripts/publish.ts
@@ -5,6 +5,27 @@ import { promisify } from 'util'
 
 const execAsync = promisify(exec)
 
+async function publishWithRetry(command: string) {
+	const maxAttempts = 3
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			await execAsync(command)
+			return
+		} catch (err) {
+			const error = err as Error & { stdout?: string; stderr?: string }
+			// Version conflicts need a new package version from the calling script.
+			if (
+				attempt === maxAttempts ||
+				[error.message, error.stdout, error.stderr].some((text) => text?.includes('already exists'))
+			) {
+				throw err
+			}
+			console.error(`Publish attempt ${attempt}/${maxAttempts} failed; retrying in 10s...`, err)
+			await new Promise((resolve) => setTimeout(resolve, 10_000))
+		}
+	}
+}
+
 function getVsixPath(): string {
 	const tempDir = join(__dirname, '../temp')
 	const files = readdirSync(tempDir)
@@ -18,7 +39,7 @@ function getVsixPath(): string {
 async function publishToVSCodeMarketplace(preRelease: boolean) {
 	// eslint-disable-next-line no-console
 	console.log(`Publishing to VS Code Marketplace${preRelease ? ' (pre-release)' : ''}`)
-	await execAsync(`vsce publish${preRelease ? ' --pre-release' : ''}`)
+	await publishWithRetry(`vsce publish${preRelease ? ' --pre-release' : ''}`)
 	// eslint-disable-next-line no-console
 	console.log('Successfully published to VS Code Marketplace')
 }
@@ -28,7 +49,7 @@ async function publishToOpenVSX(preRelease: boolean) {
 	// eslint-disable-next-line no-console
 	console.log('Publishing to Open VSX...')
 	// OVSX_PAT is read from environment variable by ovsx CLI
-	await execAsync(`npx ovsx publish${preRelease ? ' --pre-release' : ''} ${vsixPath}`)
+	await publishWithRetry(`npx ovsx publish${preRelease ? ' --pre-release' : ''} ${vsixPath}`)
 	// eslint-disable-next-line no-console
 	console.log('Successfully published to Open VSX')
 }

--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -12,7 +12,7 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
 const MAX_VERSION_CONFLICT_ATTEMPTS = 5
-const VERSION_CONFLICT_RETRY_DELAY_MS = 60_000
+const VERSION_CONFLICT_RETRY_DELAY_MS = 30_000
 
 function isVersionConflictError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : ''

--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -11,8 +11,8 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
-const MAX_RETRIES = 5
-const RETRY_DELAY_MS = 60_000
+const MAX_RETRIES = 3
+const RETRY_DELAY_MS = 10_000
 
 function isVersionConflictError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : ''

--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -11,8 +11,8 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
-const MAX_RETRIES = 3
-const RETRY_DELAY_MS = 10_000
+const MAX_VERSION_CONFLICT_ATTEMPTS = 5
+const VERSION_CONFLICT_RETRY_DELAY_MS = 60_000
 
 function isVersionConflictError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : ''
@@ -101,7 +101,7 @@ async function main() {
 	// the same next version. The "already exists" rejection is authoritative, so on conflict
 	// bump past the rejected version locally instead of re-fetching the stale listing.
 	let conflictedVersion: string | undefined
-	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+	for (let attempt = 1; attempt <= MAX_VERSION_CONFLICT_ATTEMPTS; attempt++) {
 		const version = await bumpVersion(conflictedVersion)
 
 		try {
@@ -117,12 +117,12 @@ async function main() {
 					return
 			}
 		} catch (err) {
-			if (isVersionConflictError(err) && attempt < MAX_RETRIES) {
+			if (isVersionConflictError(err) && attempt < MAX_VERSION_CONFLICT_ATTEMPTS) {
 				conflictedVersion = version
 				nicelog(
-					`Version ${version} already exists (attempt ${attempt}/${MAX_RETRIES}), bumping past it and retrying in ${RETRY_DELAY_MS / 1000}s...`
+					`Version ${version} already exists (attempt ${attempt}/${MAX_VERSION_CONFLICT_ATTEMPTS}), bumping past it and retrying in ${VERSION_CONFLICT_RETRY_DELAY_MS / 1000}s...`
 				)
-				await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+				await new Promise((resolve) => setTimeout(resolve, VERSION_CONFLICT_RETRY_DELAY_MS))
 				continue
 			}
 			throw err


### PR DESCRIPTION
This PR fixes extension publishing failures caused by temporary registry errors and a secondary post-job cleanup failure seen in [this run](https://github.com/tldraw/tldraw/actions/runs/34477002097/job/102870103770).

### Before

A Marketplace `ECONNRESET` immediately failed publishing. The failure notification then replaced the workspace with a sparse checkout containing only the Discord action, deleting `.github/actions/setup/action.yml` before its cleanup ran. The SDK publishing and version-bump workflows had the same checkout pattern.

### After

Each registry publish gets up to three attempts, with 10 seconds between attempts. A successful Marketplace publish is preserved when retrying Open VSX. Open VSX uses `--skip-duplicate` so an upload that succeeds but loses its response can recover on retry; Marketplace duplicates still trigger the version-bump logic. Version conflicts bypass these retries and reach the existing version-bump logic, which keeps its five-attempt limit with a shorter 30-second delay because subsequent versions are computed locally. Both retry policies now have explicit names. The extension publish step has a 10-minute timeout within a 20-minute job limit, leaving room for setup and failure notifications.

All four affected workflows fetch the notification action only when the initial checkout did not succeed, preserving setup cleanup after later failures while retaining notifications for early failures.

### Change type

- [x] `bugfix`

### Test plan

- [x] One-off execution harness: transient failure recovery, three-attempt exhaustion, per-registry isolation, immediate success, version-conflict propagation, and release flags. The recovery check failed before the fix and passed afterward.
- [x] Lost Open VSX upload response followed by a duplicate response, using the installed ovsx implementation: failed before adding `--skip-duplicate`, passed afterward.
- [x] One-off version-conflict harness: five attempts with four 30-second waits and final error propagation.
- [x] Parse all workflow YAML and check all four fallback conditions for successful, failed, skipped, and cancelled checkouts.
- [x] Verify both extension workflows use a 10-minute publish-step timeout and 20-minute job timeout.
- [x] Targeted formatting and lint checks; `git diff --check`.
- No live registry publish triggered.

### Code changes

| Section | LOC change |
| --- | --- |
| Config/tooling | +52 / -19 |
