### PR TITLE
feat(templates): update the chat composer to the new chat bar chrome

### DIFF
--- a/templates/chat/src/app/styles.css
+++ b/templates/chat/src/app/styles.css
@@ -340,38 +340,30 @@ body {
 	max-width: 800px;
 	margin: 0 auto;
 }
+/* the composer is a card with the text on top and the controls on their own row below it. */
 .chat-input-form {
 	display: grid;
 	grid-template-columns: auto 1fr auto;
 	grid-template-areas:
 		'images images images'
-		'attach input actions';
+		'input input input'
+		'attach . actions';
 	align-items: center;
 	column-gap: 4px;
 	background: var(--chat-surface);
 	border-radius: 28px;
-	padding: 8px;
+	padding: 12px 8px 8px;
 	position: relative;
 }
 
-/* once the text wraps or an image is attached, the composer grows into a card with the text on
-top and the controls on their own row below it. */
-.chat-input-form--expanded {
-	grid-template-areas:
-		'images images images'
-		'input input input'
-		'attach . actions';
-	padding: 12px 8px 8px;
-}
-
-/* on narrow screens there is no room for the single-row layout, so always use the expanded one. */
-@media (max-width: 600px) {
-	.chat-input-form {
+/* while the text fits on one line and nothing is attached, it collapses into a single pill-shaped
+row instead. narrow screens have no room for that, so they always use the card. */
+@media (min-width: 601px) {
+	.chat-input-form:not(.chat-input-form--expanded) {
 		grid-template-areas:
 			'images images images'
-			'input input input'
-			'attach . actions';
-		padding: 12px 8px 8px;
+			'attach input actions';
+		padding: 8px;
 	}
 }
 

--- a/templates/chat/src/app/styles.css
+++ b/templates/chat/src/app/styles.css
@@ -10,6 +10,8 @@
 	--chat-text: #f5f5f5;
 	--chat-muted: #aaa;
 	--chat-link: #8ab8ff;
+	--chat-accent: #0285ff;
+	--chat-accent-hover: #0070e0;
 	background: var(--chat-background);
 }
 
@@ -185,7 +187,7 @@ body {
 }
 
 .empty-chat-title {
-	font-size: 24px;
+	font-size: 28px;
 	font-weight: 500;
 	color: var(--chat-text);
 	margin-bottom: 32px;
@@ -339,18 +341,44 @@ body {
 	margin: 0 auto;
 }
 .chat-input-form {
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	grid-template-areas:
+		'images images images'
+		'attach input actions';
+	align-items: center;
+	column-gap: 4px;
 	background: var(--chat-surface);
 	border-radius: 28px;
-	padding: 12px 16px;
-	overflow: clip;
+	padding: 8px;
 	position: relative;
+}
+
+/* once the text wraps or an image is attached, the composer grows into a card with the text on
+top and the controls on their own row below it. */
+.chat-input-form--expanded {
+	grid-template-areas:
+		'images images images'
+		'input input input'
+		'attach . actions';
+	padding: 12px 8px 8px;
+}
+
+/* on narrow screens there is no room for the single-row layout, so always use the expanded one. */
+@media (max-width: 600px) {
+	.chat-input-form {
+		grid-template-areas:
+			'images images images'
+			'input input input'
+			'attach . actions';
+		padding: 12px 8px 8px;
+	}
 }
 
 .drag-drop-indicator {
 	position: absolute;
 	inset: 0;
+	border-radius: inherit;
 	background: var(--chat-surface);
 	color: var(--chat-muted);
 	display: flex;
@@ -387,13 +415,17 @@ body {
 }
 
 .input-container {
+	grid-area: input;
 	position: relative;
+	min-width: 0;
 }
+
 .input-images {
+	grid-area: images;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
-	padding-bottom: 8px;
+	padding: 4px 8px 12px;
 }
 
 .input-image {
@@ -469,48 +501,25 @@ body {
 	}
 }
 
-.chat-input-bottom {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin: 0 -6px;
-	margin-bottom: -4px;
-}
-
 .icon-button {
 	background: none;
 	border: none;
-	padding: 12px;
-	margin: 0 -2px;
+	width: 40px;
+	height: 40px;
+	padding: 0;
 	border-radius: 50%;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: #d4d4d4;
+	color: var(--chat-text);
 	position: relative;
+	flex-shrink: 0;
 }
 
 .icon-button svg {
-	width: 18px;
-	height: 18px;
-}
-
-.icon-button[type='submit'] {
-	margin-left: auto;
-}
-
-.icon-button[type='submit']:not(:disabled) {
-	background: #3b82f6;
-	color: white;
-}
-
-.icon-button[type='submit']:not(:disabled):hover {
-	background: #3b82f6;
-}
-
-.icon-button[type='submit'] svg {
-	transform: scale(1.2);
+	width: 22px;
+	height: 22px;
 }
 
 .icon-button:hover:not(:disabled) {
@@ -523,21 +532,110 @@ body {
 	cursor: default;
 }
 
+.icon-button--decorative {
+	cursor: default;
+}
+
+/* the "+" button and its attachment menu */
+.attach-menu {
+	grid-area: attach;
+	position: relative;
+}
+
+.attach-menu__popover {
+	position: absolute;
+	bottom: calc(100% + 8px);
+	left: 0;
+	min-width: 200px;
+	padding: 6px;
+	border-radius: 16px;
+	background: var(--chat-surface);
+	border: 1px solid var(--chat-border);
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+	z-index: 20;
+}
+
+.attach-menu__item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 8px 10px;
+	border: none;
+	border-radius: 10px;
+	background: none;
+	color: var(--chat-text);
+	font: inherit;
+	font-size: 14px;
+	text-align: left;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.attach-menu__item svg {
+	width: 18px;
+	height: 18px;
+	flex-shrink: 0;
+}
+
+.attach-menu__item:hover {
+	background: var(--chat-hover);
+}
+
+/* the controls to the right of the input */
+.chat-input-actions {
+	grid-area: actions;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.model-picker {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	height: 40px;
+	padding: 0 6px 0 10px;
+	border-radius: 20px;
+	color: var(--chat-muted);
+	font-size: 14px;
+	white-space: nowrap;
+	cursor: default;
+}
+
+.model-picker:hover {
+	background: var(--chat-hover);
+}
+
+.send-button {
+	background: var(--chat-accent);
+	color: white;
+}
+
+.send-button:hover:not(:disabled) {
+	background: var(--chat-accent-hover);
+}
+
+.send-button svg {
+	width: 24px;
+	height: 24px;
+}
+
 .chat-input {
 	color: var(--chat-text);
 	caret-color: var(--chat-text);
+	display: block;
 	width: 100%;
-	margin-top: 4px;
-	padding: 0 4px;
+	padding: 0 8px;
 	border: none;
 	background: transparent;
-	font-size: 14px;
+	font-size: 16px;
 	outline: none;
 	resize: none;
 	font-family: inherit;
-	line-height: 1.5;
+	line-height: 24px;
 	min-height: 24px;
-	max-height: 5lh;
+	max-height: 8lh;
 	overflow-y: auto;
 }
 
@@ -548,7 +646,7 @@ body {
 .input-spinner {
 	position: absolute;
 	top: 50%;
-	left: 4px;
+	left: 8px;
 	transform: translateY(-50%);
 	display: flex;
 	align-items: center;
@@ -568,6 +666,7 @@ body {
 }
 
 .icon-button:focus-visible,
+.attach-menu__item:focus-visible,
 .input-image-edit:focus-visible,
 .input-image-remove:focus-visible {
 	outline: 2px solid var(--chat-link);

--- a/templates/chat/src/components/Chat.tsx
+++ b/templates/chat/src/components/Chat.tsx
@@ -158,7 +158,7 @@ function ChatInner({
 				onDrop={handleDrop}
 			>
 				<div className="empty-chat-content">
-					<h1 className="empty-chat-title">How can I help?</h1>
+					<h1 className="empty-chat-title">What can I help with?</h1>
 					<div className="centered-input">
 						<ChatInput
 							onSendMessage={handleSendMessage}

--- a/templates/chat/src/components/ChatInput.tsx
+++ b/templates/chat/src/components/ChatInput.tsx
@@ -1,10 +1,14 @@
-import { FormEvent, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+import { FormEvent, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { DefaultSpinner } from 'tldraw'
 import { useChatInputState } from '../hooks/useChatInputState'
 import { ChatInputImage } from './ChatInputImage'
+import { ChevronDownIcon } from './icons/ChevronDownIcon'
 import { ImageIcon } from './icons/ImageIcon'
+import { MicIcon } from './icons/MicIcon'
+import { PlusIcon } from './icons/PlusIcon'
 import { SendIcon } from './icons/SendIcon'
 import { UploadIcon } from './icons/UploadIcon'
+import { WaveformIcon } from './icons/WaveformIcon'
 import { WhiteboardIcon } from './icons/WhiteboardIcon'
 import { WhiteboardImage, WhiteboardModal } from './WhiteboardModal'
 
@@ -26,27 +30,77 @@ export function ChatInput({
 	const { input, images, openWhiteboard, isDragging } = state
 	const disabled = waitingForResponse || isDragging
 
+	const formRef = useRef<HTMLFormElement>(null)
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
+	const attachMenuRef = useRef<HTMLDivElement>(null)
+
+	// The composer starts as a single pill-shaped row. Once the text wraps onto a second line or an
+	// image is attached, it expands into a taller card with the controls on their own row.
+	const [isMultiline, setIsMultiline] = useState(false)
+	const isExpanded = isMultiline || images.length > 0
+
+	// The "+" button opens a small menu with the attachment options.
+	const [attachMenuOpen, setAttachMenuOpen] = useState(false)
 
 	useEffect(() => {
 		// focus the textarea when the input is enabled
 		if (!disabled) textareaRef.current?.focus()
 	}, [disabled])
 
-	// Auto-resize textarea and scroll to bottom when content changes.
-	useLayoutEffect(() => {
-		if (textareaRef.current) {
-			// Reset height to auto to get the correct scrollHeight
-			textareaRef.current.style.height = 'auto'
-			// Set height based on scrollHeight, with max height for ~5 lines
-			textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
-		}
-	}, [input])
+	// Auto-resize the textarea to fit its content and check whether it wraps onto more than one
+	// line.
+	const measureTextarea = useCallback(() => {
+		const textarea = textareaRef.current
+		if (!textarea) return
+		// Reset height to auto to get the correct scrollHeight
+		textarea.style.height = 'auto'
+		// Set height based on scrollHeight. The max height is capped in css.
+		textarea.style.height = `${textarea.scrollHeight}px`
+		// An empty textarea never counts as multiline, even if its placeholder wraps.
+		const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight)
+		setIsMultiline(textarea.value !== '' && textarea.scrollHeight > lineHeight * 1.5)
+	}, [])
+
+	useLayoutEffect(measureTextarea, [input, measureTextarea])
+
+	// The text wraps differently as the composer changes width, so re-measure when it resizes.
+	useEffect(() => {
+		const form = formRef.current
+		if (!form) return
+		let lastWidth = form.clientWidth
+		const observer = new ResizeObserver(() => {
+			if (form.clientWidth === lastWidth) return
+			lastWidth = form.clientWidth
+			measureTextarea()
+		})
+		observer.observe(form)
+		return () => observer.disconnect()
+	}, [measureTextarea])
 
 	// Scroll to bottom when images are added.
 	useLayoutEffect(() => {
 		scrollToBottom('instant')
 	}, [images, scrollToBottom])
+
+	// Close the attachment menu when the user clicks outside it or presses escape.
+	useEffect(() => {
+		if (!attachMenuOpen) return
+		const handlePointerDown = (e: PointerEvent) => {
+			if (!attachMenuRef.current?.contains(e.target as Node)) setAttachMenuOpen(false)
+		}
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				setAttachMenuOpen(false)
+				textareaRef.current?.focus()
+			}
+		}
+		document.addEventListener('pointerdown', handlePointerDown)
+		document.addEventListener('keydown', handleKeyDown)
+		return () => {
+			document.removeEventListener('pointerdown', handlePointerDown)
+			document.removeEventListener('keydown', handleKeyDown)
+		}
+	}, [attachMenuOpen])
 
 	// the user can only send a message if the input is not disabled and there are either images or
 	// text ready to send
@@ -74,6 +128,7 @@ export function ChatInput({
 	// when the user clicks the image upload button, we open a file input to allow them to select an
 	// image from their device.
 	const handleImageUpload = useCallback(() => {
+		setAttachMenuOpen(false)
 		const input = document.createElement('input')
 		input.type = 'file'
 		input.accept = 'image/*'
@@ -85,6 +140,12 @@ export function ChatInput({
 			dispatch({ type: 'openWhiteboard', uploadedFile: file, imageName: file.name })
 		}
 		input.click()
+	}, [dispatch])
+
+	// when the user chooses to draw a sketch, we open the whiteboard modal.
+	const handleOpenWhiteboard = useCallback(() => {
+		setAttachMenuOpen(false)
+		dispatch({ type: 'openWhiteboard' })
 	}, [dispatch])
 
 	// when the user cancels the whiteboard modal, we close it.
@@ -104,7 +165,11 @@ export function ChatInput({
 	)
 
 	return (
-		<form onSubmit={handleSubmit} className="chat-input-form">
+		<form
+			ref={formRef}
+			onSubmit={handleSubmit}
+			className={`chat-input-form${isExpanded ? ' chat-input-form--expanded' : ''}`}
+		>
 			{/* if the user is dragging an image over the input area, we show a visual indicator
 			hiding the normal input content. */}
 			{isDragging && (
@@ -140,6 +205,45 @@ export function ChatInput({
 				</div>
 			)}
 
+			{/* the "+" button opens a menu with the attachment options: uploading an image or
+			drawing a sketch. */}
+			<div className="attach-menu" ref={attachMenuRef}>
+				<button
+					type="button"
+					aria-label="Add an attachment"
+					title="Add an attachment"
+					aria-haspopup="menu"
+					aria-expanded={attachMenuOpen}
+					className="icon-button attach-menu__trigger"
+					disabled={disabled}
+					onClick={() => setAttachMenuOpen((open) => !open)}
+				>
+					<PlusIcon />
+				</button>
+				{attachMenuOpen && (
+					<div className="attach-menu__popover" role="menu">
+						<button
+							type="button"
+							role="menuitem"
+							className="attach-menu__item"
+							onClick={handleImageUpload}
+						>
+							<ImageIcon />
+							Upload an image
+						</button>
+						<button
+							type="button"
+							role="menuitem"
+							className="attach-menu__item"
+							onClick={handleOpenWhiteboard}
+						>
+							<WhiteboardIcon />
+							Draw a sketch
+						</button>
+					</div>
+				)}
+			</div>
+
 			{/* the main input is a text area. we resize it automatically to fit its content. */}
 			<div className="input-container">
 				<textarea
@@ -147,7 +251,7 @@ export function ChatInput({
 					value={input}
 					onChange={(e) => dispatch({ type: 'setInput', input: e.target.value })}
 					onKeyDown={handleKeyDown}
-					placeholder={disabled ? '' : 'Type your message…'}
+					placeholder={disabled ? '' : 'Ask anything'}
 					className="chat-input"
 					disabled={disabled}
 					autoFocus={true}
@@ -160,40 +264,33 @@ export function ChatInput({
 				)}
 			</div>
 
-			{/* below the input we have several controls: */}
-			<div className="chat-input-bottom">
-				{/* a button to upload an image */}
-				<button
-					type="button"
-					aria-label="Upload an image"
-					title="Upload an image"
-					className="icon-button"
-					disabled={disabled}
-					onClick={handleImageUpload}
-				>
-					<ImageIcon />
-				</button>
-				{/* a button to open the whiteboard modal */}
-				<button
-					type="button"
-					aria-label="Draw a sketch"
-					title="Draw a sketch"
-					className="icon-button"
-					disabled={disabled}
-					onClick={() => dispatch({ type: 'openWhiteboard' })}
-				>
-					<WhiteboardIcon />
-				</button>
-				{/* a button to send the message */}
-				<button
-					type="submit"
-					disabled={!canSend || disabled}
-					className="icon-button"
-					aria-label="Send message"
-					title="Send message"
-				>
-					<SendIcon />
-				</button>
+			{/* to the right of the input we have the model picker, the mic and the send button. the
+			model picker and mic are decorative, like the rest of the app chrome. */}
+			<div className="chat-input-actions">
+				<span className="model-picker" aria-hidden="true">
+					Instant
+					<ChevronDownIcon />
+				</span>
+				<span className="icon-button icon-button--decorative" aria-hidden="true">
+					<MicIcon />
+				</span>
+				{/* the send button shows a voice waveform while the composer is empty and an arrow
+				once there is something to send (or a response is pending). */}
+				{canSend || waitingForResponse ? (
+					<button
+						type="submit"
+						className="icon-button send-button"
+						aria-label="Send message"
+						title="Send message"
+						disabled={!canSend}
+					>
+						<SendIcon />
+					</button>
+				) : (
+					<span className="icon-button send-button" aria-hidden="true">
+						<WaveformIcon />
+					</span>
+				)}
 			</div>
 
 			{/* if the user has opened the whiteboard modal, we show it. */}

--- a/templates/chat/src/components/ChatInput.tsx
+++ b/templates/chat/src/components/ChatInput.tsx
@@ -33,13 +33,14 @@ export function ChatInput({
 	const formRef = useRef<HTMLFormElement>(null)
 	const textareaRef = useRef<HTMLTextAreaElement>(null)
 	const attachMenuRef = useRef<HTMLDivElement>(null)
+	const attachButtonRef = useRef<HTMLButtonElement>(null)
+	const attachPopoverRef = useRef<HTMLDivElement>(null)
 
 	// The composer starts as a single pill-shaped row. Once the text wraps onto a second line or an
 	// image is attached, it expands into a taller card with the controls on their own row.
 	const [isMultiline, setIsMultiline] = useState(false)
 	const isExpanded = isMultiline || images.length > 0
 
-	// The "+" button opens a small menu with the attachment options.
 	const [attachMenuOpen, setAttachMenuOpen] = useState(false)
 
 	useEffect(() => {
@@ -47,19 +48,24 @@ export function ChatInput({
 		if (!disabled) textareaRef.current?.focus()
 	}, [disabled])
 
-	// Auto-resize the textarea to fit its content and check whether it wraps onto more than one
-	// line.
+	// Auto-resize the textarea to fit its content and decide whether the composer should expand.
+	const hasImages = images.length > 0
 	const measureTextarea = useCallback(() => {
+		const form = formRef.current
 		const textarea = textareaRef.current
-		if (!textarea) return
-		// Reset height to auto to get the correct scrollHeight
+		if (!form || !textarea) return
 		textarea.style.height = 'auto'
-		// Set height based on scrollHeight. The max height is capped in css.
-		textarea.style.height = `${textarea.scrollHeight}px`
-		// An empty textarea never counts as multiline, even if its placeholder wraps.
+		// The textarea is narrower in the single-row layout than in the expanded one. Always
+		// measure wrapping against the single-row width, otherwise text that fits on one line in
+		// the wide layout but not the narrow one would flip the composer back and forth on each
+		// keystroke. An empty textarea never counts as multiline, even if its placeholder wraps.
+		form.classList.remove('chat-input-form--expanded')
 		const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight)
-		setIsMultiline(textarea.value !== '' && textarea.scrollHeight > lineHeight * 1.5)
-	}, [])
+		const multiline = textarea.value !== '' && textarea.scrollHeight > lineHeight * 1.5
+		form.classList.toggle('chat-input-form--expanded', multiline || hasImages)
+		textarea.style.height = `${textarea.scrollHeight}px`
+		setIsMultiline(multiline)
+	}, [hasImages])
 
 	useLayoutEffect(measureTextarea, [input, measureTextarea])
 
@@ -68,13 +74,20 @@ export function ChatInput({
 		const form = formRef.current
 		if (!form) return
 		let lastWidth = form.clientWidth
+		let frame = 0
 		const observer = new ResizeObserver(() => {
 			if (form.clientWidth === lastWidth) return
 			lastWidth = form.clientWidth
-			measureTextarea()
+			// Defer to the next frame: resizing the textarea inside the callback would resize the
+			// observed form and trigger a resize observer loop error.
+			cancelAnimationFrame(frame)
+			frame = requestAnimationFrame(measureTextarea)
 		})
 		observer.observe(form)
-		return () => observer.disconnect()
+		return () => {
+			observer.disconnect()
+			cancelAnimationFrame(frame)
+		}
 	}, [measureTextarea])
 
 	// Scroll to bottom when images are added.
@@ -82,16 +95,18 @@ export function ChatInput({
 		scrollToBottom('instant')
 	}, [images, scrollToBottom])
 
-	// Close the attachment menu when the user clicks outside it or presses escape.
+	// Close the attachment menu when the user clicks outside it or presses escape, and move focus
+	// into it when it opens.
 	useEffect(() => {
 		if (!attachMenuOpen) return
+		attachPopoverRef.current?.querySelector('button')?.focus()
 		const handlePointerDown = (e: PointerEvent) => {
 			if (!attachMenuRef.current?.contains(e.target as Node)) setAttachMenuOpen(false)
 		}
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === 'Escape') {
 				setAttachMenuOpen(false)
-				textareaRef.current?.focus()
+				attachButtonRef.current?.focus()
 			}
 		}
 		document.addEventListener('pointerdown', handlePointerDown)
@@ -101,6 +116,24 @@ export function ChatInput({
 			document.removeEventListener('keydown', handleKeyDown)
 		}
 	}, [attachMenuOpen])
+
+	// Close the menu if the input gets disabled underneath it, e.g. when an image is dragged over.
+	useEffect(() => {
+		if (disabled) setAttachMenuOpen(false)
+	}, [disabled])
+
+	// Close the menu when focus leaves it, and let the arrow keys move between its items.
+	const handleAttachMenuBlur = (e: React.FocusEvent) => {
+		if (!e.currentTarget.contains(e.relatedTarget as Node)) setAttachMenuOpen(false)
+	}
+	const handleAttachMenuKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+		e.preventDefault()
+		const items = Array.from(e.currentTarget.querySelectorAll<HTMLButtonElement>('[role=menuitem]'))
+		const index = items.indexOf(document.activeElement as HTMLButtonElement)
+		const next = e.key === 'ArrowDown' ? index + 1 : index - 1
+		items[(next + items.length) % items.length]?.focus()
+	}
 
 	// the user can only send a message if the input is not disabled and there are either images or
 	// text ready to send
@@ -142,7 +175,6 @@ export function ChatInput({
 		input.click()
 	}, [dispatch])
 
-	// when the user chooses to draw a sketch, we open the whiteboard modal.
 	const handleOpenWhiteboard = useCallback(() => {
 		setAttachMenuOpen(false)
 		dispatch({ type: 'openWhiteboard' })
@@ -207,21 +239,27 @@ export function ChatInput({
 
 			{/* the "+" button opens a menu with the attachment options: uploading an image or
 			drawing a sketch. */}
-			<div className="attach-menu" ref={attachMenuRef}>
+			<div className="attach-menu" ref={attachMenuRef} onBlur={handleAttachMenuBlur}>
 				<button
+					ref={attachButtonRef}
 					type="button"
 					aria-label="Add an attachment"
 					title="Add an attachment"
 					aria-haspopup="menu"
 					aria-expanded={attachMenuOpen}
-					className="icon-button attach-menu__trigger"
+					className="icon-button"
 					disabled={disabled}
 					onClick={() => setAttachMenuOpen((open) => !open)}
 				>
 					<PlusIcon />
 				</button>
 				{attachMenuOpen && (
-					<div className="attach-menu__popover" role="menu">
+					<div
+						className="attach-menu__popover"
+						role="menu"
+						ref={attachPopoverRef}
+						onKeyDown={handleAttachMenuKeyDown}
+					>
 						<button
 							type="button"
 							role="menuitem"

--- a/templates/chat/src/components/icons/ChevronDownIcon.tsx
+++ b/templates/chat/src/components/icons/ChevronDownIcon.tsx
@@ -1,0 +1,17 @@
+export function ChevronDownIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="m4 6 4 4 4-4" />
+		</svg>
+	)
+}

--- a/templates/chat/src/components/icons/MicIcon.tsx
+++ b/templates/chat/src/components/icons/MicIcon.tsx
@@ -1,0 +1,18 @@
+export function MicIcon() {
+	return (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.8"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<rect x="9" y="3" width="6" height="11" rx="3" />
+			<path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6" />
+		</svg>
+	)
+}

--- a/templates/chat/src/components/icons/PlusIcon.tsx
+++ b/templates/chat/src/components/icons/PlusIcon.tsx
@@ -1,0 +1,17 @@
+export function PlusIcon() {
+	return (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.8"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="M12 5v14M5 12h14" />
+		</svg>
+	)
+}

--- a/templates/chat/src/components/icons/WaveformIcon.tsx
+++ b/templates/chat/src/components/icons/WaveformIcon.tsx
@@ -1,0 +1,16 @@
+export function WaveformIcon() {
+	return (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.2"
+			strokeLinecap="round"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="M4 10v4M8 6v12M12 9v6M16 6v12M20 10v4" />
+		</svg>
+	)
+}


### PR DESCRIPTION
In order to keep the chat starter looking like a current chat application, this PR reworks the composer in `templates/chat` to match the newer chat bar chrome, following on from #10739 which added the dark chrome around it. Stacked on `codex/chat-template-dark-ui`.

The composer is now a single pill-shaped row while it is empty: a `+` button, the text input, a decorative model picker and mic, and a blue voice button. Once the text wraps onto a second line or a sketch is attached, it grows into the taller card with the controls on their own row, and the blue button turns into the up-arrow send. The `+` button opens a small menu with the two existing attachment actions, upload an image and draw a sketch, replacing the two loose icon buttons. The model picker, mic and idle voice button are decorative and hidden from assistive tech, like the navigation chrome from #10739.

Whether the text wraps is always measured against the single-row width, since the input is narrower there than in the expanded card. Measuring in whichever layout is current would make text that fits one wide line but not one narrow line flip the composer back and forth on each keystroke. Screens under 600px always use the card layout.

### Change type

- [x] `feature`

### Test plan

1. Run `yarn dev-template chat` and open the empty chat: the composer is a single pill row.
2. Type until the text wraps: the composer expands and the blue button becomes the send arrow. Continue typing and deleting around the wrap point: the layout does not flicker.
3. Click `+`, attach a sketch: the card shows the image and the send arrow. Escape and arrow keys work in the menu.
4. Send a message: the same composer sits in the footer. Resize under 600px: the card layout is used.

### Release notes

- Update the chat template composer to a pill-shaped chat bar that expands into a card, with an attachment menu.

### Code changes

| Section   | LOC change  |
| --------- | ----------- |
| Templates | +378 / -84  |
