### PR TITLE
fix(dotcom): name the storage-load sub-stage in effect stall reports

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -57,6 +57,8 @@ interface ResolvedDoRoom {
 	deleted: boolean
 	connectedSockets: number
 	roomLoaded: boolean
+	bootStage: string | null
+	bootStageAgeMs: number | null
 }
 
 interface ResolvedDoHistory {
@@ -245,7 +247,11 @@ function ResolveDoId() {
 					<div>
 						{history ? <b>{activityVerdict(match, history)}</b> : null} · {match.connectedSockets}{' '}
 						socket{match.connectedSockets === 1 ? '' : 's'} connected · room{' '}
-						{match.roomLoaded ? 'loaded in memory' : 'not loaded (hibernated or idle)'}
+						{match.bootStage !== null
+							? `booting: ${match.bootStage} for ${Math.round((match.bootStageAgeMs ?? 0) / 1000)}s`
+							: match.roomLoaded
+								? 'loaded in memory'
+								: 'not loaded (hibernated or idle)'}
 					</div>
 					{history && (
 						<div>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1485,10 +1485,8 @@ export class TLFileDurableObject extends DurableObject {
 		return res
 	}
 
-	// The comments load is kicked off before the R2 fetch and only awaited at the merge points,
-	// so this is where a hung Postgres dial surfaces. The stage and timer are set here, at the
-	// await, rather than at the kickoff: until this point the load overlapped other work and a
-	// stall was attributed to whatever stage was awaiting alongside it (#10746).
+	// Stage and timer sit at the await, not the kickoff: the load overlaps the R2 fetch, so a
+	// hung Postgres dial was otherwise attributed to whichever stage awaited alongside it (#10746).
 	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
 		this.setBootStage('storage-load:comments')
 		const commentsTimer = this.timer()

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1485,14 +1485,11 @@ export class TLFileDurableObject extends DurableObject {
 		return res
 	}
 
-	// Stage and timer sit at the await, not the kickoff: the load overlaps the R2 fetch, so a
-	// hung Postgres dial was otherwise attributed to whichever stage awaited alongside it (#10746).
+	// The stage is set at the await, not the kickoff: the kickoff stage is overwritten by
+	// storage-load:r2 right after, so a hung Postgres dial would report as :r2 (#10746).
 	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
 		this.setBootStage('storage-load:comments')
-		const commentsTimer = this.timer()
-		const comments = await commentsPromise
-		commentsTimer.report('db_load_comments')
-		return comments
+		return await commentsPromise
 	}
 
 	/**
@@ -1696,11 +1693,15 @@ export class TLFileDurableObject extends DurableObject {
 
 	private async loadCommentsFromPostgres(): Promise<CommentLoadResult> {
 		const fileId = this.documentInfo.slug
+		// Timed here rather than at the merge-point await so the event is query latency, not the
+		// residual wait after the overlapping R2 fetch (which would read ~0 whenever R2 is slower).
+		const commentsTimer = this.timer()
 		const [threadRows, commentRows, reactionRows] = await Promise.all([
 			this.db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
 			this.db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
 			this.db.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
 		])
+		commentsTimer.report('db_load_comments')
 		// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
 		// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
 		return liveCommentDocuments(threadRows, commentRows, reactionRows)

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -283,7 +283,7 @@ export class TLFileDurableObject extends DurableObject {
 			throw new Error('documentInfo must be present when accessing room')
 		}
 		if (!this._storage) {
-			this.setBootStage('storage-load')
+			this.setBootStage('storage-load:sqlite-init')
 			// Kicked off here so the KV read resolves alongside the room load instead of after it.
 			this.versionChainRollout()
 			const promise = retry(() => this.loadStorage(this.documentInfo.slug), {
@@ -305,6 +305,7 @@ export class TLFileDurableObject extends DurableObject {
 					// head the chain recorded and cuts a keyframe when they differ. Gated on the mode: this
 					// is a second decoded copy of the board pinned for the DO's lifetime, not worth paying
 					// for where chains are off.
+					this.setBootStage('storage-load:kv-rollout')
 					const rollout = await this.versionChainRollout()
 					if (resolveVersionChainMode(rollout, getR2KeyForRoom(this.documentInfo)) !== 'off') {
 						this._lastPersistedSnapshot = storage.getSnapshot?.() ?? null
@@ -1477,11 +1478,23 @@ export class TLFileDurableObject extends DurableObject {
 			// Clone: loadCreateSourceData can return the shared DEFAULT_INITIAL_SNAPSHOT constant
 			// and the merge mutates top-level snapshot fields.
 			const snapshot: RoomSnapshot = { ...res.snapshot }
-			mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+			mergeCommentDocumentsIntoSnapshot(snapshot, await this.awaitComments(commentsPromise))
 			res.snapshot = snapshot
 		}
 
 		return res
+	}
+
+	// The comments load is kicked off before the R2 fetch and only awaited at the merge points,
+	// so this is where a hung Postgres dial surfaces. The stage and timer are set here, at the
+	// await, rather than at the kickoff: until this point the load overlapped other work and a
+	// stall was attributed to whatever stage was awaiting alongside it (#10746).
+	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
+		this.setBootStage('storage-load:comments')
+		const commentsTimer = this.timer()
+		const comments = await commentsPromise
+		commentsTimer.report('db_load_comments')
+		return comments
 	}
 
 	/**
@@ -1565,6 +1578,7 @@ export class TLFileDurableObject extends DurableObject {
 
 			// when loading, prefer to fetch documents from the bucket
 			const r2FetchTimer = this.timer()
+			this.setBootStage('storage-load:r2')
 			const roomFromBucket = await this.r2.rooms.get(key)
 			r2FetchTimer.report('db_load_r2_fetch')
 
@@ -1577,7 +1591,7 @@ export class TLFileDurableObject extends DurableObject {
 				// room open (bubbling like an R2 failure) — silently opening without comments would
 				// let the next persist treat them as deleted.
 				if (commentsPromise) {
-					mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+					mergeCommentDocumentsIntoSnapshot(snapshot, await this.awaitComments(commentsPromise))
 				}
 
 				loadTimer.report('db_load_total')
@@ -1596,6 +1610,7 @@ export class TLFileDurableObject extends DurableObject {
 
 			if (this.documentInfo.isApp) {
 				// finally check whether the file exists in the DB but not in R2 yet
+				this.setBootStage('storage-load:file-record')
 				const file = await this.getAppFileRecord()
 
 				if (!file) {
@@ -1613,14 +1628,15 @@ export class TLFileDurableObject extends DurableObject {
 					return res
 				}
 
-				loadTimer.report('db_load_total')
-
 				// Comments can exist in Postgres before the first throttled R2 persist ever runs
 				// (e.g. DO SQLite lost right after commenting on a fresh file), so rehydrate them
 				// here too. Clone the shared DEFAULT_INITIAL_SNAPSHOT constant — the merge reassigns
 				// `documents` and clamps clocks, and must not mutate the module-level object.
 				const snapshot: RoomSnapshot = { ...DEFAULT_INITIAL_SNAPSHOT }
-				mergeCommentDocumentsIntoSnapshot(snapshot, await assertExists(commentsPromise))
+				const comments = await this.awaitComments(assertExists(commentsPromise))
+				mergeCommentDocumentsIntoSnapshot(snapshot, comments)
+
+				loadTimer.report('db_load_total')
 
 				return {
 					snapshot,
@@ -1635,6 +1651,7 @@ export class TLFileDurableObject extends DurableObject {
 			}
 
 			const supabaseFetchTimer = this.timer()
+			this.setBootStage('storage-load:supabase')
 			const { data, error } = await supabaseClient
 				.from(this.supabaseTable)
 				.select('*')

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1505,6 +1505,7 @@ export class TLFileDurableObject extends DurableObject {
 		// A new workspace's first file: a fixed marker (no prefix/id) the worker resolves to the
 		// welcome template's content, or a committed default — see resolveWelcomeSnapshot.
 		if (createSource === WELCOME_CREATE_SOURCE) {
+			this.setBootStage('source-welcome')
 			return await resolveWelcomeSnapshot(this.env, (e) => this.reportError(e))
 		}
 
@@ -1543,14 +1544,19 @@ export class TLFileDurableObject extends DurableObject {
 				return text
 			}
 			case ROOM_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
 			case READ_ONLY_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
 			case READ_ONLY_LEGACY_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
 			case SNAPSHOT_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, 'snapshot')
 			case PUBLISH_PREFIX:
+				this.setBootStage('source-published')
 				return await getPublishedRoomSnapshot(this.env, id)
 			case LOCAL_FILE_PREFIX:
 				// create empty room, the client will populate it

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -267,6 +267,9 @@ export class TLFileDurableObject extends DurableObject {
 		// Postgres comment rows merged in; the storage routes those records into its objects
 		// partition.
 		const result = await this.loadFromDatabase(slug)
+		// Decoding a large board into SQLite is sync CPU; without this it runs under whichever
+		// network stage loadFromDatabase last set.
+		this.setBootStage('storage-load:sqlite-init')
 		const storage = new SQLiteSyncStorage<TLRecord>({
 			sql,
 			snapshot: result.snapshot,
@@ -298,6 +301,7 @@ export class TLFileDurableObject extends DurableObject {
 					storage.transaction((txn) => {
 						fileSyncSchema.migrateStorage(txn)
 					})
+					this.setBootStage('storage-load:kv-rollout')
 					// The next persist diffs against this rather than cutting a keyframe every time the
 					// durable object wakes. It is usually what R2 holds, but not always: a previous
 					// incarnation can die with edits SQLite has and R2 does not. That is safe because the
@@ -305,7 +309,6 @@ export class TLFileDurableObject extends DurableObject {
 					// head the chain recorded and cuts a keyframe when they differ. Gated on the mode: this
 					// is a second decoded copy of the board pinned for the DO's lifetime, not worth paying
 					// for where chains are off.
-					this.setBootStage('storage-load:kv-rollout')
 					const rollout = await this.versionChainRollout()
 					if (resolveVersionChainMode(rollout, getR2KeyForRoom(this.documentInfo)) !== 'off') {
 						this._lastPersistedSnapshot = storage.getSnapshot?.() ?? null

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
@@ -1,6 +1,11 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RoomNotFoundError, settleWithin, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
+import {
+	FileEffectStallError,
+	RoomNotFoundError,
+	settleWithin,
+	shouldSkipMissingRoomEffect,
+} from './roomEffectHelpers'
 
 function file(partial: Partial<TlaFile>): TlaFile {
 	return {
@@ -76,5 +81,27 @@ describe('settleWithin', () => {
 		reject(new Error('late'))
 		// A late rejection must not become an unhandled rejection.
 		await vi.runAllTimersAsync()
+	})
+})
+
+describe('FileEffectStallError', () => {
+	it('names the boot sub-stage and its age when the boot is still in progress', () => {
+		const error = new FileEffectStallError(
+			'slug-1',
+			'insert',
+			'storage-load:comments',
+			25000,
+			30000
+		)
+		expect(error.message).toBe(
+			'file insert effect for slug-1 still pending after 30000ms at boot stage storage-load:comments (25000ms in stage)'
+		)
+	})
+
+	it('reports post-boot work when there is no boot stage', () => {
+		const error = new FileEffectStallError('slug-1', 'update', null, null, 30000)
+		expect(error.message).toBe(
+			'file update effect for slug-1 still pending after 30000ms in post-boot work'
+		)
 	})
 })

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -31,6 +31,9 @@ export type BootStage =
 	| 'storage-load:kv-rollout'
 	| 'source-await-persist'
 	| 'source-r2-fetch'
+	| 'source-welcome'
+	| 'source-legacy'
+	| 'source-published'
 	| 'source-r2-put'
 	| 'room-create'
 

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -23,7 +23,12 @@ export function shouldSkipMissingRoomEffect(error: unknown, file: TlaFile): bool
 // a null stage means the boot settled and the stall is in post-boot work (e.g. the
 // per-session permission refresh).
 export type BootStage =
-	| 'storage-load'
+	| 'storage-load:sqlite-init'
+	| 'storage-load:r2'
+	| 'storage-load:file-record'
+	| 'storage-load:comments'
+	| 'storage-load:supabase'
+	| 'storage-load:kv-rollout'
 	| 'source-await-persist'
 	| 'source-r2-fetch'
 	| 'source-r2-put'

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -1084,7 +1084,8 @@ spec:
 
                         AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_comments')
 
                         AND blob2 = '${environment}-tldraw-multiplayer'
 
@@ -1100,7 +1101,8 @@ spec:
 
                         AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_comments')
 
                         AND blob2 = '${environment}-tldraw-multiplayer'
 
@@ -1213,7 +1215,7 @@ spec:
                         AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
                         'on_request_group_check', 'on_request_get_room', 'get_file_record',
                         'get_file_record_error', 'db_load_total', 'db_load_total_error',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source', 'db_load_comments',
                         'create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch')
 
@@ -1231,7 +1233,7 @@ spec:
                         AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
                         'on_request_group_check', 'on_request_get_room', 'get_file_record',
                         'get_file_record_error', 'db_load_total', 'db_load_total_error',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source', 'db_load_comments',
                         'create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch')
 


### PR DESCRIPTION
This PR fixes a bug where an effect stall report during a file Durable Object boot said `at boot stage storage-load` without saying which of the awaits in that stage hung, and where the `db_load_total` timer reported success on the fresh-file path while the comments Postgres load was still pending. Closes #10746. Follow-up from the 2026-09-10 Postgres dial incident ([Notion](https://app.notion.com/p/3d83e4c324c08080af74eb8ec8e0c939)).

### Before

`storage-load` covered the R2 blob fetch, the file-record lookup, the comments Postgres load, the legacy Supabase fetch and the KV rollout read, so ten `FileEffectStallError: ... at boot stage storage-load (25000ms in stage)` reports could not say which one was stuck. On the fresh-file path `loadFromDatabase` reported `db_load_total` before awaiting `commentsPromise`, so the timers claimed a 70 ms load while the comments query was timing out at ~19 s. The admin file card only knew loaded / not loaded.

### After

`BootStage` has one `storage-load:*` value per await (`sqlite-init`, `r2`, `file-record`, `comments`, `supabase`, `kv-rollout`), set right before each one, so the stall report names the exact await. The create-source arms that had no stage of their own (welcome, legacy, published) get `source-welcome` / `source-legacy` / `source-published`, so a hung welcome-template query no longer reports as `:r2`. The cold-path SQLite constructor re-sets `:sqlite-init` so a big-board decode isn't blamed on the last network stage. The comments await goes through `awaitComments`, which sets the `:comments` stage at all three merge points, and the fresh-file path reports `db_load_total` after it. `loadCommentsFromPostgres` reports a `db_load_comments` timer around the query itself. The admin file card renders `booting: <stage> for <n>s` while a boot is in progress. Both Grafana panels with an explicit event list now include `db_load_comments`.

### Implementation notes

- `loadFromCreateSource` keeps its `source-*` stages for the copy itself; only its final comments await gets `:comments`, otherwise a hang there would report as `source-r2-put`.
- `db_load_comments` is timed at the query, not at the merge-point await: the load overlaps the R2 fetch, so timing the await would measure the residual wait and read ~0 whenever R2 was slower.
- The issue named one Grafana panel. The "operation avg" table panel in the same dashboard also filters on an explicit list, so `db_load_comments` is added there too.
- Not verifiable in unit tests: `loadFromDatabase` needs R2, Postgres and DO storage. Staging check after deploy: open a new file, confirm `db_load_r2_fetch`, `db_load_comments`, `db_load_total` rows for the DO with `db_load_total >= db_load_comments`.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests: two `FileEffectStallError` message cases; the sub-stage one fails to type check on `main`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Tests          | +28 / -1   |
| Apps           | +47 / -8   |
| Config/tooling | +6 / -4    |
