### PR TITLE
refactor(state,state-react,sync): simplify pass, rebased

### DIFF
--- a/packages/state-react/src/lib/useReactor.ts
+++ b/packages/state-react/src/lib/useReactor.ts
@@ -76,7 +76,7 @@ import { useEffect } from 'react'
  */
 export function useReactor(name: string, reactFn: () => void, deps: undefined | any[] = []) {
 	useEffect(() => {
-		let cancelFn: () => void | undefined
+		let cancelFn: (() => void) | undefined
 		const scheduler = new EffectScheduler(name, reactFn, {
 			scheduleEffect: (cb) => {
 				cancelFn = throttleToNextFrame(cb)

--- a/packages/state-react/src/lib/useStateTracking.ts
+++ b/packages/state-react/src/lib/useStateTracking.ts
@@ -49,7 +49,7 @@ export function useStateTracking<T>(name: string, render: () => T, deps: unknown
 		const scheduler = new EffectScheduler(
 			`useStateTracking(${name})`,
 			// this is what `scheduler.execute()` will call
-			() => renderRef.current?.(),
+			() => renderRef.current(),
 			// this is what will be invoked when @tldraw/state detects a change in an upstream reactive value
 			{
 				scheduleEffect() {

--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -76,19 +76,15 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 		private current: Value,
 		options?: AtomOptions<Value, Diff>
 	) {
-		this.isEqual = options?.isEqual ?? null
-
-		if (!options) return
-
-		if (options.historyLength) {
+		this.isEqual = options?.isEqual ?? equals
+		if (options?.historyLength) {
 			this.historyBuffer = new HistoryBuffer(options.historyLength)
 		}
-
-		this.computeDiff = options.computeDiff
+		this.computeDiff = options?.computeDiff
 	}
 
 	/** @internal */
-	readonly isEqual: null | ((a: any, b: any) => boolean)
+	readonly isEqual: (a: any, b: any) => boolean
 
 	/** @internal */
 	computeDiff?: ComputeDiff<Value, Diff>
@@ -144,7 +140,7 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 	 */
 	set(value: Value, diff?: Diff): Value {
 		// If the value has not changed, do nothing.
-		if (this.isEqual?.(this.current, value) ?? equals(this.current, value)) {
+		if (this.isEqual(this.current, value)) {
 			return this.current
 		}
 

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -100,30 +100,31 @@ export function startCapturingParents(child: Child) {
 export function stopCapturingParents() {
 	const frame = inst.stack!
 	inst.stack = frame.below
+	const { child, offset, maybeRemoved } = frame
 
-	if (frame.offset < frame.child.parents.length) {
-		for (let i = frame.offset; i < frame.child.parents.length; i++) {
-			const maybeRemovedParent = frame.child.parents[i]
-			if (!frame.child.parentSet.has(maybeRemovedParent)) {
-				detach(maybeRemovedParent, frame.child)
+	if (offset < child.parents.length) {
+		for (let i = offset; i < child.parents.length; i++) {
+			const maybeRemovedParent = child.parents[i]
+			if (!child.parentSet.has(maybeRemovedParent)) {
+				detach(maybeRemovedParent, child)
 			}
 		}
 
-		frame.child.parents.length = frame.offset
-		frame.child.parentEpochs.length = frame.offset
+		child.parents.length = offset
+		child.parentEpochs.length = offset
 	}
 
-	if (frame.maybeRemoved) {
-		for (let i = 0; i < frame.maybeRemoved.length; i++) {
-			const maybeRemovedParent = frame.maybeRemoved[i]
-			if (!frame.child.parentSet.has(maybeRemovedParent)) {
-				detach(maybeRemovedParent, frame.child)
+	if (maybeRemoved) {
+		for (let i = 0; i < maybeRemoved.length; i++) {
+			const maybeRemovedParent = maybeRemoved[i]
+			if (!child.parentSet.has(maybeRemovedParent)) {
+				detach(maybeRemovedParent, child)
 			}
 		}
 	}
 
-	if (frame.child.__debug_ancestor_epochs__) {
-		captureAncestorEpochs(frame.child, frame.child.__debug_ancestor_epochs__)
+	if (child.__debug_ancestor_epochs__) {
+		captureAncestorEpochs(child, child.__debug_ancestor_epochs__)
 	}
 }
 
@@ -148,36 +149,38 @@ export function stopCapturingParents() {
  * @internal
  */
 export function maybeCaptureParent(p: Signal<any, any>) {
-	if (inst.stack) {
-		// `add` returns false when the parent was already captured this run. In array mode both
-		// `has` and `add` scan with indexOf, so going straight to `add` halves the scans per
-		// captured parent.
-		if (!inst.stack.child.parentSet.add(p)) {
-			return
-		}
+	const stack = inst.stack
+	if (!stack) return
+	const { child } = stack
 
-		if (inst.stack.child.isActivelyListening) {
-			attach(p, inst.stack.child)
-		}
+	// `add` returns false when the parent was already captured this run. In array mode both
+	// `has` and `add` scan with indexOf, so going straight to `add` halves the scans per
+	// captured parent.
+	if (!child.parentSet.add(p)) {
+		return
+	}
 
-		// Parents are recorded in deref order. If the slot at this offset held a different parent
-		// last run, that parent may have moved later in the order or been dropped; only
-		// stopCapturingParents can tell, so remember it for then.
-		if (inst.stack.offset < inst.stack.child.parents.length) {
-			const maybeRemovedParent = inst.stack.child.parents[inst.stack.offset]
-			if (maybeRemovedParent !== p) {
-				if (!inst.stack.maybeRemoved) {
-					inst.stack.maybeRemoved = [maybeRemovedParent]
-				} else {
-					inst.stack.maybeRemoved.push(maybeRemovedParent)
-				}
+	if (child.isActivelyListening) {
+		attach(p, child)
+	}
+
+	// Parents are recorded in deref order. If the slot at this offset held a different parent
+	// last run, that parent may have moved later in the order or been dropped; only
+	// stopCapturingParents can tell, so remember it for then.
+	if (stack.offset < child.parents.length) {
+		const maybeRemovedParent = child.parents[stack.offset]
+		if (maybeRemovedParent !== p) {
+			if (!stack.maybeRemoved) {
+				stack.maybeRemoved = [maybeRemovedParent]
+			} else {
+				stack.maybeRemoved.push(maybeRemovedParent)
 			}
 		}
-
-		inst.stack.child.parents[inst.stack.offset] = p
-		inst.stack.child.parentEpochs[inst.stack.offset] = p.lastChangedEpoch
-		inst.stack.offset++
 	}
+
+	child.parents[stack.offset] = p
+	child.parentEpochs[stack.offset] = p.lastChangedEpoch
+	stack.offset++
 }
 
 /**

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -215,13 +215,11 @@ export function whyAmIRunning() {
 function captureAncestorEpochs(child: Child, ancestorEpochs: Map<Signal<any>, number>) {
 	for (let i = 0; i < child.parents.length; i++) {
 		const parent = child.parents[i]
-		const epoch = child.parentEpochs[i]
-		ancestorEpochs.set(parent, epoch)
+		ancestorEpochs.set(parent, child.parentEpochs[i])
 		if (isComputed(parent)) {
 			captureAncestorEpochs(parent as any, ancestorEpochs)
 		}
 	}
-	return ancestorEpochs
 }
 
 type ChangeTree = { [signalName: string]: ChangeTree } | null
@@ -235,9 +233,7 @@ function collectChangedAncestors(
 		if (!ancestorEpochs.has(parent)) {
 			continue
 		}
-		const prevEpoch = ancestorEpochs.get(parent)
-		const currentEpoch = parent.lastChangedEpoch
-		if (currentEpoch !== prevEpoch) {
+		if (parent.lastChangedEpoch !== ancestorEpochs.get(parent)) {
 			if (isComputed(parent)) {
 				changeTree[parent.name] = collectChangedAncestors(parent as any, ancestorEpochs)
 			} else {

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -75,9 +75,9 @@ export function attach(parent: Signal<any>, child: Child) {
  * @internal
  */
 export function equals(a: any, b: any): boolean {
-	const shallowEquals =
+	return (
 		a === b || Object.is(a, b) || Boolean(a && b && typeof a.equals === 'function' && a.equals(b))
-	return shallowEquals
+	)
 }
 
 /**

--- a/packages/state/src/lib/transactions.ts
+++ b/packages/state/src/lib/transactions.ts
@@ -17,13 +17,8 @@ class Transaction {
 
 	initialAtomValues = new Map<_Atom, any>()
 
-	// eslint-disable-next-line tldraw/no-setter-getter
-	get isRoot() {
-		return this.parent === null
-	}
-
 	commit() {
-		if (this.isRoot) {
+		if (this.parent === null) {
 			// For root transactions, flush changed atoms
 			flushChanges(this.initialAtomValues.keys())
 			return

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -49,6 +49,20 @@ const MULTIPLAYER_EVENT_NAME = 'multiplayer.client'
 
 const defaultCustomMessageHandler: TLCustomMessageHandler = () => {}
 
+// Keyed by `reason`, which is an arbitrary string off the server's close event, so a Map rather
+// than an object literal: a reason of 'constructor' or '__proto__' would find a prototype member.
+const SYNC_ERROR_EVENT_NAMES = new Map<string, string>([
+	[TLSyncErrorCloseEventReason.NOT_FOUND, 'room-not-found'],
+	[TLSyncErrorCloseEventReason.FORBIDDEN, 'forbidden'],
+	[TLSyncErrorCloseEventReason.NOT_AUTHENTICATED, 'not-authenticated'],
+	[TLSyncErrorCloseEventReason.RATE_LIMITED, 'rate-limited'],
+])
+
+// The socket reports 'error' but the collaboration status only knows 'offline'.
+function toCollaborationStatus(status: TLPersistentClientSocket['connectionStatus']) {
+	return status === 'error' ? 'offline' : status
+}
+
 /**
  * A store wrapper specifically for remote collaboration that excludes local-only states.
  * This type represents a tldraw store that is synchronized with a remote multiplayer server.
@@ -300,12 +314,12 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 
 		let didCancel = false
 
-		function getConnectionStatus() {
-			return socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
-		}
-		const collaborationStatusSignal = atom('collaboration status', getConnectionStatus())
+		const collaborationStatusSignal = atom(
+			'collaboration status',
+			toCollaborationStatus(socket.connectionStatus)
+		)
 		const unsubscribeFromConnectionStatus = socket.onStatusChange(() => {
-			collaborationStatusSignal.set(getConnectionStatus())
+			collaborationStatusSignal.set(toCollaborationStatus(socket.connectionStatus))
 		})
 
 		const syncMode = atom('sync mode', 'readwrite' as 'readonly' | 'readwrite')
@@ -353,24 +367,10 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			onSyncError(reason) {
 				console.error('sync error', reason)
 
-				switch (reason) {
-					case TLSyncErrorCloseEventReason.NOT_FOUND:
-						track?.(MULTIPLAYER_EVENT_NAME, { name: 'room-not-found', roomId })
-						break
-					case TLSyncErrorCloseEventReason.FORBIDDEN:
-						track?.(MULTIPLAYER_EVENT_NAME, { name: 'forbidden', roomId })
-						break
-					case TLSyncErrorCloseEventReason.NOT_AUTHENTICATED:
-						track?.(MULTIPLAYER_EVENT_NAME, { name: 'not-authenticated', roomId })
-						break
-					case TLSyncErrorCloseEventReason.RATE_LIMITED:
-						track?.(MULTIPLAYER_EVENT_NAME, { name: 'rate-limited', roomId })
-						break
-					default:
-						track?.(MULTIPLAYER_EVENT_NAME, { name: 'sync-error:' + reason, roomId })
-						break
-				}
-
+				track?.(MULTIPLAYER_EVENT_NAME, {
+					name: SYNC_ERROR_EVENT_NAMES.get(reason) ?? 'sync-error:' + reason,
+					roomId,
+				})
 				setState({ error: new TLRemoteSyncError(reason) })
 				socket.close()
 			},
@@ -422,10 +422,9 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			if (!state) return { status: 'loading' }
 			if (state.error) return { status: 'error', error: state.error }
 			if (!state.readyClient) return { status: 'loading' }
-			const connectionStatus = state.readyClient.socket.connectionStatus
 			return {
 				status: 'synced-remote',
-				connectionStatus: connectionStatus === 'error' ? 'offline' : connectionStatus,
+				connectionStatus: toCollaborationStatus(state.readyClient.socket.connectionStatus),
 				store: state.readyClient.store,
 				objectAccess: state.objectAccess ?? 'write',
 			}

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -58,8 +58,13 @@ const SYNC_ERROR_EVENT_NAMES = new Map<string, string>([
 	[TLSyncErrorCloseEventReason.RATE_LIMITED, 'rate-limited'],
 ])
 
+type SyncSocket = TLPersistentClientSocket<
+	TLSocketClientSentEvent<TLRecord>,
+	TLSocketServerSentEvent<TLRecord>
+>
+
 // The socket reports 'error' but the collaboration status only knows 'offline'.
-function toCollaborationStatus(status: TLPersistentClientSocket['connectionStatus']) {
+function toCollaborationStatus(status: SyncSocket['connectionStatus']) {
 	return status === 'error' ? 'offline' : status
 }
 
@@ -228,33 +233,26 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 	useEffect(() => {
 		const storeId = uniqueId()
 
-		const users: Required<TLUserStore> = _users
-			? {
-					currentUser: _users.currentUser,
-					resolve:
-						_users.resolve ??
-						createCachedUserResolve((userId) => {
-							const current = _users.currentUser.get()
-							return current && current.id === createUserId(userId) ? current : null
-						}),
-				}
-			: {
-					currentUser: defaultUserStore.currentUser,
-					resolve: createCachedUserResolve((userId) => {
-						const current = defaultUserStore.currentUser.get()
-						if (current && current.id === createUserId(userId)) return current
-						const presences = store.query.records('instance_presence').get()
-						const match = presences.find((p) => p.userId === createUserId(userId))
-						if (match) {
-							return UserRecordType.create({
-								id: createUserId(userId),
-								name: match.userName,
-								color: match.color,
-							})
-						}
-						return null
-					}),
-				}
+		const currentUserSignal = _users?.currentUser ?? defaultUserStore.currentUser
+		const users: Required<TLUserStore> = {
+			currentUser: currentUserSignal,
+			resolve:
+				_users?.resolve ??
+				createCachedUserResolve((userId) => {
+					const id = createUserId(userId)
+					const current = currentUserSignal.get()
+					if (current && current.id === id) return current
+					// Only the default user store falls back to presence records for other users.
+					if (_users) return null
+					const match = store.query
+						.records('instance_presence')
+						.get()
+						.find((p) => p.userId === id)
+					return match
+						? UserRecordType.create({ id, name: match.userName, color: match.color })
+						: null
+				}),
+		}
 
 		// This always returns a non-null user for presence display, falling back
 		// to anonymous user preferences. The store receives the raw `users` object
@@ -271,37 +269,23 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			})
 		})
 
-		let socket: TLPersistentClientSocket<
-			TLSocketClientSentEvent<TLRecord>,
-			TLSocketServerSentEvent<TLRecord>
-		>
+		let socket: SyncSocket
 		if (connect) {
 			if (uri) {
 				throw new Error('uri and connect cannot be used together')
 			}
 
-			socket = connect({
-				sessionId: TAB_ID,
-				storeId,
-			}) as TLPersistentClientSocket<
-				TLSocketClientSentEvent<TLRecord>,
-				TLSocketServerSentEvent<TLRecord>
-			>
+			socket = connect({ sessionId: TAB_ID, storeId }) as SyncSocket
 		} else if (uri) {
 			socket = new ClientWebSocketAdapter(async () => {
-				const uriString = typeof uri === 'string' ? uri : await uri()
-
 				// set sessionId as a query param on the uri
-				const withParams = new URL(uriString)
-				if (withParams.searchParams.has('sessionId')) {
-					throw new Error(
-						'useSync. "sessionId" is a reserved query param name. Please use a different name'
-					)
-				}
-				if (withParams.searchParams.has('storeId')) {
-					throw new Error(
-						'useSync. "storeId" is a reserved query param name. Please use a different name'
-					)
+				const withParams = new URL(typeof uri === 'string' ? uri : await uri())
+				for (const param of ['sessionId', 'storeId']) {
+					if (withParams.searchParams.has(param)) {
+						throw new Error(
+							`useSync. "${param}" is a reserved query param name. Please use a different name`
+						)
+					}
 				}
 
 				withParams.searchParams.set('sessionId', TAB_ID)

--- a/packages/sync/src/useSyncDemo.ts
+++ b/packages/sync/src/useSyncDemo.ts
@@ -121,9 +121,9 @@ export function useSyncDemo(
 		assets,
 		onMount: useCallback(
 			(editor: Editor) => {
-				editor.registerExternalAssetHandler('url', async ({ url }) => {
-					return await createAssetFromUrlUsingDemoServer(host, url)
-				})
+				editor.registerExternalAssetHandler('url', ({ url }) =>
+					createAssetFromUrlUsingDemoServer(host, url)
+				)
 			},
 			[host]
 		),
@@ -182,9 +182,7 @@ function createDemoAssetStore(host: string): TLAssetStore {
 				alert('Uploading images is disabled in this demo.')
 				throw new Error('Uploading images is disabled in this demo.')
 			}
-			const id = uniqueId()
-
-			const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
+			const objectName = `${uniqueId()}-${file.name}`.replace(/\W/g, '-')
 			const url = `${host}/uploads/${objectName}`
 
 			const response = await fetch(url, {
@@ -201,34 +199,34 @@ function createDemoAssetStore(host: string): TLAssetStore {
 		},
 
 		resolve(asset, context) {
-			if (!asset.props.src) return null
+			const { src } = asset.props
+			if (!src) return null
 
 			// We don't deal with videos at the moment.
-			if (asset.type === 'video') return asset.props.src
+			if (asset.type === 'video') return src
 
 			// Assert it's an image to make TS happy.
 			if (asset.type !== 'image') return null
 
 			// Don't try to transform data: URLs, yikes.
-			if (!asset.props.src.startsWith('http:') && !asset.props.src.startsWith('https:'))
-				return asset.props.src
+			if (!src.startsWith('http:') && !src.startsWith('https:')) return src
 
-			if (context.shouldResolveToOriginal) return asset.props.src
+			if (context.shouldResolveToOriginal) return src
 
 			// Don't try to transform animated images.
-			if (MediaHelpers.isAnimatedImageType(asset?.props.mimeType) || asset.props.isAnimated)
-				return asset.props.src
+			if (MediaHelpers.isAnimatedImageType(asset.props.mimeType) || asset.props.isAnimated)
+				return src
 
 			// Don't try to transform vector images.
-			if (MediaHelpers.isVectorImageType(asset?.props.mimeType)) return asset.props.src
+			if (MediaHelpers.isVectorImageType(asset.props.mimeType)) return src
 
-			const url = new URL(asset.props.src)
+			const url = new URL(src)
 
 			// we only transform images that are hosted on domains we control
 			const isTldrawImage =
 				url.origin === host || /\.tldraw\.(?:com|xyz|dev|workers\.dev)$/.test(url.host)
 
-			if (!isTldrawImage) return asset.props.src
+			if (!isTldrawImage) return src
 
 			// Assets that are under a certain file size aren't worth transforming (and incurring cost).
 			// We still send them through the image worker to get them optimized though.
@@ -256,8 +254,7 @@ function createDemoAssetStore(host: string): TLAssetStore {
 				url.searchParams.set('w', width.toString())
 			}
 
-			const newUrl = `${IMAGE_WORKER}/${url.host}/${url.toString().slice(url.origin.length + 1)}`
-			return newUrl
+			return `${IMAGE_WORKER}/${url.host}/${url.toString().slice(url.origin.length + 1)}`
 		},
 	}
 }
@@ -285,47 +282,28 @@ function createDemoAssetStore(host: string): TLAssetStore {
  * @internal
  */
 async function createAssetFromUrlUsingDemoServer(host: string, url: string): Promise<TLAsset> {
-	const urlHash = getHashForString(url)
+	let meta: { description?: string; image?: string; favicon?: string; title?: string } | null = null
 	try {
 		// First, try to get the meta data from our endpoint
 		const fetchUrl = new URL(`${host}/bookmarks/unfurl`)
 		fetchUrl.searchParams.set('url', url)
-
-		const meta = (await (await fetch(fetchUrl, { method: 'POST' })).json()) as {
-			description?: string
-			image?: string
-			favicon?: string
-			title?: string
-		} | null
-
-		return {
-			id: AssetRecordType.createId(urlHash),
-			typeName: 'asset',
-			type: 'bookmark',
-			props: {
-				src: url,
-				description: meta?.description ?? '',
-				image: meta?.image ?? '',
-				favicon: meta?.favicon ?? '',
-				title: meta?.title ?? '',
-			},
-			meta: {},
-		}
+		meta = await (await fetch(fetchUrl, { method: 'POST' })).json()
 	} catch (error) {
-		// Otherwise, fallback to a blank bookmark
+		// Otherwise, fall back to a blank bookmark
 		console.error(error)
-		return {
-			id: AssetRecordType.createId(urlHash),
-			typeName: 'asset',
-			type: 'bookmark',
-			props: {
-				src: url,
-				description: '',
-				image: '',
-				favicon: '',
-				title: '',
-			},
-			meta: {},
-		}
+	}
+
+	return {
+		id: AssetRecordType.createId(getHashForString(url)),
+		typeName: 'asset',
+		type: 'bookmark',
+		props: {
+			src: url,
+			description: meta?.description ?? '',
+			image: meta?.image ?? '',
+			favicon: meta?.favicon ?? '',
+			title: meta?.title ?? '',
+		},
+		meta: {},
 	}
 }


### PR DESCRIPTION
Redoes the `state`/`state-react`/`sync` slice of the simplify pass (#10073) on top of current main.

#10073 was opened on 18 August. The substantive part of it — the actively-listening computed serving stale values — was split out the next day and shipped as #10145, and main has moved on since: the `@computed` decorators were already de-duplicated (with a fix #10073 doesn't have, keying per-instance storage with a unique `Symbol()` so a subclass calling `super.method()` doesn't re-enter its own computed), `ArraySet` was restructured, the per-atom closure in `flushChanges` was already removed, `useSyncDemo`'s upload path gained a `response.ok` check, and `useSync` already dropped a dead `if (connect) throw`. Rebasing #10073 now produces 38 conflict hunks across 11 files where main is the newer side in most of them, so this reapplies only what is genuinely still absent.

No behavior changes.

### What's here

- `capture.ts` — bind the capture frame once instead of re-reading `inst.stack.child` on every line; `captureAncestorEpochs` also returned the map it had just mutated, which neither caller used
- `transactions.ts` — `Transaction.isRoot` had one caller and needed an eslint-disable for the getter
- `Atom` — `isEqual` defaults to `equals` rather than `null`; `equals` was already the fallback inside `set`, and this matches what `Computed` does
- `useReactor` — `let cancelFn: () => void | undefined` parsed as a function returning `void | undefined`, so the variable read as always-assigned and the `cancelFn?.()` guard in the cleanup looked redundant when it is load-bearing
- `useStateTracking` — `renderRef` is seeded by `useRef(render)` and reassigned every render, so the optional call only widened the scheduler's type to `T | undefined` against the hook's declared `T`
- `useSync` — the two `users` branches differed only in which `currentUser` signal they read and whether the resolver falls back to presence records; the socket's instantiated type was written out twice; the five-case switch in `onSyncError` and the two reserved-query-param throws became lookups
- `useSyncDemo` — `createAssetFromUrlUsingDemoServer` built the same bookmark record in both the success and failure paths

### Change type

- [x] `improvement`

### Test plan

1. `packages/state` (214), `state-react` (33), `sync` (12), `store` (473) and `editor` (1232) suites pass; lint and `tsc --build` clean on the three touched packages.

- [x] Unit tests

### Release notes

- Internal cleanup; no user-facing changes.
