### PR TITLE
fix(editor): make a remounted local sync client wait for the previous client's flush

### DIFF
--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -476,12 +476,11 @@ test('a client created on the same key while a closed client is still flushing w
 	client.store.put([PageRecordType.create({ name: 'during write', index: 'a1' as IndexKey })])
 	client.close()
 
-	// remount on the same key while the old client is still waiting to flush its queue
+	// remount on the same key while the old client is still flushing
 	const loadSpy = vi.spyOn(LocalIndexedDb.prototype, 'load')
 	const next = testClient()
 	await tick()
-	// reading now would miss the queued edit, and the new client's first (full snapshot) write
-	// would then erase it
+	// reading now would miss the queued edit, then erase it on the first write
 	expect(loadSpy).not.toHaveBeenCalled()
 	expect(next.onLoad).not.toHaveBeenCalled()
 
@@ -503,7 +502,7 @@ test('two clients closing on the same key flush in order', async () => {
 	const b = testClient()
 	await a.tick()
 	await b.tick()
-	// a's first write is its full snapshot, and we hold it in flight
+	// hold a's first write in flight
 	a.client.db.storeSnapshot.mockImplementation(() => {
 		writes.push('a')
 		return inFlightWrite
@@ -530,7 +529,7 @@ test('two clients closing on the same key flush in order', async () => {
 	b.client.store.put([PageRecordType.create({ name: 'b1', index: 'a2' as IndexKey })])
 	b.client.close()
 	await b.tick()
-	// b writes the whole store, so letting it land before a's queued changes would lose them
+	// b's snapshot landing first would lose a's queued changes
 	expect(writes).toEqual(['a'])
 
 	inFlightWrite.resolve()

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -494,3 +494,47 @@ test('a client created on the same key while a closed client is still flushing w
 	expect(next.onLoad).toHaveBeenCalledTimes(1)
 	loadSpy.mockRestore()
 })
+
+test('two clients closing on the same key flush in order', async () => {
+	const writes: string[] = []
+	const inFlightWrite = promiseWithResolve<void>()
+
+	const a = testClient()
+	const b = testClient()
+	await a.tick()
+	await b.tick()
+	// a's first write is its full snapshot, and we hold it in flight
+	a.client.db.storeSnapshot.mockImplementation(() => {
+		writes.push('a')
+		return inFlightWrite
+	})
+	a.client.db.storeChanges.mockImplementation(() => {
+		writes.push('a')
+		return Promise.resolve()
+	})
+	b.client.db.storeSnapshot.mockImplementation(() => {
+		writes.push('b')
+		return Promise.resolve()
+	})
+	b.client.db.storeChanges.mockImplementation(() => {
+		writes.push('b')
+		return Promise.resolve()
+	})
+
+	a.client.store.put([PageRecordType.create({ name: 'a1', index: 'a0' as IndexKey })])
+	await a.tick()
+	expect(writes).toEqual(['a']) // in flight
+	a.client.store.put([PageRecordType.create({ name: 'a2', index: 'a1' as IndexKey })])
+	a.client.close()
+
+	b.client.store.put([PageRecordType.create({ name: 'b1', index: 'a2' as IndexKey })])
+	b.client.close()
+	await b.tick()
+	// b writes the whole store, so letting it land before a's queued changes would lose them
+	expect(writes).toEqual(['a'])
+
+	inFlightWrite.resolve()
+	await a.tick()
+	await b.tick()
+	expect(writes).toEqual(['a', 'a', 'b'])
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.test.ts
@@ -464,3 +464,33 @@ test('a buffered newer schema reports a load error without announcing a successf
 	client.close()
 	expect(client.db.storeSnapshot).not.toHaveBeenCalled()
 })
+
+test('a client created on the same key while a closed client is still flushing waits for that flush', async () => {
+	const inFlightWrite = promiseWithResolve<void>()
+	const { client, tick } = testClient()
+	client.db.storeSnapshot.mockImplementationOnce(() => inFlightWrite)
+	await tick()
+	client.store.put([PageRecordType.create({ name: 'first', index: 'a0' as IndexKey })])
+	await tick()
+	expect(client.db.storeSnapshot).toHaveBeenCalledTimes(1) // still in flight
+	client.store.put([PageRecordType.create({ name: 'during write', index: 'a1' as IndexKey })])
+	client.close()
+
+	// remount on the same key while the old client is still waiting to flush its queue
+	const loadSpy = vi.spyOn(LocalIndexedDb.prototype, 'load')
+	const next = testClient()
+	await tick()
+	// reading now would miss the queued edit, and the new client's first (full snapshot) write
+	// would then erase it
+	expect(loadSpy).not.toHaveBeenCalled()
+	expect(next.onLoad).not.toHaveBeenCalled()
+
+	inFlightWrite.resolve()
+	await tick()
+	expect(client.db.storeChanges).toHaveBeenCalledTimes(1)
+	for (let i = 0; i < 20; i++) await Promise.resolve()
+	await next.tick()
+	expect(loadSpy).toHaveBeenCalledTimes(1)
+	expect(next.onLoad).toHaveBeenCalledTimes(1)
+	loadSpy.mockRestore()
+})

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -64,6 +64,9 @@ export class BroadcastChannelMock {
 
 const BC = typeof BroadcastChannel === 'undefined' ? BroadcastChannelMock : BroadcastChannel
 
+// Flushes still running for closed clients, keyed by persistence key. See connect().
+const pendingFlushes = new Map<string, Promise<void>>()
+
 /** @internal */
 export class TLLocalSyncClient {
 	private disposables = new Set<() => void>()
@@ -238,6 +241,12 @@ export class TLLocalSyncClient {
 			this.channel.close()
 		})
 
+		// A client that just closed on this key may still be flushing. Read after it lands, or our
+		// first (full) db write erases the edits it was writing — React strict mode and any remount
+		// construct the new client before the old one's flush resolves.
+		await pendingFlushes.get(this.persistenceKey)
+		if (this.didDispose) return
+
 		try {
 			data = await this.db.load({ sessionId: this.sessionId })
 		} catch (error: any) {
@@ -317,7 +326,17 @@ export class TLLocalSyncClient {
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
-		this.flushAndCloseDb()
+		// chain onto any earlier flush on this key so they stay ordered, and publish the result
+		// for the next client
+		const flush = Promise.allSettled([
+			pendingFlushes.get(this.persistenceKey),
+			this.flushAndCloseDb(),
+		]).then(() => {
+			if (pendingFlushes.get(this.persistenceKey) === flush) {
+				pendingFlushes.delete(this.persistenceKey)
+			}
+		})
+		pendingFlushes.set(this.persistenceKey, flush)
 	}
 
 	/**
@@ -326,17 +345,16 @@ export class TLLocalSyncClient {
 	 * store), and only when something is queued: shouldDoFullDBWrite stays true until the first
 	 * persist, so an unconditional flush would rewrite the whole document on every no-op close.
 	 */
-	private flushAndCloseDb() {
+	private flushAndCloseDb(): Promise<void> {
 		// A persist in flight can't be joined (persistIfNeeded bails while one is running) and,
 		// now that we're disposed, won't schedule a follow-up. Edits queued during that write
 		// would be lost if the db closed now, so wait for it and flush again.
 		if (this.persistPromise) {
-			this.persistPromise.then(() => this.flushAndCloseDb())
-			return
+			return this.persistPromise.then(() => this.flushAndCloseDb())
 		}
 		if (this.didLoad && this.diffQueue.length > 0) this.persistIfNeeded()
 		// the db waits for the transaction the flush just opened before actually closing
-		this.db.close()
+		return this.db.close()
 	}
 
 	private isPersisting = false

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -1,7 +1,7 @@
 import { Signal, transact } from '@tldraw/state'
 import { RecordsDiff, SerializedSchema, UnknownRecord, squashRecordDiffs } from '@tldraw/store'
 import { TLStore } from '@tldraw/tlschema'
-import { assert } from '@tldraw/utils'
+import { assert, noop } from '@tldraw/utils'
 import {
 	TAB_ID,
 	TLSessionStateSnapshot,
@@ -326,16 +326,19 @@ export class TLLocalSyncClient {
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
-		// chain onto any earlier flush on this key so they stay ordered, and publish the result
-		// for the next client
-		const flush = Promise.allSettled([
-			pendingFlushes.get(this.persistenceKey),
-			this.flushAndCloseDb(),
-		]).then(() => {
-			if (pendingFlushes.get(this.persistenceKey) === flush) {
-				pendingFlushes.delete(this.persistenceKey)
-			}
-		})
+		// Flush right away when nothing else is flushing this key: close() runs during teardown,
+		// where a deferred write may never get the chance to run. When another client on the key is
+		// mid-flush, wait for it instead — both write to the same database, and our snapshot landing
+		// first would be overwritten by its delayed changes. connect() awaits this, so it must
+		// never reject.
+		const previous = pendingFlushes.get(this.persistenceKey)
+		const flush = (previous ? previous.then(() => this.flushAndCloseDb()) : this.flushAndCloseDb())
+			.catch(noop)
+			.then(() => {
+				if (pendingFlushes.get(this.persistenceKey) === flush) {
+					pendingFlushes.delete(this.persistenceKey)
+				}
+			})
 		pendingFlushes.set(this.persistenceKey, flush)
 	}
 

--- a/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
+++ b/packages/editor/src/lib/utils/sync/TLLocalSyncClient.ts
@@ -64,7 +64,7 @@ export class BroadcastChannelMock {
 
 const BC = typeof BroadcastChannel === 'undefined' ? BroadcastChannelMock : BroadcastChannel
 
-// Flushes still running for closed clients, keyed by persistence key. See connect().
+// Flushes still running for closed clients, by key. See connect() and close().
 const pendingFlushes = new Map<string, Promise<void>>()
 
 /** @internal */
@@ -241,9 +241,8 @@ export class TLLocalSyncClient {
 			this.channel.close()
 		})
 
-		// A client that just closed on this key may still be flushing. Read after it lands, or our
-		// first (full) db write erases the edits it was writing — React strict mode and any remount
-		// construct the new client before the old one's flush resolves.
+		// our first write is a full snapshot, so it would erase whatever a client that just closed
+		// on this key is still flushing
 		await pendingFlushes.get(this.persistenceKey)
 		if (this.didDispose) return
 
@@ -326,11 +325,9 @@ export class TLLocalSyncClient {
 		if (typeof window !== 'undefined' && (window as any).tlsync === this) {
 			delete (window as any).tlsync
 		}
-		// Flush right away when nothing else is flushing this key: close() runs during teardown,
-		// where a deferred write may never get the chance to run. When another client on the key is
-		// mid-flush, wait for it instead — both write to the same database, and our snapshot landing
-		// first would be overwritten by its delayed changes. connect() awaits this, so it must
-		// never reject.
+		// flush now when the key is idle: close() runs during teardown, where a deferred write may
+		// never run. wait when it isn't, or our snapshot lands first and gets overwritten.
+		// connect() awaits this, so it must never reject
 		const previous = pendingFlushes.get(this.persistenceKey)
 		const flush = (previous ? previous.then(() => this.flushAndCloseDb()) : this.flushAndCloseDb())
 			.catch(noop)


### PR DESCRIPTION
**Risk: low · Importance: medium**

`TLLocalSyncClient.close()` flushes whatever the persist throttle still has queued, then closes the db — but that flush is asynchronous and nothing waits for it. A client constructed on the same persistence key in the meantime calls `db.load()` straight away, so it can read IndexedDB before the old client's write lands. Its first persist is a full-snapshot write, so those edits are then erased for good.

React strict mode reaches this on every mount, and so does any remount that swaps the editor while keeping the same `persistenceKey`.

### Before

`close()` called `flushAndCloseDb()` and dropped the returned work on the floor. A new client's `connect()` went straight to `db.load()`.

### After

`flushAndCloseDb()` hands back a promise that resolves once the flush has committed (it already waited on `persistPromise`, and `db.close()` waits for the transaction the flush opened). `close()` publishes that promise in a module-level map keyed by persistence key and clears its own entry when it settles. `connect()` awaits the entry for its key before loading, and bails if it was disposed while waiting.

Flushes on the same key are also serialized against each other: when an earlier flush is still running, the next client waits for it rather than starting its own write concurrently — two clients sharing a key write to the same database, and the later one's snapshot landing first would be overwritten by the earlier one's delayed changes. When nothing else is flushing the key the write still starts synchronously inside `close()`, which teardown depends on.

Follow-up to #10332, which fixed the flush itself but not the handoff between two clients on the same key. This is the one piece of #10102 that isn't already on `main`; I'll close that PR separately.

### Change type

- [x] `bugfix`

### Test plan

1. Mount an editor with a `persistenceKey`, edit, and let it remount (strict mode, or swap the component) within the persist throttle window.
2. Reload — the edits made just before the remount must still be there.

- [x] Unit tests — two new tests, each of which fails without its half of the fix:
  - remount gating: `expected "load" to not be called at all, but actually been called 1 times`
  - flush ordering: `expected [ 'a', 'b' ] to deeply equal [ 'a' ]`

  Full `src/lib/utils/sync/` suite: 33 passed.

### Release notes

- Fix edits being lost when an editor remounts on the same persistence key while the previous client is still saving.
