### PR TITLE
perf(dotcom): load room comments over one Postgres connection

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -57,6 +57,8 @@ interface ResolvedDoRoom {
 	deleted: boolean
 	connectedSockets: number
 	roomLoaded: boolean
+	bootStage: string | null
+	bootStageAgeMs: number | null
 }
 
 interface ResolvedDoHistory {
@@ -245,7 +247,11 @@ function ResolveDoId() {
 					<div>
 						{history ? <b>{activityVerdict(match, history)}</b> : null} · {match.connectedSockets}{' '}
 						socket{match.connectedSockets === 1 ? '' : 's'} connected · room{' '}
-						{match.roomLoaded ? 'loaded in memory' : 'not loaded (hibernated or idle)'}
+						{match.bootStage !== null
+							? `booting: ${match.bootStage} for ${Math.round((match.bootStageAgeMs ?? 0) / 1000)}s`
+							: match.roomLoaded
+								? 'loaded in memory'
+								: 'not loaded (hibernated or idle)'}
 					</div>
 					{history && (
 						<div>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -65,7 +65,7 @@ import {
 	isCommentReactionFkViolation,
 	isCommentThreadFkViolation,
 	isCommentThreadIdFkViolation,
-	liveCommentDocuments,
+	loadCommentDocuments,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
 	planCommentDrain,
@@ -1695,19 +1695,12 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	private async loadCommentsFromPostgres(): Promise<CommentLoadResult> {
-		const fileId = this.documentInfo.slug
 		// Timed here rather than at the merge-point await so the event is query latency, not the
 		// residual wait after the overlapping R2 fetch (which would read ~0 whenever R2 is slower).
 		const commentsTimer = this.timer()
-		const [threadRows, commentRows, reactionRows] = await Promise.all([
-			this.db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
-			this.db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
-			this.db.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
-		])
+		const result = await loadCommentDocuments(this.db, this.documentInfo.slug)
 		commentsTimer.report('db_load_comments')
-		// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
-		// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
-		return liveCommentDocuments(threadRows, commentRows, reactionRows)
+		return result
 	}
 
 	timer() {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1485,10 +1485,8 @@ export class TLFileDurableObject extends DurableObject {
 		return res
 	}
 
-	// The comments load is kicked off before the R2 fetch and only awaited at the merge points,
-	// so this is where a hung Postgres dial surfaces. The stage and timer are set here, at the
-	// await, rather than at the kickoff: until this point the load overlapped other work and a
-	// stall was attributed to whatever stage was awaiting alongside it (#10746).
+	// Stage and timer sit at the await, not the kickoff: the load overlaps the R2 fetch, so a
+	// hung Postgres dial was otherwise attributed to whichever stage awaited alongside it (#10746).
 	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
 		this.setBootStage('storage-load:comments')
 		const commentsTimer = this.timer()

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1485,14 +1485,11 @@ export class TLFileDurableObject extends DurableObject {
 		return res
 	}
 
-	// Stage and timer sit at the await, not the kickoff: the load overlaps the R2 fetch, so a
-	// hung Postgres dial was otherwise attributed to whichever stage awaited alongside it (#10746).
+	// The stage is set at the await, not the kickoff: the kickoff stage is overwritten by
+	// storage-load:r2 right after, so a hung Postgres dial would report as :r2 (#10746).
 	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
 		this.setBootStage('storage-load:comments')
-		const commentsTimer = this.timer()
-		const comments = await commentsPromise
-		commentsTimer.report('db_load_comments')
-		return comments
+		return await commentsPromise
 	}
 
 	/**
@@ -1696,11 +1693,15 @@ export class TLFileDurableObject extends DurableObject {
 
 	private async loadCommentsFromPostgres(): Promise<CommentLoadResult> {
 		const fileId = this.documentInfo.slug
+		// Timed here rather than at the merge-point await so the event is query latency, not the
+		// residual wait after the overlapping R2 fetch (which would read ~0 whenever R2 is slower).
+		const commentsTimer = this.timer()
 		const [threadRows, commentRows, reactionRows] = await Promise.all([
 			this.db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
 			this.db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
 			this.db.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
 		])
+		commentsTimer.report('db_load_comments')
 		// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
 		// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
 		return liveCommentDocuments(threadRows, commentRows, reactionRows)

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -283,7 +283,7 @@ export class TLFileDurableObject extends DurableObject {
 			throw new Error('documentInfo must be present when accessing room')
 		}
 		if (!this._storage) {
-			this.setBootStage('storage-load')
+			this.setBootStage('storage-load:sqlite-init')
 			// Kicked off here so the KV read resolves alongside the room load instead of after it.
 			this.versionChainRollout()
 			const promise = retry(() => this.loadStorage(this.documentInfo.slug), {
@@ -305,6 +305,7 @@ export class TLFileDurableObject extends DurableObject {
 					// head the chain recorded and cuts a keyframe when they differ. Gated on the mode: this
 					// is a second decoded copy of the board pinned for the DO's lifetime, not worth paying
 					// for where chains are off.
+					this.setBootStage('storage-load:kv-rollout')
 					const rollout = await this.versionChainRollout()
 					if (resolveVersionChainMode(rollout, getR2KeyForRoom(this.documentInfo)) !== 'off') {
 						this._lastPersistedSnapshot = storage.getSnapshot?.() ?? null
@@ -1477,11 +1478,23 @@ export class TLFileDurableObject extends DurableObject {
 			// Clone: loadCreateSourceData can return the shared DEFAULT_INITIAL_SNAPSHOT constant
 			// and the merge mutates top-level snapshot fields.
 			const snapshot: RoomSnapshot = { ...res.snapshot }
-			mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+			mergeCommentDocumentsIntoSnapshot(snapshot, await this.awaitComments(commentsPromise))
 			res.snapshot = snapshot
 		}
 
 		return res
+	}
+
+	// The comments load is kicked off before the R2 fetch and only awaited at the merge points,
+	// so this is where a hung Postgres dial surfaces. The stage and timer are set here, at the
+	// await, rather than at the kickoff: until this point the load overlapped other work and a
+	// stall was attributed to whatever stage was awaiting alongside it (#10746).
+	private async awaitComments(commentsPromise: Promise<CommentLoadResult>) {
+		this.setBootStage('storage-load:comments')
+		const commentsTimer = this.timer()
+		const comments = await commentsPromise
+		commentsTimer.report('db_load_comments')
+		return comments
 	}
 
 	/**
@@ -1565,6 +1578,7 @@ export class TLFileDurableObject extends DurableObject {
 
 			// when loading, prefer to fetch documents from the bucket
 			const r2FetchTimer = this.timer()
+			this.setBootStage('storage-load:r2')
 			const roomFromBucket = await this.r2.rooms.get(key)
 			r2FetchTimer.report('db_load_r2_fetch')
 
@@ -1577,7 +1591,7 @@ export class TLFileDurableObject extends DurableObject {
 				// room open (bubbling like an R2 failure) — silently opening without comments would
 				// let the next persist treat them as deleted.
 				if (commentsPromise) {
-					mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+					mergeCommentDocumentsIntoSnapshot(snapshot, await this.awaitComments(commentsPromise))
 				}
 
 				loadTimer.report('db_load_total')
@@ -1596,6 +1610,7 @@ export class TLFileDurableObject extends DurableObject {
 
 			if (this.documentInfo.isApp) {
 				// finally check whether the file exists in the DB but not in R2 yet
+				this.setBootStage('storage-load:file-record')
 				const file = await this.getAppFileRecord()
 
 				if (!file) {
@@ -1613,14 +1628,15 @@ export class TLFileDurableObject extends DurableObject {
 					return res
 				}
 
-				loadTimer.report('db_load_total')
-
 				// Comments can exist in Postgres before the first throttled R2 persist ever runs
 				// (e.g. DO SQLite lost right after commenting on a fresh file), so rehydrate them
 				// here too. Clone the shared DEFAULT_INITIAL_SNAPSHOT constant — the merge reassigns
 				// `documents` and clamps clocks, and must not mutate the module-level object.
 				const snapshot: RoomSnapshot = { ...DEFAULT_INITIAL_SNAPSHOT }
-				mergeCommentDocumentsIntoSnapshot(snapshot, await assertExists(commentsPromise))
+				const comments = await this.awaitComments(assertExists(commentsPromise))
+				mergeCommentDocumentsIntoSnapshot(snapshot, comments)
+
+				loadTimer.report('db_load_total')
 
 				return {
 					snapshot,
@@ -1635,6 +1651,7 @@ export class TLFileDurableObject extends DurableObject {
 			}
 
 			const supabaseFetchTimer = this.timer()
+			this.setBootStage('storage-load:supabase')
 			const { data, error } = await supabaseClient
 				.from(this.supabaseTable)
 				.select('*')

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1505,6 +1505,7 @@ export class TLFileDurableObject extends DurableObject {
 		// A new workspace's first file: a fixed marker (no prefix/id) the worker resolves to the
 		// welcome template's content, or a committed default — see resolveWelcomeSnapshot.
 		if (createSource === WELCOME_CREATE_SOURCE) {
+			this.setBootStage('source-welcome')
 			return await resolveWelcomeSnapshot(this.env, (e) => this.reportError(e))
 		}
 
@@ -1543,14 +1544,19 @@ export class TLFileDurableObject extends DurableObject {
 				return text
 			}
 			case ROOM_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
 			case READ_ONLY_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
 			case READ_ONLY_LEGACY_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
 			case SNAPSHOT_PREFIX:
+				this.setBootStage('source-legacy')
 				return await getLegacyRoomData(this.env, id, 'snapshot')
 			case PUBLISH_PREFIX:
+				this.setBootStage('source-published')
 				return await getPublishedRoomSnapshot(this.env, id)
 			case LOCAL_FILE_PREFIX:
 				// create empty room, the client will populate it

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -267,6 +267,9 @@ export class TLFileDurableObject extends DurableObject {
 		// Postgres comment rows merged in; the storage routes those records into its objects
 		// partition.
 		const result = await this.loadFromDatabase(slug)
+		// Decoding a large board into SQLite is sync CPU; without this it runs under whichever
+		// network stage loadFromDatabase last set.
+		this.setBootStage('storage-load:sqlite-init')
 		const storage = new SQLiteSyncStorage<TLRecord>({
 			sql,
 			snapshot: result.snapshot,
@@ -298,6 +301,7 @@ export class TLFileDurableObject extends DurableObject {
 					storage.transaction((txn) => {
 						fileSyncSchema.migrateStorage(txn)
 					})
+					this.setBootStage('storage-load:kv-rollout')
 					// The next persist diffs against this rather than cutting a keyframe every time the
 					// durable object wakes. It is usually what R2 holds, but not always: a previous
 					// incarnation can die with edits SQLite has and R2 does not. That is safe because the
@@ -305,7 +309,6 @@ export class TLFileDurableObject extends DurableObject {
 					// head the chain recorded and cuts a keyframe when they differ. Gated on the mode: this
 					// is a second decoded copy of the board pinned for the DO's lifetime, not worth paying
 					// for where chains are off.
-					this.setBootStage('storage-load:kv-rollout')
 					const rollout = await this.versionChainRollout()
 					if (resolveVersionChainMode(rollout, getR2KeyForRoom(this.documentInfo)) !== 'off') {
 						this._lastPersistedSnapshot = storage.getSnapshot?.() ?? null

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -20,6 +20,7 @@ import {
 	isCommentThreadIdFkViolation,
 	isCommentThreadFkViolation,
 	liveCommentDocuments,
+	loadCommentDocuments,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
 	planCommentDrain,
@@ -1012,5 +1013,94 @@ describe('liveCommentDocuments', () => {
 
 	it('empty rows produce an empty, zero-floor load', () => {
 		expect(liveCommentDocuments([], [])).toEqual({ documents: [], clockFloor: 0 })
+	})
+})
+
+describe('loadCommentDocuments', () => {
+	function makeFakeDb(rows: {
+		comment_thread: unknown[]
+		comment: unknown[]
+		comment_reaction: unknown[]
+	}) {
+		const outerSelects: string[] = []
+		const boundSelects: string[] = []
+		let connectionCount = 0
+		const makeSelectFrom = (log: string[]) => (table: keyof typeof rows) => {
+			log.push(table)
+			return {
+				where: () => ({ selectAll: () => ({ execute: async () => rows[table] }) }),
+			}
+		}
+		const boundDb = { selectFrom: makeSelectFrom(boundSelects) }
+		const db: any = {
+			selectFrom: makeSelectFrom(outerSelects),
+			connection: () => ({
+				execute: async (cb: (conn: any) => Promise<any>) => {
+					connectionCount++
+					return cb(boundDb)
+				},
+			}),
+		}
+		return {
+			db,
+			outerSelects,
+			boundSelects,
+			get connectionCount() {
+				return connectionCount
+			},
+		}
+	}
+
+	it('runs all three queries on one checked-out connection', async () => {
+		const fake = makeFakeDb({ comment_thread: [], comment: [], comment_reaction: [] })
+		await loadCommentDocuments(fake.db, 'file1')
+		expect(fake.connectionCount).toBe(1)
+		expect(fake.boundSelects.sort()).toEqual(['comment', 'comment_reaction', 'comment_thread'])
+		expect(fake.outerSelects).toEqual([])
+	})
+
+	it('returns the live documents and clock floor for the rows', async () => {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1500,
+		})
+		const reaction = createCommentReaction({
+			commentId: comment.id,
+			threadId: thread.id,
+			pageId,
+			userId: 'user1',
+			emoji: '👍',
+			now: 1700,
+		})
+		const deletedThread = { ...makeThread(), isDeleted: true }
+		const deletedThreadComment = createComment({
+			threadId: deletedThread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1600,
+		})
+		const threadRows = [
+			threadRecordToRow(thread, 'file1', 42),
+			threadRecordToRow(deletedThread, 'file1', 50),
+		]
+		const commentRows = [
+			commentRecordToRow(comment, 'file1', 43),
+			commentRecordToRow(deletedThreadComment, 'file1', 51),
+		]
+		const reactionRows = [reactionRecordToRow(reaction, 'file1', 45)]
+		const fake = makeFakeDb({
+			comment_thread: threadRows,
+			comment: commentRows,
+			comment_reaction: reactionRows,
+		})
+		const expected = liveCommentDocuments(threadRows, commentRows, reactionRows)
+		expect(await loadCommentDocuments(fake.db, 'file1')).toEqual(expected)
+		expect(expected.documents.map((d) => d.state.id)).toEqual([thread.id, comment.id, reaction.id])
+		expect(expected.clockFloor).toBe(51)
 	})
 })

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -13,6 +13,7 @@ import {
 	isCommentThreadId,
 } from '@tldraw/tlschema'
 import { JsonObject } from '@tldraw/utils'
+import { Kysely } from 'kysely'
 
 /**
  * Conversions between the room's comment records and their Postgres rows. Postgres is the sole
@@ -292,6 +293,29 @@ export function liveCommentDocuments(
 		documents: rowsToSnapshotDocuments(liveThreadRows, liveCommentRows, liveReactionRows),
 		clockFloor,
 	}
+}
+
+/**
+ * Load a file's comment rows over a single checked-out connection. Each `execute()` on the bare
+ * Kysely instance checks out its own connection, and `TLPostgresPool` dials a fresh socket per
+ * checkout, so three parallel-looking queries would otherwise cost three sequential dials.
+ */
+export async function loadCommentDocuments(
+	db: Kysely<DB>,
+	fileId: string
+): Promise<CommentLoadResult> {
+	const [threadRows, commentRows, reactionRows] = await db
+		.connection()
+		.execute((conn) =>
+			Promise.all([
+				conn.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
+				conn.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
+				conn.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
+			])
+		)
+	// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
+	// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
+	return liveCommentDocuments(threadRows, commentRows, reactionRows)
 }
 
 /** A row of the DO's `comment_outbox` table: a monotonic sequence number and the touched record id. */

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.test.ts
@@ -1,6 +1,11 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RoomNotFoundError, settleWithin, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
+import {
+	FileEffectStallError,
+	RoomNotFoundError,
+	settleWithin,
+	shouldSkipMissingRoomEffect,
+} from './roomEffectHelpers'
 
 function file(partial: Partial<TlaFile>): TlaFile {
 	return {
@@ -76,5 +81,27 @@ describe('settleWithin', () => {
 		reject(new Error('late'))
 		// A late rejection must not become an unhandled rejection.
 		await vi.runAllTimersAsync()
+	})
+})
+
+describe('FileEffectStallError', () => {
+	it('names the boot sub-stage and its age when the boot is still in progress', () => {
+		const error = new FileEffectStallError(
+			'slug-1',
+			'insert',
+			'storage-load:comments',
+			25000,
+			30000
+		)
+		expect(error.message).toBe(
+			'file insert effect for slug-1 still pending after 30000ms at boot stage storage-load:comments (25000ms in stage)'
+		)
+	})
+
+	it('reports post-boot work when there is no boot stage', () => {
+		const error = new FileEffectStallError('slug-1', 'update', null, null, 30000)
+		expect(error.message).toBe(
+			'file update effect for slug-1 still pending after 30000ms in post-boot work'
+		)
 	})
 })

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -31,6 +31,9 @@ export type BootStage =
 	| 'storage-load:kv-rollout'
 	| 'source-await-persist'
 	| 'source-r2-fetch'
+	| 'source-welcome'
+	| 'source-legacy'
+	| 'source-published'
 	| 'source-r2-put'
 	| 'room-create'
 

--- a/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
+++ b/apps/dotcom/sync-worker/src/roomEffectHelpers.ts
@@ -23,7 +23,12 @@ export function shouldSkipMissingRoomEffect(error: unknown, file: TlaFile): bool
 // a null stage means the boot settled and the stall is in post-boot work (e.g. the
 // per-session permission refresh).
 export type BootStage =
-	| 'storage-load'
+	| 'storage-load:sqlite-init'
+	| 'storage-load:r2'
+	| 'storage-load:file-record'
+	| 'storage-load:comments'
+	| 'storage-load:supabase'
+	| 'storage-load:kv-rollout'
 	| 'source-await-persist'
 	| 'source-r2-fetch'
 	| 'source-r2-put'

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -1084,7 +1084,8 @@ spec:
 
                         AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_comments')
 
                         AND blob2 = '${environment}-tldraw-multiplayer'
 
@@ -1100,7 +1101,8 @@ spec:
 
                         AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_comments')
 
                         AND blob2 = '${environment}-tldraw-multiplayer'
 
@@ -1213,7 +1215,7 @@ spec:
                         AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
                         'on_request_group_check', 'on_request_get_room', 'get_file_record',
                         'get_file_record_error', 'db_load_total', 'db_load_total_error',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source', 'db_load_comments',
                         'create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch')
 
@@ -1231,7 +1233,7 @@ spec:
                         AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
                         'on_request_group_check', 'on_request_get_room', 'get_file_record',
                         'get_file_record_error', 'db_load_total', 'db_load_total_error',
-                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source', 'db_load_comments',
                         'create_from_source_fetch_total', 'create_from_source_r2_put',
                         'create_from_source_await_persist', 'create_from_source_r2_fetch')
 


### PR DESCRIPTION
This PR improves app-file room boot so that loading comments costs one Postgres dial instead of three. Stacked on #10747; retarget to `main` once that merges.

### Before

`loadCommentsFromPostgres()` ran three `selectFrom` queries in a `Promise.all`, which looks parallel but is not. Kysely checks out a connection per `execute()`, and `TLPostgresPool` deliberately creates a fresh `pg.Client` per checkout (dial Supavisor over TLS, tear it down on release, checkouts serialized behind one lock) so no idle socket blocks Durable Object hibernation. The three queries therefore became three sequential dial + query + teardown cycles. The dial is the expensive part: tens to hundreds of ms normally, 10 s (`CONNECT_TIMEOUT_MS`) when the pooler is unhealthy, no retry at that layer. A file with zero comments paid all three, and during the 2026-09-10 Postgres dial incident each room boot attempt gave the failure three chances to hit instead of one.

### After

The three queries run inside one `db.connection().execute(...)`, so they share a single checkout and a room boot pays one dial for comments. Kysely serializes queries on a bound connection, so this is one dial plus three sequential round trips on one socket, not three parallel queries. `db_load_comments` (from #10747) should drop by roughly one dial, and `postgres_client_connect` for `user-do` should fall from three per boot to one. Staging before/after rows to follow after deploy.

### Implementation notes

- `connection()` rather than `transaction()`: three reads with no cross-query consistency requirement, and `BEGIN`/`COMMIT` would add two round trips.
- The query body moved to `loadCommentDocuments()` in `commentRows.ts` so it can be unit tested with a fake Kysely; the Analytics Engine timer stays in the Durable Object.
- Out of scope: collapsing into one `SELECT` with `json_agg`, sharing the checkout with `getAppFileRecord()`, dial retries, warm connections.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests: `loadCommentDocuments` asserts one `connection()` call with all three queries on the bound connection, plus the live-document result. The first test fails if the queries go back to `this.db.selectFrom(...)`.
- [ ] Staging: check "Postgres connections by pool" and `db_load_comments` in the Dotcom events dashboard, and that comments still render.

### Release notes

- Internal, no release note.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -10  |
| Tests     | +84 / -0   |
