### PR TITLE
fix(mermaid): keep the bottom actor box for a destroyed sequence participant

### DIFF
--- a/packages/mermaid/src/mermaidDiagrams.test.ts
+++ b/packages/mermaid/src/mermaidDiagrams.test.ts
@@ -896,6 +896,71 @@ describe('sequenceToBlueprint', () => {
 		expect(creationEdge.endNodeId).toBe('actor-top-JobRunner')
 	})
 
+	it('gives a destroyed actor a tombstone box on the destroying row', () => {
+		const layout = twoActorLayout()
+		const actors = new Map([actor('Client'), actor('TempSession')])
+		// `destroy TempSession` before the third message, which TempSession receives.
+		const destroyedActors = new Map([['TempSession', 2]])
+		const messages = [
+			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Start temporary session'),
+			msg(LINETYPE.DOTTED, 'TempSession', 'Client', 'Session active'),
+			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Close session'),
+		]
+
+		const bp = sequenceToBlueprint(
+			layout,
+			actors,
+			['Client', 'TempSession'],
+			messages,
+			new Map(),
+			destroyedActors
+		)
+
+		const tombstone = findNode(bp, 'actor-bottom-TempSession')!
+		expect(tombstone).toBeDefined()
+		// Centred on the third of three rows, above the surviving actor's bottom box.
+		expect(tombstone.y).toBeLessThan(findNode(bp, 'actor-bottom-Client')!.y)
+		expect(bp.groups).toContainEqual([
+			'actor-top-TempSession',
+			'lifeline-TempSession',
+			'actor-bottom-TempSession',
+		])
+
+		const lifeline = bp.lines!.find((l) => l.id === 'lifeline-TempSession')!
+		expect(lifeline.y + lifeline.endY).toBe(tombstone.y)
+
+		const destroyingEdge = bp.edges.find((e) => e.label === 'Close session')!
+		expect(destroyingEdge.endNodeId).toBe('actor-bottom-TempSession')
+	})
+
+	it('anchors messages per lifeline so shortened lifelines keep arrows level', () => {
+		const layout = twoActorLayout()
+		const actors = new Map([actor('Client'), actor('TempSession')])
+		const destroyedActors = new Map([['TempSession', 1]])
+		const messages = [
+			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Open'),
+			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Close'),
+		]
+
+		const bp = sequenceToBlueprint(
+			layout,
+			actors,
+			['Client', 'TempSession'],
+			messages,
+			new Map(),
+			destroyedActors
+		)
+
+		const client = bp.lines!.find((l) => l.id === 'lifeline-Client')!
+		const temp = bp.lines!.find((l) => l.id === 'lifeline-TempSession')!
+		const open = bp.edges.find((e) => e.label === 'Open')!
+		// The two lifelines end at different heights, so the same row has to resolve to a
+		// different fraction on each of them for the arrow to stay horizontal.
+		const startY = client.y + client.endY * open.anchorStartY!
+		const endY = temp.y + temp.endY * open.anchorEndY!
+		expect(endY).toBeCloseTo(startY)
+	})
+
 	it('maps actor types to correct geo', () => {
 		const layout = actorLayout([0])
 		const actors = new Map([actor('User', { type: 'actor' })])

--- a/packages/mermaid/src/mermaidDiagrams.test.ts
+++ b/packages/mermaid/src/mermaidDiagrams.test.ts
@@ -994,30 +994,58 @@ describe('sequenceToBlueprint', () => {
 		expect(bye.anchorEndY).toBeCloseTo(bye.anchorStartY!)
 	})
 
-	it('keeps a lifeline for a participant created and destroyed on the same row', () => {
+	it('keeps a lifeline for a participant created and destroyed a row apart', () => {
 		const layout = twoActorLayout()
 		const actors = new Map([actor('Alice'), actor('Tmp')])
-		// `create participant Tmp` then `destroy Tmp` around one message: both lifecycle boxes
-		// want the same row, so the lifeline has no room between them.
-		const messages = [msg(LINETYPE.SOLID, 'Alice', 'Tmp', 'hi')]
+		// Ten rows packs them closer together than an actor box is tall, so Tmp's two boxes
+		// meet and the lifeline between them has nowhere to go.
+		const messages = Array.from({ length: 10 }, (_, i) =>
+			msg(LINETYPE.SOLID, 'Alice', 'Tmp', `m${i}`)
+		)
 
 		const bp = sequenceToBlueprint(
 			layout,
 			actors,
 			['Alice', 'Tmp'],
 			messages,
-			new Map([['Tmp', 0]]),
-			new Map([['Tmp', 0]])
+			new Map([['Tmp', 3]]),
+			new Map([['Tmp', 4]])
 		)
 
 		// An absent lifeline shape would take every arrow bound to it down with it.
 		const lifeline = bp.lines!.find((l) => l.id === 'lifeline-Tmp')!
 		expect(lifeline).toBeDefined()
 		expect(lifeline.endY).toBeGreaterThan(0)
+		// The bottom box is pushed down with it, so it still caps the lifeline.
+		expect(lifeline.y + lifeline.endY).toBe(findNode(bp, 'actor-bottom-Tmp')!.y)
 
-		const edge = bp.edges.find((e) => e.label === 'hi')!
-		expect(edge.anchorStartY).toBeGreaterThanOrEqual(0)
-		expect(edge.anchorStartY).toBeLessThanOrEqual(1)
+		for (const edge of bp.edges) {
+			expect(edge.anchorEndY).toBeGreaterThanOrEqual(0)
+			expect(edge.anchorEndY).toBeLessThanOrEqual(1)
+		}
+	})
+
+	it('resolves one lifecycle per message, the way mermaid does', () => {
+		const layout = twoActorLayout()
+		const actors = new Map([actor('A'), actor('B')])
+		// `create participant B` and `destroy A` both land on the same message. Mermaid
+		// resolves the three lifecycle cases as one exclusive chain, so the creation wins
+		// and A keeps its lifeline to the foot of the diagram.
+		const messages = [msg(LINETYPE.SOLID, 'A', 'B', 'bye')]
+
+		const bp = sequenceToBlueprint(
+			layout,
+			actors,
+			['A', 'B'],
+			messages,
+			new Map([['B', 0]]),
+			new Map([['A', 0]])
+		)
+
+		const edge = bp.edges[0]
+		expect(edge.endNodeId).toBe('actor-top-B')
+		expect(edge.startNodeId).toBe('lifeline-A')
+		expect(findNode(bp, 'actor-bottom-A')!.y).toBe(twoActorLayout().actorLayouts[0].bottomY)
 	})
 
 	it('maps actor types to correct geo', () => {

--- a/packages/mermaid/src/mermaidDiagrams.test.ts
+++ b/packages/mermaid/src/mermaidDiagrams.test.ts
@@ -899,13 +899,16 @@ describe('sequenceToBlueprint', () => {
 	it('gives a destroyed actor a tombstone box on the destroying row', () => {
 		const layout = twoActorLayout()
 		const actors = new Map([actor('Client'), actor('TempSession')])
-		// `destroy TempSession` before the third message, which TempSession receives.
-		const destroyedActors = new Map([['TempSession', 2]])
 		const messages = [
+			{ type: LINETYPE.LOOP_START, message: 'retry' } as unknown as Message,
 			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Start temporary session'),
+			{ type: LINETYPE.LOOP_END } as unknown as Message,
 			msg(LINETYPE.DOTTED, 'TempSession', 'Client', 'Session active'),
 			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Close session'),
 		]
+		// mermaid indexes `destroy` by statement, fragments included: statement 4 is the third
+		// row, which TempSession receives.
+		const destroyedActors = new Map([['TempSession', 4]])
 
 		const bp = sequenceToBlueprint(
 			layout,
@@ -936,10 +939,11 @@ describe('sequenceToBlueprint', () => {
 	it('anchors messages per lifeline so shortened lifelines keep arrows level', () => {
 		const layout = twoActorLayout()
 		const actors = new Map([actor('Client'), actor('TempSession')])
+		// `destroy TempSession` before the second message, which TempSession sends.
 		const destroyedActors = new Map([['TempSession', 1]])
 		const messages = [
 			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Open'),
-			msg(LINETYPE.SOLID, 'Client', 'TempSession', 'Close'),
+			msg(LINETYPE.SOLID, 'TempSession', 'Client', 'Close'),
 		]
 
 		const bp = sequenceToBlueprint(
@@ -959,6 +963,61 @@ describe('sequenceToBlueprint', () => {
 		const startY = client.y + client.endY * open.anchorStartY!
 		const endY = temp.y + temp.endY * open.anchorEndY!
 		expect(endY).toBeCloseTo(startY)
+
+		expect(bp.edges.find((e) => e.label === 'Close')!.startNodeId).toBe('actor-bottom-TempSession')
+	})
+
+	it('ignores a destroy whose next statement is a note, as mermaid does', () => {
+		const layout = twoActorLayout()
+		const actors = new Map([actor('Alice'), actor('Bob')])
+		// mermaid only applies create/destroy from its signal branch, so a `destroy` recorded
+		// against a note is one it renders as though the keyword were not there.
+		const destroyedActors = new Map([['Bob', 1]])
+		const messages = [
+			msg(LINETYPE.SOLID, 'Alice', 'Bob', 'hi'),
+			noteMsg('Bob', 'cleanup', PLACEMENT.OVER),
+			msg(LINETYPE.SOLID, 'Alice', 'Bob', 'bye'),
+		]
+
+		const bp = sequenceToBlueprint(
+			layout,
+			actors,
+			['Alice', 'Bob'],
+			messages,
+			new Map(),
+			destroyedActors
+		)
+
+		expect(findNode(bp, 'actor-bottom-Bob')!.y).toBe(findNode(bp, 'actor-bottom-Alice')!.y)
+		const bye = bp.edges.find((e) => e.label === 'bye')!
+		expect(bye.endNodeId).toBe('lifeline-Bob')
+		expect(bye.anchorEndY).toBeCloseTo(bye.anchorStartY!)
+	})
+
+	it('keeps a lifeline for a participant created and destroyed on the same row', () => {
+		const layout = twoActorLayout()
+		const actors = new Map([actor('Alice'), actor('Tmp')])
+		// `create participant Tmp` then `destroy Tmp` around one message: both lifecycle boxes
+		// want the same row, so the lifeline has no room between them.
+		const messages = [msg(LINETYPE.SOLID, 'Alice', 'Tmp', 'hi')]
+
+		const bp = sequenceToBlueprint(
+			layout,
+			actors,
+			['Alice', 'Tmp'],
+			messages,
+			new Map([['Tmp', 0]]),
+			new Map([['Tmp', 0]])
+		)
+
+		// An absent lifeline shape would take every arrow bound to it down with it.
+		const lifeline = bp.lines!.find((l) => l.id === 'lifeline-Tmp')!
+		expect(lifeline).toBeDefined()
+		expect(lifeline.endY).toBeGreaterThan(0)
+
+		const edge = bp.edges.find((e) => e.label === 'hi')!
+		expect(edge.anchorStartY).toBeGreaterThanOrEqual(0)
+		expect(edge.anchorStartY).toBeLessThanOrEqual(1)
 	})
 
 	it('maps actor types to correct geo', () => {

--- a/packages/mermaid/src/sequenceDiagram.ts
+++ b/packages/mermaid/src/sequenceDiagram.ts
@@ -187,6 +187,7 @@ const ACTOR_PADDING_WIDTH = 30
 const ACTOR_PADDING_HEIGHT = 10
 const SELF_MSG_Y_OFFSET = 0.04
 const SELF_MSG_BEND = -80
+const MIN_LIFELINE_HEIGHT = 1
 const ACTIVATION_BOX_WIDTH = 20
 const ACTIVATION_NEST_OFFSET = 6
 const ACTIVATION_PAD_RATIO = 0.15
@@ -441,9 +442,10 @@ export function sequenceToBlueprint(
 	let autonumberStep = 1
 	let autonumberVisible = false
 
-	// `createdActors`/`destroyedActors` key actors by their position in `messages`, which
-	// counts fragment and activation statements too, so we keep a translation to the
-	// renderable-event indices that the rows are laid out on.
+	// `createdActors`/`destroyedActors` index into `messages`, which counts fragment and
+	// activation statements; rows are laid out on event indices, so translate between them.
+	// Signals only: mermaid applies lifecycle placement from its signal branch alone, so a
+	// `create`/`destroy` whose next statement is a note is one mermaid ignores entirely.
 	const eventIndexByMessageIndex = new Map<number, number>()
 
 	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
@@ -524,23 +526,22 @@ export function sequenceToBlueprint(
 			if (msg.from) frag.actorKeys.add(msg.from)
 			if (msg.to) frag.actorKeys.add(msg.to)
 		}
-		eventIndexByMessageIndex.set(messageIndex, events.length)
+		const isSignal = isSignalMessage(msg.type)
+		if (isSignal) eventIndexByMessageIndex.set(messageIndex, events.length)
 		events.push(msg)
 
 		// Only signals consume a number; notes occupy a row but are never numbered.
 		// The counter advances even while numbering is off, matching mermaid.
-		const isSignal = isSignalMessage(msg.type)
 		eventAutonumbers.push(isSignal && autonumberVisible ? String(autonumber) : undefined)
 		if (isSignal) autonumber = Math.round((autonumber + autonumberStep) * 100) / 100
 	}
 
 	const layouts = layout.actorLayouts
 
-	// Pre-compute lifecycle event rows for created/destroyed actors. A `destroy` applies to
-	// the next message either way round, so going by the recorded message rather than by the
-	// first event the actor sends is what keeps `Client->>Temp` from cutting Temp's lifeline
-	// at an earlier row where Temp happened to reply. An index with no renderable message
-	// after it (a trailing `destroy`) leaves the actor alive for the whole diagram.
+	// A `destroy` applies to the next message in either direction, so keying off the recorded
+	// statement rather than the first event the actor sends stops `Client->>Temp` from cutting
+	// Temp's lifeline at an earlier row where Temp happened to reply. A recorded index that
+	// lands on no signal (a trailing `destroy`) leaves the actor alive throughout.
 	const creationEventIndex = new Map<string, number>()
 	const destructionEventIndex = new Map<string, number>()
 	for (const [key, messageIndex] of createdActors) {
@@ -567,31 +568,25 @@ export function sequenceToBlueprint(
 	// --- Z-order: lifelines -> activations -> fragments -> actor boxes -> notes/arrows ---
 
 	// 1. Lifelines (behind everything)
-	const lifelineSpans: { topY: number; botY: number }[] = []
+	const lifelineSpans: { topY: number; bottomY: number }[] = []
 	for (let i = 0; i < actorCount; i++) {
 		const key = actorKeys[i]
-		const { x, y, w, h, bottomY } = layouts[i]
+		const { x, y, w, h, bottomY: layoutBottomY } = layouts[i]
 
 		const createdAt = creationEventIndex.get(key)
 		const destroyedAt = destructionEventIndex.get(key)
 		// Lifecycle boxes are centered on their row, so the lifeline stops half a box short of it.
 		const topY = createdAt !== undefined ? eventY(createdAt) + h / 2 : y + h
-		const botY = destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : bottomY
+		// A participant created and destroyed a row or two apart leaves no gap between its two
+		// boxes. Keep the span positive regardless: with no lifeline shape to bind to, every
+		// arrow that reaches this participant is dropped without a trace.
+		const bottomY = Math.max(
+			destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : layoutBottomY,
+			topY + MIN_LIFELINE_HEIGHT
+		)
 
-		lifelineSpans.push({ topY, botY })
-		const lifelineHeight = botY - topY
-		if (lifelineHeight > 0) {
-			lines.push({ id: `lifeline-${key}`, x: x + w / 2, y: topY, endY: lifelineHeight })
-		}
-	}
-
-	// Arrow terminals bind at a fraction of the shape they land on. Created and destroyed
-	// participants have shorter lifelines than the rest, so a row resolves to a different
-	// fraction on each one; sharing a single fraction tilts every arrow that touches them.
-	const anchorOnLifeline = (actorIndex: number, y: number) => {
-		const { topY, botY } = lifelineSpans[actorIndex]
-		if (botY <= topY) return 0.5
-		return Math.min(1, Math.max(0, (y - topY) / (botY - topY)))
+		lifelineSpans.push({ topY, bottomY })
+		lines.push({ id: `lifeline-${key}`, x: x + w / 2, y: topY, endY: bottomY - topY })
 	}
 
 	// 2. Activation boxes (just after lifelines)
@@ -752,6 +747,15 @@ export function sequenceToBlueprint(
 	}
 
 	// 5. Events: signals and notes
+
+	// Created and destroyed participants have shorter lifelines than the rest, so the same row
+	// is a different fraction along each one; one shared fraction would tilt their arrows.
+	const anchorOnLifeline = (actorIndex: number, y: number) => {
+		const { topY, bottomY } = lifelineSpans[actorIndex]
+		return (y - topY) / (bottomY - topY)
+	}
+	const clampAnchor = (value: number) => Math.min(1, Math.max(0, value))
+
 	for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
 		const msg = events[eventIndex]
 
@@ -767,36 +771,41 @@ export function sequenceToBlueprint(
 			const isSelf = fromKey === toKey
 			const bidir = !isSelf && isBidirectional(msgType)
 
-			// A lifecycle row has no lifeline to point at, so the message terminates on the box
-			// that opens or closes there, the way mermaid draws it.
-			const startsOnBox = !isSelf && destructionEventIndex.get(fromKey) === eventIndex
-			const endsOnTopBox = !isSelf && creationEventIndex.get(toKey) === eventIndex
-			const endsOnBottomBox = !isSelf && destructionEventIndex.get(toKey) === eventIndex
-			const endsOnBox = endsOnTopBox || endsOnBottomBox
+			// A lifeline stops half a box short of its lifecycle row, so a message on that row
+			// terminates on the box that opens or closes there, the way mermaid draws it.
+			const startBoxId =
+				!isSelf && destructionEventIndex.get(fromKey) === eventIndex
+					? `actor-bottom-${fromKey}`
+					: undefined
+			let endBoxId: string | undefined
+			if (!isSelf) {
+				if (creationEventIndex.get(toKey) === eventIndex) endBoxId = `actor-top-${toKey}`
+				else if (destructionEventIndex.get(toKey) === eventIndex) endBoxId = `actor-bottom-${toKey}`
+			}
 
 			const rowY = eventY(eventIndex)
 			const startAnchor = anchorOnLifeline(fromIdx, rowY)
 			const endAnchor = anchorOnLifeline(toIdx, rowY)
 
 			const edge: MermaidBlueprintEdge = {
-				startNodeId: startsOnBox ? `actor-bottom-${fromKey}` : `lifeline-${fromKey}`,
-				endNodeId: endsOnTopBox
-					? `actor-top-${toKey}`
-					: endsOnBottomBox
-						? `actor-bottom-${toKey}`
-						: `lifeline-${toKey}`,
+				startNodeId: startBoxId ?? `lifeline-${fromKey}`,
+				endNodeId: endBoxId ?? `lifeline-${toKey}`,
 				label: getMessageLabel(msg),
 				bend: isSelf ? SELF_MSG_BEND : 0,
 				dash,
 				arrowheadEnd,
 				arrowheadStart: bidir ? 'arrow' : 'none',
 				size: 's',
-				anchorStartY: startsOnBox ? 0.5 : isSelf ? startAnchor - SELF_MSG_Y_OFFSET : startAnchor,
-				anchorEndY: endsOnBox ? 0.5 : isSelf ? endAnchor + SELF_MSG_Y_OFFSET : endAnchor,
-				isExact: !startsOnBox,
-				isPrecise: !startsOnBox,
-				isExactEnd: !endsOnBox,
-				isPreciseEnd: !endsOnBox,
+				anchorStartY: startBoxId
+					? 0.5
+					: clampAnchor(isSelf ? startAnchor - SELF_MSG_Y_OFFSET : startAnchor),
+				anchorEndY: endBoxId
+					? 0.5
+					: clampAnchor(isSelf ? endAnchor + SELF_MSG_Y_OFFSET : endAnchor),
+				isExact: !startBoxId,
+				isPrecise: !startBoxId,
+				isExactEnd: !endBoxId,
+				isPreciseEnd: !endBoxId,
 			}
 
 			const autonumberLabel = eventAutonumbers[eventIndex]

--- a/packages/mermaid/src/sequenceDiagram.ts
+++ b/packages/mermaid/src/sequenceDiagram.ts
@@ -1,6 +1,7 @@
+import { invLerp } from '@tldraw/utils'
 import type { SequenceDB } from 'mermaid/dist/diagrams/sequence/sequenceDb.d.ts'
 import type { Actor, Message } from 'mermaid/dist/diagrams/sequence/types.js'
-import { TLArrowShapeArrowheadStyle, TLDefaultDashStyle } from 'tldraw'
+import { clamp, TLArrowShapeArrowheadStyle, TLDefaultDashStyle } from 'tldraw'
 import type {
 	DiagramMermaidBlueprint,
 	MermaidBlueprintEdge,
@@ -443,10 +444,9 @@ export function sequenceToBlueprint(
 	let autonumberVisible = false
 
 	// `createdActors`/`destroyedActors` index into `messages`, which counts fragment and
-	// activation statements; rows are laid out on event indices, so translate between them.
-	// Signals only: mermaid applies lifecycle placement from its signal branch alone, so a
-	// `create`/`destroy` whose next statement is a note is one mermaid ignores entirely.
-	const eventIndexByMessageIndex = new Map<number, number>()
+	// activation statements, so a lifecycle row can only be recognised during this walk.
+	const creationEventIndex = new Map<string, number>()
+	const destructionEventIndex = new Map<string, number>()
 
 	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
 		const msg = messages[messageIndex]
@@ -527,7 +527,21 @@ export function sequenceToBlueprint(
 			if (msg.to) frag.actorKeys.add(msg.to)
 		}
 		const isSignal = isSignalMessage(msg.type)
-		if (isSignal) eventIndexByMessageIndex.set(messageIndex, events.length)
+		if (isSignal) {
+			// Mermaid's own `adjustCreatedDestroyedData`: one exclusive chain, reached from its
+			// signal branch alone. So a `destroy` recorded against a note is one mermaid ignores,
+			// and a message that both creates its target and destroys its sender opens a box
+			// rather than closing one. Going by the recorded statement rather than the first
+			// event the actor sends is what stops `Client->>Temp` from cutting Temp's lifeline
+			// at an earlier row where Temp happened to reply.
+			const from = msg.from!
+			const to = msg.to!
+			if (createdActors.get(to) === messageIndex) creationEventIndex.set(to, events.length)
+			else if (destroyedActors.get(from) === messageIndex)
+				destructionEventIndex.set(from, events.length)
+			else if (destroyedActors.get(to) === messageIndex)
+				destructionEventIndex.set(to, events.length)
+		}
 		events.push(msg)
 
 		// Only signals consume a number; notes occupy a row but are never numbered.
@@ -538,21 +552,6 @@ export function sequenceToBlueprint(
 
 	const layouts = layout.actorLayouts
 
-	// A `destroy` applies to the next message in either direction, so keying off the recorded
-	// statement rather than the first event the actor sends stops `Client->>Temp` from cutting
-	// Temp's lifeline at an earlier row where Temp happened to reply. A recorded index that
-	// lands on no signal (a trailing `destroy`) leaves the actor alive throughout.
-	const creationEventIndex = new Map<string, number>()
-	const destructionEventIndex = new Map<string, number>()
-	for (const [key, messageIndex] of createdActors) {
-		const eventIndex = eventIndexByMessageIndex.get(messageIndex)
-		if (eventIndex !== undefined) creationEventIndex.set(key, eventIndex)
-	}
-	for (const [key, messageIndex] of destroyedActors) {
-		const eventIndex = eventIndexByMessageIndex.get(messageIndex)
-		if (eventIndex !== undefined) destructionEventIndex.set(key, eventIndex)
-	}
-
 	// Build blueprint
 	const svgNoteRects = layout.noteRects
 	let svgNoteIndex = 0
@@ -560,33 +559,43 @@ export function sequenceToBlueprint(
 	const lines: MermaidBlueprintLineNode[] = []
 	const edges: MermaidBlueprintEdge[] = []
 
-	const { y: firstY, h: firstH, bottomY: firstBottomY } = layouts[0]
-	const lifelineTop = firstY + firstH
-	const eventStep = (firstBottomY - lifelineTop) / (events.length + 1)
+	const lifelineTop = layouts[0].y + layouts[0].h
+	// Surviving actors all share the footer row, but a destroyed actor's bottom box sits
+	// mid-diagram, so it must not be the baseline the whole row grid is priced against.
+	const diagramBottomY = Math.max(...layouts.map((l) => l.bottomY))
+	const eventStep = (diagramBottomY - lifelineTop) / (events.length + 1)
 	const eventY = (eventIndex: number) => lifelineTop + eventStep * (eventIndex + 1)
+
+	// Where each actor's two boxes sit, and the lifeline strung between their inner edges.
+	// A created or destroyed participant puts its box on the message row that opens or closes
+	// it rather than at the edge of the diagram, so all three move together.
+	const lifecycles = layouts.map(({ y, h, bottomY }, i) => {
+		const createdAt = creationEventIndex.get(actorKeys[i])
+		const destroyedAt = destructionEventIndex.get(actorKeys[i])
+		const topBoxY = createdAt !== undefined ? eventY(createdAt) - h / 2 : y
+		const lifelineTopY = topBoxY + h
+		// Boxes a row apart leave no gap between them. Push the bottom box down rather than let
+		// the lifeline vanish: with no lifeline shape to bind to, every arrow that reaches this
+		// participant is dropped without a trace.
+		const bottomBoxY = Math.max(
+			destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : bottomY,
+			lifelineTopY + MIN_LIFELINE_HEIGHT
+		)
+		return { topBoxY, lifelineTopY, bottomBoxY }
+	})
 
 	// --- Z-order: lifelines -> activations -> fragments -> actor boxes -> notes/arrows ---
 
 	// 1. Lifelines (behind everything)
-	const lifelineSpans: { topY: number; bottomY: number }[] = []
 	for (let i = 0; i < actorCount; i++) {
-		const key = actorKeys[i]
-		const { x, y, w, h, bottomY: layoutBottomY } = layouts[i]
-
-		const createdAt = creationEventIndex.get(key)
-		const destroyedAt = destructionEventIndex.get(key)
-		// Lifecycle boxes are centered on their row, so the lifeline stops half a box short of it.
-		const topY = createdAt !== undefined ? eventY(createdAt) + h / 2 : y + h
-		// A participant created and destroyed a row or two apart leaves no gap between its two
-		// boxes. Keep the span positive regardless: with no lifeline shape to bind to, every
-		// arrow that reaches this participant is dropped without a trace.
-		const bottomY = Math.max(
-			destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : layoutBottomY,
-			topY + MIN_LIFELINE_HEIGHT
-		)
-
-		lifelineSpans.push({ topY, bottomY })
-		lines.push({ id: `lifeline-${key}`, x: x + w / 2, y: topY, endY: bottomY - topY })
+		const { x, w } = layouts[i]
+		const { lifelineTopY, bottomBoxY } = lifecycles[i]
+		lines.push({
+			id: `lifeline-${actorKeys[i]}`,
+			x: x + w / 2,
+			y: lifelineTopY,
+			endY: bottomBoxY - lifelineTopY,
+		})
 	}
 
 	// 2. Activation boxes (just after lifelines)
@@ -717,7 +726,8 @@ export function sequenceToBlueprint(
 		const key = actorKeys[i]
 		const actor = actors.get(key)
 		if (!actor) continue
-		const { x, y, w, h, bottomY } = layouts[i]
+		const { x, w, h } = layouts[i]
+		const { topBoxY, bottomBoxY } = lifecycles[i]
 		const shared = {
 			kind: actor.type,
 			label: actor.description || actor.name || key,
@@ -729,32 +739,21 @@ export function sequenceToBlueprint(
 			size: 's' as const,
 		}
 
-		const createdAt = creationEventIndex.get(key)
-		nodes.push({
-			id: `actor-top-${key}`,
-			y: createdAt !== undefined ? eventY(createdAt) - h / 2 : y,
-			...shared,
-		})
-
+		nodes.push({ id: `actor-top-${key}`, y: topBoxY, ...shared })
 		// A destroyed participant still gets a bottom box; mermaid draws it as a tombstone on
 		// the destroying row instead of at the foot of the diagram.
-		const destroyedAt = destructionEventIndex.get(key)
-		nodes.push({
-			id: `actor-bottom-${key}`,
-			y: destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : bottomY,
-			...shared,
-		})
+		nodes.push({ id: `actor-bottom-${key}`, y: bottomBoxY, ...shared })
 	}
 
 	// 5. Events: signals and notes
 
 	// Created and destroyed participants have shorter lifelines than the rest, so the same row
 	// is a different fraction along each one; one shared fraction would tilt their arrows.
+	// A row can also fall past a truncated lifeline, which mermaid draws into empty space.
 	const anchorOnLifeline = (actorIndex: number, y: number) => {
-		const { topY, bottomY } = lifelineSpans[actorIndex]
-		return (y - topY) / (bottomY - topY)
+		const { lifelineTopY, bottomBoxY } = lifecycles[actorIndex]
+		return clamp(invLerp(lifelineTopY, bottomBoxY, y), 0, 1)
 	}
-	const clampAnchor = (value: number) => Math.min(1, Math.max(0, value))
 
 	for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
 		const msg = events[eventIndex]
@@ -798,10 +797,14 @@ export function sequenceToBlueprint(
 				size: 's',
 				anchorStartY: startBoxId
 					? 0.5
-					: clampAnchor(isSelf ? startAnchor - SELF_MSG_Y_OFFSET : startAnchor),
+					: isSelf
+						? clamp(startAnchor - SELF_MSG_Y_OFFSET, 0, 1)
+						: startAnchor,
 				anchorEndY: endBoxId
 					? 0.5
-					: clampAnchor(isSelf ? endAnchor + SELF_MSG_Y_OFFSET : endAnchor),
+					: isSelf
+						? clamp(endAnchor + SELF_MSG_Y_OFFSET, 0, 1)
+						: endAnchor,
 				isExact: !startBoxId,
 				isPrecise: !startBoxId,
 				isExactEnd: !endBoxId,

--- a/packages/mermaid/src/sequenceDiagram.ts
+++ b/packages/mermaid/src/sequenceDiagram.ts
@@ -441,7 +441,13 @@ export function sequenceToBlueprint(
 	let autonumberStep = 1
 	let autonumberVisible = false
 
-	for (const msg of messages) {
+	// `createdActors`/`destroyedActors` key actors by their position in `messages`, which
+	// counts fragment and activation statements too, so we keep a translation to the
+	// renderable-event indices that the rows are laid out on.
+	const eventIndexByMessageIndex = new Map<number, number>()
+
+	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+		const msg = messages[messageIndex]
 		const type = msg.type ?? -1
 		if (type === LINETYPE.AUTONUMBER) {
 			// `autonumber [start [step]]` / `autonumber off`; mermaid stores the options on
@@ -518,6 +524,7 @@ export function sequenceToBlueprint(
 			if (msg.from) frag.actorKeys.add(msg.from)
 			if (msg.to) frag.actorKeys.add(msg.to)
 		}
+		eventIndexByMessageIndex.set(messageIndex, events.length)
 		events.push(msg)
 
 		// Only signals consume a number; notes occupy a row but are never numbered.
@@ -529,21 +536,20 @@ export function sequenceToBlueprint(
 
 	const layouts = layout.actorLayouts
 
-	// Pre-compute lifecycle event indices for created/destroyed actors.
-	// We scan events for the first signal targeting each created actor
-	// and the first signal from each destroyed actor.
+	// Pre-compute lifecycle event rows for created/destroyed actors. A `destroy` applies to
+	// the next message either way round, so going by the recorded message rather than by the
+	// first event the actor sends is what keeps `Client->>Temp` from cutting Temp's lifeline
+	// at an earlier row where Temp happened to reply. An index with no renderable message
+	// after it (a trailing `destroy`) leaves the actor alive for the whole diagram.
 	const creationEventIndex = new Map<string, number>()
 	const destructionEventIndex = new Map<string, number>()
-	for (let i = 0; i < events.length; i++) {
-		const ev = events[i]
-		if (!isSignalMessage(ev.type)) continue
-
-		if (ev.to && createdActors.has(ev.to) && !creationEventIndex.has(ev.to)) {
-			creationEventIndex.set(ev.to, i)
-		}
-		if (ev.from && destroyedActors.has(ev.from) && !destructionEventIndex.has(ev.from)) {
-			destructionEventIndex.set(ev.from, i)
-		}
+	for (const [key, messageIndex] of createdActors) {
+		const eventIndex = eventIndexByMessageIndex.get(messageIndex)
+		if (eventIndex !== undefined) creationEventIndex.set(key, eventIndex)
+	}
+	for (const [key, messageIndex] of destroyedActors) {
+		const eventIndex = eventIndexByMessageIndex.get(messageIndex)
+		if (eventIndex !== undefined) destructionEventIndex.set(key, eventIndex)
 	}
 
 	// Build blueprint
@@ -561,19 +567,31 @@ export function sequenceToBlueprint(
 	// --- Z-order: lifelines -> activations -> fragments -> actor boxes -> notes/arrows ---
 
 	// 1. Lifelines (behind everything)
+	const lifelineSpans: { topY: number; botY: number }[] = []
 	for (let i = 0; i < actorCount; i++) {
 		const key = actorKeys[i]
 		const { x, y, w, h, bottomY } = layouts[i]
 
 		const createdAt = creationEventIndex.get(key)
 		const destroyedAt = destructionEventIndex.get(key)
+		// Lifecycle boxes are centered on their row, so the lifeline stops half a box short of it.
 		const topY = createdAt !== undefined ? eventY(createdAt) + h / 2 : y + h
-		const botY = destroyedAt !== undefined ? eventY(destroyedAt) : bottomY
+		const botY = destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : bottomY
 
+		lifelineSpans.push({ topY, botY })
 		const lifelineHeight = botY - topY
 		if (lifelineHeight > 0) {
 			lines.push({ id: `lifeline-${key}`, x: x + w / 2, y: topY, endY: lifelineHeight })
 		}
+	}
+
+	// Arrow terminals bind at a fraction of the shape they land on. Created and destroyed
+	// participants have shorter lifelines than the rest, so a row resolves to a different
+	// fraction on each one; sharing a single fraction tilts every arrow that touches them.
+	const anchorOnLifeline = (actorIndex: number, y: number) => {
+		const { topY, botY } = lifelineSpans[actorIndex]
+		if (botY <= topY) return 0.5
+		return Math.min(1, Math.max(0, (y - topY) / (botY - topY)))
 	}
 
 	// 2. Activation boxes (just after lifelines)
@@ -723,45 +741,62 @@ export function sequenceToBlueprint(
 			...shared,
 		})
 
-		if (!destructionEventIndex.has(key)) {
-			nodes.push({ id: `actor-bottom-${key}`, y: bottomY, ...shared })
-		}
+		// A destroyed participant still gets a bottom box; mermaid draws it as a tombstone on
+		// the destroying row instead of at the foot of the diagram.
+		const destroyedAt = destructionEventIndex.get(key)
+		nodes.push({
+			id: `actor-bottom-${key}`,
+			y: destroyedAt !== undefined ? eventY(destroyedAt) - h / 2 : bottomY,
+			...shared,
+		})
 	}
 
 	// 5. Events: signals and notes
-	const pendingCreations = new Set(createdActors.keys())
-
 	for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
 		const msg = events[eventIndex]
-		const anchor = (eventIndex + 1) / (events.length + 1)
 
 		if (isSignalMessage(msg.type)) {
 			const fromKey = msg.from!
 			const toKey = msg.to!
-			if (!keyIndex.has(fromKey) || !keyIndex.has(toKey)) continue
-
-			const isCreationMessage = pendingCreations.has(toKey)
-			if (isCreationMessage) pendingCreations.delete(toKey)
+			const fromIdx = keyIndex.get(fromKey)
+			const toIdx = keyIndex.get(toKey)
+			if (fromIdx === undefined || toIdx === undefined) continue
 
 			const msgType = msg.type ?? LINETYPE.SOLID
 			const { dash, arrowheadEnd } = mapLineTypeToArrowProps(msgType)
 			const isSelf = fromKey === toKey
 			const bidir = !isSelf && isBidirectional(msgType)
 
+			// A lifecycle row has no lifeline to point at, so the message terminates on the box
+			// that opens or closes there, the way mermaid draws it.
+			const startsOnBox = !isSelf && destructionEventIndex.get(fromKey) === eventIndex
+			const endsOnTopBox = !isSelf && creationEventIndex.get(toKey) === eventIndex
+			const endsOnBottomBox = !isSelf && destructionEventIndex.get(toKey) === eventIndex
+			const endsOnBox = endsOnTopBox || endsOnBottomBox
+
+			const rowY = eventY(eventIndex)
+			const startAnchor = anchorOnLifeline(fromIdx, rowY)
+			const endAnchor = anchorOnLifeline(toIdx, rowY)
+
 			const edge: MermaidBlueprintEdge = {
-				startNodeId: `lifeline-${fromKey}`,
-				endNodeId: isCreationMessage ? `actor-top-${toKey}` : `lifeline-${toKey}`,
+				startNodeId: startsOnBox ? `actor-bottom-${fromKey}` : `lifeline-${fromKey}`,
+				endNodeId: endsOnTopBox
+					? `actor-top-${toKey}`
+					: endsOnBottomBox
+						? `actor-bottom-${toKey}`
+						: `lifeline-${toKey}`,
 				label: getMessageLabel(msg),
 				bend: isSelf ? SELF_MSG_BEND : 0,
 				dash,
 				arrowheadEnd,
 				arrowheadStart: bidir ? 'arrow' : 'none',
 				size: 's',
-				anchorStartY: isSelf ? anchor - SELF_MSG_Y_OFFSET : anchor,
-				anchorEndY: isCreationMessage ? 0.5 : isSelf ? anchor + SELF_MSG_Y_OFFSET : anchor,
-				isExact: true,
-				isPrecise: true,
-				...(isCreationMessage && { isExactEnd: false, isPreciseEnd: false }),
+				anchorStartY: startsOnBox ? 0.5 : isSelf ? startAnchor - SELF_MSG_Y_OFFSET : startAnchor,
+				anchorEndY: endsOnBox ? 0.5 : isSelf ? endAnchor + SELF_MSG_Y_OFFSET : endAnchor,
+				isExact: !startsOnBox,
+				isPrecise: !startsOnBox,
+				isExactEnd: !endsOnBox,
+				isPreciseEnd: !endsOnBox,
 			}
 
 			const autonumberLabel = eventAutonumbers[eventIndex]
@@ -826,12 +861,6 @@ export function sequenceToBlueprint(
 		nodes,
 		edges,
 		lines,
-		groups: actorKeys.map((key) => {
-			const group = [`actor-top-${key}`, `lifeline-${key}`]
-			if (!destructionEventIndex.has(key)) {
-				group.push(`actor-bottom-${key}`)
-			}
-			return group
-		}),
+		groups: actorKeys.map((key) => [`actor-top-${key}`, `lifeline-${key}`, `actor-bottom-${key}`]),
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where a sequence diagram loses a participant's bottom box and tilts its arrows whenever the source uses `destroy`.

### Before

`sequenceToBlueprint` worked out when an actor was destroyed by scanning the renderable events for the first signal that actor *sent*, ignoring the message index mermaid already records in `getDestroyedActors()`. Three things fell out of that:

- The destroying message usually targets the actor (`Client->>TempSession: Close session`), so the scan matched an earlier row where the actor happened to reply, and cut the lifeline there.
- An actor that never sends anything was never destroyed at all.
- A trailing `destroy` with no message after it — which mermaid itself ignores — still destroyed the actor, at whatever row it last replied on.

The bottom box was then skipped outright for a destroyed actor, leaving the lifeline ending in mid-air. And because arrow terminals bind at a *fraction* of the shape they land on while every message used one fraction of the whole diagram, a shortened lifeline resolved the same row to a different absolute Y at each end, so every arrow touching it came out slanted.

### After

- Lifecycle rows are resolved during the message walk the way mermaid's own `adjustCreatedDestroyedData` does, so the lifeline is cut on the message mermaid says destroys the actor — whichever end of the arrow it is — and a trailing `destroy` leaves the actor alive.
- A destroyed actor keeps its bottom box, placed as the tombstone mermaid draws centered on the destroying row, with the lifeline stopping at its top edge.
- Anchors are computed per lifeline, so a created or destroyed participant's shorter lifeline resolves a row to its own fraction.
- Create and destroy messages terminate on the lifecycle box rather than the lifeline, since the lifeline stops half a box short of that row.

### Implementation notes

Mermaid resolves the three lifecycle cases — creates its target, else destroys its sender, else destroys its target — as one exclusive chain, and only from the signal branch of its draw switch. Matching that shape is what makes a `create`/`destroy` recorded against a note a no-op, as mermaid renders it, and it means a message that both creates and destroys opens one box rather than two.

Two smaller things fall out of keeping a uniform event grid where mermaid bumps the vertical position per row:

- The lifeline span is clamped positive. Boxes a row apart leave no gap, and with no lifeline shape to bind to, every arrow reaching that participant was dropped without a trace. The bottom box moves down with the clamp so it still caps the lifeline. Porting mermaid's bump model would mean giving up the uniform grid for every row type, not just lifecycle rows, so that is left alone.
- The grid is now priced against the lowest bottom box instead of the first actor's. A destroyed first participant was setting the baseline from its own mid-diagram tombstone, which collapsed the whole diagram's row spacing. This is a no-op for any diagram without a `destroy`, since surviving actors share the footer row.

Still open, and out of scope here: `computeActorLayouts` also folds a tombstone into `bottomRowTop`, which inflates `yStretch` and adds vertical whitespace. Telling footer rects from tombstones needs a signature change up through `parseSequenceLayout`, and the symptom is cosmetic.

Screenshots are the `Client` / `TempSession` diagram from the "Hundreds of Mermaid diagrams" example, which ends on a trailing `destroy`; native shapes on the left, mermaid's own SVG of the same source on the right.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests — the tombstone, per-lifeline-anchor and exclusive-chain tests all fail on `main`. The note and collapsed-lifeline tests guard regressions this branch could introduce rather than bugs on `main`; each was checked to fail against the version of the branch that lacked its fix.
- Checked end to end in the "Hundreds of Mermaid diagrams" example across all 133 diagrams, with no console errors.

### Release notes

- Fix sequence diagrams dropping a participant's bottom box and tilting their arrows when the source uses `destroy`.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +107 / -66 |
| Tests     | +152 / -0  |
