### PR TITLE
feat(dotcom): store the last error on effect_outbox rows and show it on the admin page

### DIFF
--- a/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
@@ -106,6 +106,7 @@ export function EffectsSection() {
 								<th>Attempts</th>
 								<th>Age</th>
 								<th>Next retry</th>
+								<th>Last error</th>
 								<th>Actions</th>
 							</tr>
 						</thead>
@@ -131,6 +132,11 @@ export function EffectsSection() {
 			)}
 		</section>
 	)
+}
+
+function truncate(text: string | null, max: number): string {
+	if (!text) return ''
+	return text.length > max ? `${text.slice(0, max)}…` : text
 }
 
 // Human-readable summary of what a row's effect represents, diffing the same columns
@@ -196,6 +202,7 @@ function OutboxRowView({
 				</td>
 				<td>{row.ageSeconds}s</td>
 				<td>{row.nextRetryAt ? new Date(row.nextRetryAt).toLocaleString() : 'n/a'}</td>
+				<td title={row.lastError ?? undefined}>{truncate(row.lastError, 60)}</td>
 				<td onClick={(e) => e.stopPropagation()}>
 					<AdminButton
 						onClick={onRetry}
@@ -217,7 +224,7 @@ function OutboxRowView({
 			</tr>
 			{expanded && (
 				<tr>
-					<td colSpan={8}>
+					<td colSpan={9}>
 						<div className={styles.outboxDetails}>
 							<div className={styles.outboxDetailsColumn}>
 								<div className={styles.fieldLabel}>Payload</div>

--- a/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/EffectsSection.tsx
@@ -5,7 +5,7 @@ import {
 	TlaFile,
 } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useState } from 'react'
-import { fetch } from 'tldraw'
+import { fetch, truncateStringWithEllipsis } from 'tldraw'
 import { AdminButton } from './AdminButton'
 import { getResponseError } from './shared'
 import styles from './admin.module.css'
@@ -134,11 +134,6 @@ export function EffectsSection() {
 	)
 }
 
-function truncate(text: string | null, max: number): string {
-	if (!text) return ''
-	return text.length > max ? `${text.slice(0, max)}…` : text
-}
-
 // Human-readable summary of what a row's effect represents, diffing the same columns
 // the file trigger considers effect-relevant.
 function describeChange(row: AdminOutboxRow): string {
@@ -202,7 +197,9 @@ function OutboxRowView({
 				</td>
 				<td>{row.ageSeconds}s</td>
 				<td>{row.nextRetryAt ? new Date(row.nextRetryAt).toLocaleString() : 'n/a'}</td>
-				<td title={row.lastError ?? undefined}>{truncate(row.lastError, 60)}</td>
+				<td title={row.lastError ?? undefined}>
+					{row.lastError ? truncateStringWithEllipsis(row.lastError, 60) : ''}
+				</td>
 				<td onClick={(e) => e.stopPropagation()}>
 					<AdminButton
 						onClick={onRetry}

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -8,6 +8,7 @@ import {
 	MAX_ATTEMPTS,
 	computeNextAlarm,
 	drainOutbox,
+	formatOutboxError,
 	shouldReportEffectFailure,
 } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
@@ -137,7 +138,7 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
 					processed++
 				},
-				bumpAttempts: async (row) => {
+				bumpAttempts: async (row, error) => {
 					failed++
 					// Exponential backoff from the row's current attempt count, capped at 5 minutes.
 					// The base IS the effect timeout, so the first retry can't land before a
@@ -155,6 +156,7 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 						.set((eb) => ({
 							attempts: eb('attempts', '+', 1),
 							nextRetryAt: backoff,
+							lastError: formatOutboxError(error),
 						}))
 						.where('id', '=', row.id)
 						.execute()

--- a/apps/dotcom/sync-worker/src/fileEffects.test.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.test.ts
@@ -103,6 +103,7 @@ function effectRow(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
 		attempts: 0,
 		createdAt: new Date(0),
 		nextRetryAt: null,
+		lastError: null,
 		...partial,
 	}
 }

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -186,6 +186,22 @@ describe('drainOutbox', () => {
 		expect(deps.onError).toHaveBeenCalledTimes(1)
 		const err = (deps.onError as any).mock.calls[0][0]
 		expect(String(err)).toMatch(/timed out/i)
+		expect(formatOutboxError(deps.bumped[0].error)).toBe(
+			'EffectTimeoutError: effect for file:f1 (outbox 1) timed out after 5ms'
+		)
+	})
+
+	it('reports the effect error before bumping so a failing bump cannot hide it', async () => {
+		const deps = makeDeps([row({ id: 1 })])
+		const effectError = new Error('effect failed')
+		deps.process = async () => {
+			throw effectError
+		}
+		deps.bumpAttempts = async () => {
+			throw new Error('db down')
+		}
+		await expect(drainOutbox(deps)).rejects.toThrow('db down')
+		expect(deps.onError).toHaveBeenCalledWith(effectError, expect.objectContaining({ id: 1 }))
 	})
 
 	it('late resolution after a timeout does not double-delete or double-bump', async () => {
@@ -244,12 +260,25 @@ describe('formatOutboxError', () => {
 
 	it('stringifies non-Error values', () => {
 		expect(formatOutboxError('proxy request failed')).toBe('proxy request failed')
-		expect(formatOutboxError({ code: 42 })).toBe('[object Object]')
+		expect(formatOutboxError({ code: 42 })).toBe('{"code":42}')
 		expect(formatOutboxError(undefined)).toBe('undefined')
 	})
 
+	it('appends one level of cause', () => {
+		const inner = new Error('connect ECONNREFUSED', { cause: new Error('deeper') })
+		expect(formatOutboxError(new TypeError('fetch failed', { cause: inner }))).toBe(
+			'TypeError: fetch failed (cause: Error: connect ECONNREFUSED)'
+		)
+		expect(formatOutboxError(new Error('x', { cause: { code: 'ETIMEDOUT' } }))).toBe(
+			'Error: x (cause: {"code":"ETIMEDOUT"})'
+		)
+	})
+
 	it('never throws and strips NUL bytes so the attempts bump cannot fail on it', () => {
-		expect(formatOutboxError(Object.create(null))).toBe('[unformattable object]')
+		const circular: any = {}
+		circular.self = circular
+		expect(formatOutboxError(circular)).toBe('[unformattable object]')
+		expect(formatOutboxError(new Error('x', { cause: circular }))).toBe('[unformattable object]')
 		expect(formatOutboxError(new Error('a\0b'))).toBe('Error: ab')
 	})
 

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -5,6 +5,7 @@ import {
 	OutboxDeps,
 	computeNextAlarm,
 	drainOutbox,
+	formatOutboxError,
 	shouldReportEffectFailure,
 } from './outboxDrain'
 
@@ -19,18 +20,19 @@ function row(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
 		attempts: 0,
 		createdAt: new Date(0),
 		nextRetryAt: null,
+		lastError: null,
 		...partial,
 	}
 }
 
 interface TestDeps extends OutboxDeps {
 	calls: string[]
-	bumped: Array<{ id: number; attempts: number }>
+	bumped: Array<{ id: number; attempts: number; error: unknown }>
 }
 
 function makeDeps(rows: TlaEffectOutbox[], timeoutMs = 30_000): TestDeps {
 	const calls: string[] = []
-	const bumped: Array<{ id: number; attempts: number }> = []
+	const bumped: Array<{ id: number; attempts: number; error: unknown }> = []
 	let batch = rows
 	return {
 		calls,
@@ -44,9 +46,9 @@ function makeDeps(rows: TlaEffectOutbox[], timeoutMs = 30_000): TestDeps {
 		deleteRow: async (id) => {
 			calls.push(`deleteRow:${id}`)
 		},
-		bumpAttempts: async (r) => {
+		bumpAttempts: async (r, error) => {
 			calls.push(`bump:${r.id}`)
-			bumped.push({ id: r.id, attempts: r.attempts })
+			bumped.push({ id: r.id, attempts: r.attempts, error })
 		},
 		deleteParkedRowsOlderThan: async () => {},
 		process: async (r) => {
@@ -204,13 +206,14 @@ describe('drainOutbox', () => {
 		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
 	})
 
-	it('passes the row current attempts to bumpAttempts so backoff can be scheduled', async () => {
+	it('passes the row current attempts and the error to bumpAttempts', async () => {
 		const deps = makeDeps([row({ id: 7, attempts: 3 })])
+		const error = new Error('fail')
 		deps.process = async () => {
-			throw new Error('fail')
+			throw error
 		}
 		await drainOutbox(deps)
-		expect(deps.bumped).toEqual([{ id: 7, attempts: 3 }])
+		expect(deps.bumped).toEqual([{ id: 7, attempts: 3, error }])
 	})
 
 	it('passes the FULL failed row to bumpAttempts so the impl can defer later siblings', async () => {
@@ -231,6 +234,24 @@ describe('drainOutbox', () => {
 		// the later sibling (id 6) is NOT processed this drain — the DO's sibling deferral keeps it
 		// out of the next drain too, but here we only assert the in-drain skip.
 		expect(deps.calls).not.toContain('process:6')
+	})
+})
+
+describe('formatOutboxError', () => {
+	it('formats an Error as name: message', () => {
+		expect(formatOutboxError(new TypeError('cannot connect'))).toBe('TypeError: cannot connect')
+	})
+
+	it('stringifies non-Error values', () => {
+		expect(formatOutboxError('proxy request failed')).toBe('proxy request failed')
+		expect(formatOutboxError({ code: 42 })).toBe('[object Object]')
+		expect(formatOutboxError(undefined)).toBe('undefined')
+	})
+
+	it('truncates to 500 chars', () => {
+		const out = formatOutboxError(new Error('x'.repeat(1000)))
+		expect(out).toHaveLength(500)
+		expect(out.startsWith('Error: xxx')).toBe(true)
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -278,6 +278,7 @@ describe('formatOutboxError', () => {
 		const circular: any = {}
 		circular.self = circular
 		expect(formatOutboxError(circular)).toBe('[unformattable object]')
+		expect(formatOutboxError({ toJSON: () => undefined })).toBe('[object Object]')
 		expect(formatOutboxError(new Error('x', { cause: circular }))).toBe('[unformattable object]')
 		expect(formatOutboxError(new Error('a\0b'))).toBe('Error: ab')
 	})

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -248,6 +248,11 @@ describe('formatOutboxError', () => {
 		expect(formatOutboxError(undefined)).toBe('undefined')
 	})
 
+	it('never throws and strips NUL bytes so the attempts bump cannot fail on it', () => {
+		expect(formatOutboxError(Object.create(null))).toBe('[unformattable object]')
+		expect(formatOutboxError(new Error('a\0b'))).toBe('Error: ab')
+	})
+
 	it('truncates to 500 chars', () => {
 		const out = formatOutboxError(new Error('x'.repeat(1000)))
 		expect(out).toHaveLength(500)

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -23,13 +23,24 @@ export const MAX_LAST_ERROR_LENGTH = 500
 export function formatOutboxError(error: unknown): string {
 	let text: string
 	try {
-		text = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+		text = describeError(error)
+		// One level of cause: pg and fetch errors put the useful part (ECONNREFUSED, the dial
+		// target) there, and for attempts 2..n this column is the only record of it.
+		if (error instanceof Error && error.cause !== undefined) {
+			text += ` (cause: ${describeError(error.cause)})`
+		}
 	} catch {
 		text = `[unformattable ${typeof error}]`
 	}
 	// Written in the same UPDATE as the attempts bump, so it must never be what fails it:
 	// PG TEXT rejects NUL bytes.
 	return text.replaceAll('\u0000', '').slice(0, MAX_LAST_ERROR_LENGTH)
+}
+
+function describeError(error: unknown): string {
+	if (error instanceof Error) return `${error.name}: ${error.message}`
+	if (typeof error === 'object' && error !== null) return JSON.stringify(error)
+	return String(error)
 }
 
 export interface OutboxDeps {
@@ -95,8 +106,10 @@ async function processWithTimeout(deps: OutboxDeps, row: TlaEffectOutbox): Promi
 		await deps.deleteRow(row.id)
 		return true
 	} catch (error) {
-		await deps.bumpAttempts(row, error)
+		// Report first: if the bump UPDATE itself fails (DB down), the effect's own error would
+		// otherwise never be reported with row context.
 		deps.onError(error, row)
+		await deps.bumpAttempts(row, error)
 		return false
 	} finally {
 		if (timer) clearTimeout(timer)

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -39,7 +39,8 @@ export function formatOutboxError(error: unknown): string {
 
 function describeError(error: unknown): string {
 	if (error instanceof Error) return `${error.name}: ${error.message}`
-	if (typeof error === 'object' && error !== null) return JSON.stringify(error)
+	// JSON.stringify returns undefined (not a string) when toJSON() returns undefined.
+	if (typeof error === 'object' && error !== null) return JSON.stringify(error) ?? String(error)
 	return String(error)
 }
 

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -21,8 +21,15 @@ export function shouldReportEffectFailure(attempts: number): boolean {
 // response body, say) can't bloat the table.
 export const MAX_LAST_ERROR_LENGTH = 500
 export function formatOutboxError(error: unknown): string {
-	const text = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
-	return text.slice(0, MAX_LAST_ERROR_LENGTH)
+	let text: string
+	try {
+		text = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+	} catch {
+		text = `[unformattable ${typeof error}]`
+	}
+	// Written in the same UPDATE as the attempts bump, so it must never be what fails it:
+	// PG TEXT rejects NUL bytes.
+	return text.replaceAll('\u0000', '').slice(0, MAX_LAST_ERROR_LENGTH)
 }
 
 export interface OutboxDeps {

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -17,6 +17,14 @@ export function shouldReportEffectFailure(attempts: number): boolean {
 	return attempts === 0 || attempts + 1 >= MAX_ATTEMPTS
 }
 
+// Row-stored form of a failed attempt's error. Capped so a runaway message (a stringified
+// response body, say) can't bloat the table.
+export const MAX_LAST_ERROR_LENGTH = 500
+export function formatOutboxError(error: unknown): string {
+	const text = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+	return text.slice(0, MAX_LAST_ERROR_LENGTH)
+}
+
 export interface OutboxDeps {
 	getBatch(): Promise<TlaEffectOutbox[]> // WHERE attempts < MAX_ATTEMPTS AND ("nextRetryAt" IS NULL OR "nextRetryAt" <= now()) ORDER BY id LIMIT 50
 	deleteRow(id: number): Promise<void>
@@ -24,7 +32,8 @@ export interface OutboxDeps {
 	// The implementation must both back off the failed row AND defer its later same-entity
 	// siblings (see the drainOutbox comment) so per-entity ordering holds across drains, not just
 	// within one.
-	bumpAttempts(row: TlaEffectOutbox): Promise<void>
+	// `error` is stored on the row as lastError (see migration 051 for why).
+	bumpAttempts(row: TlaEffectOutbox, error: unknown): Promise<void>
 	deleteParkedRowsOlderThan(days: number): Promise<void>
 	process(row: TlaEffectOutbox): Promise<void> // dispatches by tableName (wired in the DO)
 	onError(error: unknown, row: TlaEffectOutbox): void
@@ -79,7 +88,7 @@ async function processWithTimeout(deps: OutboxDeps, row: TlaEffectOutbox): Promi
 		await deps.deleteRow(row.id)
 		return true
 	} catch (error) {
-		await deps.bumpAttempts(row)
+		await deps.bumpAttempts(row, error)
 		deps.onError(error, row)
 		return false
 	} finally {

--- a/apps/dotcom/zero-cache/effect_outbox.test.ts
+++ b/apps/dotcom/zero-cache/effect_outbox.test.ts
@@ -124,11 +124,13 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 		prevPayload: any
 		attempts: number
 		nextRetryAt: string | null
+		lastError: string | null
 	}
 
 	async function outboxRows(entityId: string): Promise<OutboxRow[]> {
 		const res = await client.query<OutboxRow>(
-			`SELECT "tableName", "entityId", command, payload, "prevPayload", attempts, "nextRetryAt"
+			`SELECT "tableName", "entityId", command, payload, "prevPayload", attempts, "nextRetryAt",
+			        "lastError"
 			 FROM effect_outbox WHERE "entityId" = $1 ORDER BY id`,
 			[entityId]
 		)
@@ -227,5 +229,32 @@ describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () 
 		expect(rows).toHaveLength(1)
 		expect(rows[0].attempts).toBe(0)
 		expect(rows[0].nextRetryAt).toBeNull()
+	})
+
+	it('new rows start with lastError IS NULL and a failed attempt can record it (051 applied)', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+		expect((await outboxRows('f1'))[0].lastError).toBeNull()
+
+		// The same statement shape the DO's bumpAttempts issues: attempts + 1 and lastError in one
+		// UPDATE. A later attempt overwrites; an admin retry (attempts = 0) leaves it in place.
+		const bump = (error: string) =>
+			client.query(
+				`UPDATE effect_outbox SET attempts = attempts + 1, "lastError" = $2 WHERE "entityId" = $1`,
+				['f1', error]
+			)
+		await bump('EffectTimeoutError: timed out after 30000ms')
+		await bump('Error: proxy request failed')
+		let [row] = await outboxRows('f1')
+		expect(row.attempts).toBe(2)
+		expect(row.lastError).toBe('Error: proxy request failed')
+
+		await client.query(
+			`UPDATE effect_outbox SET attempts = 0, "nextRetryAt" = NULL WHERE "entityId" = $1`,
+			['f1']
+		)
+		;[row] = await outboxRows('f1')
+		expect(row.attempts).toBe(0)
+		expect(row.lastError).toBe('Error: proxy request failed')
 	})
 })

--- a/apps/dotcom/zero-cache/migrations/051_effect_outbox_last_error.sql
+++ b/apps/dotcom/zero-cache/migrations/051_effect_outbox_last_error.sql
@@ -1,0 +1,4 @@
+-- Last failure message for an effect_outbox row, overwritten on every failed attempt.
+-- The drain only reports the first and parking attempts to Sentry, so without this a
+-- parked row shows "attempts 10" and nothing else; the row carries its own diagnosis.
+ALTER TABLE public.effect_outbox ADD COLUMN "lastError" TEXT;

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -443,6 +443,8 @@ export interface TlaEffectOutbox {
 	attempts: number
 	createdAt: Date
 	nextRetryAt: Date | null
+	/** Latest failed attempt's error text; survives an admin retry. */
+	lastError: string | null
 }
 
 /**


### PR DESCRIPTION
This PR improves the effect outbox so that a parked row on `/admin` shows why it failed, without opening Sentry.

### Before

A row that exhausted its attempts showed "attempts 10 (parked)" and its age, nothing else. The drain only reports the first attempt and the parking attempt to Sentry (`shouldReportEffectFailure`), and `bumpAttempts` recorded nothing about the failure on the row. On 2026-09-10 row 125792 parked after a Postgres dial timed out inside the file DO ("proxy request failed, cannot connect to the specified address"), and finding that took an hour of Sentry and Analytics Engine digging.

### After

Every failed attempt writes `formatOutboxError(error)` (`name: message`, capped at 500 chars) to a new nullable `lastError` column in the same UPDATE that bumps `attempts`. The admin effects table has a "Last error" column showing the first 60 chars with the full text in a tooltip. An admin retry resets attempts but leaves `lastError` in place, so the pre-retry diagnosis stays visible while the retry is pending.

### Implementation notes

- Migration 051 adds the column. `effect_outbox` is server-only and not in the `zero_data` publication, so no split deploy; `deploy-dotcom.ts` runs migrations before the worker ships.
- `formatOutboxError` keeps one level of `error.cause` (pg and fetch errors put the dial target there), JSON-encodes plain objects, strips NUL bytes and guards a throwing formatter so the diagnostic write can never be what fails the attempts bump.
- `processWithTimeout` now calls `onError` before `bumpAttempts`. Previously a failing bump UPDATE (DB down) meant the effect's own error never reached Sentry with row context.

### Change type

- [x] `improvement`

### Test plan

1. Apply migration 051 locally, make a file effect fail (e.g. point the room DO at a bad URL), open `/admin` effects.
2. The row shows the error in the "Last error" column; hover for the full text. Retry keeps it.

- [x] Unit tests
- [x] Postgres integration test (`effect_outbox.test.ts`, opt-in via `ZERO_CACHE_TEST_POSTGRES_URL`): column exists and is null on new rows, bump statement persists it, retry leaves it

### Release notes

- Show the last error on parked effect outbox rows in the admin page

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -0    |
| Tests     | +93 / -8   |
| Apps      | +44 / -5   |
